### PR TITLE
Enhancement: When a ruler is defined, include real world coords in model export.

### DIFF
--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -103,6 +103,7 @@
 #include "effects/StateEffect.h"
 #include "graphics/opengl/xlGLCanvas.h"
 #include "models/ModelGroup.h"
+#include "models/RulerObject.h"
 #include "models/SubModel.h"
 #include "models/ViewObject.h"
 #include "outputs/ControllerEthernet.h"
@@ -4432,7 +4433,15 @@ void xLightsFrame::ExportModels(wxString const& filename)
         col_widths[col] = std::max(text.size() + FACTOR, col_widths[col]);
     };
 
-    const std::vector<std::string> model_header_cols{ "Model Name", "Shadowing", "Description", "Display As", "Dimensions", "String Type", "String Count", "Node Count", "Light Count", "Est Current (Amps)", "Channels Per Node", "Channel Count", "Start Channel", "Start Channel No", "#Universe(or id):Start Channel", "End Channel No", "Default Buffer W x H", "Preview", "Controller Ports", "Connection Protocol", "Connection Attributes", "Controller Name", "Controller Type", "Protocol", "Controller Description", "IP", "Baud", "Universe/Id", "Universe Channel", "Controller Channel", "Active" };
+    RulerObject* ruler = RulerObject::GetRuler();
+
+    std::vector<std::string> model_header_cols{ "Model Name", "Shadowing", "Description", "Display As", "Dimensions", "String Type", "String Count", "Node Count", "Light Count", "Est Current (Amps)", "Channels Per Node", "Channel Count", "Start Channel", "Start Channel No", "#Universe(or id):Start Channel", "End Channel No", "Default Buffer W x H", "Preview", "Controller Ports", "Connection Protocol", "Connection Attributes", "Controller Name", "Controller Type", "Protocol", "Controller Description", "IP", "Baud", "Universe/Id", "Universe Channel", "Controller Channel", "Active"};
+    if (ruler != nullptr) {
+        std::string unitDescription = ruler->GetUnitDescription();
+        model_header_cols.push_back("Location X (" + unitDescription + ")");
+        model_header_cols.push_back("Location Y (" + unitDescription + ")");
+        model_header_cols.push_back("Location Z (" + unitDescription + ")");
+    }
 
     std::map<int, double> _model_col_widths;
     for (int i = 0; i < model_header_cols.size(); i++) {
@@ -4512,6 +4521,14 @@ void xLightsFrame::ExportModels(wxString const& filename)
             worksheet_write_number(modelsheet, row, 28, stuc, format);
             worksheet_write_number(modelsheet, row, 29, channeloffset, format);
             write_worksheet_string(modelsheet, row, 30, inactive, format, _model_col_widths);
+
+            glm::vec3 position = model->GetBaseObjectScreenLocation().GetWorldPosition();
+            if (ruler != nullptr) {
+                worksheet_write_number(modelsheet, row, 31, ruler->Measure(position.x), format);
+                worksheet_write_number(modelsheet, row, 32, ruler->Measure(position.y), format);
+                worksheet_write_number(modelsheet, row, 33, ruler->Measure(position.z), format);
+            }
+
             ++row;
 
             if (ch < minchannel) {


### PR DESCRIPTION
…he selection using "real world" units as well in the text.

Purpose: Many users who take advantage of the 3d view in xLights use CAD or photogrammetry models of their house to layout their displays.  A user may wish to lay out their display entirely in xLights and then translate the position of models to the real world for setup.  If the user adjusts their display so that the world origin in xLights corresponds to a known reference point in the real world (e.g. the corner of a lot) the real world coordinates of the props in xLights can be used to lay out their display.  Exporting the X/Y/Z coordinates of models helps when laying out the props in the real world.

Change: When the user has defined a ruler to map between the xLights coordinate system and a known distance in the real world, add 3 new columns to the model export spreadsheet containing the "real world" X/Y/Z coordinates of each model.

Here's an example of of this will look like:
![Example export](https://github.com/xLightsSequencer/xLights/assets/7344421/a3523d33-6e65-4a24-996e-db80043107a4)
