### PR TITLE
#3876 - set a default depth on model imports

### DIFF
--- a/xLights/models/BoxedScreenLocation.cpp
+++ b/xLights/models/BoxedScreenLocation.cpp
@@ -1286,18 +1286,10 @@ float BoxedScreenLocation::GetBack() const {
 }
 
 float BoxedScreenLocation::GetRestorableMWidth() const {
-    if (RenderWi == 1) {
-        return scalex;
-    } else {
-        return (RenderWi-1) * scalex;
-    }
+    return (RenderWi-1) * scalex;
 }
 float BoxedScreenLocation::GetRestorableMHeight() const {
-    if (RenderHt == 1) {
-        return scaley;
-    } else {
-        return (RenderHt-1) * scaley;
-    }
+    return (RenderHt-1) * scaley;
 }
 float BoxedScreenLocation::GetMWidth() const {
     return RenderWi * scalex;
@@ -1308,11 +1300,7 @@ float BoxedScreenLocation::GetMHeight() const {
 void BoxedScreenLocation::SetMWidth(float w) {
     if (RenderWi == 1)
     { 
-        if (w != 0) {
-            scalex = w;
-        } else {
-            scalex = 1;
-        }
+        scalex = 1;
     }
     else
     {
@@ -1338,11 +1326,7 @@ float BoxedScreenLocation::GetRestorableMDepth() const {
 void BoxedScreenLocation::SetMHeight(float h) {
     if (RenderHt == 1 || h == 0)
     {
-        if (h != 0) {
-            scaley = h;
-        } else {
-            scaley = 1;
-        }
+        scaley = 1;
     }
     else
     {

--- a/xLights/models/BoxedScreenLocation.cpp
+++ b/xLights/models/BoxedScreenLocation.cpp
@@ -1286,10 +1286,18 @@ float BoxedScreenLocation::GetBack() const {
 }
 
 float BoxedScreenLocation::GetRestorableMWidth() const {
-    return (RenderWi-1) * scalex;
+    if (RenderWi == 1) {
+        return scalex;
+    } else {
+        return (RenderWi-1) * scalex;
+    }
 }
 float BoxedScreenLocation::GetRestorableMHeight() const {
-    return (RenderHt-1) * scaley;
+    if (RenderHt == 1) {
+        return scaley;
+    } else {
+        return (RenderHt-1) * scaley;
+    }
 }
 float BoxedScreenLocation::GetMWidth() const {
     return RenderWi * scalex;
@@ -1300,7 +1308,11 @@ float BoxedScreenLocation::GetMHeight() const {
 void BoxedScreenLocation::SetMWidth(float w) {
     if (RenderWi == 1)
     { 
-        scalex = 1;
+        if (w != 0) {
+            scalex = w;
+        } else {
+            scalex = 1;
+        }
     }
     else
     {
@@ -1326,7 +1338,11 @@ float BoxedScreenLocation::GetRestorableMDepth() const {
 void BoxedScreenLocation::SetMHeight(float h) {
     if (RenderHt == 1 || h == 0)
     {
-        scaley = 1;
+        if (h != 0) {
+            scaley = h;
+        } else {
+            scaley = 1;
+        }
     }
     else
     {

--- a/xLights/models/CustomModel.cpp
+++ b/xLights/models/CustomModel.cpp
@@ -1165,6 +1165,7 @@ void CustomModel::ImportXlightsModel(wxXmlNode* root, xLightsFrame* xlights, flo
 
         GetModelScreenLocation().SetMWidth(max_x - min_x);
         GetModelScreenLocation().SetMHeight(max_y - min_y);
+        GetModelScreenLocation().SetMDepth(1.0);
 
         ImportModelChildren(root, xlights, newname, min_x, max_x, min_y, max_y);
 


### PR DESCRIPTION
#3876 - when importing or downloading xmodels the z was not set and could end up with a very large z/depth value being defined. This caused some issues with 3d. This change puts in a reasonable default.
@AzGilrock Gil -- does this seem like the right place/code to address this? Seems to work.