### PR TITLE
Add background effect image for the Single strand chase #3930

### DIFF
--- a/xLights/effects/SingleStrandEffect.h
+++ b/xLights/effects/SingleStrandEffect.h
@@ -97,7 +97,7 @@ protected:
     virtual xlEffectPanel* CreatePanel(wxWindow* parent) override;
 
 private:
-    void RenderSingleStrandChase(RenderBuffer& buffer,
+    void RenderSingleStrandChase(RenderBuffer& buffer, Effect* eff,
                                  const std::string& ColorScheme, int Number_Chases, int chaseSize,
                                  const std::string& Chase_Type1,
                                  bool Chase_3dFade1, bool Chase_Group_All,


### PR DESCRIPTION
The single strand would only show the background image for the skips tab, this adds it for the chase tab as well. #3930 