### PR TITLE
Clear the red status of the shader file after downloading #3888

### DIFF
--- a/xLights/effects/ShaderPanel.cpp
+++ b/xLights/effects/ShaderPanel.cpp
@@ -213,6 +213,7 @@ void ShaderPanel::OnFilePickerCtrl1FileChanged(wxFileDirPickerEvent& event)
         if (BuildUI(FilePickerCtrl1->GetFileName().GetFullPath(), &((xLightsFrame*)xLightsApp::GetFrame())->GetSequenceElements())) {
             last = newf;
         }
+        FilePickerCtrl1->Enable(true); // force a validate
     }
     else {
         Freeze();


### PR DESCRIPTION
When adding a shader from the download button the filename box would stay red even if it's a valid shader. #3888 .