### PR TITLE
Add preference to hide color update warning #3821

### DIFF
--- a/xLights/ColorPanel.cpp
+++ b/xLights/ColorPanel.cpp
@@ -1157,8 +1157,10 @@ void ColorPanel::OnUpdateColorClick(wxCommandEvent& event)
 {
     int alleffects = xLightsApp::GetFrame()->GetMainSequencer()->GetSelectedEffectCount("");
     if (alleffects > 1) {
-        if (wxMessageBox("Are you sure you want to change the colours on all selected effects?", "Update all", wxYES_NO | wxCENTRE, this) == wxNO)
-            return;
+        if (!xLightsApp::GetFrame()->IsSuppressColorWarn()) {
+            if (wxMessageBox("Are you sure you want to change the colours on all selected effects?", "Update all", wxYES_NO | wxCENTRE, this) == wxNO)
+                return;
+        }
     }
 
     wxCommandEvent eventEffectUpdated(EVT_EFFECT_PALETTE_UPDATED);

--- a/xLights/preferences/EffectsGridSettingsPanel.cpp
+++ b/xLights/preferences/EffectsGridSettingsPanel.cpp
@@ -30,6 +30,7 @@ const long EffectsGridSettingsPanel::ID_CHECKBOX3 = wxNewId();
 const long EffectsGridSettingsPanel::ID_STATICTEXT1 = wxNewId();
 const long EffectsGridSettingsPanel::ID_CHECKBOX4 = wxNewId();
 const long EffectsGridSettingsPanel::ID_CHECKBOX6 = wxNewId();
+const long EffectsGridSettingsPanel::ID_CHECKBOX5 = wxNewId();
 const long EffectsGridSettingsPanel::ID_CHOICE2 = wxNewId();
 //*)
 
@@ -72,6 +73,9 @@ EffectsGridSettingsPanel::EffectsGridSettingsPanel(wxWindow* parent, xLightsFram
 	TransistionMarksCheckBox = new wxCheckBox(this, ID_CHECKBOX6, _("Display Transition Marks"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX6"));
 	TransistionMarksCheckBox->SetValue(true);
 	GridBagSizer1->Add(TransistionMarksCheckBox, wxGBPosition(6, 0), wxGBSpan(1, 2), wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+	ColorUpdateWarnCheckBox = new wxCheckBox(this, ID_CHECKBOX5, _("Hide Color Update Warning"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX5"));
+	ColorUpdateWarnCheckBox->SetValue(false);
+	GridBagSizer1->Add(ColorUpdateWarnCheckBox, wxGBPosition(7, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
 	DoubleClickChoice = new wxChoice(this, ID_CHOICE2, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE2"));
 	DoubleClickChoice->Append(_("Edit Text"));
 	DoubleClickChoice->SetSelection( DoubleClickChoice->Append(_("Play Timing")) );
@@ -86,6 +90,7 @@ EffectsGridSettingsPanel::EffectsGridSettingsPanel(wxWindow* parent, xLightsFram
 	Connect(ID_CHECKBOX3,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&EffectsGridSettingsPanel::OnSnapToTimingCheckBoxClick);
 	Connect(ID_CHECKBOX4,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&EffectsGridSettingsPanel::OnSmallWaveformCheckBoxClick);
 	Connect(ID_CHECKBOX6,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&EffectsGridSettingsPanel::OnTransistionMarksCheckBoxClick);
+	Connect(ID_CHECKBOX5,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&EffectsGridSettingsPanel::OnColorUpdateWarnCheckBoxClick);
 	Connect(ID_CHOICE2,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&EffectsGridSettingsPanel::OnDoubleClickChoiceSelect);
 	//*)
 }
@@ -104,6 +109,7 @@ bool EffectsGridSettingsPanel::TransferDataToWindow() {
     SmallWaveformCheckBox->SetValue(frame->SmallWaveform());
     SnapToTimingCheckBox->SetValue(frame->SnapToTimingMarks());
     TransistionMarksCheckBox->SetValue(!frame->SuppressFadeHints());
+    ColorUpdateWarnCheckBox->SetValue(frame->SuppressColorWarn());
     int gs = frame->GridSpacing();
     switch (gs) {
         case 48:
@@ -150,6 +156,7 @@ bool EffectsGridSettingsPanel::TransferDataFromWindow() {
     frame->SetSmallWaveform(SmallWaveformCheckBox->IsChecked());
     frame->SetSnapToTimingMarks(SnapToTimingCheckBox->IsChecked());
     frame->SetSuppressFadeHints(!TransistionMarksCheckBox->IsChecked());
+    frame->SetSuppressColorWarn(ColorUpdateWarnCheckBox->IsChecked());
     return true;
 }
 
@@ -197,6 +204,13 @@ void EffectsGridSettingsPanel::OnTransistionMarksCheckBoxClick(wxCommandEvent& e
 }
 
 void EffectsGridSettingsPanel::OnDoubleClickChoiceSelect(wxCommandEvent& event)
+{
+    if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
+        TransferDataFromWindow();
+    }
+}
+
+void EffectsGridSettingsPanel::OnColorUpdateWarnCheckBoxClick(wxCommandEvent& event)
 {
     if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
         TransferDataFromWindow();

--- a/xLights/preferences/EffectsGridSettingsPanel.h
+++ b/xLights/preferences/EffectsGridSettingsPanel.h
@@ -27,6 +27,7 @@ class EffectsGridSettingsPanel: public wxPanel
 		virtual ~EffectsGridSettingsPanel();
 
 		//(*Declarations(EffectsGridSettingsPanel)
+		wxCheckBox* ColorUpdateWarnCheckBox;
 		wxCheckBox* IconBackgroundsCheckBox;
 		wxCheckBox* NodeValuesCheckBox;
 		wxCheckBox* SmallWaveformCheckBox;
@@ -50,6 +51,7 @@ class EffectsGridSettingsPanel: public wxPanel
 		static const long ID_STATICTEXT1;
 		static const long ID_CHECKBOX4;
 		static const long ID_CHECKBOX6;
+		static const long ID_CHECKBOX5;
 		static const long ID_CHOICE2;
 		//*)
 
@@ -65,6 +67,7 @@ class EffectsGridSettingsPanel: public wxPanel
 		void OnGridSpacingChoiceSelect(wxCommandEvent& event);
 		void OnTransistionMarksCheckBoxClick(wxCommandEvent& event);
 		void OnDoubleClickChoiceSelect(wxCommandEvent& event);
+		void OnColorUpdateWarnCheckBoxClick(wxCommandEvent& event);
 		//*)
 
 		DECLARE_EVENT_TABLE()

--- a/xLights/wxsmith/EffectsGridSettingsPanel.wxs
+++ b/xLights/wxsmith/EffectsGridSettingsPanel.wxs
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <wxsmith>
 	<object class="wxPanel" name="EffectsGridSettingsPanel">
-		<pos_arg>1</pos_arg>
-		<size_arg>1</size_arg>
+		<id_arg>0</id_arg>
 		<object class="wxGridBagSizer" variable="GridBagSizer1" member="no">
 			<object class="sizeritem">
 				<object class="wxStaticText" name="wxID_ANY" variable="StaticText5" member="no">
@@ -99,6 +98,17 @@
 				<colspan>2</colspan>
 				<col>0</col>
 				<row>6</row>
+				<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxCheckBox" name="ID_CHECKBOX5" variable="ColorUpdateWarnCheckBox" member="yes">
+					<label>Hide Color Update Warning</label>
+					<handler function="OnColorUpdateWarnCheckBoxClick" entry="EVT_CHECKBOX" />
+				</object>
+				<col>0</col>
+				<row>7</row>
 				<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
 				<border>5</border>
 				<option>1</option>

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -9645,6 +9645,12 @@ void xLightsFrame::SetSuppressFadeHints(bool b)
     mainSequencer->PanelEffectGrid->Refresh();
 }
 
+void xLightsFrame::SetSuppressColorWarn(bool b)
+{
+    mSuppressColorWarn = b;
+    mainSequencer->PanelEffectGrid->Refresh();
+}
+
 bool xLightsFrame::IsNewModel(Model* m) const
 {
     return layoutPanel->IsNewModel(m);

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -1256,6 +1256,10 @@ public:
     bool SuppressFadeHints() const { return mSuppressFadeHints; }
     void SetSuppressFadeHints(bool b);
 
+    bool IsSuppressColorWarn() const { return mSuppressColorWarn; }
+    bool SuppressColorWarn() const { return mSuppressColorWarn; }
+    void SetSuppressColorWarn(bool b);
+
     bool PlayControlsOnPreview() const { return _playControlsOnPreview;}
     void SetPlayControlsOnPreview(bool b);
 
@@ -1572,6 +1576,7 @@ private:
     bool mBackupOnLaunch = true;
     bool me131Sync = false;
     bool mSuppressFadeHints = false;
+    bool mSuppressColorWarn = false;
     wxString mAltBackupDir;
     int mIconSize;
     int mGridSpacing;


### PR DESCRIPTION
If checked, when you use the update button in the color palette window, it does not issue the warning.
Perhaps in the future, it could be part of a bigger preference to something like an "advanced user" type of setting
#3821 
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/430a2476-d719-4754-bc88-5b0b5efc1a6f)
