### PR TITLE
4244 Shape Effect - Flip the Y value for Emoji 

### DIFF
--- a/xLights/effects/ShapeEffect.cpp
+++ b/xLights/effects/ShapeEffect.cpp
@@ -1210,6 +1210,30 @@ void ShapeEffect::Drawpresent(RenderBuffer& buffer, int xc, int yc, double radiu
     }
 }
 
+bool ShapeEffect::needToAdjustSettings(const std::string& version)
+{
+    // give the base class a chance to adjust any settings
+    return IsVersionOlder("2024.02", version);
+}
+
+void ShapeEffect::adjustSettings(const std::string& version, Effect* effect, bool removeDefaults)
+{
+    // give the base class a chance to adjust any settings
+    if (RenderableEffect::needToAdjustSettings(version)) {
+        RenderableEffect::adjustSettings(version, effect, removeDefaults);
+    }
+    SettingsMap& settings = effect->GetSettings();
+    if (settings.Contains("E_CHOICE_Shape_ObjectToDraw")) {
+        if (settings["E_CHOICE_Shape_ObjectToDraw"] == "Emoji") {
+            std::string val = settings.Get("E_SLIDER_Shape_CentreY", "");
+            // int val = effect->GetSettings().GetInt("E_SLIDER_Shape_CentreY", 0);
+            if (val != "") {
+                settings["E_SLIDER_Shape_CentreY"] = wxString::Format(wxT("%d"), 100 - wxAtoi(val));
+            }
+        }
+    }
+}
+
 void ShapeEffect::Drawemoji(RenderBuffer& buffer, int xc, int yc, double radius, xlColor color, int emoji, int emojiTone, wxFontInfo& font) const
 {
     if (radius < 1)

--- a/xLights/effects/ShapeEffect.cpp
+++ b/xLights/effects/ShapeEffect.cpp
@@ -1237,7 +1237,7 @@ void ShapeEffect::Drawemoji(RenderBuffer& buffer, int xc, int yc, double radius,
     context->GetTextExtent(text, &width, &height);
 
     context->SetOverlayMode(true);
-    context->DrawText(text, std::round((float)xc - width / 2.0), std::round((float)yc - height / 2.0));
+    context->DrawText(text, std::round((float)xc - width / 2.0), std::round((float)(50.0 - yc) - height / 2.0));
     context->SetOverlayMode(false);
 }
 

--- a/xLights/effects/ShapeEffect.h
+++ b/xLights/effects/ShapeEffect.h
@@ -64,6 +64,8 @@ public:
     {
         return true;
     }
+    virtual bool needToAdjustSettings(const std::string& version) override;
+    virtual void adjustSettings(const std::string& version, Effect* effect, bool removeDefaults = true) override;
     virtual std::list<std::string> GetFileReferences(Model* model, const SettingsMap& SettingsMap) const override;
     virtual bool CleanupFileLocations(xLightsFrame* frame, SettingsMap& SettingsMap) override;
 #ifdef LINUX


### PR DESCRIPTION
The Y value was reversed for the emoji shape. ie a 0 was at the top, and 100 was at the bottom. This is the opposite to all the other objects in the shape effect. Corrects the results when using a value curve. No issue with x value.

Issue #4244 