### PR TITLE
Add a short comment to the failed backup

### DIFF
--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -2895,7 +2895,10 @@ bool xLightsFrame::CopyFiles(const wxString& wildcard, wxDir& srcDir, wxString& 
             if (!success) {
                 logger_base.error("    Copy Failed.");
                 errors += "Unable to copy file \"" + srcDir.GetNameWithSep() + fname + "\"\n";
-            }
+                if (srcDir.GetNameWithSep().length() + fname.length() > 225) {
+                    errors += "Consider shortening the directory path or filename.\n";
+                }
+            }   
         }
     }
 


### PR DESCRIPTION
#3090 Just adding a short additional message on the error to alert the user that the fix/cause is the path is too long.
