### PR TITLE
#2062 Add sort and up/down/top/bottom to preset list

### DIFF
--- a/xLights/EffectTreeDialog.cpp
+++ b/xLights/EffectTreeDialog.cpp
@@ -1449,9 +1449,14 @@ std::list<std::string> EffectTreeDialog::GetGifFileNamesRecursive(wxTreeItemId i
     while (child.IsOk()) {
         std::string gifName = generatePresetName(child).ToStdString();
 
+        // ignore empty group
         if (gifName != "") {
             wxFileName gifFileName(xLightParent->GetPresetIconFilename(gifName));
             gifNames.push_back(gifFileName.GetFullPath());
+        }
+
+        if (TreeCtrl1->ItemHasChildren(child)) {
+            gifNames.merge(GetGifFileNamesRecursive(child));
         }
 
         child = TreeCtrl1->GetNextChild(itemId, cookie);
@@ -1499,7 +1504,7 @@ void EffectTreeDialog::OnDropEffect(wxCommandEvent& event) {
             // Effect Dropped
             int flags = wxTREE_HITTEST_ONITEM;
 
-            wxTreeItemId dstItemId = TreeCtrl1->HitTest(wxPoint(x, y), flags);           
+            wxTreeItemId dstItemId = TreeCtrl1->HitTest(wxPoint(x, y), flags);
 
             if (dstItemId.IsOk()) {
 

--- a/xLights/EffectTreeDialog.cpp
+++ b/xLights/EffectTreeDialog.cpp
@@ -1449,14 +1449,9 @@ std::list<std::string> EffectTreeDialog::GetGifFileNamesRecursive(wxTreeItemId i
     while (child.IsOk()) {
         std::string gifName = generatePresetName(child).ToStdString();
 
-        // ignore empty group
         if (gifName != "") {
             wxFileName gifFileName(xLightParent->GetPresetIconFilename(gifName));
             gifNames.push_back(gifFileName.GetFullPath());
-        }
-
-        if (TreeCtrl1->ItemHasChildren(child)) {
-          //dwe  gifNames.merge(GetGifFileNamesRecursive(child));
         }
 
         child = TreeCtrl1->GetNextChild(itemId, cookie);
@@ -1495,7 +1490,6 @@ void EffectTreeDialog::PurgeDanglingGifs() {
 
 void EffectTreeDialog::OnDropEffect(wxCommandEvent& event) {
     wxArrayString parms = wxSplit(event.GetString(), ',');
-    static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
     int x = event.GetExtraLong() >> 16;
     int y = event.GetExtraLong() & 0xFFFF;
 
@@ -1505,8 +1499,7 @@ void EffectTreeDialog::OnDropEffect(wxCommandEvent& event) {
             // Effect Dropped
             int flags = wxTREE_HITTEST_ONITEM;
 
-            wxTreeItemId dstItemId = TreeCtrl1->HitTest(wxPoint(x, y), flags);
-            logger_base.debug("DropEffect: Dest %s", (const char*)TreeCtrl1->GetItemText(dstItemId).c_str());            
+            wxTreeItemId dstItemId = TreeCtrl1->HitTest(wxPoint(x, y), flags);           
 
             if (dstItemId.IsOk()) {
 
@@ -1520,7 +1513,6 @@ void EffectTreeDialog::OnDropEffect(wxCommandEvent& event) {
                 // gather drag source item info
                 wxTreeItemId srcItemId = TreeCtrl1->GetSelection();
                 wxString srcName = TreeCtrl1->GetItemText(srcItemId);
-                logger_base.debug("DropEffect: Source %s", (const char*)TreeCtrl1->GetItemText(srcItemId).c_str()); 
 
                 if (TreeCtrl1->HasChildren(srcItemId)) {
                     srcIsGroup = true;

--- a/xLights/EffectTreeDialog.cpp
+++ b/xLights/EffectTreeDialog.cpp
@@ -31,6 +31,10 @@ wxDEFINE_EVENT(EVT_EFFTREEDROP, wxCommandEvent);
 
 //(*IdInit(EffectTreeDialog)
 const long EffectTreeDialog::ID_TREECTRL1 = wxNewId();
+const long EffectTreeDialog::ID_BUTTON11 = wxNewId();
+const long EffectTreeDialog::ID_BUTTON9 = wxNewId();
+const long EffectTreeDialog::ID_BUTTON10 = wxNewId();
+const long EffectTreeDialog::ID_BUTTON12 = wxNewId();
 const long EffectTreeDialog::ID_STATICBITMAP_GIF = wxNewId();
 const long EffectTreeDialog::ID_BUTTON6 = wxNewId();
 const long EffectTreeDialog::ID_BUTTON1 = wxNewId();
@@ -59,6 +63,7 @@ EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint&
 	//(*Initialize(EffectTreeDialog)
 	wxBoxSizer* BoxSizer1;
 	wxBoxSizer* BoxSizer2;
+	wxBoxSizer* BoxSizer3;
 	wxFlexGridSizer* FlexGridSizer1;
 	wxFlexGridSizer* FlexGridSizer2;
 	wxFlexGridSizer* FlexGridSizer3;
@@ -68,12 +73,22 @@ EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint&
 	FlexGridSizer1 = new wxFlexGridSizer(0, 1, 0, 0);
 	FlexGridSizer1->AddGrowableCol(0);
 	FlexGridSizer1->AddGrowableRow(0);
-	FlexGridSizer2 = new wxFlexGridSizer(0, 2, 0, 0);
+	FlexGridSizer2 = new wxFlexGridSizer(0, 3, 0, 0);
 	FlexGridSizer2->AddGrowableCol(0);
 	FlexGridSizer2->AddGrowableRow(0);
 	TreeCtrl1 = new wxTreeCtrl(this, ID_TREECTRL1, wxDefaultPosition, wxDefaultSize, wxTR_DEFAULT_STYLE, wxDefaultValidator, _T("ID_TREECTRL1"));
 	TreeCtrl1->SetMinSize(wxDLG_UNIT(this,wxSize(80,-1)));
 	FlexGridSizer2->Add(TreeCtrl1, 1, wxALL|wxEXPAND, 5);
+	BoxSizer3 = new wxBoxSizer(wxVERTICAL);
+	Button_Top = new wxButton(this, ID_BUTTON11, _("^^"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON11"));
+	BoxSizer3->Add(Button_Top, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	Button_MoveUp = new wxButton(this, ID_BUTTON9, _("^"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON9"));
+	BoxSizer3->Add(Button_MoveUp, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	Button_MoveDown = new wxButton(this, ID_BUTTON10, _("v"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON10"));
+	BoxSizer3->Add(Button_MoveDown, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	Button_Bottom = new wxButton(this, ID_BUTTON12, _("vv"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON12"));
+	BoxSizer3->Add(Button_Bottom, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer2->Add(BoxSizer3, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
 	FlexGridSizer3 = new wxFlexGridSizer(2, 1, 0, 0);
 	FlexGridSizer3->AddGrowableCol(0);
 	FlexGridSizer3->AddGrowableRow(0);
@@ -125,6 +140,10 @@ EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint&
 	Connect(ID_TREECTRL1,wxEVT_COMMAND_TREE_ITEM_ACTIVATED,(wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1ItemActivated);
 	Connect(ID_TREECTRL1,wxEVT_COMMAND_TREE_SEL_CHANGED,(wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1SelectionChanged);
 	Connect(ID_TREECTRL1,wxEVT_COMMAND_TREE_KEY_DOWN,(wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1KeyDown);
+	Connect(ID_BUTTON11,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&EffectTreeDialog::OnButton_TopClick);
+	Connect(ID_BUTTON9,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&EffectTreeDialog::OnButton_MoveUpClick);
+	Connect(ID_BUTTON10,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&EffectTreeDialog::OnButton_MoveDownClick);
+	Connect(ID_BUTTON12,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&EffectTreeDialog::OnButton_BottomClick);
 	Connect(ID_BUTTON6,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&EffectTreeDialog::OnbtApplyClick);
 	Connect(ID_BUTTON1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&EffectTreeDialog::OnbtNewPresetClick);
 	Connect(ID_BUTTON2,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&EffectTreeDialog::OnbtUpdateClick);
@@ -1432,7 +1451,7 @@ std::list<std::string> EffectTreeDialog::GetGifFileNamesRecursive(wxTreeItemId i
         }
 
         if (TreeCtrl1->ItemHasChildren(child)) {
-            gifNames.merge(GetGifFileNamesRecursive(child));
+          //dwe  gifNames.merge(GetGifFileNamesRecursive(child));
         }
 
         child = TreeCtrl1->GetNextChild(itemId, cookie);
@@ -1671,4 +1690,20 @@ bool EffectTreeDialogTextDropTarget::OnDropText(wxCoord x, wxCoord y, const wxSt
     }
 
     return false;
+}
+
+void EffectTreeDialog::OnButton_TopClick(wxCommandEvent& event)
+{
+}
+
+void EffectTreeDialog::OnButton_MoveUpClick(wxCommandEvent& event)
+{
+}
+
+void EffectTreeDialog::OnButton_MoveDownClick(wxCommandEvent& event)
+{
+}
+
+void EffectTreeDialog::OnButton_BottomClick(wxCommandEvent& event)
+{
 }

--- a/xLights/EffectTreeDialog.h
+++ b/xLights/EffectTreeDialog.h
@@ -63,7 +63,11 @@ class EffectTreeDialog : public wxDialog
         wxTreeItemId treeRootID;
         void InitItems(wxXmlNode *e);
         bool NameCollissionInGroup(wxTreeItemId groupId, std::string name);
-    
+        static const long ID_GRID_MNU_SORT_ASC;
+        static const long ID_GRID_MNU_SORT_ALL_ASC;
+        void MoveNode(wxTreeItemId& srcItem, wxTreeItemId& destItem, bool selSrc);
+        void SortTreeCtrl(wxTreeCtrl* treeCtrl, const wxTreeItemId& itemId);
+  
 	protected:
 
 		//(*Identifiers(EffectTreeDialog)
@@ -98,7 +102,6 @@ class EffectTreeDialog : public wxDialog
 		void OnTreeCtrl1ItemActivated(wxTreeEvent& event);
 		void OnButton_OKClick(wxCommandEvent& event);
 		void OnTreeCtrl1BeginDrag(wxTreeEvent& event);
-		void OnTreeCtrl1EndDrag(wxTreeEvent& event);
 		void OnbtImportClick(wxCommandEvent& event);
 		void OnbtExportClick(wxCommandEvent& event);
 		void OnTreeCtrl1SelectionChanged(wxTreeEvent& event);
@@ -106,11 +109,11 @@ class EffectTreeDialog : public wxDialog
 		void OnTextCtrl1TextEnter(wxCommandEvent& event);
 		void OnTimerGifTrigger(wxTimerEvent& event);
 		void OnTreeCtrl1KeyDown(wxTreeEvent& event);
-		void OnButton2Click(wxCommandEvent& event);
 		void OnButton_TopClick(wxCommandEvent& event);
 		void OnButton_MoveUpClick(wxCommandEvent& event);
 		void OnButton_MoveDownClick(wxCommandEvent& event);
 		void OnButton_BottomClick(wxCommandEvent& event);
+		void OnTreeCtrl1ItemRightClick(wxTreeEvent& event);
 		//*)
 
         void DeleteSelectedItem();
@@ -123,6 +126,7 @@ class EffectTreeDialog : public wxDialog
         wxTreeItemId m_draggedItem;
         std::mutex preset_mutex;
         bool _effectsFixed = false;
+        void OnGridPopup(wxCommandEvent& event);
         void AddTreeElementsRecursive(wxXmlNode *EffectsNode, wxTreeItemId curGroupID);
         wxXmlNode* CreateEffectGroupNode(wxString& name);
         void ApplyEffect(bool dblClick=false);
@@ -155,7 +159,6 @@ class EffectTreeDialog : public wxDialog
         void DeleteGifsRecursive(wxTreeItemId parentId);
         void PurgeDanglingGifs();
         bool PromptForName(wxWindow* parent, wxString& name, bool isNew, bool isGroup);
-        void UnHighlightItemsRecursively(const wxTreeItemId& parentId, const wxTreeItemId& skipId, wxTreeItemIdValue cookie);
         void OnDropEffect(wxCommandEvent& event);
 
 };

--- a/xLights/EffectTreeDialog.h
+++ b/xLights/EffectTreeDialog.h
@@ -42,6 +42,10 @@ class EffectTreeDialog : public wxDialog
 		virtual ~EffectTreeDialog();
 
 		//(*Declarations(EffectTreeDialog)
+		wxButton* Button_Bottom;
+		wxButton* Button_MoveDown;
+		wxButton* Button_MoveUp;
+		wxButton* Button_Top;
 		wxButton* ETButton1;
 		wxButton* btAddGroup;
 		wxButton* btApply;
@@ -64,6 +68,10 @@ class EffectTreeDialog : public wxDialog
 
 		//(*Identifiers(EffectTreeDialog)
 		static const long ID_TREECTRL1;
+		static const long ID_BUTTON11;
+		static const long ID_BUTTON9;
+		static const long ID_BUTTON10;
+		static const long ID_BUTTON12;
 		static const long ID_STATICBITMAP_GIF;
 		static const long ID_BUTTON6;
 		static const long ID_BUTTON1;
@@ -98,6 +106,11 @@ class EffectTreeDialog : public wxDialog
 		void OnTextCtrl1TextEnter(wxCommandEvent& event);
 		void OnTimerGifTrigger(wxTimerEvent& event);
 		void OnTreeCtrl1KeyDown(wxTreeEvent& event);
+		void OnButton2Click(wxCommandEvent& event);
+		void OnButton_TopClick(wxCommandEvent& event);
+		void OnButton_MoveUpClick(wxCommandEvent& event);
+		void OnButton_MoveDownClick(wxCommandEvent& event);
+		void OnButton_BottomClick(wxCommandEvent& event);
 		//*)
 
         void DeleteSelectedItem();

--- a/xLights/wxsmith/EffectTreeDialog.wxs
+++ b/xLights/wxsmith/EffectTreeDialog.wxs
@@ -10,7 +10,7 @@
 			<growablerows>0</growablerows>
 			<object class="sizeritem">
 				<object class="wxFlexGridSizer" variable="FlexGridSizer2" member="no">
-					<cols>2</cols>
+					<cols>3</cols>
 					<growablecols>0</growablecols>
 					<growablerows>0</growablerows>
 					<object class="sizeritem">
@@ -32,6 +32,49 @@
 						</object>
 						<flag>wxALL|wxEXPAND</flag>
 						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxBoxSizer" variable="BoxSizer3" member="no">
+							<orient>wxVERTICAL</orient>
+							<object class="sizeritem">
+								<object class="wxButton" name="ID_BUTTON11" variable="Button_Top" member="yes">
+									<label>^^</label>
+									<handler function="OnButton_TopClick" entry="EVT_BUTTON" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxButton" name="ID_BUTTON9" variable="Button_MoveUp" member="yes">
+									<label>^</label>
+									<handler function="OnButton_MoveUpClick" entry="EVT_BUTTON" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxButton" name="ID_BUTTON10" variable="Button_MoveDown" member="yes">
+									<label>v</label>
+									<handler function="OnButton_MoveDownClick" entry="EVT_BUTTON" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxButton" name="ID_BUTTON12" variable="Button_Bottom" member="yes">
+									<label>vv</label>
+									<handler function="OnButton_BottomClick" entry="EVT_BUTTON" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 						<option>1</option>
 					</object>
 					<object class="sizeritem">

--- a/xLights/wxsmith/EffectTreeDialog.wxs
+++ b/xLights/wxsmith/EffectTreeDialog.wxs
@@ -27,6 +27,7 @@
 							<minsize>80,-1d</minsize>
 							<handler function="OnTreeCtrl1BeginDrag" entry="EVT_TREE_BEGIN_DRAG" />
 							<handler function="OnTreeCtrl1ItemActivated" entry="EVT_TREE_ITEM_ACTIVATED" />
+							<handler function="OnTreeCtrl1ItemRightClick" entry="EVT_TREE_ITEM_RIGHT_CLICK" />
 							<handler function="OnTreeCtrl1SelectionChanged" entry="EVT_TREE_SEL_CHANGED" />
 							<handler function="OnTreeCtrl1KeyDown" entry="EVT_TREE_KEY_DOWN" />
 						</object>


### PR DESCRIPTION
Right click to sort the selected group or sort recursively. Buttons also added to move presets up and down the list.
#2062 
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/6e9ffc9c-7354-4b29-b71d-50565fa0f59a)
