### PR TITLE
Remapping of missing submodels skips over some #2409

### DIFF
--- a/xLights/SeqFileUtilities.cpp
+++ b/xLights/SeqFileUtilities.cpp
@@ -524,7 +524,7 @@ void xLightsFrame::OpenSequence(const wxString& passed_filename, ConvertLogDialo
             _seqData.init(numChan, CurrentSeqXmlFile->GetSequenceDurationMS() / ms, ms);
         }
 
-        logger_base.debug("Initializeing Display Elements");
+        logger_base.debug("Initializing Display Elements");
         displayElementsPanel->Initialize();
 
         // if we loaded the fseq but not the xml then we need to populate views

--- a/xLights/sequencer/tabSequencer.cpp
+++ b/xLights/sequencer/tabSequencer.cpp
@@ -752,10 +752,15 @@ void xLightsFrame::CheckForValidModels()
                                     ModelSMNames.push_back(m->GetSubModel(z)->GetName());
                                 }
                                 if ((!_renderMode && !_checkSequenceMode) || _promptBatchRenderIssues) {
+                                    int priorCnt = el->GetSubModelAndStrandCount();
                                     HandleChoices(this, AllSMNames, ModelSMNames, sme,
                                         "SubModel " + sme->GetName() + " of Model " + m->GetName() + " does not exist.\n"
                                         + "How should we handle this?",
                                         toMap, ignore, mapall);
+                                    // if count after is less than the count before then the submodel list is shorter, so rewind the index
+                                    if (priorCnt != el->GetSubModelAndStrandCount()) {
+                                        --x1;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
When opening a sequence with missing sub-models, it will show you every other one that was missing. This is because the list of sub-models changes as you map or delete them. #2409 
If one has a cleaner way to handle this, please comment.