### PR TITLE
Remove the default sorting of Import View #4278

### DIFF
--- a/xLights/xLightsImportChannelMapDialog.cpp
+++ b/xLights/xLightsImportChannelMapDialog.cpp
@@ -738,7 +738,6 @@ bool xLightsImportChannelMapDialog::InitImport(std::string checkboxText) {
     TreeListCtrl_Mapping->Freeze();
     TreeListCtrl_Mapping->AssociateModel(_dataModel);
     TreeListCtrl_Mapping->AppendColumn(new wxDataViewColumn("Model", new wxDataViewTextRenderer("string", wxDATAVIEW_CELL_INERT, wxALIGN_LEFT), 0, 150, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE));
-    TreeListCtrl_Mapping->GetColumn(0)->SetSortOrder(true);
     TreeListCtrl_Mapping->AppendColumn(new wxDataViewColumn("Map To", new wxDataViewTextRenderer("string", wxDATAVIEW_CELL_ACTIVATABLE, wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL), 1, 150, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE));
     if (_allowColorChoice) {
         TreeListCtrl_Mapping->AppendColumn(new wxDataViewColumn("Color", new ColorRenderer(), 2, 150, wxALIGN_LEFT, wxDATAVIEW_COL_RESIZABLE));


### PR DESCRIPTION
This removes the initial sort of your master view (left side) in the import effects dialog. You can still click on the column heading to sort, if desired. It is needed esp now with sub-models. As they were being sorted alpha when you want them to retain their original "sort" order.
#4278 

Currently you lose all that effort taken to present the subs in a meaningful way.

![image](https://github.com/xLightsSequencer/xLights/assets/4643499/01723666-1e39-48ec-9d83-738449719215)
