### PR TITLE
Add sort by location to model groups in the layout  #3248

### DIFF
--- a/xLights/ModelGroupPanel.h
+++ b/xLights/ModelGroupPanel.h
@@ -136,6 +136,7 @@ protected:
 	static const long ID_MNU_CLEARALL;
 	static const long ID_MNU_COPY;
 	static const long ID_MNU_SORTBYNAME;
+    static const long ID_MNU_SORTBYLOCATION;
 
 private:
 	LayoutPanel* layoutPanel = nullptr;
@@ -190,6 +191,7 @@ private:
 	int GetFirstSelectedModel(wxListCtrl* list);
 	void ResizeColumns();
 	void SortModelsByName();
+    void SortModelsByLocation();
 	void CopyModelList();
 	wxArrayString getGroupList();
     void OnSpinCtrlTextEnter(wxCommandEvent& evt);


### PR DESCRIPTION
For some effects and render styles the physical order of the props is important. This makes it easier to ensure they are left to right in the group list. #3248 (sorting on x pos)