### PR TITLE
Correct issues with import/export of polyline models.

### DIFF
--- a/xLights/models/PolyLineModel.cpp
+++ b/xLights/models/PolyLineModel.cpp
@@ -1451,15 +1451,14 @@ void PolyLineModel::ImportXlightsModel(wxXmlNode* root, xLightsFrame* xlights, f
         ModelXml->DeleteAttribute("IndivSegs");
         if (is == "1") {
             ModelXml->AddAttribute("IndivSegs", "1");
-            num_segments = num_points - 1;
-            for (int x = 0; x < num_segments; x++) {
+            for (int x = 0; x < num_points - 1; x++) {
                 ModelXml->DeleteAttribute(SegAttrName(x));
                 wxString seg = root->GetAttribute(SegAttrName(x), "");
                 // TODO this needs to be fixed like the individual start channel code in model
                 int seg_length = wxAtoi(seg);
                 ModelXml->AddAttribute(SegAttrName(x), wxString::Format("%d", seg_length));
             }
-            for (int x = 0; x < num_segments-1; x++) {
+            for (int x = 0; x < num_points; x++) {
                 ModelXml->DeleteAttribute(CornerAttrName(x));
                 wxString corner = root->GetAttribute(CornerAttrName(x), "Neither");
                 SetProperty(CornerAttrName(x), corner);
@@ -1527,11 +1526,11 @@ void PolyLineModel::ExportXlightsModel()
     f.Write(wxString::Format("IndivSegs=\"%s\" ", is));
     f.Write(wxString::Format("NumPoints=\"%s\" ", pts));
     int count = wxAtoi(pts);
-    for (int x = 0; x < count; x++) {
+    for (int x = 0; x < count-1; x++) {
         wxString seg = ModelXml->GetAttribute(SegAttrName(x), "");
         f.Write(wxString::Format("%s=\"%s\" ", SegAttrName(x), seg));
     }
-    for (int x = 0; x < count-1; x++) {
+    for (int x = 0; x < count; x++) {
         wxString corner = ModelXml->GetAttribute(CornerAttrName(x), "Neither");
         f.Write(wxString::Format("%s=\"%s\" ", CornerAttrName(x), corner));
     }
@@ -1595,9 +1594,9 @@ void PolyLineModel::NormalizePointData()
     float minX = 100000.0f;
     float minY = 100000.0f;
     float minZ = 100000.0f;
-    float maxX = 0.0f;
-    float maxY = 0.0f;
-    float maxZ = 0.0f;
+    float maxX = -100000.0f;
+    float maxY = -100000.0f;
+    float maxZ = -100000.0f;
 
     for (int i = 0; i < num_points; ++i) {
         if (pPos[i].x < minX)
@@ -1616,27 +1615,12 @@ void PolyLineModel::NormalizePointData()
             pPos[i].curve->check_min_max(minX, maxX, minY, maxY, minZ, maxZ);
         }
     }
-    float deltax = maxX - minX;
-    float deltay = maxY - minY;
-    float deltaz = maxZ - minZ;
 
     // normalize all the point data
     for (int i = 0; i < num_points; ++i) {
-        if (deltax == 0.0f) {
-            pPos[i].x = 0.0f;
-        } else {
-            pPos[i].x = (pPos[i].x - minX) / deltax;
-        }
-        if (deltay == 0.0f) {
-            pPos[i].y = 0.0f;
-        } else {
-            pPos[i].y = (pPos[i].y - minY) / deltay;
-        }
-        if (deltaz == 0.0f) {
-            pPos[i].z = 0.0f;
-        } else {
-            pPos[i].z = (pPos[i].z - minZ) / deltaz;
-        }
+        pPos[i].x = pPos[i].x - minX;
+        pPos[i].y = pPos[i].y - minY;
+        pPos[i].z = pPos[i].z - minZ;
         if (pPos[i].has_curve) {
             float cp0x = pPos[i].curve->get_cp0x();
             float cp0y = pPos[i].curve->get_cp0y();
@@ -1644,12 +1628,12 @@ void PolyLineModel::NormalizePointData()
             float cp1x = pPos[i].curve->get_cp1x();
             float cp1y = pPos[i].curve->get_cp1y();
             float cp1z = pPos[i].curve->get_cp1z();
-            cp0x = (cp0x - minX) / deltax;
-            cp0y = (cp0y - minY) / deltay;
-            cp0z = (cp0z - minZ) / deltaz;
-            cp1x = (cp1x - minX) / deltax;
-            cp1y = (cp1y - minY) / deltay;
-            cp1z = (cp1z - minZ) / deltaz;
+            cp0x = cp0x - minX;
+            cp0y = cp0y - minY;
+            cp0z = cp0z - minZ;
+            cp1x = cp1x - minX;
+            cp1y = cp1y - minY;
+            cp1z = cp1z - minZ;
             pPos[i].curve->set_cp0(cp0x, cp0y, cp0z);
             pPos[i].curve->set_cp1(cp1x, cp1y, cp1z);
         }

--- a/xLights/models/PolyPointScreenLocation.cpp
+++ b/xLights/models/PolyPointScreenLocation.cpp
@@ -208,9 +208,9 @@ void PolyPointScreenLocation::Read(wxXmlNode* ModelNode)
         worldPos_z = wxAtof(ModelNode->GetAttribute("WorldPosZ", "0.0"));
         if (isnan(worldPos_z)) worldPos_z = 0.0;
 
-        scalex = wxAtof(ModelNode->GetAttribute("ScaleX", "100.0"));
-        scaley = wxAtof(ModelNode->GetAttribute("ScaleY", "100.0"));
-        scalez = wxAtof(ModelNode->GetAttribute("ScaleZ", "100.0"));
+        scalex = wxAtof(ModelNode->GetAttribute("ScaleX", "1.0"));
+        scaley = wxAtof(ModelNode->GetAttribute("ScaleY", "1.0"));
+        scalez = wxAtof(ModelNode->GetAttribute("ScaleZ", "1.0"));
 
         if (scalex <= 0 || std::isinf(scalex) || isnan(scalex)) {
             scalex = 1.0f;


### PR DESCRIPTION
Hello xLights Devs!  I've been playing around with the Poly Line tool as a means to import some models I'm creating with some Python scripts for my 3d printing endeavors. I've run into some interesting wrinkles that I'd like to propose some fixes for.  
Please have a look and let me know what you think.

### Summary of Problems
1. When polyline models are exported, the last *Corner* attribute is missing in the XML.
2. When a new import is started after exporting, the original model immediately shrinks in size ~1/100th of the original size.
3. When importing the polyline model, the missing *Corner* attribute in the XML means the imported model is missing that data.
4. The aspect ratio of the imported polyline model does not match the original model.

### Reproducing the Problem

First, in an empty layout, I created a new polyline with 4 points:
![01_create_a_poly_line](https://github.com/xLightsSequencer/xLights/assets/7344421/885c922a-72f4-489e-9a48-f60cfd2c4b6c)
I enabled the *Indiv Segments* option as shown and configured the *Corner Settings* as well.  On a side note, this particular configuration of a polyline is what I'm using to import a line of pixels in a sine-wave configuration.

At this point I exported the model and this is the XML we see:
```
<?xml version="1.0" encoding="UTF-8"?>
<polylinemodel 
name="Poly Line" parm1="1" parm2="4" parm3="1" StringType="RGB Nodes" Transparency="0" PixelSize="20" ModelBrightness="0" Antialias="1" StartSide="B" Dir="L" StrandNames="" NodeNames="" IndivSegs="1" NumPoints="4" Seg1="1" Seg2="1" Seg3="2" Seg4="" Corner1="Trailing Segment" Corner2="Trailing Segment" Corner3="Trailing Segment" PointData="0.000000,0.191543,0.000000,0.263320,0.796824,0.000000,0.707533,0.000000,0.000000,1.000000,1.000000,0.000000" cPointData="" SourceVersion="2023.23"  >
</polylinemodel>
```
The exported XML demonstrates one of the first issues I ran into; the *Corner4* attribute is missing in the XML.

I next proceeded to import the model I just exported:
![02_import_the_exported_poly_line](https://github.com/xLightsSequencer/xLights/assets/7344421/31651b6d-ea45-4fb8-86a6-0cee692ec84b)
There are two interesting things to note here:
1. The original model is now ~1/100th the original size.
2. The imported model is missing the corner 4 attribute.
3. The imported model has the incorrect aspect ratio. 

### Proposed Fixes

1. PolyLineModel::ExportModel, tweaked segment and corner export code to export one less segment than points and the correct number of points.  
2. PolyLineModel::ImportXlightsModel, I updated the import code to read the same number of segments and corners as the export was making.
3. PolyLineModel::NormalizePointData, I observed the default values for maxX, maxY, maxZ were set to 0; theoretically if the max value for the points is < 0 then the max would get tracked as 0.  I didn't see this in practice in my testing but it felt like a bug that could happen.
4. PolyLineModel::NormalizePointData, I removed the deltaX, deltaY, deltaZ.  My understanding of the code is that this was to attempt to uniformly scale the X/Y/Z coordinates based on the actual size of the polyline.  In practice I observed that the scale along the different axes would become dissimilar and this is why the model would import with a different aspect ratio.  My thought here is that xLights world coords should be pretty universal, and it would generally be desirable to bring a model back in with the same aspect ratio.
5. PolyPointScreenLocation::Read, I noticed that the scale factors (e.g `scalex = wxAtof(ModelNode->GetAttribute("ScaleX", "100.0"));`) were set to `100`, where the scale for other models is `1.0`.  Changing this to 1.0 eliminates the issue where the original model resizes itself on export/import.