### PR TITLE
#3873 VU Meter Random bars missed last bar

### DIFF
--- a/xLights/effects/VUMeterEffect.cpp
+++ b/xLights/effects/VUMeterEffect.cpp
@@ -2970,9 +2970,9 @@ void VUMeterEffect::RenderLevelBarFrame(RenderBuffer &buffer, int bars, int sens
             }
 
             if (random && bars > 2) {
-                int lb = lastbar;
-                while (lb == (int)lastbar) {
-                    lastbar = 1 + rand01() * bars;
+                int lb = (int)lastbar + 1;
+                while (lb == (int)lastbar + 1) {
+                    lastbar = 1 + static_cast<int>(rand01() * bars);
                 }
                 if (lastbar > bars) lastbar = 1;
             }
@@ -2990,7 +2990,7 @@ void VUMeterEffect::RenderLevelBarFrame(RenderBuffer &buffer, int bars, int sens
 
         if (bar >= 0)
         {
-            for (int x = startx; x < endx; ++x)
+            for (int x = startx; x < endx + 1; ++x)
             {
                 for (int y = 0; y < buffer.BufferHt; ++y)
                 {
@@ -3013,11 +3013,11 @@ void VUMeterEffect::RenderTimingEventBarFrame(RenderBuffer& buffer, int bars, st
             }
 
             if (random && bars > 2) {
-                int lb = lastbar;
-                while (lb == (int)lastbar) {
-                    lastbar = 1 + rand01() * bars;
+                int lb = (int)lastbar + 1;
+                while (lb == (int)lastbar + 1) {
+                    lastbar = 1 + static_cast<int>(rand01() * bars);
                 }
-                if (lastbar > bars + 1)
+                if (lastbar > bars)
                     lastbar = 1;
             } else {
                 lastbar++;
@@ -3042,7 +3042,7 @@ void VUMeterEffect::RenderTimingEventBarFrame(RenderBuffer& buffer, int bars, st
                 if (endx > buffer.BufferWi)
                     endx = buffer.BufferWi;
 
-                for (int x = startx; x < endx; x++) {
+                for (int x = startx; x < endx + 1; x++) {
                     for (int y = 0; y < buffer.BufferHt; y++) {
                         buffer.SetPixel(x, y, color);
                     }
@@ -3060,7 +3060,7 @@ void VUMeterEffect::RenderTimingEventBarFrame(RenderBuffer& buffer, int bars, st
                 endx = buffer.BufferWi;
 
             if (bar >= 0) {
-                for (int x = startx; x < endx; x++) {
+                for (int x = startx; x < endx + 1; x++) {
                     for (int y = 0; y < buffer.BufferHt; y++) {
                         buffer.SetPixel(x, y, color);
                     }
@@ -3097,9 +3097,9 @@ void VUMeterEffect::RenderNoteLevelBarFrame(RenderBuffer& buffer, int bars, int 
             }
 
             if (random && bars > 2) {
-                int lb = lastbar;
-                while (lb == (int)lastbar) {
-                    lastbar = 1 + rand01() * bars;
+                int lb = (int)lastbar + 1;
+                while (lb == (int)lastbar + 1) {
+                    lastbar = 1 + static_cast<int>(rand01() * bars);
                 }
                 if (lastbar > bars)
                     lastbar = 1;
@@ -3119,7 +3119,7 @@ void VUMeterEffect::RenderNoteLevelBarFrame(RenderBuffer& buffer, int bars, int 
             endx = buffer.BufferWi;
 
         if (bar >= 0) {
-            for (int x = startx; x < endx; ++x) {
+            for (int x = startx; x < endx +1; ++x) {
                 for (int y = 0; y < buffer.BufferHt; ++y) {
                     buffer.SetPixel(x, y, color1);
                 }


### PR DESCRIPTION
Because of rounding the final bar (slice) would be skipped. Same issue on Random Note and Random Timing Track
It also skipped the last pixel in the buffer so in the case of a single node bulb, it would never trigger that bulb
Was also seen in other props where it would not light up the last column of pixels in the buffer.
Bug #3873 
(A resubmission this time ignoring all the formatting changes)