### PR TITLE
Ability to add and edit aliases on submodels #4214

### DIFF
--- a/xLights/EditSubmodelAliasesDialog.cpp
+++ b/xLights/EditSubmodelAliasesDialog.cpp
@@ -1,0 +1,145 @@
+/***************************************************************
+ * This source files comes from the xLights project
+ * https://www.xlights.org
+ * https://github.com/xLightsSequencer/xLights
+ * See the github commit history for a record of contributing
+ * developers.
+ * Copyright claimed based on commit dates recorded in Github
+ * License: https://github.com/xLightsSequencer/xLights/blob/master/License.txt
+ **************************************************************/
+
+#include "EditSubmodelAliasesDialog.h"
+#include "models/Model.h"
+#include "models/SubModel.h"
+
+#include <log4cpp/Category.hh>
+
+//(*InternalHeaders(EditSubmodelAliasesDialog)
+#include <wx/intl.h>
+#include <wx/string.h>
+//*)
+
+//(*IdInit(EditSubmodelAliasesDialog)
+const long EditSubmodelAliasesDialog::ID_LISTBOX1 = wxNewId();
+const long EditSubmodelAliasesDialog::ID_BUTTON1 = wxNewId();
+const long EditSubmodelAliasesDialog::ID_BUTTON2 = wxNewId();
+const long EditSubmodelAliasesDialog::ID_BUTTON3 = wxNewId();
+const long EditSubmodelAliasesDialog::ID_BUTTON4 = wxNewId();
+//*)
+
+BEGIN_EVENT_TABLE(EditSubmodelAliasesDialog, wxDialog)
+//(*EventTable(EditSubmodelAliasesDialog)
+//*)
+END_EVENT_TABLE()
+
+EditSubmodelAliasesDialog::EditSubmodelAliasesDialog(wxWindow* parent, Model* m, wxString submodelname, wxWindowID id, const wxPoint& pos, const wxSize& size) : _m(m)
+{
+    //(*Initialize(EditSubmodelAliasesDialog)
+    wxFlexGridSizer* FlexGridSizer1;
+    wxFlexGridSizer* FlexGridSizer2;
+    wxFlexGridSizer* FlexGridSizer3;
+
+    Create(parent, wxID_ANY, _("Submodel Aliases"), wxDefaultPosition, wxDefaultSize, wxCAPTION|wxRESIZE_BORDER|wxMAXIMIZE_BOX, _T("wxID_ANY"));
+    FlexGridSizer1 = new wxFlexGridSizer(0, 2, 0, 0);
+    FlexGridSizer1->AddGrowableCol(0);
+    FlexGridSizer1->AddGrowableRow(0);
+    ListBoxAliases = new wxListBox(this, ID_LISTBOX1, wxDefaultPosition, wxDefaultSize, 0, 0, wxLB_SINGLE|wxLB_SORT, wxDefaultValidator, _T("ID_LISTBOX1"));
+    FlexGridSizer1->Add(ListBoxAliases, 1, wxALL|wxEXPAND, 5);
+    FlexGridSizer2 = new wxFlexGridSizer(0, 1, 0, 0);
+    ButtonAdd = new wxButton(this, ID_BUTTON1, _("Add"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON1"));
+    FlexGridSizer2->Add(ButtonAdd, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    ButtonDelete = new wxButton(this, ID_BUTTON2, _("Delete"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON2"));
+    FlexGridSizer2->Add(ButtonDelete, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    FlexGridSizer1->Add(FlexGridSizer2, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    FlexGridSizer3 = new wxFlexGridSizer(0, 3, 0, 0);
+    ButtonOk = new wxButton(this, ID_BUTTON3, _("Ok"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON3"));
+    ButtonOk->SetDefault();
+    FlexGridSizer3->Add(ButtonOk, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    ButtonCancel = new wxButton(this, ID_BUTTON4, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON4"));
+    FlexGridSizer3->Add(ButtonCancel, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    FlexGridSizer1->Add(FlexGridSizer3, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    SetSizer(FlexGridSizer1);
+    FlexGridSizer1->Fit(this);
+    FlexGridSizer1->SetSizeHints(this);
+
+    Connect(ID_LISTBOX1,wxEVT_COMMAND_LISTBOX_SELECTED,(wxObjectEventFunction)&EditSubmodelAliasesDialog::OnListBoxAliasesSelect);
+    Connect(ID_BUTTON1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&EditSubmodelAliasesDialog::OnButtonAddClick);
+    Connect(ID_BUTTON2,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&EditSubmodelAliasesDialog::OnButtonDeleteClick);
+    Connect(ID_BUTTON3,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&EditSubmodelAliasesDialog::OnButtonOkClick);
+    Connect(ID_BUTTON4,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&EditSubmodelAliasesDialog::OnButtonCancelClick);
+    //*)
+
+    _sm = _m->GetSubModel(submodelname);
+
+    for (const auto& it : _sm->GetAliases()) {
+        ListBoxAliases->Append(it);
+    }
+
+    SetSizerAndFit(FlexGridSizer1);
+    SetEscapeId(ID_BUTTON4);
+
+    ValidateWindow();
+}
+
+EditSubmodelAliasesDialog::~EditSubmodelAliasesDialog()
+{
+    //(*Destroy(EditSubmodelAliasesDialog)
+    //*)
+}
+
+void EditSubmodelAliasesDialog::ValidateWindow()
+{
+    if (ListBoxAliases->GetSelection() >= 0) {
+        ButtonDelete->Enable();
+    } else {
+        ButtonDelete->Disable();
+    }
+}
+
+void EditSubmodelAliasesDialog::OnButtonAddClick(wxCommandEvent& event)
+{
+    wxTextEntryDialog te(this, "Alias to add", "Add an alias");
+
+    if (te.ShowModal() == wxID_OK) {
+        auto add = te.GetValue().Lower();
+
+        bool found = false;
+        for (int i = 0; !found && i < ListBoxAliases->GetCount(); ++i) {
+            if (ListBoxAliases->GetString(i) == add)
+                found = true;
+        }
+
+        if (!found) {
+            ListBoxAliases->Append(add);
+        }
+    }
+    ValidateWindow();
+}
+
+void EditSubmodelAliasesDialog::OnButtonDeleteClick(wxCommandEvent& event)
+{
+    if (ListBoxAliases->GetSelection() >= 0) {
+        ListBoxAliases->Delete(ListBoxAliases->GetSelection());
+    }
+    ValidateWindow();
+}
+
+void EditSubmodelAliasesDialog::OnButtonOkClick(wxCommandEvent& event)
+{
+    std::list<std::string> aliases;
+    for (int i = 0; i < ListBoxAliases->GetCount(); ++i) {
+        aliases.push_back(ListBoxAliases->GetString(i));
+    }
+    _sm->SetAliases(aliases);
+    EndDialog(wxID_OK);
+}
+
+void EditSubmodelAliasesDialog::OnButtonCancelClick(wxCommandEvent& event)
+{
+    EndDialog(wxID_CANCEL);
+}
+
+void EditSubmodelAliasesDialog::OnListBoxAliasesSelect(wxCommandEvent& event)
+{
+    ValidateWindow();
+}

--- a/xLights/EditSubmodelAliasesDialog.h
+++ b/xLights/EditSubmodelAliasesDialog.h
@@ -1,0 +1,52 @@
+#ifndef EDITSUBMODELALIASESDIALOG_H
+#define EDITSUBMODELALIASESDIALOG_H
+
+//(*Headers(EditSubmodelAliasesDialog)
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/listbox.h>
+#include <wx/sizer.h>
+//*)
+
+class Model;
+
+class EditSubmodelAliasesDialog : public wxDialog
+{
+public:
+    EditSubmodelAliasesDialog(wxWindow* parent, Model* m, wxString name, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize);
+    virtual ~EditSubmodelAliasesDialog();
+
+    //(*Declarations(EditSubmodelAliasesDialog)
+    wxButton* ButtonAdd;
+    wxButton* ButtonCancel;
+    wxButton* ButtonDelete;
+    wxButton* ButtonOk;
+    wxListBox* ListBoxAliases;
+    //*)
+
+protected:
+    Model* _m = nullptr;
+    Model* _sm = nullptr;
+    void ValidateWindow();
+
+    //(*Identifiers(EditSubmodelAliasesDialog)
+    static const long ID_LISTBOX1;
+    static const long ID_BUTTON1;
+    static const long ID_BUTTON2;
+    static const long ID_BUTTON3;
+    static const long ID_BUTTON4;
+    //*)
+
+private:
+    //(*Handlers(EditSubmodelAliasesDialog)
+    void OnButtonAddClick(wxCommandEvent& event);
+    void OnButtonDeleteClick(wxCommandEvent& event);
+    void OnButtonOkClick(wxCommandEvent& event);
+    void OnButtonCancelClick(wxCommandEvent& event);
+    void OnListBoxAliasesSelect(wxCommandEvent& event);
+    //*)
+
+    DECLARE_EVENT_TABLE()
+};
+
+#endif

--- a/xLights/SubModelsDialog.cpp
+++ b/xLights/SubModelsDialog.cpp
@@ -38,6 +38,7 @@
 #include "models/Model.h"
 #include "SubBufferPanel.h"
 #include "SubModelGenerateDialog.h"
+#include "EditSubmodelAliasesDialog.h"
 #include "NodeSelectGrid.h"
 #include "UtilFunctions.h"
 #include "xLightsApp.h"
@@ -101,6 +102,7 @@ const long SubModelsDialog::SUBMODEL_DIALOG_EXPORT_CSV = wxNewId();
 const long SubModelsDialog::SUBMODEL_DIALOG_EXPORT_XMODEL = wxNewId();
 const long SubModelsDialog::SUBMODEL_DIALOG_EXPORT_TOOTHERS = wxNewId();
 const long SubModelsDialog::SUBMODEL_DIALOG_GENERATE = wxNewId();
+const long SubModelsDialog::SUBMODEL_DIALOG_ALIASES = wxNewId();
 const long SubModelsDialog::SUBMODEL_DIALOG_SHIFT = wxNewId();
 const long SubModelsDialog::SUBMODEL_DIALOG_FLIP_HOR = wxNewId();
 const long SubModelsDialog::SUBMODEL_DIALOG_FLIP_VER = wxNewId();
@@ -296,7 +298,7 @@ SubModelsDialog::SubModelsDialog(wxWindow* parent, OutputManager* om) :
 	FlexGridSizer5->Add(AddRowButton, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	DeleteRowButton = new wxButton(Panel1, ID_BUTTON2, _("Delete Row"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON2"));
 	FlexGridSizer5->Add(DeleteRowButton, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	Button_MoveUp = new wxButton(Panel1, ID_BUTTON_MOVE_UP, _T("^"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_MOVE_UP"));
+	Button_MoveUp = new wxButton(Panel1, ID_BUTTON_MOVE_UP, _("^"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_MOVE_UP"));
 	FlexGridSizer5->Add(Button_MoveUp, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	Button_MoveDown = new wxButton(Panel1, ID_BUTTON_MOVE_DOWN, _("v"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_MOVE_DOWN"));
 	FlexGridSizer5->Add(Button_MoveDown, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
@@ -342,38 +344,38 @@ SubModelsDialog::SubModelsDialog(wxWindow* parent, OutputManager* om) :
 	Center();
 
 	Connect(ID_CHECKBOX2, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnCheckBox_OutputToLightsClick);
-	Connect(ID_LISTCTRL_SUB_MODELS, wxEVT_COMMAND_LIST_BEGIN_DRAG, (wxObjectEventFunction)&SubModelsDialog::OnListCtrl_SubModelsBeginDrag);
-	Connect(ID_LISTCTRL_SUB_MODELS, wxEVT_COMMAND_LIST_ITEM_SELECTED, (wxObjectEventFunction)&SubModelsDialog::OnListCtrl_SubModelsItemSelect);
-	Connect(ID_LISTCTRL_SUB_MODELS, wxEVT_COMMAND_LIST_ITEM_RIGHT_CLICK, (wxObjectEventFunction)&SubModelsDialog::OnListCtrl_SubModelsItemRClick);
-	Connect(ID_LISTCTRL_SUB_MODELS, wxEVT_COMMAND_LIST_KEY_DOWN, (wxObjectEventFunction)&SubModelsDialog::OnListCtrl_SubModelsKeyDown);
-	Connect(ID_LISTCTRL_SUB_MODELS, wxEVT_COMMAND_LIST_COL_CLICK, (wxObjectEventFunction)&SubModelsDialog::OnListCtrl_SubModelsColumnClick);
-	Connect(ID_SEARCHCTRL1, wxEVT_COMMAND_TEXT_ENTER, (wxObjectEventFunction)&SubModelsDialog::OnButton_SearchClick);
-	Connect(ID_SEARCHCTRL1, wxEVT_COMMAND_SEARCHCTRL_SEARCH_BTN, (wxObjectEventFunction)&SubModelsDialog::OnButton_SearchClick);
-	Connect(ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnAddButtonClick);
-	Connect(ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnDeleteButtonClick);
-	Connect(ID_BUTTONCOPY, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_Sub_CopyClick);
-	Connect(ID_BUTTON_EDIT, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_EditClick);
-	Connect(ID_BUTTON_IMPORT, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButtonImportClick);
-	Connect(ID_BUTTON10, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_ExportClick);
-	Connect(ID_TEXTCTRL_NAME, wxEVT_COMMAND_TEXT_UPDATED, (wxObjectEventFunction)&SubModelsDialog::OnTextCtrl_NameText_Change);
-	Connect(ID_CHOICE_BUFFER_STYLE, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&SubModelsDialog::OnChoiceBufferStyleSelect);
-	Connect(ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnLayoutCheckboxClick);
-	Connect(ID_GRID1, wxEVT_GRID_CELL_RIGHT_CLICK, (wxObjectEventFunction)&SubModelsDialog::OnNodesGridCellRightClick);
-	Connect(ID_GRID1, wxEVT_GRID_CELL_LEFT_DCLICK, (wxObjectEventFunction)&SubModelsDialog::OnNodesGridCellLeftDClick);
-	Connect(ID_GRID1, wxEVT_GRID_LABEL_LEFT_CLICK, (wxObjectEventFunction)&SubModelsDialog::OnNodesGridLabelLeftClick);
-	Connect(ID_GRID1, wxEVT_GRID_LABEL_RIGHT_CLICK, (wxObjectEventFunction)&SubModelsDialog::OnNodesGridCellRightClick);
-	Connect(ID_GRID1, wxEVT_GRID_LABEL_LEFT_DCLICK, (wxObjectEventFunction)&SubModelsDialog::OnNodesGridLabelLeftDClick);
-	Connect(ID_GRID1, wxEVT_GRID_SELECT_CELL, (wxObjectEventFunction)&SubModelsDialog::OnNodesGridCellSelect);
-	Connect(ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_ReverseNodesClick);
-	Connect(ID_BUTTON8, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_ReverseRowsClick);
-	Connect(ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnAddRowButtonClick);
-	Connect(ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnDeleteRowButtonClick);
-	Connect(ID_BUTTON_MOVE_UP, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_MoveUpClick);
-	Connect(ID_BUTTON_MOVE_DOWN, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_MoveDownClick);
-	Connect(ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_ReverseRowClick);
-	Connect(ID_BUTTON_SORT_ROW, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_SortRowClick);
-	Connect(ID_BUTTON_DRAW_MODEL, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_Draw_ModelClick);
-	Connect(wxID_ANY, wxEVT_INIT_DIALOG, (wxObjectEventFunction)&SubModelsDialog::OnInit);
+    Connect(ID_LISTCTRL_SUB_MODELS, wxEVT_COMMAND_LIST_BEGIN_DRAG, (wxObjectEventFunction)&SubModelsDialog::OnListCtrl_SubModelsBeginDrag);
+    Connect(ID_LISTCTRL_SUB_MODELS, wxEVT_COMMAND_LIST_ITEM_SELECTED, (wxObjectEventFunction)&SubModelsDialog::OnListCtrl_SubModelsItemSelect);
+    Connect(ID_LISTCTRL_SUB_MODELS, wxEVT_COMMAND_LIST_ITEM_RIGHT_CLICK, (wxObjectEventFunction)&SubModelsDialog::OnListCtrl_SubModelsItemRClick);
+    Connect(ID_LISTCTRL_SUB_MODELS, wxEVT_COMMAND_LIST_KEY_DOWN, (wxObjectEventFunction)&SubModelsDialog::OnListCtrl_SubModelsKeyDown);
+    Connect(ID_LISTCTRL_SUB_MODELS, wxEVT_COMMAND_LIST_COL_CLICK, (wxObjectEventFunction)&SubModelsDialog::OnListCtrl_SubModelsColumnClick);
+    Connect(ID_SEARCHCTRL1, wxEVT_COMMAND_TEXT_ENTER, (wxObjectEventFunction)&SubModelsDialog::OnButton_SearchClick);
+    Connect(ID_SEARCHCTRL1, wxEVT_COMMAND_SEARCHCTRL_SEARCH_BTN, (wxObjectEventFunction)&SubModelsDialog::OnButton_SearchClick);
+    Connect(ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnAddButtonClick);
+    Connect(ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnDeleteButtonClick);
+    Connect(ID_BUTTONCOPY, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_Sub_CopyClick);
+    Connect(ID_BUTTON_EDIT, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_EditClick);
+    Connect(ID_BUTTON_IMPORT, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButtonImportClick);
+    Connect(ID_BUTTON10, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_ExportClick);
+    Connect(ID_TEXTCTRL_NAME, wxEVT_COMMAND_TEXT_UPDATED, (wxObjectEventFunction)&SubModelsDialog::OnTextCtrl_NameText_Change);
+    Connect(ID_CHOICE_BUFFER_STYLE, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&SubModelsDialog::OnChoiceBufferStyleSelect);
+    Connect(ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnLayoutCheckboxClick);
+    Connect(ID_GRID1, wxEVT_GRID_CELL_RIGHT_CLICK, (wxObjectEventFunction)&SubModelsDialog::OnNodesGridCellRightClick);
+    Connect(ID_GRID1, wxEVT_GRID_CELL_LEFT_DCLICK, (wxObjectEventFunction)&SubModelsDialog::OnNodesGridCellLeftDClick);
+    Connect(ID_GRID1, wxEVT_GRID_LABEL_LEFT_CLICK, (wxObjectEventFunction)&SubModelsDialog::OnNodesGridLabelLeftClick);
+    Connect(ID_GRID1, wxEVT_GRID_LABEL_RIGHT_CLICK, (wxObjectEventFunction)&SubModelsDialog::OnNodesGridCellRightClick);
+    Connect(ID_GRID1, wxEVT_GRID_LABEL_LEFT_DCLICK, (wxObjectEventFunction)&SubModelsDialog::OnNodesGridLabelLeftDClick);
+    Connect(ID_GRID1, wxEVT_GRID_SELECT_CELL, (wxObjectEventFunction)&SubModelsDialog::OnNodesGridCellSelect);
+    Connect(ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_ReverseNodesClick);
+    Connect(ID_BUTTON8, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_ReverseRowsClick);
+    Connect(ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnAddRowButtonClick);
+    Connect(ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnDeleteRowButtonClick);
+    Connect(ID_BUTTON_MOVE_UP, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_MoveUpClick);
+    Connect(ID_BUTTON_MOVE_DOWN, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_MoveDownClick);
+    Connect(ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_ReverseRowClick);
+    Connect(ID_BUTTON_SORT_ROW, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_SortRowClick);
+    Connect(ID_BUTTON_DRAW_MODEL, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnButton_Draw_ModelClick);
+    Connect(wxID_ANY, wxEVT_INIT_DIALOG, (wxObjectEventFunction)&SubModelsDialog::OnInit);
 	//*)
 
     Connect(ID_NOTEBOOK1, wxEVT_NOTEBOOK_PAGE_CHANGED, (wxObjectEventFunction)& SubModelsDialog::OnTypeNotebookPageChanged);
@@ -607,8 +609,16 @@ void SubModelsDialog::SaveXML(Model *m)
     xLightsFrame* xlights = xLightsApp::GetFrame();
     wxXmlNode * root = m->GetModelXml();
     wxXmlNode * child = root->GetChildren();
+    std::vector<std::pair<wxString, wxString>> submodelAliases;
     while (child != nullptr) {
         if (child->GetName() == "subModel") {
+            for (auto node = child->GetChildren(); node != nullptr; node = node->GetNext()) {
+                if (node->GetName() == "Aliases") {
+                    for (auto a = node->GetChildren(); a != nullptr; a = a->GetNext()) {
+                        submodelAliases.push_back(std::make_pair(child->GetAttribute("name"), a->GetAttribute("name")));
+                    }
+                }
+            }
             wxXmlNode *n = child;
             child = child->GetNext();
             root->RemoveChild(n);
@@ -624,6 +634,16 @@ void SubModelsDialog::SaveXML(Model *m)
         child->AddAttribute("layout", (*a)->vertical ? "vertical" : "horizontal");
         child->AddAttribute("type", (*a)->isRanges ? "ranges" : "subbuffer");
         child->AddAttribute("bufferstyle", (*a)->bufferStyle);
+
+        auto aliases = new wxXmlNode(wxXmlNodeType::wxXML_ELEMENT_NODE, "Aliases");
+        for (const auto& entry : submodelAliases) {
+            if (entry.first == (*a)->name) {
+                auto n = new wxXmlNode(wxXmlNodeType::wxXML_ELEMENT_NODE, "alias");
+                n->AddAttribute("name", entry.second.Lower());
+                aliases->AddChild(n);
+            }
+        }
+        child->AddChild(aliases);
 
         // If the submodel name has changed ... we need to rename the model
         if ((*a)->oldName != (*a)->name)
@@ -776,6 +796,7 @@ void SubModelsDialog::OnButton_EditClick(wxCommandEvent& event)
 {
     wxMenu mnu;
     mnu.Append(SUBMODEL_DIALOG_GENERATE, "Generate Slices");
+    mnu.Append(SUBMODEL_DIALOG_ALIASES, "Add/Edit Aliases");
     if (ListCtrl_SubModels->GetItemCount() > 0) {
         mnu.Append(SUBMODEL_DIALOG_FLIP_VER, "Flip All SubModels Vertical");
         mnu.Append(SUBMODEL_DIALOG_FLIP_HOR, "Flip All SubModels Horizontial");
@@ -850,6 +871,8 @@ void SubModelsDialog::OnEditBtnPopup(wxCommandEvent& event)
 {
     if (event.GetId() == SUBMODEL_DIALOG_GENERATE) {
         Generate();
+    } else if (event.GetId() == SUBMODEL_DIALOG_ALIASES) {
+        Aliases();
     }
     else if (event.GetId() == SUBMODEL_DIALOG_FLIP_VER) {
         FlipVertical();
@@ -2432,6 +2455,17 @@ void SubModelsDialog::MoveSelectedModelsTo(int indexTo)
         wxString first = tokenizer.GetNextToken();
         Select(first);
     }
+}
+
+void SubModelsDialog::Aliases()
+{
+    wxString submodelname = GetSelectedName();
+    if (submodelname.empty()) {
+        return;
+    }
+    EditSubmodelAliasesDialog dlg(GetParent(), model, submodelname);
+    
+    dlg.ShowModal();
 }
 
 void SubModelsDialog::Generate()

--- a/xLights/SubModelsDialog.h
+++ b/xLights/SubModelsDialog.h
@@ -225,6 +225,7 @@ protected:
     static const long SUBMODEL_DIALOG_EXPORT_XMODEL;
     static const long SUBMODEL_DIALOG_EXPORT_TOOTHERS;
     static const long SUBMODEL_DIALOG_GENERATE;
+    static const long SUBMODEL_DIALOG_ALIASES;
     static const long SUBMODEL_DIALOG_SHIFT;
     static const long SUBMODEL_DIALOG_FLIP_HOR;
     static const long SUBMODEL_DIALOG_FLIP_VER;
@@ -275,6 +276,7 @@ protected:
     void UnSelectAll();
 
     void Generate();
+    void Aliases();
     void Shift();
     void FlipHorizontal();
     void FlipVertical();

--- a/xLights/Xlights.vcxproj
+++ b/xLights/Xlights.vcxproj
@@ -293,6 +293,7 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
     <ClCompile Include="DragValueCurveBitmapButton.cpp" />
     <ClCompile Include="DuplicateDialog.cpp" />
     <ClCompile Include="EditAliasesDialog.cpp" />
+    <ClCompile Include="EditSubmodelAliasesDialog.cpp" />
     <ClCompile Include="effects\AdjustEffect.cpp" />
     <ClCompile Include="effects\AdjustPanel.cpp" />
     <ClCompile Include="effects\assist\SketchAssistPanel.cpp" />
@@ -787,6 +788,7 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
     <ClInclude Include="DragValueCurveBitmapButton.h" />
     <ClInclude Include="DuplicateDialog.h" />
     <ClInclude Include="EditAliasesDialog.h" />
+    <ClInclude Include="EditSubmodelAliasesDialog.h" />
     <ClInclude Include="effects\AdjustEffect.h" />
     <ClInclude Include="effects\AdjustPanel.h" />
     <ClInclude Include="effects\assist\AssistPanel.h" />

--- a/xLights/Xlights.vcxproj.filters
+++ b/xLights/Xlights.vcxproj.filters
@@ -1048,6 +1048,7 @@
     <ClCompile Include="TempFileManager.cpp" />
     <ClCompile Include="xlColourData.cpp" />
     <ClCompile Include="SpecialOptions.cpp" />
+    <ClCompile Include="EditSubmodelAliasesDialog.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="BatchRenderDialog.h" />
@@ -2108,6 +2109,7 @@
     </ClInclude>
     <ClInclude Include="TempFileManager.h" />
     <ClInclude Include="xlColourData.h" />
+    <ClInclude Include="EditSubmodelAliasesDialog.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Models">

--- a/xLights/wxsmith/EditSubmodelAliasesDialog.wxs
+++ b/xLights/wxsmith/EditSubmodelAliasesDialog.wxs
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<wxsmith>
+	<object class="wxDialog" name="EditSubmodelAliasesDialog">
+		<title>Submodel Aliases</title>
+		<id_arg>0</id_arg>
+		<style>wxCAPTION|wxRESIZE_BORDER|wxMAXIMIZE_BOX</style>
+		<object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
+			<cols>2</cols>
+			<growablecols>0</growablecols>
+			<growablerows>0</growablerows>
+			<object class="sizeritem">
+				<object class="wxListBox" name="ID_LISTBOX1" variable="ListBoxAliases" member="yes">
+					<default>-1</default>
+					<style>wxLB_SINGLE|wxLB_SORT</style>
+					<handler function="OnListBoxAliasesSelect" entry="EVT_LISTBOX" />
+				</object>
+				<flag>wxALL|wxEXPAND</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxFlexGridSizer" variable="FlexGridSizer2" member="no">
+					<cols>1</cols>
+					<object class="sizeritem">
+						<object class="wxButton" name="ID_BUTTON1" variable="ButtonAdd" member="yes">
+							<label>Add</label>
+							<handler function="OnButtonAddClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxButton" name="ID_BUTTON2" variable="ButtonDelete" member="yes">
+							<label>Delete</label>
+							<handler function="OnButtonDeleteClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxFlexGridSizer" variable="FlexGridSizer3" member="no">
+					<cols>3</cols>
+					<object class="sizeritem">
+						<object class="wxButton" name="ID_BUTTON3" variable="ButtonOk" member="yes">
+							<label>Ok</label>
+							<default>1</default>
+							<handler function="OnButtonOkClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxButton" name="ID_BUTTON4" variable="ButtonCancel" member="yes">
+							<label>Cancel</label>
+							<handler function="OnButtonCancelClick" entry="EVT_BUTTON" />
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+		</object>
+	</object>
+</wxsmith>

--- a/xLights/xLights.cbp
+++ b/xLights/xLights.cbp
@@ -537,6 +537,8 @@
 		<Unit filename="DuplicateDialog.h" />
 		<Unit filename="EditAliasesDialog.cpp" />
 		<Unit filename="EditAliasesDialog.h" />
+		<Unit filename="EditSubmodelAliasesDialog.cpp" />
+		<Unit filename="EditSubmodelAliasesDialog.h" />
 		<Unit filename="EffectAssist.cpp" />
 		<Unit filename="EffectAssist.h" />
 		<Unit filename="EffectIconPanel.cpp" />
@@ -721,6 +723,8 @@
 		<Unit filename="SevenSegmentDialog.h" />
 		<Unit filename="ShaderDownloadDialog.cpp" />
 		<Unit filename="ShaderDownloadDialog.h" />
+		<Unit filename="SpecialOptions.cpp" />
+		<Unit filename="SpecialOptions.h" />
 		<Unit filename="SplashDialog.cpp" />
 		<Unit filename="SplashDialog.h" />
 		<Unit filename="StartChannelDialog.cpp" />
@@ -1353,8 +1357,6 @@
 		<Unit filename="sequencer/Waveform.h" />
 		<Unit filename="sequencer/tabSequencer.cpp" />
 		<Unit filename="serial.h" />
-		<Unit filename="SpecialOptions.cpp" />
-		<Unit filename="SpecialOptions.h" />
 		<Unit filename="support/EzGrid.cpp" />
 		<Unit filename="support/EzGrid.h" />
 		<Unit filename="support/FastComboEditor.cpp" />
@@ -1451,6 +1453,7 @@
 		<Unit filename="wxsmith/DuplicateDialog.wxs" />
 		<Unit filename="wxsmith/DuplicatePanel.wxs" />
 		<Unit filename="wxsmith/EditAliasesDialog.wxs" />
+		<Unit filename="wxsmith/EditSubmodelAliasesDialog.wxs" />
 		<Unit filename="wxsmith/EffectAssist.wxs" />
 		<Unit filename="wxsmith/EffectIconPanel.wxs" />
 		<Unit filename="wxsmith/EffectTimingDialog.wxs" />
@@ -1811,6 +1814,7 @@
 					<wxDialog wxs="wxsmith/FPPUploadProgressDialog.wxs" src="controllers/FPPUploadProgressDialog.cpp" hdr="controllers/FPPUploadProgressDialog.h" fwddecl="0" i18n="1" name="FPPUploadProgressDialog" language="CPP" />
 					<wxDialog wxs="wxsmith/AutoLabelDialog.wxs" src="AutoLabelDialog.cpp" hdr="AutoLabelDialog.h" fwddecl="0" i18n="1" name="AutoLabelDialog" language="CPP" />
 					<wxDialog wxs="wxsmith/EditAliasesDialog.wxs" src="EditAliasesDialog.cpp" hdr="EditAliasesDialog.h" fwddecl="0" i18n="1" name="EditAliasesDialog" language="CPP" />
+					<wxDialog wxs="wxsmith/EditSubmodelAliasesDialog.wxs" src="EditSubmodelAliasesDialog.cpp" hdr="EditSubmodelAliasesDialog.h" fwddecl="0" i18n="1" name="EditSubmodelAliasesDialog" language="CPP" />
 				</resources>
 			</wxsmith>
 		</Extensions>


### PR DESCRIPTION
Aliases to be used in future changes to import mapping, this will let the user add, update and delete aliases at the submodel level.
#4214. Added to the rgbeffects.xml file:
```
      <subModel name="09 Big Petals- Odd" layout="horizontal" type="ranges" bufferstyle="Default" line0="3,20,etc..etc">
        <Aliases>
          <alias name="spinner"/>
        </Aliases>
        <ControllerConnection/>
```

Added to the existing submodel menu.
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/4eade078-1c59-4b50-a1c7-4bd99e7e673e)
Using a clone of the Add aliases dialog box.
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/04f931f3-0032-48ca-8aef-255db80a62e6)
