### PR TITLE
Make Linux Chapter Bookmarks visible and the menu to show checkmarks #4023

### DIFF
--- a/xLights/sequencer/TimeLine.cpp
+++ b/xLights/sequencer/TimeLine.cpp
@@ -55,8 +55,7 @@ void TimeLine::mouseRightDown(wxMouseEvent& event)
     }
     for (int i = 0; i < 10; ++i)
     {
-        auto mnu = mnuLayer.Append(i+1, wxString::Format("%i", i));
-        mnu->SetCheckable(true);
+        auto mnu = mnuLayer.AppendCheckItem(i+1, wxString::Format("%i", i));
         if (_tagPositions[i] != -1)
         {
             mnu->Check();
@@ -891,7 +890,6 @@ void TimeLine::Paint( wxPaintEvent& event )
 
 void TimeLine::render( wxDC& dc ) {
     wxCoord w,h;
-    int labelCount=0;
     wxPen pen(wxColor(128,128,128));
     const wxPen* pen_black = wxBLACK_PEN;
     const wxPen* pen_green = wxGREEN_PEN;
@@ -958,7 +956,6 @@ void TimeLine::render( wxDC& dc ) {
                 else
                     sTime =  wxString::Format("%2d.%.2d",seconds,subsecs/10);
             }
-            labelCount++;
             dc.DrawLabel(sTime,r,wxALIGN_CENTER);
         }
     }
@@ -1031,7 +1028,9 @@ void TimeLine::DrawTag(wxDC& dc, int tag, int position, int y_bottom)
     dc.DrawLine(position+5, y_bottom - 1, position+5, y_bottom - 12);
     dc.DrawLine(position-5, y_bottom - 12, position, y_bottom - 15);
     dc.DrawLine(position+5, y_bottom - 12, position, y_bottom - 15);
+#ifndef __LINUX__
     dc.FloodFill(position, y_bottom - 6, *wxLIGHT_GREY);
+#endif
     dc.DrawLabel(wxString::Format("%i", tag), wxRect(position - 4, y_bottom - 13, 10, 13), wxALIGN_CENTRE_HORIZONTAL | wxALIGN_CENTRE_VERTICAL);
 }
 


### PR DESCRIPTION
On the Linux version, bookmark menu didn't show checkmarks. The bookmarks would also blackout the timeline and was unusable.
#4023 and #2781
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/3ed0accd-c842-43e7-aee5-443f5e980aad)
