### PR TITLE
4109 unused outputs

### DIFF
--- a/xLights/PixelTestDialog.h
+++ b/xLights/PixelTestDialog.h
@@ -99,8 +99,8 @@ public:
     {
         auto it = _ranges.begin();
 
-        while (it != _ranges.end())
-		{
+        while (it != _ranges.end()) 
+        {
             long s = GetStart(*it);
             long e = GetEnd(*it);
 
@@ -109,7 +109,7 @@ public:
             ++it;
         }
         
-		return false;
+        return false;
     }
 
     long GetFirst()

--- a/xLights/PixelTestDialog.h
+++ b/xLights/PixelTestDialog.h
@@ -108,7 +108,7 @@ public:
 
             ++it;
         }
-        
+
         return false;
     }
 

--- a/xLights/PixelTestDialog.h
+++ b/xLights/PixelTestDialog.h
@@ -100,16 +100,16 @@ public:
         auto it = _ranges.begin();
 
         while (it != _ranges.end())
-        {
+		{
             long s = GetStart(*it);
             long e = GetEnd(*it);
 
-            if ((start >= s && start <= e) || (end >= s && end <= e)) return true;
+            if ((s >= start && s <= end) || (e >= start && e <= end)) return true;
 
             ++it;
         }
-
-        return false;
+        
+		return false;
     }
 
     long GetFirst()

--- a/xLights/PixelTestDialog.h
+++ b/xLights/PixelTestDialog.h
@@ -99,7 +99,7 @@ public:
     {
         auto it = _ranges.begin();
 
-        while (it != _ranges.end()) 
+        while (it != _ranges.end())
         {
             long s = GetStart(*it);
             long e = GetEnd(*it);


### PR DESCRIPTION
When selecting channels and have the don't send unused ports flag it would not send data unless you selected the first or last node in the output.
@keithsw1111 Keith -- can you validate this? My testing shows it working.