### PR TITLE
Honor the dont send data to unused ports when opening the tools test

### DIFF
--- a/xLights/PixelTestDialog.cpp
+++ b/xLights/PixelTestDialog.cpp
@@ -1581,7 +1581,7 @@ PixelTestDialog::PixelTestDialog(xLightsFrame* parent, OutputManager* outputMana
     wxConfigBase* config = wxConfigBase::Get();
     DeserialiseSettings(config->Read("xLightsTestSettings").ToStdString());
 
-    SetSuspend(false);
+    SetSuspend(CheckBox_SuppressUnusedOutputs->GetValue());
 
     _starttime = wxDateTime::UNow();
 


### PR DESCRIPTION
When opening tools test, honor the don't send data checkbox #4330