### PR TITLE
Add expand and collapse to import mapping dialog #3752

### DIFF
--- a/xLights/wxsmith/xLightsImportChannelMapDialog.wxs
+++ b/xLights/wxsmith/xLightsImportChannelMapDialog.wxs
@@ -143,6 +143,7 @@
 									<object class="sizeritem">
 										<object class="wxCheckListBox" name="ID_CHECKLISTBOX1" variable="TimingTrackListBox" member="yes">
 											<style>wxVSCROLL</style>
+											<handler function="OnTimingTrackListBoxRightClick" entry="EVT_LISTBOX_DCLICK" />
 										</object>
 										<flag>wxALL|wxEXPAND</flag>
 										<option>1</option>

--- a/xLights/xLightsImportChannelMapDialog.h
+++ b/xLights/xLightsImportChannelMapDialog.h
@@ -470,6 +470,9 @@ protected:
 
         static const long ID_MNU_SELECTALL;
         static const long ID_MNU_SELECTNONE;
+        static const long ID_MNU_COLLAPSEALL;
+        static const long ID_MNU_EXPANDALL;
+        static const long ID_MNU_SHOWALLMAPPED;
 
 	private:
         wxString FindTab(wxString &line);
@@ -495,7 +498,12 @@ protected:
 		//*)
 
         void RightClickTimingTracks(wxContextMenuEvent& event);
+        void RightClickModels(wxDataViewEvent& event);
+        void CollapseAll();
+        void ExpandAll();
+        void ShowAllMapped();
         void OnPopupTimingTracks(wxCommandEvent& event);
+        void OnPopupModels(wxCommandEvent& event);
         void OnDrop(wxCommandEvent& event);
         void HandleDropAvailable(wxDataViewItem dropTarget, std::string availableModelName);
         void SetImportMediaTooltip();


### PR DESCRIPTION
On the import effects dialog, add right click option to expand all (submodels and first strand) or collapse all along with a show all mapped models #3752