### PR TITLE
Resize window based on content and also align the buttons. #4367

### DIFF
--- a/xLights/ColorCurveDialog.cpp
+++ b/xLights/ColorCurveDialog.cpp
@@ -9,9 +9,9 @@
  **************************************************************/
 
  //(*InternalHeaders(ColorCurveDialog)
-#include <wx/intl.h>
-#include <wx/string.h>
-//*)
+ #include <wx/intl.h>
+ #include <wx/string.h>
+ //*)
 
 #include <wx/dcbuffer.h>
 #include <wx/file.h>
@@ -98,16 +98,13 @@ ColorCurveDialog::ColorCurveDialog(wxWindow* parent, ColorCurve* cc, wxWindowID 
     _cc = cc;
 
     //(*Initialize(ColorCurveDialog)
+    wxBoxSizer* ButtonSizer;
     wxFlexGridSizer* FlexGridSizer1;
     wxFlexGridSizer* FlexGridSizer2;
-    wxFlexGridSizer* FlexGridSizer3;
     wxFlexGridSizer* FlexGridSizer4;
-    wxFlexGridSizer* FlexGridSizer5;
     wxFlexGridSizer* FlexGridSizer6;
 
-    Create(parent, id, _("Color Curve"), wxDefaultPosition, wxDefaultSize, wxCAPTION|wxRESIZE_BORDER|wxMAXIMIZE_BOX, _T("id"));
-    SetClientSize(wxDefaultSize);
-    Move(wxDefaultPosition);
+    Create(parent, wxID_ANY, _("Color Curve"), wxDefaultPosition, wxDefaultSize, wxCAPTION|wxRESIZE_BORDER|wxMAXIMIZE_BOX, _T("wxID_ANY"));
     FlexGridSizer1 = new wxFlexGridSizer(0, 1, 0, 0);
     FlexGridSizer1->AddGrowableCol(0);
     FlexGridSizer1->AddGrowableRow(2);
@@ -133,18 +130,17 @@ ColorCurveDialog::ColorCurveDialog(wxWindow* parent, ColorCurve* cc, wxWindowID 
     FlexGridSizer1->Add(FlexGridSizer2, 1, wxALL|wxEXPAND, 2);
     PresetSizer = new wxFlexGridSizer(0, 5, 0, 0);
     FlexGridSizer1->Add(PresetSizer, 1, wxALL|wxEXPAND, 5);
-    FlexGridSizer5 = new wxFlexGridSizer(0, 2, 0, 0);
+    ButtonSizer = new wxBoxSizer(wxHORIZONTAL);
     ButtonLoad = new wxButton(this, ID_BUTTON3, _("Load"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON3"));
-    FlexGridSizer5->Add(ButtonLoad, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    ButtonSizer->Add(ButtonLoad, 0, wxALL, 5);
     ButtonExport = new wxButton(this, ID_BUTTON4, _("Export"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON4"));
-    FlexGridSizer5->Add(ButtonExport, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-    FlexGridSizer1->Add(FlexGridSizer5, 1, wxALL|wxEXPAND, 5);
-    FlexGridSizer3 = new wxFlexGridSizer(0, 3, 0, 0);
-    Button_Ok = new wxButton(this, ID_BUTTON1, _("Ok"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON1"));
-    FlexGridSizer3->Add(Button_Ok, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    ButtonSizer->Add(ButtonExport, 0, wxALL, 5);
+    ButtonSizer->Add(-1,-1,1, wxALL|wxEXPAND, 5);
+    Button_Ok = new wxButton(this, ID_BUTTON1, _("Ok!!"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON1"));
+    ButtonSizer->Add(Button_Ok, 0, wxALL, 5);
     Button_Cancel = new wxButton(this, ID_BUTTON2, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON2"));
-    FlexGridSizer3->Add(Button_Cancel, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-    FlexGridSizer1->Add(FlexGridSizer3, 1, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
+    ButtonSizer->Add(Button_Cancel, 0, wxALL, 5);
+    FlexGridSizer1->Add(ButtonSizer, 1, wxALL|wxEXPAND, 5);
     SetSizer(FlexGridSizer1);
     FlexGridSizer1->Fit(this);
     FlexGridSizer1->SetSizeHints(this);
@@ -191,6 +187,7 @@ ColorCurveDialog::ColorCurveDialog(wxWindow* parent, ColorCurve* cc, wxWindowID 
     PopulatePresets();
 
     SetEscapeId(Button_Cancel->GetId());
+    Fit();
 
     ValidateWindow();
 }

--- a/xLights/ColorCurveDialog.cpp
+++ b/xLights/ColorCurveDialog.cpp
@@ -136,7 +136,7 @@ ColorCurveDialog::ColorCurveDialog(wxWindow* parent, ColorCurve* cc, wxWindowID 
     ButtonExport = new wxButton(this, ID_BUTTON4, _("Export"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON4"));
     ButtonSizer->Add(ButtonExport, 0, wxALL, 5);
     ButtonSizer->Add(-1,-1,1, wxALL|wxEXPAND, 5);
-    Button_Ok = new wxButton(this, ID_BUTTON1, _("Ok!!"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON1"));
+    Button_Ok = new wxButton(this, ID_BUTTON1, _("Ok"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON1"));
     ButtonSizer->Add(Button_Ok, 0, wxALL, 5);
     Button_Cancel = new wxButton(this, ID_BUTTON2, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON2"));
     ButtonSizer->Add(Button_Cancel, 0, wxALL, 5);

--- a/xLights/ColorCurveDialog.h
+++ b/xLights/ColorCurveDialog.h
@@ -11,12 +11,12 @@
  **************************************************************/
 
  //(*Headers(ColorCurveDialog)
-#include <wx/button.h>
-#include <wx/choice.h>
-#include <wx/dialog.h>
-#include <wx/sizer.h>
-#include <wx/stattext.h>
-//*)
+ #include <wx/button.h>
+ #include <wx/choice.h>
+ #include <wx/dialog.h>
+ #include <wx/sizer.h>
+ #include <wx/stattext.h>
+ //*)
 
 #include <wx/colourdata.h>
 #include <wx/dir.h>

--- a/xLights/wxsmith/ColorCurveDialog.wxs
+++ b/xLights/wxsmith/ColorCurveDialog.wxs
@@ -106,7 +106,7 @@
 					</object>
 					<object class="sizeritem">
 						<object class="wxButton" name="ID_BUTTON1" variable="Button_Ok" member="yes">
-							<label>Ok!!</label>
+							<label>Ok</label>
 							<handler function="OnButton_OkClick" entry="EVT_BUTTON" />
 						</object>
 						<flag>wxALL</flag>

--- a/xLights/wxsmith/ColorCurveDialog.wxs
+++ b/xLights/wxsmith/ColorCurveDialog.wxs
@@ -2,8 +2,7 @@
 <wxsmith>
 	<object class="wxDialog" name="ColorCurveDialog">
 		<title>Color Curve</title>
-		<pos_arg>1</pos_arg>
-		<size_arg>1</size_arg>
+		<id_arg>0</id_arg>
 		<style>wxCAPTION|wxRESIZE_BORDER|wxMAXIMIZE_BOX</style>
 		<handler function="OnResize" entry="EVT_SIZE" />
 		<object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
@@ -83,54 +82,46 @@
 				<option>1</option>
 			</object>
 			<object class="sizeritem">
-				<object class="wxFlexGridSizer" variable="FlexGridSizer5" member="no">
-					<cols>2</cols>
+				<object class="wxBoxSizer" variable="ButtonSizer" member="no">
 					<object class="sizeritem">
 						<object class="wxButton" name="ID_BUTTON3" variable="ButtonLoad" member="yes">
 							<label>Load</label>
 							<handler function="OnButtonLoadClick" entry="EVT_BUTTON" />
 						</object>
-						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<flag>wxALL</flag>
 						<border>5</border>
-						<option>1</option>
 					</object>
 					<object class="sizeritem">
 						<object class="wxButton" name="ID_BUTTON4" variable="ButtonExport" member="yes">
 							<label>Export</label>
 							<handler function="OnButtonExportClick" entry="EVT_BUTTON" />
 						</object>
-						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<flag>wxALL</flag>
+						<border>5</border>
+					</object>
+					<object class="spacer">
+						<flag>wxALL|wxEXPAND</flag>
 						<border>5</border>
 						<option>1</option>
 					</object>
-				</object>
-				<flag>wxALL|wxEXPAND</flag>
-				<border>5</border>
-				<option>1</option>
-			</object>
-			<object class="sizeritem">
-				<object class="wxFlexGridSizer" variable="FlexGridSizer3" member="no">
-					<cols>3</cols>
 					<object class="sizeritem">
 						<object class="wxButton" name="ID_BUTTON1" variable="Button_Ok" member="yes">
-							<label>Ok</label>
+							<label>Ok!!</label>
 							<handler function="OnButton_OkClick" entry="EVT_BUTTON" />
 						</object>
-						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<flag>wxALL</flag>
 						<border>5</border>
-						<option>1</option>
 					</object>
 					<object class="sizeritem">
 						<object class="wxButton" name="ID_BUTTON2" variable="Button_Cancel" member="yes">
 							<label>Cancel</label>
 							<handler function="OnButton_CancelClick" entry="EVT_BUTTON" />
 						</object>
-						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<flag>wxALL</flag>
 						<border>5</border>
-						<option>1</option>
 					</object>
 				</object>
-				<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+				<flag>wxALL|wxEXPAND</flag>
 				<border>5</border>
 				<option>1</option>
 			</object>


### PR DESCRIPTION
The current code doesn't store window sizes anywhere that I am aware of, but this change resizes the box based on the data loaded. Also moved the buttons up to the same line as Load and Export. #4367 
(excuse my poor test data ;-) )
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/cc25f988-2d10-48a5-8208-a464085d450d)
