### PR TITLE
Improve the sort models by location on a Group #3248

### DIFF
--- a/xLights/ModelGroupPanel.cpp
+++ b/xLights/ModelGroupPanel.cpp
@@ -1357,7 +1357,14 @@ void ModelGroupPanel::SortModelsByLocation()
         Model* model = mModels[modelName];
         float pos;
         if (model != nullptr) {
-            pos = model->GetLeft();
+            if (model->GetDisplayAs() == "ModelGroup") {
+                Model* m = dynamic_cast<ModelGroup*>(model)->GetFirstModel();
+                if (m == nullptr)
+                    m = model;
+                pos = m->GetLeft();
+            } else {
+                pos = model->GetLeft();
+            }
         } else {
             pos = 0;
         }


### PR DESCRIPTION
Found that the position of a group within a group is not reliable and changed to use the left position of the first model in the group #3248 