### PR TITLE
New preference to set a default sequence folder

### DIFF
--- a/xLights/SeqFileUtilities.cpp
+++ b/xLights/SeqFileUtilities.cpp
@@ -227,7 +227,7 @@ void xLightsFrame::OpenSequence(const wxString& passed_filename, ConvertLogDialo
     wxString filename;
     wxString wildcards = "xLights Sequence files (*.xsq;*.xml)|*.xsq;*.xml|Old xLights Sequence files (*.xml)|*.xml|FSEQ files (*.fseq)|*.fseq|Sequence Backups (*.xbkp)|*.xbkp";
     if (passed_filename.IsEmpty()) {
-        filename = wxFileSelector("Choose sequence file to open", CurrentDir, wxEmptyString, "*.xsq", wildcards, wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+        filename = wxFileSelector("Choose sequence file to open", xsqDirectory, wxEmptyString, "*.xsq", wildcards, wxFD_OPEN | wxFD_FILE_MUST_EXIST);
     } else {
         filename = passed_filename;
     }

--- a/xLights/SequencePackage.cpp
+++ b/xLights/SequencePackage.cpp
@@ -94,6 +94,7 @@ void SequencePackage::InitDefaultImportOptions()
     // can still change these in the Mapping Dialog to whatever they would like.
 
     std::string showFolder = _xlights->GetShowDirectory();
+    wxString xsqDir = _xlights->GetXsqDirectory();
 
     // always default faces/shaders to default download folder as they tend to be reused
     _importOptions.SetDir(MediaTargetDir::FACES_DIR, wxString::Format("%s%c%s", showFolder, PATH_SEP, SUBFLD_FACES), true);
@@ -104,7 +105,7 @@ void SequencePackage::InitDefaultImportOptions()
 
     wxString mediaBaseFolder;
 
-    if (targetDir.ToStdString() != showFolder) {
+    if (targetDir.ToStdString() != showFolder && targetDir.ToStdString() != xsqDir) {
         // target xsq is not at the root of show folder, assume user manages show folder
         // with a subfolder per sequence as Gil noted
         mediaBaseFolder = targetDir;

--- a/xLights/TabSequence.cpp
+++ b/xLights/TabSequence.cpp
@@ -307,8 +307,6 @@ wxString xLightsFrame::LoadEffectsFileNoCheck()
 
     //Load FSEQ and Backup directory settings
     fseqDirectory = GetXmlSetting("fseqDir", showDirectory);
-    renderCacheDirectory = GetXmlSetting("renderCacheDir", fseqDirectory); // we user fseq directory if no setting is present
-    ObtainAccessToURL(renderCacheDirectory);
     ObtainAccessToURL(fseqDirectory);
     if (!wxDir::Exists(fseqDirectory)) {
         logger_base.warn("FSEQ Directory not Found ... switching to Show Directory.");
@@ -317,6 +315,16 @@ wxString xLightsFrame::LoadEffectsFileNoCheck()
         UnsavedRgbEffectsChanges = true;
     }
     FseqDir = fseqDirectory;
+    xsqDirectory = GetXmlSetting("xsqDir", showDirectory);
+    ObtainAccessToURL(xsqDirectory);
+    if (!wxDir::Exists(xsqDirectory)) {
+        logger_base.warn("Sequence XSQ Directory not Found ... switching to Show Directory.");
+        xsqDirectory = showDirectory;
+        SetXmlSetting("xsqDir", showDirectory);
+        UnsavedRgbEffectsChanges = true;
+    }
+    renderCacheDirectory = GetXmlSetting("renderCacheDir", fseqDirectory); // we user fseq directory if no setting is present
+    ObtainAccessToURL(renderCacheDirectory);
     if (!wxDir::Exists(renderCacheDirectory)) {
         logger_base.warn("Render Cache Directory not Found ... switching to Show Directory.");
         renderCacheDirectory = showDirectory;
@@ -1283,7 +1291,7 @@ void xLightsFrame::SaveSequence()
 
         wxFileDialog fd(this,
                         "Choose filename to Save Sequence:",
-                        CurrentDir,
+                        xsqDirectory,
                         startname,
                         strSequenceSaveAsFileTypes,
                         wxFD_SAVE | wxFD_OVERWRITE_PROMPT);

--- a/xLights/TabSequence.cpp
+++ b/xLights/TabSequence.cpp
@@ -320,8 +320,7 @@ wxString xLightsFrame::LoadEffectsFileNoCheck()
     if (!wxDir::Exists(xsqDirectory)) {
         logger_base.warn("Sequence XSQ Directory not Found ... switching to Show Directory.");
         xsqDirectory = showDirectory;
-    }
-    if (xsqDirectory.compare(0, showDirectory.length(), showDirectory) != 0) {
+    } else if (xsqDirectory.compare(0, showDirectory.length(), showDirectory) != 0) {
         logger_base.warn("Sequence Directory not within the Show Folder ... switching to Show Directory.");
         xsqDirectory = showDirectory;
     }

--- a/xLights/TabSequence.cpp
+++ b/xLights/TabSequence.cpp
@@ -1459,7 +1459,7 @@ void xLightsFrame::SaveAsSequence()
     wxString newFilename;
     wxFileDialog fd(this,
                     "Choose filename to Save Sequence:",
-                    CurrentDir,
+                    xsqDirectory,
                     CurrentSeqXmlFile->GetName(),
                     strSequenceSaveAsFileTypes,
                     wxFD_SAVE | wxFD_OVERWRITE_PROMPT);

--- a/xLights/TabSequence.cpp
+++ b/xLights/TabSequence.cpp
@@ -323,6 +323,12 @@ wxString xLightsFrame::LoadEffectsFileNoCheck()
         SetXmlSetting("xsqDir", showDirectory);
         UnsavedRgbEffectsChanges = true;
     }
+    if (xsqDirectory.compare(0, showDirectory.length(), showDirectory) != 0) { // dwe
+        logger_base.warn("Sequence Directory not within the Show Folder ... switching to Show Directory.");
+        xsqDirectory = showDirectory;
+        SetXmlSetting("xsqDir", showDirectory);
+        UnsavedRgbEffectsChanges = true;
+    }
     renderCacheDirectory = GetXmlSetting("renderCacheDir", fseqDirectory); // we user fseq directory if no setting is present
     ObtainAccessToURL(renderCacheDirectory);
     if (!wxDir::Exists(renderCacheDirectory)) {

--- a/xLights/TabSequence.cpp
+++ b/xLights/TabSequence.cpp
@@ -320,14 +320,10 @@ wxString xLightsFrame::LoadEffectsFileNoCheck()
     if (!wxDir::Exists(xsqDirectory)) {
         logger_base.warn("Sequence XSQ Directory not Found ... switching to Show Directory.");
         xsqDirectory = showDirectory;
-        SetXmlSetting("xsqDir", showDirectory);
-        UnsavedRgbEffectsChanges = true;
     }
-    if (xsqDirectory.compare(0, showDirectory.length(), showDirectory) != 0) { // dwe
+    if (xsqDirectory.compare(0, showDirectory.length(), showDirectory) != 0) {
         logger_base.warn("Sequence Directory not within the Show Folder ... switching to Show Directory.");
         xsqDirectory = showDirectory;
-        SetXmlSetting("xsqDir", showDirectory);
-        UnsavedRgbEffectsChanges = true;
     }
     renderCacheDirectory = GetXmlSetting("renderCacheDir", fseqDirectory); // we user fseq directory if no setting is present
     ObtainAccessToURL(renderCacheDirectory);

--- a/xLights/TabSetup.cpp
+++ b/xLights/TabSetup.cpp
@@ -296,11 +296,7 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
         logger_base.debug("FSEQ Directory set to : %s.", (const char*)fseqDirectory.c_str());
     }
 
-    long xsqLinkFlag = 0;
-    config->Read(_("XSQLinkFlag"), &xsqLinkFlag);
-    if (xsqLinkFlag) {
-        xsqDirectory = CurrentDir;
-        config->Write(_("XSQDir"), wxString(xsqDirectory));
+    if (xsqDirectory == CurrentDir) {
         logger_base.debug("Sequence XSQ Directory set to : %s.", (const char*)xsqDirectory.c_str());
     }
 

--- a/xLights/TabSetup.cpp
+++ b/xLights/TabSetup.cpp
@@ -296,6 +296,14 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
         logger_base.debug("FSEQ Directory set to : %s.", (const char*)fseqDirectory.c_str());
     }
 
+    long xsqLinkFlag = 0;
+    config->Read(_("XSQLinkFlag"), &xsqLinkFlag);
+    if (xsqLinkFlag) {
+        xsqDirectory = CurrentDir;
+        config->Write(_("XSQDir"), wxString(xsqDirectory));
+        logger_base.debug("Sequence XSQ Directory set to : %s.", (const char*)xsqDirectory.c_str());
+    }
+
     EnableNetworkChanges();
     DisplayXlightsFilename(wxEmptyString);
 

--- a/xLights/preferences/SequenceFileSettingsPanel.cpp
+++ b/xLights/preferences/SequenceFileSettingsPanel.cpp
@@ -37,6 +37,7 @@ const long SequenceFileSettingsPanel::ID_CHOICE2 = wxNewId();
 const long SequenceFileSettingsPanel::ID_CHOICE3 = wxNewId();
 const long SequenceFileSettingsPanel::ID_CHECKBOX6 = wxNewId();
 const long SequenceFileSettingsPanel::ID_DIRPICKERCTRL3 = wxNewId();
+const long SequenceFileSettingsPanel::ID_DIRPICKERCTRL4 = wxNewId();
 const long SequenceFileSettingsPanel::ID_STATICTEXT3 = wxNewId();
 const long SequenceFileSettingsPanel::ID_CHOICE5 = wxNewId();
 const long SequenceFileSettingsPanel::ID_CHECKBOX5 = wxNewId();
@@ -166,6 +167,14 @@ SequenceFileSettingsPanel::SequenceFileSettingsPanel(wxWindow* parent,xLightsFra
 	GridBagSizer1->Fit(this);
 	GridBagSizer1->SetSizeHints(this);
 
+	StaticBoxSizer3 = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Sequence XSQ Directory"));
+    CheckBox_XSQ = new wxCheckBox(this, ID_CHECKBOX5, _("Use Show Folder"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX6"));
+    CheckBox_XSQ->SetValue(false);
+    StaticBoxSizer3->Add(CheckBox_XSQ, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 5);
+    DirPickerCtrl_XSQ = new wxDirPickerCtrl(this, ID_DIRPICKERCTRL4, wxEmptyString, wxEmptyString, wxDefaultPosition, wxSize(400, -1), wxDIRP_DIR_MUST_EXIST | wxDIRP_USE_TEXTCTRL, wxDefaultValidator, _T("ID_DIRPICKERCTRL4"));
+    StaticBoxSizer3->Add(DirPickerCtrl_XSQ, 1, wxALL | wxEXPAND, 5);
+    GridBagSizer1->Add(StaticBoxSizer3, wxGBPosition(11, 0), wxGBSpan(1, 2), wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 5);
+
 	Connect(ID_CHECKBOX1,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnRenderOnSaveCheckBoxClick);
 	Connect(ID_CHECKBOX3,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnCheckBox_LowDefinitionRenderClick);
 	Connect(ID_CHECKBOX2,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnFSEQSaveCheckBoxClick);
@@ -178,6 +187,7 @@ SequenceFileSettingsPanel::SequenceFileSettingsPanel(wxWindow* parent,xLightsFra
 	Connect(ID_CHOICE5,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnChoice_MaximumRenderCacheSelect);
 	Connect(ID_CHECKBOX5,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnCheckBox_FSEQClick);
 	Connect(ID_DIRPICKERCTRL2,wxEVT_COMMAND_DIRPICKER_CHANGED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnDirPickerCtrl_FSEQDirChanged);
+    Connect(ID_DIRPICKERCTRL4, wxEVT_COMMAND_DIRPICKER_CHANGED, (wxObjectEventFunction)&SequenceFileSettingsPanel::OnDirPickerCtrl_XSQDirChanged);
 	Connect(ID_LISTBOX_MEDIA,wxEVT_COMMAND_LISTBOX_SELECTED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnMediaDirectoryListSelect);
 	Connect(ID_BUTTON_ADDMEDIA,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnAddMediaButtonClick);
 	Connect(ID_BUTTON_REMOVE_MEDIA,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnRemoveMediaButtonClick);
@@ -237,6 +247,7 @@ bool SequenceFileSettingsPanel::TransferDataFromWindow() {
     frame->SetMediaFolders(mediaFolders);
 
     frame->SetFSEQFolder(CheckBox_FSEQ->GetValue(), DirPickerCtrl_FSEQ->GetPath());
+    frame->SetXSQFolder(CheckBox_XSQ->GetValue(), DirPickerCtrl_XSQ->GetPath());
     frame->SetRenderCacheFolder(CheckBox_RenderCache->GetValue(), DirPickerCtrl_RenderCache->GetPath());
 
     frame->SetDefaultSeqView(ViewDefaultChoice->GetStringSelection());
@@ -342,6 +353,10 @@ bool SequenceFileSettingsPanel::TransferDataToWindow() {
     CheckBox_FSEQ->SetValue(cb);
     DirPickerCtrl_FSEQ->SetPath(folder);
 
+    frame->GetXSQFolder(cb, folder);
+    CheckBox_XSQ->SetValue(cb);
+    DirPickerCtrl_XSQ->SetPath(folder);
+
 
     folder = frame->GetShowDirectory();
     MediaDirectoryList->Clear();
@@ -425,6 +440,14 @@ bool SequenceFileSettingsPanel::ValidateWindow()
         DirPickerCtrl_FSEQ->Enable(true);
     }
 
+    if (CheckBox_XSQ->GetValue()) {
+        DirPickerCtrl_XSQ->Enable(false);
+    } else {
+        if (!wxDir::Exists(DirPickerCtrl_XSQ->GetPath()))
+            res = false;
+        DirPickerCtrl_XSQ->Enable(true);
+    }
+
     if (CheckBox_RenderCache->GetValue()) {
         DirPickerCtrl_RenderCache->Enable(false);
     } else {
@@ -458,6 +481,14 @@ void SequenceFileSettingsPanel::OnCheckBox_FSEQClick(wxCommandEvent& event)
     }
 }
 
+void SequenceFileSettingsPanel::OnCheckBox_XSQClick(wxCommandEvent& event)
+{
+    ValidateWindow();
+    if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
+        TransferDataFromWindow();
+    }
+}
+
 void SequenceFileSettingsPanel::OnDirPickerCtrl_RenderCacheDirChanged(wxFileDirPickerEvent& event)
 {
     if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
@@ -473,6 +504,13 @@ void SequenceFileSettingsPanel::OnDirPickerCtrl_MediaDirChanged(wxFileDirPickerE
 }
 
 void SequenceFileSettingsPanel::OnDirPickerCtrl_FSEQDirChanged(wxFileDirPickerEvent& event)
+{
+    if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
+        TransferDataFromWindow();
+    }
+}
+
+void SequenceFileSettingsPanel::OnDirPickerCtrl_XSQDirChanged(wxFileDirPickerEvent& event)
 {
     if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
         TransferDataFromWindow();

--- a/xLights/preferences/SequenceFileSettingsPanel.cpp
+++ b/xLights/preferences/SequenceFileSettingsPanel.cpp
@@ -37,7 +37,6 @@ const long SequenceFileSettingsPanel::ID_CHOICE2 = wxNewId();
 const long SequenceFileSettingsPanel::ID_CHOICE3 = wxNewId();
 const long SequenceFileSettingsPanel::ID_CHECKBOX6 = wxNewId();
 const long SequenceFileSettingsPanel::ID_DIRPICKERCTRL3 = wxNewId();
-const long SequenceFileSettingsPanel::ID_DIRPICKERCTRL4 = wxNewId();
 const long SequenceFileSettingsPanel::ID_STATICTEXT3 = wxNewId();
 const long SequenceFileSettingsPanel::ID_CHOICE5 = wxNewId();
 const long SequenceFileSettingsPanel::ID_CHECKBOX5 = wxNewId();
@@ -47,6 +46,8 @@ const long SequenceFileSettingsPanel::ID_BUTTON_ADDMEDIA = wxNewId();
 const long SequenceFileSettingsPanel::ID_BUTTON_REMOVE_MEDIA = wxNewId();
 const long SequenceFileSettingsPanel::ID_STATICTEXT2 = wxNewId();
 const long SequenceFileSettingsPanel::ID_CHOICE_VIEW_DEFAULT = wxNewId();
+const long SequenceFileSettingsPanel::ID_CHECKBOX4 = wxNewId();
+const long SequenceFileSettingsPanel::ID_DIRPICKERCTRL1 = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(SequenceFileSettingsPanel,wxPanel)
@@ -64,6 +65,7 @@ SequenceFileSettingsPanel::SequenceFileSettingsPanel(wxWindow* parent,xLightsFra
 	wxStaticBoxSizer* StaticBoxSizer1;
 	wxStaticBoxSizer* StaticBoxSizer2;
 	wxStaticBoxSizer* StaticBoxSizer3;
+	wxStaticBoxSizer* StaticBoxSizer4;
 	wxStaticText* StaticText1;
 	wxStaticText* StaticText2;
 	wxStaticText* StaticText3;
@@ -163,17 +165,16 @@ SequenceFileSettingsPanel::SequenceFileSettingsPanel(wxWindow* parent,xLightsFra
 	ViewDefaultChoice = new wxChoice(this, ID_CHOICE_VIEW_DEFAULT, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_VIEW_DEFAULT"));
 	ViewDefaultChoice->SetToolTip(_("This option is used to select which models will populate the master view when a new sequence is created."));
 	GridBagSizer1->Add(ViewDefaultChoice, wxGBPosition(3, 1), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+	StaticBoxSizer4 = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Sequence Directory"));
+	CheckBox_XSQ = new wxCheckBox(this, ID_CHECKBOX4, _("Use Show Folder"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX4"));
+	CheckBox_XSQ->SetValue(false);
+	StaticBoxSizer4->Add(CheckBox_XSQ, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	DirPickerCtrl_XSQ = new wxDirPickerCtrl(this, ID_DIRPICKERCTRL1, wxEmptyString, wxEmptyString, wxDefaultPosition, wxSize(400,-1), wxDIRP_DIR_MUST_EXIST|wxDIRP_USE_TEXTCTRL, wxDefaultValidator, _T("ID_DIRPICKERCTRL1"));
+	StaticBoxSizer4->Add(DirPickerCtrl_XSQ, 1, wxALL|wxEXPAND, 5);
+	GridBagSizer1->Add(StaticBoxSizer4, wxGBPosition(11, 0), wxGBSpan(1, 2), wxALL|wxALIGN_LEFT|wxALIGN_TOP, 5);
 	SetSizer(GridBagSizer1);
 	GridBagSizer1->Fit(this);
 	GridBagSizer1->SetSizeHints(this);
-
-	StaticBoxSizer3 = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Sequence XSQ Directory"));
-    CheckBox_XSQ = new wxCheckBox(this, ID_CHECKBOX5, _("Use Show Folder"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX6"));
-    CheckBox_XSQ->SetValue(false);
-    StaticBoxSizer3->Add(CheckBox_XSQ, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 5);
-    DirPickerCtrl_XSQ = new wxDirPickerCtrl(this, ID_DIRPICKERCTRL4, wxEmptyString, wxEmptyString, wxDefaultPosition, wxSize(400, -1), wxDIRP_DIR_MUST_EXIST | wxDIRP_USE_TEXTCTRL, wxDefaultValidator, _T("ID_DIRPICKERCTRL4"));
-    StaticBoxSizer3->Add(DirPickerCtrl_XSQ, 1, wxALL | wxEXPAND, 5);
-    GridBagSizer1->Add(StaticBoxSizer3, wxGBPosition(11, 0), wxGBSpan(1, 2), wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 5);
 
 	Connect(ID_CHECKBOX1,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnRenderOnSaveCheckBoxClick);
 	Connect(ID_CHECKBOX3,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnCheckBox_LowDefinitionRenderClick);
@@ -187,11 +188,12 @@ SequenceFileSettingsPanel::SequenceFileSettingsPanel(wxWindow* parent,xLightsFra
 	Connect(ID_CHOICE5,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnChoice_MaximumRenderCacheSelect);
 	Connect(ID_CHECKBOX5,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnCheckBox_FSEQClick);
 	Connect(ID_DIRPICKERCTRL2,wxEVT_COMMAND_DIRPICKER_CHANGED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnDirPickerCtrl_FSEQDirChanged);
-    Connect(ID_DIRPICKERCTRL4, wxEVT_COMMAND_DIRPICKER_CHANGED, (wxObjectEventFunction)&SequenceFileSettingsPanel::OnDirPickerCtrl_XSQDirChanged);
 	Connect(ID_LISTBOX_MEDIA,wxEVT_COMMAND_LISTBOX_SELECTED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnMediaDirectoryListSelect);
 	Connect(ID_BUTTON_ADDMEDIA,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnAddMediaButtonClick);
 	Connect(ID_BUTTON_REMOVE_MEDIA,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnRemoveMediaButtonClick);
 	Connect(ID_CHOICE_VIEW_DEFAULT,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnViewDefaultChoiceSelect);
+	Connect(ID_CHECKBOX4,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnCheckBox_XSQClick);
+	Connect(ID_DIRPICKERCTRL1,wxEVT_COMMAND_DIRPICKER_CHANGED,(wxObjectEventFunction)&SequenceFileSettingsPanel::OnDirPickerCtrl_XSQDirChanged);
 	//*)
 
 	GridBagSizer1->Fit(this);
@@ -323,7 +325,7 @@ bool SequenceFileSettingsPanel::TransferDataToWindow() {
     RenderCacheChoice->SetStringSelection(rc);
     FSEQSaveCheckBox->SetValue(frame->SaveFseqOnSave());
     RenderOnSaveCheckBox->SetValue(frame->RenderOnSave());
-    
+
     ModelBlendDefaultChoice->SetSelection(frame->ModelBlendDefaultOff());
     switch (frame->AutoSaveInterval()) {
         case 30:
@@ -481,14 +483,6 @@ void SequenceFileSettingsPanel::OnCheckBox_FSEQClick(wxCommandEvent& event)
     }
 }
 
-void SequenceFileSettingsPanel::OnCheckBox_XSQClick(wxCommandEvent& event)
-{
-    ValidateWindow();
-    if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
-        TransferDataFromWindow();
-    }
-}
-
 void SequenceFileSettingsPanel::OnDirPickerCtrl_RenderCacheDirChanged(wxFileDirPickerEvent& event)
 {
     if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
@@ -571,6 +565,14 @@ void SequenceFileSettingsPanel::OnCheckBox_LowDefinitionRenderClick(wxCommandEve
 
 void SequenceFileSettingsPanel::OnChoice_MaximumRenderCacheSelect(wxCommandEvent& event)
 {
+    if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
+        TransferDataFromWindow();
+    }
+}
+
+void SequenceFileSettingsPanel::OnCheckBox_XSQClick(wxCommandEvent& event)
+{
+    ValidateWindow();
     if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
         TransferDataFromWindow();
     }

--- a/xLights/preferences/SequenceFileSettingsPanel.cpp
+++ b/xLights/preferences/SequenceFileSettingsPanel.cpp
@@ -433,6 +433,9 @@ void SequenceFileSettingsPanel::OnRenderModeChoiceSelect(wxCommandEvent& event)
 bool SequenceFileSettingsPanel::ValidateWindow()
 {
     bool res = true;
+    std::string showfolder;
+    showfolder = frame->GetShowDirectory();
+
     RemoveMediaButton->Enable(MediaDirectoryList->GetSelection() != wxNOT_FOUND);
 
     if (CheckBox_FSEQ->GetValue()) {
@@ -455,6 +458,15 @@ bool SequenceFileSettingsPanel::ValidateWindow()
     } else {
         if (!wxDir::Exists(DirPickerCtrl_RenderCache->GetPath())) res = false;
         DirPickerCtrl_RenderCache->Enable(true);
+    }
+
+    if (DirPickerCtrl_XSQ->GetPath().compare(0, showfolder.length(), showfolder)) { // dwe
+        wxMessageDialog msgDlg(this, "Sequence Directory not within the Show Folder", "Error", wxOK | wxCENTRE);
+        msgDlg.ShowModal();
+        res = false;
+        DirPickerCtrl_XSQ->Enable(false);
+        CheckBox_XSQ->SetValue(true);
+        DirPickerCtrl_XSQ->SetPath(showfolder);
     }
 
     return res;
@@ -506,6 +518,7 @@ void SequenceFileSettingsPanel::OnDirPickerCtrl_FSEQDirChanged(wxFileDirPickerEv
 
 void SequenceFileSettingsPanel::OnDirPickerCtrl_XSQDirChanged(wxFileDirPickerEvent& event)
 {
+    ValidateWindow();
     if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
         TransferDataFromWindow();
     }

--- a/xLights/preferences/SequenceFileSettingsPanel.h
+++ b/xLights/preferences/SequenceFileSettingsPanel.h
@@ -41,6 +41,7 @@ class SequenceFileSettingsPanel: public wxPanel
 		wxButton* AddMediaButton;
 		wxButton* RemoveMediaButton;
 		wxCheckBox* CheckBox_FSEQ;
+		wxCheckBox* CheckBox_XSQ;
 		wxCheckBox* CheckBox_LowDefinitionRender;
 		wxCheckBox* CheckBox_RenderCache;
 		wxCheckBox* FSEQSaveCheckBox;
@@ -52,6 +53,7 @@ class SequenceFileSettingsPanel: public wxPanel
 		wxChoice* RenderCacheChoice;
 		wxChoice* ViewDefaultChoice;
 		wxDirPickerCtrl* DirPickerCtrl_FSEQ;
+		wxDirPickerCtrl* DirPickerCtrl_XSQ;
 		wxDirPickerCtrl* DirPickerCtrl_RenderCache;
 		wxListBox* MediaDirectoryList;
 		wxStaticText* StaticText4;
@@ -79,6 +81,7 @@ class SequenceFileSettingsPanel: public wxPanel
 		static const long ID_CHOICE5;
 		static const long ID_CHECKBOX5;
 		static const long ID_DIRPICKERCTRL2;
+		static const long ID_DIRPICKERCTRL4;
 		static const long ID_LISTBOX_MEDIA;
 		static const long ID_BUTTON_ADDMEDIA;
 		static const long ID_BUTTON_REMOVE_MEDIA;
@@ -99,9 +102,11 @@ class SequenceFileSettingsPanel: public wxPanel
 		void OnCheckBox_RenderCacheClick(wxCommandEvent& event);
 		void OnCheckBox_MediaClick(wxCommandEvent& event);
 		void OnCheckBox_FSEQClick(wxCommandEvent& event);
+		void OnCheckBox_XSQClick(wxCommandEvent& event);
 		void OnDirPickerCtrl_RenderCacheDirChanged(wxFileDirPickerEvent& event);
 		void OnDirPickerCtrl_MediaDirChanged(wxFileDirPickerEvent& event);
 		void OnDirPickerCtrl_FSEQDirChanged(wxFileDirPickerEvent& event);
+		void OnDirPickerCtrl_XSQDirChanged(wxFileDirPickerEvent& event);
 		void OnAddMediaButtonClick(wxCommandEvent& event);
 		void OnRemoveMediaButtonClick(wxCommandEvent& event);
 		void OnMediaDirectoryListSelect(wxCommandEvent& event);

--- a/xLights/preferences/SequenceFileSettingsPanel.h
+++ b/xLights/preferences/SequenceFileSettingsPanel.h
@@ -41,9 +41,9 @@ class SequenceFileSettingsPanel: public wxPanel
 		wxButton* AddMediaButton;
 		wxButton* RemoveMediaButton;
 		wxCheckBox* CheckBox_FSEQ;
-		wxCheckBox* CheckBox_XSQ;
 		wxCheckBox* CheckBox_LowDefinitionRender;
 		wxCheckBox* CheckBox_RenderCache;
+		wxCheckBox* CheckBox_XSQ;
 		wxCheckBox* FSEQSaveCheckBox;
 		wxCheckBox* RenderOnSaveCheckBox;
 		wxChoice* AutoSaveIntervalChoice;
@@ -53,14 +53,14 @@ class SequenceFileSettingsPanel: public wxPanel
 		wxChoice* RenderCacheChoice;
 		wxChoice* ViewDefaultChoice;
 		wxDirPickerCtrl* DirPickerCtrl_FSEQ;
-		wxDirPickerCtrl* DirPickerCtrl_XSQ;
 		wxDirPickerCtrl* DirPickerCtrl_RenderCache;
+		wxDirPickerCtrl* DirPickerCtrl_XSQ;
 		wxListBox* MediaDirectoryList;
 		wxStaticText* StaticText4;
 		wxStaticText* StaticText5;
 		wxStaticText* StaticText6;
 		//*)
-        
+
         virtual bool TransferDataFromWindow() override;
         virtual bool TransferDataToWindow() override;
 
@@ -81,12 +81,13 @@ class SequenceFileSettingsPanel: public wxPanel
 		static const long ID_CHOICE5;
 		static const long ID_CHECKBOX5;
 		static const long ID_DIRPICKERCTRL2;
-		static const long ID_DIRPICKERCTRL4;
 		static const long ID_LISTBOX_MEDIA;
 		static const long ID_BUTTON_ADDMEDIA;
 		static const long ID_BUTTON_REMOVE_MEDIA;
 		static const long ID_STATICTEXT2;
 		static const long ID_CHOICE_VIEW_DEFAULT;
+		static const long ID_CHECKBOX4;
+		static const long ID_DIRPICKERCTRL1;
 		//*)
 
 	private:

--- a/xLights/wxsmith/SequenceFileSettingsPanel.wxs
+++ b/xLights/wxsmith/SequenceFileSettingsPanel.wxs
@@ -322,6 +322,36 @@
 				<border>5</border>
 				<option>1</option>
 			</object>
+			<object class="sizeritem">
+				<object class="wxStaticBoxSizer" variable="StaticBoxSizer4" member="no">
+					<label>Sequence Directory</label>
+					<object class="sizeritem">
+						<object class="wxCheckBox" name="ID_CHECKBOX4" variable="CheckBox_XSQ" member="yes">
+							<label>Use Show Folder</label>
+							<handler function="OnCheckBox_XSQClick" entry="EVT_CHECKBOX" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxDirPickerCtrl" name="ID_DIRPICKERCTRL1" variable="DirPickerCtrl_XSQ" member="yes">
+							<message></message>
+							<size>400,-1</size>
+							<handler function="OnDirPickerCtrl_XSQDirChanged" entry="EVT_DIRPICKER_CHANGED" />
+						</object>
+						<flag>wxALL|wxEXPAND</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<colspan>2</colspan>
+				<col>0</col>
+				<row>11</row>
+				<flag>wxALL|wxALIGN_LEFT|wxALIGN_TOP</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
 		</object>
 	</object>
 </wxsmith>

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -4305,14 +4305,12 @@ void xLightsFrame::SetXSQFolder(bool useShow, const std::string& folder)
     wxConfigBase* config = wxConfigBase::Get();
 
     if (useShow) {
-        config->Write("XSQLinkFlag", true);
         if (xsqDirectory == showDirectory)
             return;
         xsqDirectory = showDirectory;
     } else {
         if (wxDir::Exists(folder)) {
             ObtainAccessToURL(folder);
-            config->Write("XSQLinkFlag", false);
             if (xsqDirectory == folder)
                 return;
             xsqDirectory = folder;

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -4292,6 +4292,44 @@ void xLightsFrame::SetFSEQFolder(bool useShow, const std::string& folder)
     logger_base.debug("FSEQ directory set to : %s.", (const char*)fseqDirectory.c_str());
 }
 
+void xLightsFrame::GetXSQFolder(bool& useShow, std::string& folder)
+{
+    useShow = (showDirectory == xsqDirectory);
+    folder = xsqDirectory;
+}
+
+void xLightsFrame::SetXSQFolder(bool useShow, const std::string& folder)
+{
+    static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+
+    wxConfigBase* config = wxConfigBase::Get();
+
+    if (useShow) {
+        config->Write("XSQLinkFlag", true);
+        if (xsqDirectory == showDirectory)
+            return;
+        xsqDirectory = showDirectory;
+    } else {
+        if (wxDir::Exists(folder)) {
+            ObtainAccessToURL(folder);
+            config->Write("XSQLinkFlag", false);
+            if (xsqDirectory == folder)
+                return;
+            xsqDirectory = folder;
+        } else {
+            DisplayError("Sequence XSQ directory does not exist. XSQ folder was not changed to " + folder + ". XSQ folder remains : " + xsqDirectory, this);
+            return;
+        }
+    }
+
+    SetXmlSetting("xsqDir", xsqDirectory);
+    UnsavedRgbEffectsChanges = true;
+    UpdateLayoutSave();
+    UpdateControllerSave();
+
+    logger_base.debug("Sequence XSQ directory set to : %s.", (const char*)xsqDirectory.c_str());
+}
+
 void xLightsFrame::GetRenderCacheFolder(bool& useShow, std::string& folder)
 {
     useShow = (showDirectory == renderCacheDirectory);

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -390,6 +390,7 @@ public:
     static xLightsXmlFile* CurrentSeqXmlFile; // global object for currently opened XML file
     const std::string &GetShowDirectory() const { return showDirectory; }
     const std::string &GetFseqDirectory() const { return fseqDirectory; }
+    const std::string &GetXsqDirectory() const { return xsqDirectory; }
     static wxString GetFilename() { return xlightsFilename; }
     void ConversionInit();
     void ConversionError(const wxString& msg);
@@ -1129,6 +1130,8 @@ public:
     void SetMediaFolders(const std::list<std::string> &folders);
     void GetFSEQFolder(bool& useShow, std::string& folder);
     void SetFSEQFolder(bool useShow, const std::string& folder);
+    void GetXSQFolder(bool& useShow, std::string& folder);
+    void SetXSQFolder(bool useShow, const std::string& folder);
     void GetRenderCacheFolder(bool& useShow, std::string& folder);
     void SetRenderCacheFolder(bool useShow, const std::string& folder);
     void UpdateViewMenu();
@@ -1373,6 +1376,7 @@ public:
     std::string showDirectory;
     std::list<std::string> mediaDirectories;
     std::string fseqDirectory;
+    std::string xsqDirectory;
     std::string renderCacheDirectory;
     std::string _backupDirectory;
     SeqDataType _seqData;


### PR DESCRIPTION
Issue #3826 Adds a preference to store your sequences. Seems many folks are putting sequences in a subfolder off their show folder. This is great but when you forget, you end up having 2 copies and not knowing which one is which.
The default is unchecked - so retaining the show folder as their default.