### PR TITLE
Add lua script and code changes to update the master view of sequence…

### DIFF
--- a/documentation/xlDo Commands.txt
+++ b/documentation/xlDo Commands.txt
@@ -262,6 +262,19 @@ Get List of all the Models and Model Groups
 Response
     {"res":200, "models": ["All House","MegaTree","Arch1","Arch2","Outline","WindowFrame1"]}
 
+Get List of all the Views from an open Sequence
+    {"cmd":"getViews"}
+Response
+    {"res":200, "views": ["Master View","Singing","Template"]}
+    {"res":503, "msg": "No sequence open."}
+
+Make a given view the Master View
+    {"cmd":"makeMaster" "view": "viewname"}
+Response
+    {"res":200}
+    {"res":503, "msg": "No sequence open."}
+    {"res":504, "msg": "No template view selected."}
+
 Get List of all the Controllers
     {"cmd":"getControllers"}
 Response

--- a/scripts/MakeMaster.lua
+++ b/scripts/MakeMaster.lua
@@ -1,0 +1,87 @@
+--
+-- 
+-- Select View from a sequence and Make it the Master View for selected Sequences
+--
+
+ShowMessage("First step ... Select a template sequence.")
+template_seq = PromptSequences()
+if #template_seq < 1 then
+	Log("You must select a template sequence. Abort")
+	return
+end
+if #template_seq > 1 then
+	Log("You should only select 1 template sequence. Abort")
+	return
+end
+
+properties = {}
+properties['seq'] = template_seq[1]
+Log("Template Sequence: "..template_seq[1])
+properties['promptIssues'] = 'false'
+result = RunCommand('openSequence', properties)
+
+properties = {}
+views_str = RunCommand('getViews', properties)
+
+if views_str['res'] == 503 then
+	Log(views_str['msg'])
+    return -- Exit the script or the Lua interpreter
+end
+
+views = views_str['views']
+sel_view = PromptSelection(views,'Select View')
+Log("Status: "..sel_view)
+
+if sel_view == "Master View" then
+	Log("Already the master view, no work to do. Abort.")
+	return
+end
+
+seqs = PromptSequences()
+
+-- Close the template sequence
+properties = {}
+properties['quiet'] = 'true'
+properties['force'] = 'true'	
+result = RunCommand('closeSequence', properties)
+Log("Status: "..result['msg'])
+	
+ for i,seq in ipairs(seqs) do 
+	Log("Processing .. "..seq)
+	--
+	-- Open Sequence
+	--
+    properties = {}
+    properties['seq'] = seq
+	properties['promptIssues'] = 'false'
+    result = RunCommand('openSequence', properties)
+	Log("SequenceName: "..result['seq'].."Sequence Opened.")
+	--
+	-- Make the selected view, the master view
+	--
+    properties = {}
+    properties['view'] = sel_view
+    result = RunCommand('makeMaster', properties)
+	Log("Status: "..result['msg'].." Code: "..result['res'].." View: "..sel_view)
+	
+	--
+	-- Save the sequence
+	--
+	if result['res'] == 200 then
+		properties = {}
+		properties['seq'] = seq
+		result = RunCommand('saveSequence', properties)
+		Log("Status: "..result['msg'])
+	else
+		Log("Error: Sequence not saved.")
+	end
+	--
+	-- Close the sequence
+	--
+	properties = {}
+	properties['quiet'] = 'true'
+	properties['force'] = 'true'	
+	result = RunCommand('closeSequence', properties)
+    Log("Status: "..result['msg'])
+ end
+Log("Done.")

--- a/xLights/ViewsModelsPanel.cpp
+++ b/xLights/ViewsModelsPanel.cpp
@@ -2487,7 +2487,7 @@ void ViewsModelsPanel::RemoveModelFromLists(const std::string& modelName)
     }
 }
 
-void ViewsModelsPanel::OnButton_MakeMasterClick(wxCommandEvent& event)
+void ViewsModelsPanel::DoMakeMaster()
 {
     // this should never happen
     if (_sequenceElements == nullptr || _sequenceViewManager == nullptr) return;
@@ -2500,7 +2500,7 @@ void ViewsModelsPanel::OnButton_MakeMasterClick(wxCommandEvent& event)
     if (view != nullptr) {
         auto models = view->GetModels();
 
-//        bool hadEffects = false;
+        //        bool hadEffects = false;
         std::vector<std::string> hadEffects;
         for (int i = 0; i < _sequenceElements->GetElementCount(MASTER_VIEW); ++i) {
             std::string name = _sequenceElements->GetElement(i)->GetFullName();
@@ -2515,18 +2515,18 @@ void ViewsModelsPanel::OnButton_MakeMasterClick(wxCommandEvent& event)
                         //_sequenceElements->DeleteElement(name); //this removes models not found in the "new" master view from ALL Views, not just the master view, causing models to disappear from random Views
                         RemoveModelFromLists(name);
                         --i;
-                    }
+                    } 
                     else {
-//                        hadEffects = true;
+                        //                        hadEffects = true;
                         hadEffects.push_back(name);
                     }
                 }
             }
         }
 
-//        if (hadEffects) {
+        //        if (hadEffects) {
         if (hadEffects.size()) { //show which one(s)
-//            DisplayWarning("One or more models had effects on them so they were not removed.");
+            //            DisplayWarning("One or more models had effects on them so they were not removed.");
             std::string msg = std::to_string(hadEffects.size()) + " model";
             if (hadEffects.size() != 1) msg += "s"; //OCD/grammar police :P
             msg += " had effects, were not removed: ";
@@ -2556,6 +2556,11 @@ void ViewsModelsPanel::OnButton_MakeMasterClick(wxCommandEvent& event)
 
         ValidateWindow();
     }
+}
+
+void ViewsModelsPanel::OnButton_MakeMasterClick(wxCommandEvent& event)
+{
+    DoMakeMaster();
 }
 
 int wxCALLBACK MyCompareFunctionVMPAsc(wxIntPtr item1, wxIntPtr item2, wxIntPtr sortData)

--- a/xLights/ViewsModelsPanel.h
+++ b/xLights/ViewsModelsPanel.h
@@ -138,6 +138,7 @@ public:
     void OnListCtrlItemCheck(wxCommandEvent& event);
     void UpdateModelsForSelectedView();
     void RemoveModelFromLists(const std::string& modelName);
+    void DoMakeMaster();
 
     //(*Declarations(ViewsModelsPanel)
     wxButton* ButtonClone;

--- a/xLights/automation/xLightsAutomations.cpp
+++ b/xLights/automation/xLightsAutomations.cpp
@@ -868,6 +868,36 @@ bool xLightsFrame::ProcessAutomation(std::vector<std::string> &paths,
         models = "[" + models + "]";
         return sendResponse(models, "models", 200, true);
         
+    } else if (cmd == "getViews") {
+        std::string views; 
+        if (CurrentSeqXmlFile == nullptr) {
+            return sendResponse("No sequence open.", "msg", 503, false);
+        }
+        auto AllViews = GetViewsManager()->GetViews();
+        for (auto it = AllViews.begin(); it != AllViews.end(); ++it) {
+            views += "\"" + JSONSafe((*it)->GetName()) + "\",";            
+        }
+        if (!views.empty()) {
+            views.pop_back(); // remove last comma
+        }
+        views = "[" + views + "]";
+        return sendResponse(views, "views", 200, true);
+
+    } else if (cmd == "makeMaster") {
+        if (CurrentSeqXmlFile == nullptr) {
+            return sendResponse("No sequence open.", "msg", 503, false);
+        }
+        if (params["view"].empty()) {
+            return sendResponse("No template view selected.", "msg", 504, false);
+        }
+        auto view = params["view"];
+
+        displayElementsPanel->SelectView(view);
+
+        // Click on the Make Master item
+        displayElementsPanel->DoMakeMaster();
+        std::string response = "{\"msg\":\"Master view updated.\"}";
+        return sendResponse(response, "", 200, true);
     } else if (cmd == "getModel") {
         auto model = params["model"];
         auto m = AllModels.GetModel(model);


### PR DESCRIPTION
The script lets you choose a "template" sequence to grab the new master view then use that to update all the chose sequences with this new master view. A way to go thru all your sequences and either update the render order or add a new prop or props
#4433
Note Devs: Please check my handling of the ViewModelsPanel.cpp. I needed to call the same code as the button click but it was hidden in a private call. So I pulled it out and made the button call the new proc. 