### PR TITLE
Add color palette to Picture Assistant #1231

### DIFF
--- a/xLights/effects/assist/AssistPanel.cpp
+++ b/xLights/effects/assist/AssistPanel.cpp
@@ -41,8 +41,12 @@ AssistPanel::AssistPanel(wxWindow* parent,wxWindowID id,const wxPoint& pos,const
 	FlexGridSizer2->AddGrowableCol(0);
 	FlexGridSizer2->AddGrowableRow(0);
 	ScrolledWindowAssist->SetSizer(FlexGridSizer2);
+	FlexGridSizer2->Fit(ScrolledWindowAssist);
+	FlexGridSizer2->SetSizeHints(ScrolledWindowAssist);
 	FlexGridSizer1->Add(ScrolledWindowAssist, 1, wxALL|wxEXPAND, 5);
 	SetSizer(FlexGridSizer1);
+	FlexGridSizer1->Fit(this);
+	FlexGridSizer1->SetSizeHints(this);
 	//*)
 }
 

--- a/xLights/effects/assist/PicturesAssistPanel.cpp
+++ b/xLights/effects/assist/PicturesAssistPanel.cpp
@@ -7,11 +7,17 @@
  * Copyright claimed based on commit dates recorded in Github
  * License: https://github.com/xLightsSequencer/xLights/blob/master/License.txt
  **************************************************************/
- 
+
 //(*InternalHeaders(PicturesAssistPanel)
 #include <wx/intl.h>
 #include <wx/string.h>
 //*)
+
+#include <wx/artprov.h>
+#include <wx/odcombo.h>
+#include <wx/regex.h>
+#include <wx/stdpaths.h>
+#include <wx/txtstrm.h>
 
 #include "PicturesAssistPanel.h"
 #include "../../xlColorPicker.h"
@@ -20,6 +26,13 @@
 #include "../../models/Model.h"
 #include "../../xLightsMain.h"
 #include "../../xLightsXmlFile.h"
+#include "ExternalHooks.h"
+#include "ColorPanel.h"
+
+#include <log4cpp/Category.hh>
+
+#define ZERO 0
+#define PALETTE_SIZE 8
 
 //(*IdInit(PicturesAssistPanel)
 const long PicturesAssistPanel::ID_BUTTON_NewImage = wxNewId();
@@ -35,10 +48,76 @@ const long PicturesAssistPanel::ID_SCROLLED_EffectAssist = wxNewId();
 const long PicturesAssistPanel::ID_PANEL1 = wxNewId();
 //*)
 
+#define SWATCH_WIDTH 11
+class PAColourList : public wxOwnerDrawnComboBox
+{
+public:
+    PAColourList(wxWindow* parent, wxWindowID id,
+        const wxPoint& pos = wxDefaultPosition,
+        const wxSize& size = wxDefaultSize,
+        long style = 0,
+        const wxValidator& validator = wxDefaultValidator,
+        const wxString& name = "ColourList") : wxOwnerDrawnComboBox(parent, id, wxEmptyString, pos, size, 0, nullptr, style | wxCB_READONLY, validator, name)
+    {
+
+    }
+
+    virtual wxCoord OnMeasureItem(size_t item) const
+    {
+        return 18;
+    }
+
+    virtual wxCoord OnMeasureItemWidth(size_t item) const
+    {
+        return PALETTE_SIZE * SWATCH_WIDTH - 1;
+    }
+
+    virtual void OnDrawItem(wxDC& dc, const wxRect& rect, int item, int flags) const
+    {
+        if (item == wxNOT_FOUND)
+            return;
+
+        wxString s = GetString(item);
+
+        if (s == "(Load)") {
+            if (rect.GetHeight() != 18) {
+                wxFontMetrics fm = dc.GetFontMetrics();
+                dc.SetTextForeground(*wxBLACK);
+                dc.DrawText(s, rect.GetLeft() + 2, rect.GetTop() + (rect.GetHeight() - fm.height) / 2);
+            }
+            GetVListBoxComboPopup()->UnsetToolTip();
+        } else {
+            wxArrayString as = wxSplit(s, ',');
+
+            int i = 0;
+
+            for (auto it = as.begin(); it != as.end() && i < PALETTE_SIZE; ++it) {
+                xlColor c;
+                c.SetFromString(it->ToStdString());
+                wxPen p(c.asWxColor());
+                wxBrush b(c.asWxColor());
+                dc.SetPen(p);
+                dc.SetBrush(b);
+                dc.DrawRectangle(i * SWATCH_WIDTH, rect.GetTop(), SWATCH_WIDTH - 1, rect.GetHeight() - 1);
+                i++;
+            }
+
+            if (flags & wxODCB_PAINTING_SELECTED) {
+                wxString file = as.back();
+                GetVListBoxComboPopup()->SetToolTip(file);
+            }
+        }
+    }
+};
+
+
 const long PicturesAssistPanel::ID_BITMAPBUTTON_Paint_Pencil = wxNewId();
 const long PicturesAssistPanel::ID_BITMAPBUTTON_Paint_Eraser = wxNewId();
 const long PicturesAssistPanel::ID_BITMAPBUTTON_Paint_Eyedropper = wxNewId();
 const long PicturesAssistPanel::ID_BITMAPBUTTON_Paint_Selectcopy = wxNewId();
+const long PicturesAssistPanel::ID_BITMAPBUTTON_COLOR_SWATCHES = wxNewId();
+const long ID_BITMAPBUTTON_SavePalette = wxNewId();
+const long ID_BITMAPBUTTON_DeletePalette = wxNewId();
 
 wxDEFINE_EVENT(EVT_PAINT_COLOR, wxCommandEvent);
 wxDEFINE_EVENT(EVT_IMAGE_FILE_SELECTED, wxCommandEvent);
@@ -55,8 +134,7 @@ BEGIN_EVENT_TABLE(PicturesAssistPanel,wxPanel)
 END_EVENT_TABLE()
 
 PicturesAssistPanel::PicturesAssistPanel(wxWindow* parent, wxWindowID id,const wxPoint& pos,const wxSize& size)
-: mPaintMode(xlGridCanvasPictures::PAINT_PENCIL),
-  mPaintColor(xlRED)
+: mPaintMode(xlGridCanvasPictures::PAINT_PENCIL), mPaintColor(xlRED)
 {
     paint_pencil = wxBITMAP_PNG_FROM_DATA(pencil);
     paint_pencil_selected = wxBITMAP_PNG_FROM_DATA(pencil_sel);
@@ -74,7 +152,7 @@ PicturesAssistPanel::PicturesAssistPanel(wxWindow* parent, wxWindowID id,const w
 	wxFlexGridSizer* PaintFuntionsSizer;
 	wxFlexGridSizer* PaintToolsSizer;
 
-	Create(parent, id, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL|wxWANTS_CHARS, _T("id"));
+	Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL|wxWANTS_CHARS, _T("wxID_ANY"));
 	FlexGridSizer1 = new wxFlexGridSizer(1, 1, 0, 0);
 	Panel_Sizer = new wxPanel(this, ID_PANEL1, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL|wxWANTS_CHARS, _T("ID_PANEL1"));
 	FlexGridSizer2 = new wxFlexGridSizer(0, 1, 0, 0);
@@ -85,9 +163,9 @@ PicturesAssistPanel::PicturesAssistPanel(wxWindow* parent, wxWindowID id,const w
 	Panel_RightSide = new wxPanel(ScrolledWindowEffectAssist, ID_PANEL_RightSide, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("ID_PANEL_RightSide"));
 	FlexGridSizer_RightSide = new wxFlexGridSizer(0, 1, 0, 0);
 	ColorPickerSizer = new wxFlexGridSizer(0, 1, 0, 0);
-	FlexGridSizer_RightSide->Add(ColorPickerSizer, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
-	PaintToolsSizer = new wxFlexGridSizer(0, 4, 0, 10);
-	FlexGridSizer_RightSide->Add(PaintToolsSizer, 1, wxALL|wxEXPAND, 5);
+	FlexGridSizer_RightSide->Add(ColorPickerSizer, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
+	PaintToolsSizer = new wxFlexGridSizer(0, 6, 0, 10);
+	FlexGridSizer_RightSide->Add(PaintToolsSizer, 1, wxALL, 0);
 	PaintFuntionsSizer = new wxFlexGridSizer(0, 1, 0, 0);
 	FlexGridSizer3 = new wxFlexGridSizer(0, 6, 0, 0);
 	Button_NewImage = new wxButton(Panel_RightSide, ID_BUTTON_NewImage, _("New\nImage"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_NewImage"));
@@ -100,21 +178,29 @@ PicturesAssistPanel::PicturesAssistPanel(wxWindow* parent, wxWindowID id,const w
 	FlexGridSizer3->Add(Button_SaveAs, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	Button_Resize = new wxButton(Panel_RightSide, ID_BUTTON1, _("Resize\nImage"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON1"));
 	FlexGridSizer3->Add(Button_Resize, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	PaintFuntionsSizer->Add(FlexGridSizer3, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	PaintFuntionsSizer->Add(FlexGridSizer3, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
 	StaticText_CurrentImage = new wxStaticText(Panel_RightSide, ID_STATICTEXT_CurrentImage, _("Current Image:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_CurrentImage"));
 	PaintFuntionsSizer->Add(StaticText_CurrentImage, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
 	StaticText_ImageSize = new wxStaticText(Panel_RightSide, ID_STATICTEXT_ImageSize, _("Image Size:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_ImageSize"));
 	PaintFuntionsSizer->Add(StaticText_ImageSize, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
 	StaticText_ModelSize = new wxStaticText(Panel_RightSide, ID_STATICTEXT_ModelSize, _("Model Size:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_ModelSize"));
 	PaintFuntionsSizer->Add(StaticText_ModelSize, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
-	FlexGridSizer_RightSide->Add(PaintFuntionsSizer, 1, wxALL|wxEXPAND, 5);
+	FlexGridSizer_RightSide->Add(PaintFuntionsSizer, 1, wxALL, 0);
 	Panel_RightSide->SetSizer(FlexGridSizer_RightSide);
-	FlexGridSizer_Container->Add(Panel_RightSide, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer_RightSide->Fit(Panel_RightSide);
+	FlexGridSizer_RightSide->SetSizeHints(Panel_RightSide);
+	FlexGridSizer_Container->Add(Panel_RightSide, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
 	ScrolledWindowEffectAssist->SetSizer(FlexGridSizer_Container);
-	FlexGridSizer2->Add(ScrolledWindowEffectAssist, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer_Container->Fit(ScrolledWindowEffectAssist);
+	FlexGridSizer_Container->SetSizeHints(ScrolledWindowEffectAssist);
+	FlexGridSizer2->Add(ScrolledWindowEffectAssist, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
 	Panel_Sizer->SetSizer(FlexGridSizer2);
-	FlexGridSizer1->Add(Panel_Sizer, 1, wxALL|wxEXPAND, 5);
+	FlexGridSizer2->Fit(Panel_Sizer);
+	FlexGridSizer2->SetSizeHints(Panel_Sizer);
+	FlexGridSizer1->Add(Panel_Sizer, 1, wxALL, 0);
 	SetSizer(FlexGridSizer1);
+	FlexGridSizer1->Fit(this);
+	FlexGridSizer1->SetSizeHints(this);
 
 	Connect(ID_BUTTON_NewImage,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&PicturesAssistPanel::OnButton_NewImageClick);
 	Connect(ID_BUTTON_LoadImage,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&PicturesAssistPanel::OnButton_LoadImageClick);
@@ -123,10 +209,8 @@ PicturesAssistPanel::PicturesAssistPanel(wxWindow* parent, wxWindowID id,const w
 	Connect(ID_BUTTON1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&PicturesAssistPanel::OnButton_ResizeClick);
 	//*)
 
-	//PanelEffectGrid = new xlGridCanvasEmpty(ScrolledWindowEffectAssist, ID_PANEL_EffectGrid, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL|wxFULL_REPAINT_ON_RESIZE, _T("ID_PANEL_EffectGrid"));
-	//FlexGridSizer_Container->Insert(0, PanelEffectGrid, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-
     CreatePaintTools(Panel_RightSide, PaintToolsSizer);
+    Connect(wxID_ANY, wxEVT_COMBOBOX, (wxObjectEventFunction)&PicturesAssistPanel::OnColourChoiceSelect, 0, this);
 
     mColorPicker = new xlColorPickerFields(Panel_RightSide, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("ID_PANEL_ColorPicker"));
 	ColorPickerSizer->Add(mColorPicker, 1, wxALL|wxALIGN_TOP|wxALIGN_CENTER_HORIZONTAL, 5);
@@ -143,7 +227,249 @@ PicturesAssistPanel::PicturesAssistPanel(wxWindow* parent, wxWindowID id,const w
     for (int i=wxEVT_SCROLLWIN_TOP; i<=wxEVT_SCROLLWIN_THUMBRELEASE; i++) {
         ScrolledWindowEffectAssist->Connect(wxID_ANY, i, wxScrollWinEventHandler(PicturesAssistPanel::OnWindowScrolled), NULL, this);
     }
+    SetDefaultPalette();
+}
 
+void PicturesAssistPanel::LoadPalettes(wxDir& directory, bool subdirs)
+{
+    static wxRegEx cregex("^\\$[^:]*: rgba\\(([^)]*)\\)");
+
+    wxArrayString files;
+    GetAllFilesInDir(directory.GetName(), files, "*.xpalette");
+    for (auto& filename : files) {
+        if (FileExists(filename)) {
+            wxFileName fn(filename);
+            wxFileInputStream input(fn.GetFullPath());
+            if (input.IsOk()) {
+                wxTextInputStream text(input);
+                wxString s = text.ReadLine();
+                wxString scomp = s.BeforeLast(',');
+
+                bool found = false;
+                for (auto it = _loadedPalettes.begin(); it != _loadedPalettes.end(); ++it) {
+                    wxString p(*it);
+                    if (p.BeforeLast(',') == scomp) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    _loadedPalettes.push_back(s.ToStdString() + fn.GetFullName().ToStdString());
+                }
+            }
+        }
+    }
+
+    files.clear();
+    GetAllFilesInDir(directory.GetNameWithSep(), files, "*.scss");
+    for (auto& filename : files) {
+        if (FileExists(filename)) {
+            wxFileName fn(filename);
+            wxFileInputStream input(fn.GetFullPath());
+            if (input.IsOk()) {
+                wxString pal;
+                int cols = 0;
+                wxTextInputStream text(input);
+                while (!input.Eof()) {
+                    wxString line = text.ReadLine();
+                    if (cregex.Matches(line)) {
+                        wxString rgb = cregex.GetMatch(line, 1);
+                        wxArrayString comp = wxSplit(rgb, ',');
+                        if (comp.size() == 4) {
+                            pal += wxString::Format("#%2x%2x%2x,",
+                                                    wxAtoi(comp[0]),
+                                                    wxAtoi(comp[1]),
+                                                    wxAtoi(comp[2]));
+                            cols++;
+                        }
+                    }
+                }
+                if (cols > 0) {
+                    while (cols < 8) {
+                        pal += "#FFFFFF,";
+                        cols++;
+                    }
+                    bool found = false;
+                    for (auto it = _loadedPalettes.begin(); it != _loadedPalettes.end(); ++it) {
+                        wxString p(*it);
+                        if (p.BeforeLast(',') == pal) {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        _loadedPalettes.push_back(pal.ToStdString() + fn.GetFullName().ToStdString());
+                    }
+                }
+            }
+        }
+    }
+    files.clear();
+    GetAllFilesInDir(directory.GetNameWithSep(), files, "*.svg");
+    for (auto& filename : files) {
+        if (FileExists(filename)) {
+            wxFileName fn(filename);
+            wxXmlDocument svg;
+            svg.Load(filename);
+
+            if (svg.IsOk()) {
+                wxString pal;
+                int cols = 0;
+                for (auto n = svg.GetRoot()->GetChildren(); n != nullptr; n = n->GetNext()) {
+                    if (n->GetName() == "rect") {
+                        if (n->HasAttribute("fill")) {
+                            pal += n->GetAttribute("fill") + ",";
+                            cols++;
+                        }
+                    }
+                }
+                if (cols > 0) {
+                    while (cols < 8) {
+                        pal += "#FFFFFF,";
+                        cols++;
+                    }
+                    bool found = false;
+                    for (auto it = _loadedPalettes.begin(); it != _loadedPalettes.end(); ++it) {
+                        wxString p(*it);
+                        if (p.BeforeLast(',') == pal) {
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) {
+                        _loadedPalettes.push_back(pal.ToStdString() + fn.GetFullName().ToStdString());
+                    }
+                }
+            }
+        }
+    }
+
+    if (subdirs) {
+        wxString filename;
+        bool cont = directory.GetFirst(&filename, "*", wxDIR_DIRS);
+        while (cont) {
+            wxDir dir(directory.GetNameWithSep() + filename);
+            LoadPalettes(dir, subdirs);
+            cont = directory.GetNext(&filename);
+        }
+    }
+}
+
+void PicturesAssistPanel::LoadAllPalettes()
+{
+    _loadedPalettes.clear();
+
+    wxDir dir;
+    if (wxDir::Exists(xLightsFrame::CurrentDir)) {
+        dir.Open(xLightsFrame::CurrentDir);
+        LoadPalettes(dir, false);
+    }
+
+    wxString d = xLightsFrame::CurrentDir + "/Palettes";
+    if (wxDir::Exists(d)) {
+        dir.Open(d);
+        LoadPalettes(dir, true);
+    }
+
+    wxStandardPaths stdp = wxStandardPaths::Get();
+#ifndef __WXMSW__
+    d = wxStandardPaths::Get().GetResourcesDir() + "/palettes";
+#else
+    d = wxFileName(stdp.GetExecutablePath()).GetPath() + "/palettes";
+#endif
+    if (wxDir::Exists(d)) {
+        dir.Open(d);
+        LoadPalettes(dir, true);
+    }
+
+    if (BitmapButton_ColourChoice->GetCount() != 0) {
+        BitmapButton_ColourChoice->Clear();
+    }
+    BitmapButton_ColourChoice->AppendString("(Load)");
+    for (auto it = _loadedPalettes.begin(); it != _loadedPalettes.end(); ++it) {
+        BitmapButton_ColourChoice->AppendString(*it);
+    }
+}
+
+void PicturesAssistPanel::SetSwatchColor(const std::string& cstr, const int i)
+{
+    xlColor c;
+    c.SetFromString(cstr);
+    mColorPicker->SetButtonColor(i, c);
+    mColorPicker->SetColor(c);
+    ValidateWindow();
+}
+
+void PicturesAssistPanel::SetDefaultPalette()
+{
+    SetSwatchColor("#FFFFFF", 1);
+    SetSwatchColor("#FF0000", 2);
+    SetSwatchColor("#00FF00", 3);
+    SetSwatchColor("#0000FF", 4);
+    SetSwatchColor("#FFFF00", 5);
+    SetSwatchColor("#000000", 6);
+    SetSwatchColor("#00FFFF", 7);
+    SetSwatchColor("#FF00FF", 8);
+
+    mColorPicker->ResetPanel();
+
+    xlColor c;
+    c.SetFromString(wxString("#FFFFFF"));
+    mColorPicker->SetButtonColor(1, c);
+    mColorPicker->SetColor(c);
+    if (BitmapButton_ColourChoice->GetCount() < 2) {
+        LoadAllPalettes();
+    }
+    ValidateWindow();
+}
+
+void PicturesAssistPanel::OnColourChoiceDropDown(wxCommandEvent& WXUNUSED(event))
+{
+    if (_lastShowDir != xLightsFrame::CurrentDir) {
+        _lastShowDir = xLightsFrame::CurrentDir;
+        LoadAllPalettes();
+        ValidateWindow();
+    }
+}
+
+void PicturesAssistPanel::OnColourChoiceSelect(wxCommandEvent& event)
+{
+    long sel = event.GetInt();
+    wxString s = BitmapButton_ColourChoice->GetString(sel);
+    int activeButton = mColorPicker->GetActiveButton();
+    if (s != "(Load)") {
+        wxArrayString as = wxSplit(s, ',');
+        for (size_t i = 0; i < std::min(as.size(), (size_t)PALETTE_SIZE); i++) {
+            xlColor c;
+            c.SetFromString(as[i].ToStdString());
+            mColorPicker->SetButtonColor(i+1, c);
+            if (activeButton == i+1) {
+                mColorPicker->SetColor(c);
+            }            
+        }
+    }
+    BitmapButton_ColourChoice->SetSelection(0); // set dropdown back to 0
+    ValidateWindow();
+}
+
+void PicturesAssistPanel::ValidateWindow()
+{
+    // only enable save if this palette was not loaded from disk or has been saved to disk
+    wxString pal = wxString(GetCurrentPalette()).BeforeLast(',');
+    for (auto it = _loadedPalettes.begin(); it != _loadedPalettes.end(); ++it) {
+        wxString ss(it->c_str());
+        if (ss.BeforeLast(',') == pal) {
+            BitmapButton_SavePalette->Disable();
+            if (FindPaletteFile(ss.AfterLast(','), pal + ",") != "") {
+                BitmapButton_DeletePalette->Enable();
+            } else {
+                BitmapButton_DeletePalette->Disable();
+            }
+            return;
+        }
+    }
+    BitmapButton_SavePalette->Enable();
+    BitmapButton_DeletePalette->Disable();
 }
 
 PicturesAssistPanel::~PicturesAssistPanel()
@@ -179,10 +505,25 @@ void PicturesAssistPanel::CreatePaintTools(wxWindow* parent, wxFlexGridSizer* co
     BitmapButton_Paint_Selectcopy->SetBitmapFocus(paint_selectcopy_selected);
     BitmapButton_Paint_Selectcopy->SetBitmapCurrent(paint_selectcopy_selected);
     container->Add(BitmapButton_Paint_Selectcopy, 1, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+
+	BitmapButton_ColourChoice = new PAColourList(Panel_RightSide, ID_BITMAPBUTTON_COLOR_SWATCHES, wxDefaultPosition, wxDefaultSize, ZERO, wxDefaultValidator, _T("ID_BITMAPBUTTON_COLOR_SWATCHES"));
+    container->Add(BitmapButton_ColourChoice, 1, wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 2);
+
+    FlexGridSizer_Palette = new wxFlexGridSizer(0, 1, 0, 0);
+    BoxSizer_PaletteButtons = new wxBoxSizer(wxVERTICAL);
+    BitmapButton_SavePalette = new xlSizedBitmapButton(Panel_RightSide, ID_BITMAPBUTTON_SavePalette, wxArtProvider::GetBitmapBundle("xlART_colorpanel_save_xpm", wxART_BUTTON), wxDefaultPosition, wxSize(24, 24), wxBU_AUTODRAW | wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_SavePalette"));
+    BoxSizer_PaletteButtons->Add(BitmapButton_SavePalette, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 5);
+    BitmapButton_DeletePalette = new xlSizedBitmapButton(Panel_RightSide, ID_BITMAPBUTTON_DeletePalette, wxArtProvider::GetBitmapBundle("xlART_colorpanel_delete_xpm", wxART_BUTTON), wxDefaultPosition, wxSize(24, 24), wxBU_AUTODRAW | wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_DeletePalette"));
+    BoxSizer_PaletteButtons->Add(BitmapButton_DeletePalette, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 5);
+    FlexGridSizer_Palette->Add(BoxSizer_PaletteButtons, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 5);
+    container->Add(FlexGridSizer_Palette, 1, wxALL | wxALIGN_LEFT, 5);
+
     Connect(ID_BITMAPBUTTON_Paint_Pencil,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&PicturesAssistPanel::OnBitmapButton_Paint_PencilClick);
     Connect(ID_BITMAPBUTTON_Paint_Eraser,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&PicturesAssistPanel::OnBitmapButton_Paint_EraserClick);
     Connect(ID_BITMAPBUTTON_Paint_Eyedropper,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&PicturesAssistPanel::OnBitmapButton_Paint_EyedropperClick);
     Connect(ID_BITMAPBUTTON_Paint_Selectcopy,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&PicturesAssistPanel::OnBitmapButton_Paint_SelectcopyClick);
+    Connect(ID_BITMAPBUTTON_SavePalette, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&PicturesAssistPanel::OnBitmapButton_SavePaletteClick);
+    Connect(ID_BITMAPBUTTON_DeletePalette, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&PicturesAssistPanel::OnBitmapButton_DeletePaletteClick);
 }
 
 void PicturesAssistPanel::OnBitmapButton_Paint_PencilClick(wxCommandEvent& event)
@@ -225,6 +566,7 @@ void PicturesAssistPanel::OnColorChange(wxCommandEvent& event)
 {
     xlColor* color = (xlColor*)event.GetClientData();
     mGridCanvas->SetPaintColor(*color);
+    ValidateWindow();
 }
 
 void PicturesAssistPanel::OnEyedropperColor(wxCommandEvent& event)
@@ -281,4 +623,110 @@ void PicturesAssistPanel::OnButton_ResizeClick(wxCommandEvent& event)
 void PicturesAssistPanel::OnWindowScrolled(wxScrollWinEvent &event)
 {
     ForceRefresh();
+}
+
+void PicturesAssistPanel::OnBitmapButton_SavePaletteClick(wxCommandEvent& event)
+{
+    // Double check that this has not been saved before
+    if (BitmapButton_ColourChoice->GetCount() == 1) {
+        LoadAllPalettes();
+        ValidateWindow();
+        if (!BitmapButton_SavePalette->IsEnabled()) {
+            static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+            logger_base.error("Already saved xpalette ... skipped.");
+            return;
+        }
+    }
+
+    if (!wxDir::Exists(xLightsFrame::CurrentDir + "/Palettes")) {
+        wxDir::Make(xLightsFrame::CurrentDir + "/Palettes");
+    }
+
+    int i = 1;
+    wxString fn = "PAL001.xpalette";
+
+    while (FileExists(xLightsFrame::CurrentDir + "/Palettes/" + fn)) {
+        i++;
+        fn = wxString::Format("PAL%03d.xpalette", i);
+    }
+
+    wxFile f;
+    f.Create(xLightsFrame::CurrentDir + "/Palettes/" + fn);
+
+    if (f.IsOpened()) {
+        std::string pal = GetCurrentPalette();
+
+        f.Write(wxString(pal.c_str()));
+        f.Close();
+
+        _loadedPalettes.push_back(pal);
+    } else {
+        static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+        logger_base.error("Unable to create file %s.", (const char*)fn.c_str());
+    }
+
+    LoadAllPalettes();
+
+    ValidateWindow();
+}
+
+wxString PicturesAssistPanel::FindPaletteFile(const wxString& filename, const wxString& palette) const
+{
+    if (FileExists(xLightsFrame::CurrentDir + wxFileName::GetPathSeparator() + filename)) {
+        wxFileInputStream input(xLightsFrame::CurrentDir + wxFileName::GetPathSeparator() + filename);
+        if (input.IsOk()) {
+            wxTextInputStream text(input);
+            wxString s = text.ReadLine();
+            if (s == palette) {
+                return xLightsFrame::CurrentDir + wxFileName::GetPathSeparator() + filename;
+            }
+        }
+    }
+
+    if (FileExists(xLightsFrame::CurrentDir + wxFileName::GetPathSeparator() + "Palettes" + wxFileName::GetPathSeparator() + filename)) {
+        wxFileInputStream input(xLightsFrame::CurrentDir + wxFileName::GetPathSeparator() + "Palettes" + wxFileName::GetPathSeparator() + filename);
+        if (input.IsOk()) {
+            wxTextInputStream text(input);
+            wxString s = text.ReadLine();
+            if (s == palette) {
+                return xLightsFrame::CurrentDir + wxFileName::GetPathSeparator() + "Palettes" + wxFileName::GetPathSeparator() + filename;
+            }
+        }
+    }
+
+    return "";
+}
+
+wxColour PicturesAssistPanel::GetPaletteColor(int idx) const
+{
+    if (idx < PALETTE_SIZE)
+        return mColorPicker->GetButtonColor(idx + 1);
+    return *wxBLACK;
+}
+
+std::string PicturesAssistPanel::GetCurrentPalette() const
+{
+    std::string res;
+    for (size_t i = 0; i < PALETTE_SIZE; i++) {
+        wxColour c = GetPaletteColor(i);
+        res += c.GetAsString(wxC2S_HTML_SYNTAX).ToStdString() + ",";
+    }
+    return res;
+}
+
+void PicturesAssistPanel::OnBitmapButton_DeletePaletteClick(wxCommandEvent& event)
+{
+    std::string pal = GetCurrentPalette();
+
+    for (auto it = _loadedPalettes.begin(); it != _loadedPalettes.end(); ++it) {
+        wxString ss(it->c_str());
+        if (ss.BeforeLast(',') + "," == pal) {
+            wxString filename = FindPaletteFile(ss.AfterLast(','), pal);
+            if (filename != "") {
+                ::wxRemoveFile(filename);
+            }
+        }
+    }
+    LoadAllPalettes();
+    ValidateWindow();
 }

--- a/xLights/effects/assist/PicturesAssistPanel.h
+++ b/xLights/effects/assist/PicturesAssistPanel.h
@@ -21,9 +21,12 @@
 #include "../../FlickerFreeBitmapButton.h"
 #include "xlGridCanvasPictures.h"
 #include "../../sequencer/Effect.h"
+#include "ColorPanel.h"
 
 class xlColorPicker;
 class xLightsFrame;
+
+class PAColourList;
 
 class PicturesAssistPanel: public wxPanel
 {
@@ -32,9 +35,17 @@ class PicturesAssistPanel: public wxPanel
 		PicturesAssistPanel(wxWindow* parent, wxWindowID id=wxID_ANY,const wxPoint& pos=wxDefaultPosition,const wxSize& size=wxDefaultSize);
 		virtual ~PicturesAssistPanel();
 
+		std::list<std::string> _loadedPalettes;
+        wxString _lastShowDir;
         void ForceRefresh();
         void SetGridCanvas(xlGridCanvasPictures* canvas) { mGridCanvas = canvas; }
         void SetxLightsFrame(xLightsFrame* xlights_parent) { mxLightsParent = xlights_parent; }
+        void ValidateWindow();
+        void SetSwatchColor(const std::string& v, const int i);
+        wxFlexGridSizer* FlexGridSizer_Palette;
+        xlSizedBitmapButton* BitmapButton_DeletePalette;
+        xlSizedBitmapButton* BitmapButton_SavePalette;
+        wxBoxSizer* BoxSizer_PaletteButtons;
 
 		//(*Declarations(PicturesAssistPanel)
 		wxButton* Button_LoadImage;
@@ -59,12 +70,13 @@ class PicturesAssistPanel: public wxPanel
         static const long ID_BITMAPBUTTON_Paint_Eraser;
         static const long ID_BITMAPBUTTON_Paint_Eyedropper;
         static const long ID_BITMAPBUTTON_Paint_Selectcopy;
+        static const long ID_BITMAPBUTTON_COLOR_SWATCHES;
 
 		FlickerFreeBitmapButton* BitmapButton_Paint_Pencil;
 		FlickerFreeBitmapButton* BitmapButton_Paint_Eraser;
 		FlickerFreeBitmapButton* BitmapButton_Paint_Eyedropper;
 		FlickerFreeBitmapButton* BitmapButton_Paint_Selectcopy;
-
+        PAColourList* BitmapButton_ColourChoice;
 
 		//(*Identifiers(PicturesAssistPanel)
 		static const long ID_BUTTON_NewImage;
@@ -80,10 +92,10 @@ class PicturesAssistPanel: public wxPanel
 		static const long ID_PANEL1;
 		//*)
 
+
 	private:
 
 		//(*Handlers(PicturesAssistPanel)
-		void OnResize(wxSizeEvent& event);
 		void OnButton_SaveImageClick(wxCommandEvent& event);
 		void OnButton_NewImageClick(wxCommandEvent& event);
 		void OnButton_LoadImageClick(wxCommandEvent& event);
@@ -96,11 +108,21 @@ class PicturesAssistPanel: public wxPanel
 		void OnBitmapButton_Paint_EraserClick(wxCommandEvent& event);
 		void OnBitmapButton_Paint_EyedropperClick(wxCommandEvent& event);
 		void OnBitmapButton_Paint_SelectcopyClick(wxCommandEvent& event);
+        wxString FindPaletteFile(const wxString& filename, const wxString& palette) const;
+        std::string GetCurrentPalette() const;
+        wxColour GetPaletteColor(int idx) const;
+        void OnBitmapButton_SavePaletteClick(wxCommandEvent& event);
+        void OnBitmapButton_DeletePaletteClick(wxCommandEvent& event);
 		void OnColorChange(wxCommandEvent& event);
 		void OnImageFileSelected(wxCommandEvent& event);
 		void OnImageSize(wxCommandEvent& event);
 		void OnEyedropperColor(wxCommandEvent& event);
         void OnWindowScrolled(wxScrollWinEvent &event);
+        void LoadPalettes(wxDir& directory, bool subdirs);
+        void LoadAllPalettes();
+        void SetDefaultPalette();
+        void OnColourChoiceDropDown(wxCommandEvent& WXUNUSED(event));
+        void OnColourChoiceSelect(wxCommandEvent& event);
 
         xLightsFrame* mxLightsParent;
         xlGridCanvasPictures* mGridCanvas;

--- a/xLights/wxsmith/PicturesAssistPanel.wxs
+++ b/xLights/wxsmith/PicturesAssistPanel.wxs
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <wxsmith>
 	<object class="wxPanel" name="PicturesAssistPanel">
-		<pos_arg>1</pos_arg>
-		<size_arg>1</size_arg>
+		<id_arg>0</id_arg>
 		<style>wxTAB_TRAVERSAL|wxWANTS_CHARS</style>
 		<object class="wxFlexGridSizer" variable="FlexGridSizer1" member="yes">
 			<cols>1</cols>
@@ -27,17 +26,15 @@
 													<object class="wxFlexGridSizer" variable="ColorPickerSizer" member="no">
 														<cols>1</cols>
 													</object>
-													<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
-													<border>5</border>
+													<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 													<option>1</option>
 												</object>
 												<object class="sizeritem">
 													<object class="wxFlexGridSizer" variable="PaintToolsSizer" member="no">
-														<cols>4</cols>
+														<cols>6</cols>
 														<hgap>10</hgap>
 													</object>
-													<flag>wxALL|wxEXPAND</flag>
-													<border>5</border>
+													<flag>wxALL</flag>
 													<option>1</option>
 												</object>
 												<object class="sizeritem">
@@ -93,7 +90,6 @@
 																</object>
 															</object>
 															<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
-															<border>5</border>
 															<option>1</option>
 														</object>
 														<object class="sizeritem">
@@ -121,26 +117,22 @@
 															<option>1</option>
 														</object>
 													</object>
-													<flag>wxALL|wxEXPAND</flag>
-													<border>5</border>
+													<flag>wxALL</flag>
 													<option>1</option>
 												</object>
 											</object>
 										</object>
 										<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
-										<border>5</border>
 										<option>1</option>
 									</object>
 								</object>
 							</object>
 							<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
-							<border>5</border>
 							<option>1</option>
 						</object>
 					</object>
 				</object>
-				<flag>wxALL|wxEXPAND</flag>
-				<border>5</border>
+				<flag>wxALL</flag>
 				<option>1</option>
 			</object>
 		</object>

--- a/xLights/xlColorPicker.h
+++ b/xLights/xlColorPicker.h
@@ -21,6 +21,10 @@ class xlColorPicker: public wxPanel
 		virtual ~xlColorPicker();
 
         virtual void SetColor(xlColor& color ) = 0;
+        virtual int GetActiveButton() = 0;
+        virtual wxColour GetButtonColor(int p) = 0;
+        virtual void SetButtonColor(int p, xlColor& color) = 0;
+        virtual void ResetPanel() = 0;
         const xlColor& GetColor() { return mCurrentColor; }
 
         virtual void NotifyColorChange() = 0;

--- a/xLights/xlColorPickerFields.h
+++ b/xLights/xlColorPickerFields.h
@@ -34,7 +34,11 @@ class xlColorPickerFields: public xlColorPicker
 		virtual ~xlColorPickerFields();
 
         virtual void SetColor(xlColor& color );
+		virtual int GetActiveButton();
+        virtual void SetButtonColor(const int, xlColor& color);
+        wxColour GetButtonColor(const int);
         virtual void NotifyColorChange();
+        virtual void ResetPanel();
 
 		//(*Declarations(xlColorPickerFields)
 		wxBitmapButton* BitmapButton_Swatch1;
@@ -116,7 +120,6 @@ class xlColorPickerFields: public xlColorPicker
 
         ColorDisplayMode mDisplayMode;
         wxBitmapButton* mActiveButton;
-        wxWindow* mMsgParent;
 
 		DECLARE_EVENT_TABLE()
 };


### PR DESCRIPTION
Added the same color panel  "color palette" code to the picture assistant. This is not likely used much anymore but the functionality is now there. #1231 .. 
The resizing issue of #1465 was not really seen - the wxwidget functionality seems to address the scaling of the grid - you just need to scale from the left side of the window. The color picture (right side) is all "hard coded" sizes and not practical to redo for "scaling".