### PR TITLE
wxSpinCtrl:  work around macOS issue

### DIFF
--- a/xLights/CustomTimingDialog.cpp
+++ b/xLights/CustomTimingDialog.cpp
@@ -41,7 +41,7 @@ CustomTimingDialog::CustomTimingDialog(wxWindow* parent,wxWindowID id,const wxPo
 	FlexGridSizer1 = new wxFlexGridSizer(0, 3, 0, 0);
 	StaticText1 = new wxStaticText(this, ID_STATICTEXT1, _("Frame interval (msec):"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT1"));
 	FlexGridSizer1->Add(StaticText1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	SpinCtrl_Interval = new wxSpinCtrl(this, ID_SPINCTRL_Interval, _T("33"), wxDefaultPosition, wxDefaultSize, 0, 15, 1000, 33, _T("ID_SPINCTRL_Interval"));
+	SpinCtrl_Interval = new wxSpinCtrl(this, ID_SPINCTRL_Interval, _T("33"), wxDefaultPosition, wxDefaultSize, 0, 1, 1000, 33, _T("ID_SPINCTRL_Interval"));
 	SpinCtrl_Interval->SetValue(_T("33"));
 	FlexGridSizer1->Add(SpinCtrl_Interval, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	TextCtrl_FPS = new wxTextCtrl(this, ID_TEXTCTRL_FPS, _("33.30 fps"), wxDefaultPosition, wxDefaultSize, wxTE_READONLY, wxDefaultValidator, _T("ID_TEXTCTRL_FPS"));
@@ -95,6 +95,11 @@ void CustomTimingDialog::UpdateFPS()
     if( init )
     {
         int spin_value = SpinCtrl_Interval->GetValue();
+        if ( spin_value < 15 )
+        {
+            spin_value = 15;
+            SpinCtrl_Interval->SetValue(spin_value);
+        }
         TextCtrl_FPS->SetValue(wxString::Format("%.2f fps", 1000.0 / spin_value));
     }
 }

--- a/xLights/ModelGroupPanel.cpp
+++ b/xLights/ModelGroupPanel.cpp
@@ -169,7 +169,7 @@ ModelGroupPanel::ModelGroupPanel(wxWindow* parent, ModelManager &Models, LayoutP
 	FlexGridSizer6->Add(ChoiceModelLayoutType, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	GridSizeLabel = new wxStaticText(this, ID_STATICTEXT4, _("Max Grid Size:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT4"));
 	FlexGridSizer6->Add(GridSizeLabel, 1, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
-	SizeSpinCtrl = new wxSpinCtrl(this, ID_SPINCTRL1, _T("400"), wxDefaultPosition, wxDefaultSize, 0, 10, 2000, 400, _T("ID_SPINCTRL1"));
+	SizeSpinCtrl = new wxSpinCtrl(this, ID_SPINCTRL1, _T("400"), wxDefaultPosition, wxDefaultSize, 0, 1, 2000, 400, _T("ID_SPINCTRL1"));
 	SizeSpinCtrl->SetValue(_T("400"));
 	FlexGridSizer6->Add(SizeSpinCtrl, 1, wxALL|wxEXPAND, 2);
 	StaticText6 = new wxStaticText(this, wxID_ANY, _("Preview:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
@@ -671,6 +671,10 @@ void ModelGroupPanel::SaveGroupChanges()
 
     e->DeleteAttribute("GridSize");
     e->DeleteAttribute("layout");
+    if ( SizeSpinCtrl->GetValue() < 10 )
+    {
+        SizeSpinCtrl->SetValue(10);
+    }
     e->AddAttribute("GridSize", wxString::Format("%d", SizeSpinCtrl->GetValue()));
     e->DeleteAttribute("XCentreOffset");
     e->DeleteAttribute("YCentreOffset");

--- a/xLights/SeqSettingsDialog.cpp
+++ b/xLights/SeqSettingsDialog.cpp
@@ -994,10 +994,15 @@ void SeqSettingsDialog::OnButton_Xml_New_TimingClick(wxCommandEvent& event)
                 if (selected_timing == "Metronome")
                 {
                     int base_timing = xml_file->GetFrameMS();
-                    wxNumberEntryDialog dlg(this, "Enter metronome timing", "Milliseconds", "Metronome timing", base_timing, base_timing, 60000);
+                    wxNumberEntryDialog dlg(this, "Enter metronome timing", "Milliseconds", "Metronome timing", base_timing, 1, 60000);
                     if (dlg.ShowModal() == wxID_OK)
                     {
                         int ms = (dlg.GetValue() + base_timing / 2) / base_timing * base_timing;
+
+                        if ( ms < base_timing )
+                        {
+                            ms = base_timing;
+                        }
 
                         if (ms != dlg.GetValue())
                         {

--- a/xLights/sequencer/RowHeading.cpp
+++ b/xLights/sequencer/RowHeading.cpp
@@ -672,10 +672,15 @@ void RowHeading::OnLayerPopup(wxCommandEvent& event)
                     name = selected_timing;
                     if (selected_timing == "Metronome") {
                         int base_timing = xml_file->GetFrameMS();
-                        wxNumberEntryDialog dlg(this, "Enter metronome timing", "Milliseconds", "Metronome timing", 10 * base_timing, base_timing, 60000);
+                        wxNumberEntryDialog dlg(this, "Enter metronome timing", "Milliseconds", "Metronome timing", 10 * base_timing, 1, 60000);
                         OptimiseDialogPosition(&dlg);
                         if (dlg.ShowModal() == wxID_OK) {
                             int ms = (dlg.GetValue() + base_timing / 2) / base_timing * base_timing;
+
+                            if ( ms < base_timing )
+                            {
+                                ms = base_timing;
+                            }
 
                             if (ms != dlg.GetValue()) {
                                 DisplayWarning(wxString::Format("Timing adjusted to match sequence timing %dms -> %dms", dlg.GetValue(), ms).ToStdString());


### PR DESCRIPTION
The wxWidget wxSpinCtrl() checks value in the spinner
against the min and max continuously.  If you attempt
to key a value directly and the min value is greater
than 1, it prevents the user from entering a value.

This commit fixes four instances of this issue in xLights by
changing the min value to 1 and performing min value
checking when wxSpinCtrl returns a value.