### PR TITLE
#4056 Number of effects listed on Import Sequence panel

### DIFF
--- a/xLights/SeqFileUtilities.cpp
+++ b/xLights/SeqFileUtilities.cpp
@@ -1250,7 +1250,7 @@ void xLightsFrame::ImportXLights(SequenceElements& se, const std::vector<Element
                 hasEffects |= el->GetEffectLayer(l)->GetEffectCount() > 0;
             }
             if (hasEffects) {
-                dlg.AddChannel(el->GetName(), el->GetEffectCount());
+                dlg.AddChannel(el->GetName(), el->GetModelEffectCount());
             }
             elementMap[el->GetName()] = el;
             int s = 0;
@@ -1258,7 +1258,7 @@ void xLightsFrame::ImportXLights(SequenceElements& se, const std::vector<Element
                 SubModelElement* sme = el->GetSubModel(sm);
 
                 StrandElement* ste = dynamic_cast<StrandElement*>(sme);
-                std::string smName = sme->GetName();
+                std::string smName = sme->GetName();                
                 if (ste != nullptr) {
                     ++s;
                     if (smName == "") {

--- a/xLights/sequencer/Element.cpp
+++ b/xLights/sequencer/Element.cpp
@@ -595,6 +595,18 @@ bool ModelElement::HasEffects() const
     return false;
 }
 
+int ModelElement::GetModelEffectCount() const
+{
+    int sum = std::accumulate(
+        mEffectLayers.begin(),
+        mEffectLayers.end(), 0,
+        [](int i, EffectLayer* l) {
+            return l->GetEffectCount() + i;
+        });
+
+    return sum;
+}
+
 int ModelElement::GetEffectCount() const {
 
     int sum = std::accumulate(

--- a/xLights/sequencer/Element.h
+++ b/xLights/sequencer/Element.h
@@ -261,6 +261,7 @@ class ModelElement : public Element
 
         [[nodiscard]] virtual bool HasEffects() const override;
         [[nodiscard]] int GetEffectCount() const override;
+        [[nodiscard]] int GetModelEffectCount() const;
         int GetSubModelAndStrandCount() const;
         int GetSubModelCount() const;
         SubModelElement *GetSubModel(int i) const;


### PR DESCRIPTION
The number of effects shown for a model (right side) included all the submodels. If one were to map over that model, it potentially could have way less impact then you would think - as the effects are all on the submodels.
This PR only shows the number of effects directly on the model (left side).
Thoughts on the implementation? I created a new method.
![2024-01-24 20_14_52-xLights (Ver 2023 23 64bit) Dec 28 2023](https://github.com/xLightsSequencer/xLights/assets/4643499/736adf51-f2a0-4bdf-8690-7f968d89e07a)
