### PR TITLE
#3890 Dont drop placeholder values in submodel remap

### DIFF
--- a/xLights/ModelRemap.cpp
+++ b/xLights/ModelRemap.cpp
@@ -160,7 +160,10 @@ void RemapModelProperties::RemapNodes(wxXmlNode* n, const std::string& attr, con
     std::vector<uint32_t> nnl;
     for (const auto it : nl) {
         if (mapping.find(it) == mapping.end()) {
-            // this should not happen
+            // didnt find value, check if a placeholder
+            if (it == 0) {
+                nnl.push_back(0);
+            }
         } else {
             nnl.push_back(mapping.at(it));
         }


### PR DESCRIPTION
When remapping custom models don't silently drop placeholders like ,,,1-5,,,
#3890 