### PR TITLE
Add X and Y positioning to Circle effect when using radial options #3807

### DIFF
--- a/xLights/effects/CirclesEffect.cpp
+++ b/xLights/effects/CirclesEffect.cpp
@@ -145,6 +145,8 @@ void CirclesEffect::SetDefaultParameters() {
     SetSliderValue(cp->Slider_Circles_Count, 3);
     SetSliderValue(cp->Slider_Circles_Size, 5);
     SetSliderValue(cp->Slider_Circles_Speed, 10);
+    SetSliderValue(cp->Slider_Circles_XC, 0);
+    SetSliderValue(cp->Slider_Circles_YC, 0);
 
     SetCheckBoxValue(cp->CheckBox_Circles_Bounce, false);
     SetCheckBoxValue(cp->CheckBox_Circles_Radial, false);
@@ -190,6 +192,8 @@ void CirclesEffect::Render(Effect* effect, const SettingsMap& SettingsMap, Rende
 
     if (radial || radial_3D)
     {
+        start_x = start_x + (GetValueCurveInt("Circles_XC", 0, SettingsMap, oset, CIRCLES_POS_MIN, CIRCLES_POS_MAX, buffer.GetStartTimeMS(), buffer.GetEndTimeMS()) / float(CIRCLES_POS_MAX) * start_x);
+        start_y = start_y + (GetValueCurveInt("Circles_YC", 0, SettingsMap, oset, CIRCLES_POS_MIN, CIRCLES_POS_MAX, buffer.GetStartTimeMS(), buffer.GetEndTimeMS()) / float(CIRCLES_POS_MAX) * start_y);
         RenderRadial(buffer, start_x, start_y, radius, colorCnt, number, radial_3D, effectState);
         return; //radial is the easiest case so just get out.
     }

--- a/xLights/effects/CirclesEffect.h
+++ b/xLights/effects/CirclesEffect.h
@@ -24,6 +24,9 @@ class MetaBall;
 #define CIRCLES_SPEED_MIN 1
 #define CIRCLES_SPEED_MAX 30
 
+#define CIRCLES_POS_MIN -50
+#define CIRCLES_POS_MAX 50
+
 class CirclesEffect : public RenderableEffect
 {
 public:
@@ -44,6 +47,10 @@ public:
             return CIRCLES_SIZE_MIN;
         if (name == "E_VALUECURVE_Circles_Speed")
             return CIRCLES_SPEED_MIN;
+        if (name == "E_VALUECURVE_Circles_XC")
+            return CIRCLES_POS_MIN;
+        if (name == "E_VALUECURVE_Circles_YC")
+            return CIRCLES_POS_MIN;
         return RenderableEffect::GetSettingVCMin(name);
     }
     virtual double GetSettingVCMax(const std::string& name) const override
@@ -54,6 +61,10 @@ public:
             return CIRCLES_SIZE_MAX;
         if (name == "E_VALUECURVE_Circles_Speed")
             return CIRCLES_SPEED_MAX;
+        if (name == "E_VALUECURVE_Circles_XC")
+            return CIRCLES_POS_MAX;
+        if (name == "E_VALUECURVE_Circles_YC")
+            return CIRCLES_POS_MAX;
         return RenderableEffect::GetSettingVCMax(name);
     }
 

--- a/xLights/effects/CirclesPanel.cpp
+++ b/xLights/effects/CirclesPanel.cpp
@@ -58,6 +58,16 @@ const long CirclesPanel::ID_CHECKBOX_Circles_Random_m = wxNewId();
 const long CirclesPanel::ID_BITMAPBUTTON_CHECKBOX_Circles_Random_m = wxNewId();
 const long CirclesPanel::ID_CHECKBOX_Circles_Linear_Fade = wxNewId();
 const long CirclesPanel::ID_BITMAPBUTTON_CHECKBOX_Circles_Linear_Fade = wxNewId();
+const long CirclesPanel::ID_STATICTEXT_X_CENTER = wxNewId();
+const long CirclesPanel::ID_SLIDER_Circles_XC = wxNewId();
+const long CirclesPanel::ID_VALUECURVE_Circles_XC = wxNewId();
+const long CirclesPanel::ID_TEXTCTRL_Circles_XC = wxNewId();
+const long CirclesPanel::ID_BITMAPBUTTON_CHECKBOX_CIRCLES_XC = wxNewId();
+const long CirclesPanel::ID_STATICTEXT_Y_CENTER = wxNewId();
+const long CirclesPanel::ID_SLIDER_Circles_YC = wxNewId();
+const long CirclesPanel::ID_VALUECURVE_Circles_YC = wxNewId();
+const long CirclesPanel::ID_TEXTCTRL_Circles_YC = wxNewId();
+const long CirclesPanel::ID_BITMAPBUTTON_CHECKBOX_CIRCLES_YC = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(CirclesPanel,wxPanel)
@@ -76,6 +86,8 @@ CirclesPanel::CirclesPanel(wxWindow* parent) : xlEffectPanel(parent)
 	wxFlexGridSizer* FlexGridSizer22;
 	wxFlexGridSizer* FlexGridSizer3;
 	wxFlexGridSizer* FlexGridSizer80;
+	wxFlexGridSizer* FlexGridSizerCenterX;
+	wxFlexGridSizer* FlexGridSizerCenterY;
 
 	Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("wxID_ANY"));
 	FlexGridSizer80 = new wxFlexGridSizer(0, 1, 0, 0);
@@ -179,8 +191,40 @@ CirclesPanel::CirclesPanel(wxWindow* parent) : xlEffectPanel(parent)
 	BitmapButton_Circles_Linear_Fade = new xlLockButton(this, ID_BITMAPBUTTON_CHECKBOX_Circles_Linear_Fade, wxNullBitmap, wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_CHECKBOX_Circles_Linear_Fade"));
 	BitmapButton_Circles_Linear_Fade->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
 	FlexGridSizer3->Add(BitmapButton_Circles_Linear_Fade, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 1);
+	FlexGridSizerCenterX = new wxFlexGridSizer(0, 4, 0, 0);
+	FlexGridSizerCenterX->AddGrowableCol(1);
+	StaticText1 = new wxStaticText(this, ID_STATICTEXT_X_CENTER, _("X Center"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_X_CENTER"));
+	FlexGridSizerCenterX->Add(StaticText1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
+	Slider_Circles_XC = new BulkEditSlider(this, ID_SLIDER_Circles_XC, 0, -50, 50, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_SLIDER_Circles_XC"));
+	FlexGridSizerCenterX->Add(Slider_Circles_XC, 1, wxALL|wxEXPAND, 2);
+	BitmapButton_Circles_XC = new BulkEditValueCurveButton(this, ID_VALUECURVE_Circles_XC, GetValueCurveNotSelectedBitmap(), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_VALUECURVE_Circles_XC"));
+	FlexGridSizerCenterX->Add(BitmapButton_Circles_XC, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
+	TextCtrl_Circles_XC = new BulkEditTextCtrl(this, ID_TEXTCTRL_Circles_XC, _("0"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(20,-1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_Circles_XC"));
+	TextCtrl_Circles_XC->SetMaxLength(3);
+	FlexGridSizerCenterX->Add(TextCtrl_Circles_XC, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
+	FlexGridSizer3->Add(FlexGridSizerCenterX, 1, wxALL|wxEXPAND, 0);
+	BitmapButton_Circles_XC_Lock = new xlLockButton(this, ID_BITMAPBUTTON_CHECKBOX_CIRCLES_XC, wxNullBitmap, wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_CHECKBOX_CIRCLES_XC"));
+	BitmapButton_Circles_XC_Lock->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
+	FlexGridSizer3->Add(BitmapButton_Circles_XC_Lock, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 1);
+	FlexGridSizerCenterY = new wxFlexGridSizer(0, 4, 0, 0);
+	FlexGridSizerCenterY->AddGrowableCol(1);
+	StaticText2 = new wxStaticText(this, ID_STATICTEXT_Y_CENTER, _("Y Center"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Y_CENTER"));
+	FlexGridSizerCenterY->Add(StaticText2, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
+	Slider_Circles_YC = new BulkEditSlider(this, ID_SLIDER_Circles_YC, 0, -50, 50, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_SLIDER_Circles_YC"));
+	FlexGridSizerCenterY->Add(Slider_Circles_YC, 1, wxALL|wxEXPAND, 2);
+	BitmapButton_Circles_YC = new BulkEditValueCurveButton(this, ID_VALUECURVE_Circles_YC, GetValueCurveNotSelectedBitmap(), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_VALUECURVE_Circles_YC"));
+	FlexGridSizerCenterY->Add(BitmapButton_Circles_YC, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
+	TextCtrl_Circles_YC = new BulkEditTextCtrl(this, ID_TEXTCTRL_Circles_YC, _("0"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(20,-1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_Circles_YC"));
+	TextCtrl_Circles_YC->SetMaxLength(3);
+	FlexGridSizerCenterY->Add(TextCtrl_Circles_YC, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
+	FlexGridSizer3->Add(FlexGridSizerCenterY, 1, wxALL|wxEXPAND, 0);
+	BitmapButton_Circles_YC_Lock = new xlLockButton(this, ID_BITMAPBUTTON_CHECKBOX_CIRCLES_YC, wxNullBitmap, wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_CHECKBOX_CIRCLES_YC"));
+	BitmapButton_Circles_YC_Lock->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
+	FlexGridSizer3->Add(BitmapButton_Circles_YC_Lock, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 1);
 	FlexGridSizer80->Add(FlexGridSizer3, 1, wxALL|wxEXPAND, 2);
 	SetSizer(FlexGridSizer80);
+	FlexGridSizer80->Fit(this);
+	FlexGridSizer80->SetSizeHints(this);
 
 	Connect(ID_VALUECURVE_Circles_Count,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnVCButtonClick);
 	Connect(ID_BITMAPBUTTON_SLIDER_Circles_Count,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnLockButtonClick);
@@ -189,14 +233,23 @@ CirclesPanel::CirclesPanel(wxWindow* parent) : xlEffectPanel(parent)
 	Connect(ID_VALUECURVE_Circles_Speed,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnVCButtonClick);
 	Connect(ID_BITMAPBUTTON_SLIDER_Circles_Speed,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnLockButtonClick);
 	Connect(ID_BITMAPBUTTON_CHECKBOX_Circles_Bounce,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnLockButtonClick);
+	Connect(ID_CHECKBOX_Circles_Radial,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&CirclesPanel::ValidateWindow);
 	Connect(ID_BITMAPBUTTON_CHECKBOX_Circles_Radial,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnLockButtonClick);
+	Connect(ID_CHECKBOX_Circles_Plasma,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&CirclesPanel::ValidateWindow);
 	Connect(ID_BITMAPBUTTON_CHECKBOX_Circles_Plasma,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnLockButtonClick);
+	Connect(ID_CHECKBOX_Circles_Radial_3D,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&CirclesPanel::ValidateWindow);
 	Connect(ID_BITMAPBUTTON_CHECKBOX_Circles_Radial_3D,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnLockButtonClick);
-	Connect(ID_CHECKBOX_Circles_Bubbles,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnCheckBox_Circles_BubblesClick);
+	Connect(ID_CHECKBOX_Circles_Bubbles,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&CirclesPanel::ValidateWindow);
 	Connect(ID_BITMAPBUTTON_CHECKBOX_Circles_Bubbles,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnLockButtonClick);
+	Connect(ID_CHECKBOX_Circles_Collide,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&CirclesPanel::ValidateWindow);
 	Connect(ID_BITMAPBUTTON_CHECKBOX_Circles_Collide,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnLockButtonClick);
+	Connect(ID_CHECKBOX_Circles_Random_m,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&CirclesPanel::ValidateWindow);
 	Connect(ID_BITMAPBUTTON_CHECKBOX_Circles_Random_m,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnLockButtonClick);
 	Connect(ID_BITMAPBUTTON_CHECKBOX_Circles_Linear_Fade,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnLockButtonClick);
+	Connect(ID_VALUECURVE_Circles_XC,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnVCButtonClick);
+	Connect(ID_BITMAPBUTTON_CHECKBOX_CIRCLES_XC,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnLockButtonClick);
+	Connect(ID_VALUECURVE_Circles_YC,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnVCButtonClick);
+	Connect(ID_BITMAPBUTTON_CHECKBOX_CIRCLES_YC,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CirclesPanel::OnVCButtonClick);
 	//*)
 
     Connect(wxID_ANY, EVT_VC_CHANGED, (wxObjectEventFunction)&CirclesPanel::OnVCChanged, 0, this);
@@ -219,8 +272,25 @@ CirclesPanel::~CirclesPanel()
 
 void CirclesPanel::ValidateWindow()
 {
-}
+    if (CheckBox_Circles_Radial->IsChecked() || CheckBox_Circles_Radial_3D->IsChecked()) {
+        BitmapButton_Circles_XC->Enable();
+        Slider_Circles_XC->Enable();
+        TextCtrl_Circles_XC->Enable();
+        BitmapButton_Circles_XC_Lock->Enable();
 
-void CirclesPanel::OnCheckBox_Circles_BubblesClick(wxCommandEvent& event)
-{
+        BitmapButton_Circles_YC->Enable();
+        Slider_Circles_YC->Enable();
+        TextCtrl_Circles_YC->Enable();
+        BitmapButton_Circles_YC_Lock->Enable();
+    } else {
+        BitmapButton_Circles_XC->Disable();
+        Slider_Circles_XC->Disable();
+        TextCtrl_Circles_XC->Disable();
+        BitmapButton_Circles_XC_Lock->Disable();
+
+        BitmapButton_Circles_YC->Disable();
+        Slider_Circles_YC->Disable();
+        TextCtrl_Circles_YC->Disable();
+        BitmapButton_Circles_YC_Lock->Disable();
+    }
 }

--- a/xLights/effects/CirclesPanel.h
+++ b/xLights/effects/CirclesPanel.h
@@ -43,11 +43,19 @@ class CirclesPanel: public xlEffectPanel
 		BulkEditSlider* Slider_Circles_Count;
 		BulkEditSlider* Slider_Circles_Size;
 		BulkEditSlider* Slider_Circles_Speed;
+		BulkEditSlider* Slider_Circles_XC;
+		BulkEditSlider* Slider_Circles_YC;
+		BulkEditTextCtrl* TextCtrl_Circles_XC;
+		BulkEditTextCtrl* TextCtrl_Circles_YC;
 		BulkEditValueCurveButton* BitmapButton_Circles_Count;
 		BulkEditValueCurveButton* BitmapButton_Circles_Size;
 		BulkEditValueCurveButton* BitmapButton_Circles_Speed;
+		BulkEditValueCurveButton* BitmapButton_Circles_XC;
+		BulkEditValueCurveButton* BitmapButton_Circles_YC;
 		wxStaticText* StaticText136;
 		wxStaticText* StaticText137;
+		wxStaticText* StaticText1;
+		wxStaticText* StaticText2;
 		wxStaticText* StaticText31;
 		xlLockButton* BitmapButton2;
 		xlLockButton* BitmapButton_CirclesBounce;
@@ -59,6 +67,8 @@ class CirclesPanel: public xlEffectPanel
 		xlLockButton* BitmapButton_CirclesRadial;
 		xlLockButton* BitmapButton_CirclesSize;
 		xlLockButton* BitmapButton_Circles_Linear_Fade;
+		xlLockButton* BitmapButton_Circles_XC_Lock;
+		xlLockButton* BitmapButton_Circles_YC_Lock;
 		xlLockButton* BitmapButton_RandomMotion;
 		//*)
 
@@ -96,12 +106,21 @@ class CirclesPanel: public xlEffectPanel
 		static const long ID_BITMAPBUTTON_CHECKBOX_Circles_Random_m;
 		static const long ID_CHECKBOX_Circles_Linear_Fade;
 		static const long ID_BITMAPBUTTON_CHECKBOX_Circles_Linear_Fade;
+		static const long ID_STATICTEXT_X_CENTER;
+		static const long ID_SLIDER_Circles_XC;
+		static const long ID_VALUECURVE_Circles_XC;
+		static const long ID_TEXTCTRL_Circles_XC;
+		static const long ID_BITMAPBUTTON_CHECKBOX_CIRCLES_XC;
+		static const long ID_STATICTEXT_Y_CENTER;
+		static const long ID_SLIDER_Circles_YC;
+		static const long ID_VALUECURVE_Circles_YC;
+		static const long ID_TEXTCTRL_Circles_YC;
+		static const long ID_BITMAPBUTTON_CHECKBOX_CIRCLES_YC;
 		//*)
 
 	public:
 
 		//(*Handlers(CirclesPanel)
-		void OnCheckBox_Circles_BubblesClick(wxCommandEvent& event);
 		//*)
 
 		DECLARE_EVENT_TABLE()

--- a/xLights/wxsmith/CirclesPanel.wxs
+++ b/xLights/wxsmith/CirclesPanel.wxs
@@ -199,6 +199,7 @@
 					<object class="sizeritem">
 						<object class="wxCheckBox" name="ID_CHECKBOX_Circles_Radial" subclass="BulkEditCheckBox" variable="CheckBox_Circles_Radial" member="yes">
 							<label>Radial</label>
+							<handler function="ValidateWindow" entry="EVT_CHECKBOX" />
 						</object>
 						<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
 						<border>2</border>
@@ -218,6 +219,7 @@
 					<object class="sizeritem">
 						<object class="wxCheckBox" name="ID_CHECKBOX_Circles_Plasma" subclass="BulkEditCheckBox" variable="CheckBox_Circles_Plasma" member="yes">
 							<label>Plasma</label>
+							<handler function="ValidateWindow" entry="EVT_CHECKBOX" />
 						</object>
 						<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
 						<border>2</border>
@@ -237,6 +239,7 @@
 					<object class="sizeritem">
 						<object class="wxCheckBox" name="ID_CHECKBOX_Circles_Radial_3D" subclass="BulkEditCheckBox" variable="CheckBox_Circles_Radial_3D" member="yes">
 							<label>Radial 3D</label>
+							<handler function="ValidateWindow" entry="EVT_CHECKBOX" />
 						</object>
 						<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
 						<border>2</border>
@@ -256,7 +259,7 @@
 					<object class="sizeritem">
 						<object class="wxCheckBox" name="ID_CHECKBOX_Circles_Bubbles" subclass="BulkEditCheckBox" variable="CheckBox_Circles_Bubbles" member="yes">
 							<label>Bubbles</label>
-							<handler function="OnCheckBox_Circles_BubblesClick" entry="EVT_CHECKBOX" />
+							<handler function="ValidateWindow" entry="EVT_CHECKBOX" />
 						</object>
 						<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
 						<border>2</border>
@@ -277,6 +280,7 @@
 						<object class="wxCheckBox" name="ID_CHECKBOX_Circles_Collide" subclass="BulkEditCheckBox" variable="CheckBox_Circles_Collide" member="yes">
 							<label>Collide</label>
 							<hidden>1</hidden>
+							<handler function="ValidateWindow" entry="EVT_CHECKBOX" />
 						</object>
 						<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
 						<border>2</border>
@@ -298,6 +302,7 @@
 						<object class="wxCheckBox" name="ID_CHECKBOX_Circles_Random_m" subclass="BulkEditCheckBox" variable="CheckBox_Circles_Random_m" member="yes">
 							<label>Random Motion</label>
 							<hidden>1</hidden>
+							<handler function="ValidateWindow" entry="EVT_CHECKBOX" />
 						</object>
 						<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
 						<border>2</border>
@@ -329,6 +334,116 @@
 							<bg>wxSYS_COLOUR_BTNHIGHLIGHT</bg>
 							<style>wxBU_AUTODRAW|wxBORDER_NONE</style>
 							<handler function="OnLockButtonClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>1</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxFlexGridSizer" variable="FlexGridSizerCenterX" member="no">
+							<cols>4</cols>
+							<growablecols>1</growablecols>
+							<object class="sizeritem">
+								<object class="wxStaticText" name="ID_STATICTEXT_X_CENTER" variable="StaticText1" member="yes">
+									<label>X Center</label>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>2</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxSlider" name="ID_SLIDER_Circles_XC" subclass="BulkEditSlider" variable="Slider_Circles_XC" member="yes">
+									<min>-50</min>
+									<max>50</max>
+								</object>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>2</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxBitmapButton" name="ID_VALUECURVE_Circles_XC" subclass="BulkEditValueCurveButton" variable="BitmapButton_Circles_XC" member="yes">
+									<bitmap code="GetValueCurveNotSelectedBitmap()" />
+									<style>wxBU_AUTODRAW|wxBORDER_NONE</style>
+									<handler function="OnVCButtonClick" entry="EVT_BUTTON" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxTextCtrl" name="ID_TEXTCTRL_Circles_XC" subclass="BulkEditTextCtrl" variable="TextCtrl_Circles_XC" member="yes">
+									<value>0</value>
+									<maxlength>3</maxlength>
+									<size>20,-1d</size>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>2</border>
+								<option>1</option>
+							</object>
+						</object>
+						<flag>wxALL|wxEXPAND</flag>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxBitmapButton" name="ID_BITMAPBUTTON_CHECKBOX_CIRCLES_XC" subclass="xlLockButton" variable="BitmapButton_Circles_XC_Lock" member="yes">
+							<size>14,14</size>
+							<bg>wxSYS_COLOUR_BTNHIGHLIGHT</bg>
+							<style>wxBU_AUTODRAW|wxBORDER_NONE</style>
+							<handler function="OnLockButtonClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>1</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxFlexGridSizer" variable="FlexGridSizerCenterY" member="no">
+							<cols>4</cols>
+							<growablecols>1</growablecols>
+							<object class="sizeritem">
+								<object class="wxStaticText" name="ID_STATICTEXT_Y_CENTER" variable="StaticText2" member="yes">
+									<label>Y Center</label>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>2</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxSlider" name="ID_SLIDER_Circles_YC" subclass="BulkEditSlider" variable="Slider_Circles_YC" member="yes">
+									<min>-50</min>
+									<max>50</max>
+								</object>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>2</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxBitmapButton" name="ID_VALUECURVE_Circles_YC" subclass="BulkEditValueCurveButton" variable="BitmapButton_Circles_YC" member="yes">
+									<bitmap code="GetValueCurveNotSelectedBitmap()" />
+									<style>wxBU_AUTODRAW|wxBORDER_NONE</style>
+									<handler function="OnVCButtonClick" entry="EVT_BUTTON" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxTextCtrl" name="ID_TEXTCTRL_Circles_YC" subclass="BulkEditTextCtrl" variable="TextCtrl_Circles_YC" member="yes">
+									<value>0</value>
+									<maxlength>3</maxlength>
+									<size>20,-1d</size>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>2</border>
+								<option>1</option>
+							</object>
+						</object>
+						<flag>wxALL|wxEXPAND</flag>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxBitmapButton" name="ID_BITMAPBUTTON_CHECKBOX_CIRCLES_YC" subclass="xlLockButton" variable="BitmapButton_Circles_YC_Lock" member="yes">
+							<size>14,14</size>
+							<bg>wxSYS_COLOUR_BTNHIGHLIGHT</bg>
+							<style>wxBU_AUTODRAW|wxBORDER_NONE</style>
+							<handler function="OnVCButtonClick" entry="EVT_BUTTON" />
 						</object>
 						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 						<border>1</border>


### PR DESCRIPTION
Can set the Circle effect radial and radial3d options to start and various x and y positions including value curves.
#3807 
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/0c47a92a-5c72-476e-b1e7-4fe34c6f5ee0)
