### PR TITLE
Allow check update to use xlights.php file to determine if update

### DIFF
--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -8617,7 +8617,7 @@ bool xLightsFrame::CheckForUpdate(int maxRetries, bool canSkipUpdates, bool show
 
     // wxString path = _T("/downloads/");
     wxString downloadUrl = wxT("https://xlights.org/downloads/");
-    wxString path = _T("/releases/");
+    wxString path = _T("/xlights.php");
     // wxString downloadUrl = wxT("https://xlights.org/releases/");
 
     logger_base.debug("Downloading %s", (const char*)downloadUrl.c_str());


### PR DESCRIPTION
This works to determine if an update is available. Perhaps there is a reason this cant be used?