### PR TITLE
3428 lua script

### DIFF
--- a/xLights/automation/LuaRunner.cpp
+++ b/xLights/automation/LuaRunner.cpp
@@ -88,7 +88,6 @@ std::pair<std::list<std::string>, std::string> LuaRunner::PromptSequences() cons
             forceHighDefinitionRender = "true";
         }
     }
-    
     return std::make_pair(sequenceList, forceHighDefinitionRender);
 }
 

--- a/xLights/automation/LuaRunner.cpp
+++ b/xLights/automation/LuaRunner.cpp
@@ -65,9 +65,10 @@ std::string LuaRunner::PromptSelection(sol::object const& items, std::string con
     return {};
 }
 
-std::list<std::string> LuaRunner::PromptSequences() const
+std::pair<std::list<std::string>, std::string> LuaRunner::PromptSequences() const
 {
     std::list<std::string> sequenceList;
+    std::string forceHighDefinitionRender = "false";
     static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
 
     BatchRenderDialog dlg(_frame);
@@ -83,8 +84,12 @@ std::list<std::string> LuaRunner::PromptSequences() const
                 logger_base.info("PromptSequences: Sequence File not Found: %s.", (const char*)fname.GetFullPath().c_str());
             }
         }
+        if (dlg.CheckBox_ForceHighDefinition->IsChecked()) {
+            forceHighDefinitionRender = "true";
+        }
     }
-    return sequenceList;
+    
+    return std::make_pair(sequenceList, forceHighDefinitionRender);
 }
 
 std::list<std::string> LuaRunner::SplitString(std::string const& text, char const& delimiter) const

--- a/xLights/automation/LuaRunner.h
+++ b/xLights/automation/LuaRunner.h
@@ -39,7 +39,7 @@ public:
     void ShowMessage(std::string const& text) const;
     [[nodiscard]] std::string PromptString(std::string const& text) const;
     [[nodiscard]] std::string PromptSelection(sol::object const& items, std::string const& message) const;
-    [[nodiscard]] std::list<std::string> PromptSequences() const;
+    [[nodiscard]] std::pair<std::list<std::string>, std::string> PromptSequences() const;
     
     [[nodiscard]] sol::object JSONToTable(std::string const& json, sol::this_state s) const;
     [[nodiscard]] std::list<std::string> SplitString(std::string const& text, char const& delimiter) const;


### PR DESCRIPTION
A small tweak to allow Lua script to get the force high def checkbox value.
https://github.com/xLightsSequencer/xLights/issues/3428
Existing scripts should not need to be changed but the following is an example of the code.
```
seqs,highdefflag = PromptSequences()
for i,seq in ipairs(seqs) do
	Log(seq)
	properties = {}
	properties['seq'] = seq
	properties['promptIssues'] = 'false'
	result = RunCommand('openSequence', properties)
	properties = {}
	properties['highdef'] = highdefflag
	result = RunCommand('renderAll',properties)
	Log("Render Result: ".. result['msg'])
end
```