### PR TITLE
Dont initially expand the vendors on the download models screen #4332

### DIFF
--- a/xLights/VendorModelDialog.cpp
+++ b/xLights/VendorModelDialog.cpp
@@ -938,7 +938,6 @@ bool VendorModelDialog::LoadTree(wxProgressDialog* prog, int low, int high)
         {
             AddHierachy(v, it, it->_categories);
         }
-        TreeCtrl_Navigator->Expand(v);
     }
 
     if (first.IsOk() && first != root)


### PR DESCRIPTION
Makes for cleaner and easier navigation