### PR TITLE
Always sel/desel highlighted item even if previously was already selected #4350

### DIFF
--- a/xLights/controllers/FPPConnectDialog.cpp
+++ b/xLights/controllers/FPPConnectDialog.cpp
@@ -556,9 +556,9 @@ void FPPConnectDialog::OnPopup(wxCommandEvent &event)
             CheckListBox_Sequences->CheckItem(item);
         } else if (id == ID_MNU_SELECTNONE && isChecked) {
             CheckListBox_Sequences->UncheckItem(item);
-        } else if (id == ID_MNU_SELECTHIGH && !isChecked && isSelected) {
+        } else if (id == ID_MNU_SELECTHIGH && isSelected) {
             CheckListBox_Sequences->CheckItem(item);
-        } else if (id == ID_MNU_SELECTHIGH && isChecked && isSelected) {
+        } else if (id == ID_MNU_DESELECTHIGH && isSelected) {
             CheckListBox_Sequences->UncheckItem(item);
         }
         item = CheckListBox_Sequences->GetNextItem(item);


### PR DESCRIPTION
Especially on Macs, when y ou click an item (sequence) it gets selected. Shift + Click will highlight the range, but if you right click and choose Select (Deselect) Hightlighted, the first one would "flip" and not have the desired effect.