### PR TITLE
Handle on Arches was excessively long #3473

### DIFF
--- a/xLights/models/ThreePointScreenLocation.cpp
+++ b/xLights/models/ThreePointScreenLocation.cpp
@@ -92,7 +92,7 @@ void ThreePointScreenLocation::AddDimensionProperties(wxPropertyGridInterface* p
     wxPGProperty* prop = propertyEditor->Append(new wxFloatProperty(wxString::Format("Height (%s)", RulerObject::GetUnitDescription()), "RealHeight", 
                                                                      (width * height) / 2.0 * factor
                                                                     ));
-    prop->ChangeFlag(wxPG_PROP_READONLY, true);
+    prop->ChangeFlag(wxPGPropertyFlags::ReadOnly, true);
     prop->SetAttribute("Precision", 2);
     prop->SetTextColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
 }
@@ -337,7 +337,10 @@ void ThreePointScreenLocation::SetActiveAxis(MSLAXIS axis)
 bool ThreePointScreenLocation::DrawHandles(xlGraphicsProgram *program, float zoom, int scale, bool drawBounding, bool fromBase) const {
     if (active_handle != -1) {
 
-        float ymax = RenderHt;
+        float HandleHt = RenderHt;
+        if (HandleHt > RenderWi)
+            HandleHt = RenderWi;
+        float ymax = HandleHt;
         
         auto vac = program->getAccumulator();
         int startVertex = vac->getCount();
@@ -345,7 +348,7 @@ bool ThreePointScreenLocation::DrawHandles(xlGraphicsProgram *program, float zoo
 
         float x = RenderWi / 2;
         if (supportsAngle) {
-            ymax = RenderHt * height;
+            ymax = HandleHt * height;
             rotate_point(RenderWi / 2.0, 0, toRadians(angle), x, ymax);
         }
 
@@ -399,7 +402,10 @@ bool ThreePointScreenLocation::DrawHandles(xlGraphicsProgram *program, float zoo
     float sx1 = center.x;
     float sy1 = center.y;
 
-    float ymax = RenderHt;
+    float HandleHt = RenderHt;
+    if (HandleHt > RenderWi)
+        HandleHt = RenderWi;
+    float ymax = HandleHt;
 
     auto vac = program->getAccumulator();
     int startVertex = vac->getCount();
@@ -407,7 +413,7 @@ bool ThreePointScreenLocation::DrawHandles(xlGraphicsProgram *program, float zoo
 
     float x = RenderWi / 2;
     if (supportsAngle) {
-        ymax = RenderHt * height;
+        ymax = HandleHt * height;
         rotate_point(RenderWi / 2.0, 0, toRadians(angle), x, ymax);
     }
 
@@ -467,7 +473,10 @@ int ThreePointScreenLocation::MoveHandle(ModelPreview* preview, int handle, bool
         float posx = ray_origin.x - center.x;
         float posy = ray_origin.y - center.y;
 
-        float ymax = RenderHt;
+        float HandleHt = RenderHt;
+        if (HandleHt > RenderWi)
+            HandleHt = RenderWi;
+        float ymax = HandleHt;
         if (ymax < 0.01f) {
             ymax = 0.01f;
         }
@@ -490,7 +499,7 @@ int ThreePointScreenLocation::MoveHandle(ModelPreview* preview, int handle, bool
                 angle = (int)(angle / 5) * 5;
             }
             float length = std::sqrt(posy*posy + posx * posx);
-            height = length / (RenderHt * scaley);
+            height = length / (HandleHt * scaley);
         } else if (supportsShear) {
             glm::mat4 m = glm::inverse(matrix);
             glm::vec3 v = glm::vec3(m * glm::vec4(ray_origin, 1.0f));
@@ -504,7 +513,7 @@ int ThreePointScreenLocation::MoveHandle(ModelPreview* preview, int handle, bool
             } else if (shear > 3.0f) {
                 shear = 3.0f;
             }
-            height = posy / (RenderHt * scaley);
+            height = posy / (HandleHt * scaley);
         } else {
             height = height * posy / ymax;
         }
@@ -547,7 +556,10 @@ int ThreePointScreenLocation::MoveHandle3D(ModelPreview* preview, int handle, bo
             //float posx = saved_position.x + drag_delta.x - center.x;
             //float posy = saved_position.y + drag_delta.y - center.y;
 
-            float ymax = RenderHt;
+            float HandleHt = RenderHt;
+            if (HandleHt > RenderWi)
+                HandleHt = RenderWi;
+            float ymax = HandleHt;
             if (ymax < 0.01f) {
                 ymax = 0.01f;
             }
@@ -570,7 +582,7 @@ int ThreePointScreenLocation::MoveHandle3D(ModelPreview* preview, int handle, bo
                     angle = (int)(angle / 5) * 5;
                 }
                 float length = std::sqrt(posy*posy + posx * posx);
-                height = length / (RenderHt * scaley);
+                height = length / (HandleHt * scaley);
             }
             else if (supportsShear) {
                 glm::mat4 m = glm::inverse(matrix);
@@ -587,7 +599,7 @@ int ThreePointScreenLocation::MoveHandle3D(ModelPreview* preview, int handle, bo
                 else if (shear > 3.0f) {
                     shear = 3.0f;
                 }
-                height = posy / (RenderHt * scaley);
+                height = posy / (HandleHt * scaley);
             }
             else {
                 height = height * posy / ymax;


### PR DESCRIPTION
The vertical handle on an arch and other models (icicles, canes) are based on the node count. As the node count got larger on arches (for multi layered arches esp.) the vertical handle went up higher and higher. This change puts the initial max height to not exceed the (render) width.  #3473 
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/99142f64-44dd-4a53-a15d-f570342fb94e)
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/4383bcdd-8b76-4125-9e05-6779f39d9a91)
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/ce67d12a-a307-456b-b2cb-59e66b1ff7a0)
