### PR TITLE
#4316 Check duplicates at the submodel layer level

### DIFF
--- a/xLights/models/SubModel.cpp
+++ b/xLights/models/SubModel.cpp
@@ -25,9 +25,9 @@ static const std::string STACKED_STRANDS("Stacked Strands");
 const std::vector<std::string> SubModel::BUFFER_STYLES{ DEFAULT, KEEP_XY, STACKED_STRANDS };
 
 // Check for duplicate nodes in a submodel
-void SubModel::CheckDuplicates(const std::vector<int>& nodeIndexes)
+wxString SubModel::CheckDuplicates(const std::vector<int>& nodeIndexes, std::string dupNodes)
 {
-    _duplicateNodes = "";
+    _duplicateNodes = dupNodes;
 
     auto it = begin(nodeIndexes);
 
@@ -43,6 +43,7 @@ void SubModel::CheckDuplicates(const std::vector<int>& nodeIndexes)
         }
         ++it;
     }
+    return _duplicateNodes;
 }
 
 SubModel::SubModel(Model* p, wxXmlNode* n) :
@@ -110,7 +111,7 @@ SubModel::SubModel(Model* p, wxXmlNode* n) :
                 line++;
             }
 
-            CheckDuplicates(nodeIndexes);
+            CheckDuplicates(nodeIndexes, (std::string) "");
 
             float minx = 10000;
             float maxx = -1;
@@ -159,8 +160,10 @@ SubModel::SubModel(Model* p, wxXmlNode* n) :
             int line = 0;
             int maxRow = 0;
             int maxCol = 0;
+            std::string dupNodes = "";
             std::vector<int> nodeIndexes;
             while (n->HasAttribute(wxString::Format("line%d", line))) {
+                nodeIndexes.clear();
                 wxString nodes = n->GetAttribute(wxString::Format("line%d", line));
                 //logger_base.debug("    Line %d: %s", line, (const char*)nodes.c_str());
                 _properyGridDisplay = nodes + "," + _properyGridDisplay;
@@ -240,8 +243,8 @@ SubModel::SubModel(Model* p, wxXmlNode* n) :
                     }
                 }
                 line++;
+                dupNodes = CheckDuplicates(nodeIndexes, dupNodes);
             }
-            CheckDuplicates(nodeIndexes);
             SetBufferSize(maxRow + 1, maxCol + 1);
         }
     }

--- a/xLights/models/SubModel.h
+++ b/xLights/models/SubModel.h
@@ -53,7 +53,7 @@ public:
     std::string GetDuplicateNodes() const { return _duplicateNodes; }
 
 private:
-    void CheckDuplicates(const std::vector<int>& nodeIndexes);
+    wxString CheckDuplicates(const std::vector<int>& nodeIndexes, std::string dupNodes);
 
     Model *parent = nullptr;
     bool _nodesAllValid = false;


### PR DESCRIPTION
#4316 and #4292 - this no longer flags the intentional duplications that take place in many of the newer props.

The bottom one is not flagged, the others are.
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/0633bdbc-1456-4659-8c60-d8d48075482a)
Keep XY is unchanged and still works and catches the dup.

![image](https://github.com/xLightsSequencer/xLights/assets/4643499/8a7e2aac-9b3f-4dd8-982d-b5997869c9f4)
New results.

![image](https://github.com/xLightsSequencer/xLights/assets/4643499/5b3a5794-b474-4781-8d11-f7a9fad5e6b4)