### PR TITLE
Faster text, slower twinkle #4248 #4099

### DIFF
--- a/xLights/effects/TextPanel.cpp
+++ b/xLights/effects/TextPanel.cpp
@@ -198,7 +198,7 @@ TextPanel::TextPanel(wxWindow* parent) : xlEffectPanel(parent)
 	FlexGridSizer119->Add(StaticText186, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	FlexGridSizer66 = new wxFlexGridSizer(0, 2, 0, 0);
 	FlexGridSizer66->AddGrowableCol(0);
-	Slider_Text_Speed = new BulkEditSlider(Panel_Text1, IDD_SLIDER_Text_Speed, 10, 0, 50, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("IDD_SLIDER_Text_Speed"));
+	Slider_Text_Speed = new BulkEditSlider(Panel_Text1, IDD_SLIDER_Text_Speed, 10, 0, 100, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("IDD_SLIDER_Text_Speed"));
 	FlexGridSizer66->Add(Slider_Text_Speed, 1, wxALL|wxEXPAND, 1);
 	TextCtrl72 = new BulkEditTextCtrl(Panel_Text1, ID_TEXTCTRL_Text_Speed, _("10"), wxDefaultPosition, wxDLG_UNIT(Panel_Text1,wxSize(20,-1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_Text_Speed"));
 	TextCtrl72->SetMaxLength(3);

--- a/xLights/effects/TwinklePanel.cpp
+++ b/xLights/effects/TwinklePanel.cpp
@@ -75,7 +75,7 @@ TwinklePanel::TwinklePanel(wxWindow* parent) : xlEffectPanel(parent)
 	FlexGridSizer4->Add(BitmapButton_TwinkleCount, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 1);
 	StaticText104 = new wxStaticText(this, ID_STATICTEXT_Twinkle_Steps, _("Twinkle Steps"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Twinkle_Steps"));
 	FlexGridSizer4->Add(StaticText104, 1, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
-	Slider_Twinkle_Steps = new BulkEditSlider(this, ID_SLIDER_Twinkle_Steps, 30, 2, 200, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_SLIDER_Twinkle_Steps"));
+	Slider_Twinkle_Steps = new BulkEditSlider(this, ID_SLIDER_Twinkle_Steps, 30, 2, 400, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_SLIDER_Twinkle_Steps"));
 	FlexGridSizer4->Add(Slider_Twinkle_Steps, 1, wxALL|wxEXPAND, 5);
 	BitmapButton_Twinkle_StepsVC = new BulkEditValueCurveButton(this, ID_VALUECURVE_Twinkle_Steps, GetValueCurveNotSelectedBitmap(), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW, wxDefaultValidator, _T("ID_VALUECURVE_Twinkle_Steps"));
 	FlexGridSizer4->Add(BitmapButton_Twinkle_StepsVC, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);


### PR DESCRIPTION
Increase the slider limits for text and twinkle. No change to existing sequences but now allows one to make text go even faster for larger props and for the twinkle will take longer to fade away. #4248 and #4099