### PR TITLE
Save and use 3d mode stored with layout #2138

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -480,7 +480,7 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
     is_3d = config->ReadBool("LayoutMode3D", false);
     bool allow_3d_previews = true; //false; //set to false for previous behavior
 
-    CheckBox_3D->SetValue(is_3d);
+    CheckBox_3D->SetValue(is_3d); 
     xlights->GetHousePreview()->Set3D(is_3d);
 
     if (!allow_3d_previews && is_3d)
@@ -8921,6 +8921,7 @@ void LayoutPanel::OnCheckBox_3DClick(wxCommandEvent& event)
 
     wxConfigBase* config = wxConfigBase::Get();
     config->Write("LayoutMode3D", is_3d);
+    xlights->SetXmlSetting("LayoutMode3D", is_3d ? "1" : "0");
     Refresh();
 }
 

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -480,7 +480,7 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
     is_3d = config->ReadBool("LayoutMode3D", false);
     bool allow_3d_previews = true; //false; //set to false for previous behavior
 
-    CheckBox_3D->SetValue(is_3d); 
+    CheckBox_3D->SetValue(is_3d);
     xlights->GetHousePreview()->Set3D(is_3d);
 
     if (!allow_3d_previews && is_3d)

--- a/xLights/TabSequence.cpp
+++ b/xLights/TabSequence.cpp
@@ -260,6 +260,7 @@ wxString xLightsFrame::LoadEffectsFileNoCheck()
         root->AddChild(SettingsNode);
         SetXmlSetting("previewWidth", "1280");
         SetXmlSetting("previewHeight", "720");
+        SetXmlSetting("LayoutMode3D", "0");
         UnsavedRgbEffectsChanges = true;
     }
     int previewWidth = wxAtoi(GetXmlSetting("previewWidth", "1280"));
@@ -374,6 +375,9 @@ wxString xLightsFrame::LoadEffectsFileNoCheck()
         modelPreview->SetBackgroundBrightness(layoutPanel->GetBackgroundBrightnessForSelectedPreview(), layoutPanel->GetBackgroundAlphaForSelectedPreview());
         modelPreview->SetScaleBackgroundImage(layoutPanel->GetBackgroundScaledForSelectedPreview());
     }
+    bool is_3d = GetXmlSetting("LayoutMode3D", "0") == "1";
+    modelPreview->Set3D(is_3d);
+    layoutPanel->CheckBox_3D->SetValue(is_3d);
 
     UpdateLayoutSave();
     UpdateControllerSave();

--- a/xLights/TabSetup.cpp
+++ b/xLights/TabSetup.cpp
@@ -1575,6 +1575,8 @@ void xLightsFrame::InitialiseControllersTab(bool rebuildPropGrid) {
         List_Controllers->EnsureVisible(itemSelected);
     }
 
+    Panel2->SetMinSize(wxSize(400, -1));
+    Panel5->SetMinSize(wxSize(600, -1));
     List_Controllers->Thaw();
 
     Panel2->Layout();


### PR DESCRIPTION
This will put the 3d flag in the rgb_effects file so as you switch folders it will recognize and flip to the 2d or 3d as needed.
Note that it will assume 2d until it sees this setting in the rgb_effects file so you will likely need to click it once as you first open that 3d show folder. #2138 
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/0c2979f1-a990-4d54-871a-794783f18c6f)
