### PR TITLE
Show any model warnings prior to editing Face Dialog #2403

### DIFF
--- a/xLights/ModelFaceDialog.cpp
+++ b/xLights/ModelFaceDialog.cpp
@@ -198,6 +198,8 @@ ModelFaceDialog::ModelFaceDialog(wxWindow* parent, OutputManager* outputManager,
 	FlexGridSizer8->Add(SingleNodeGrid, 1, wxALL|wxEXPAND, 0);
 	FlexGridSizer2->Add(FlexGridSizer8, 1, wxALL|wxEXPAND, 0);
 	CoroPanel->SetSizer(FlexGridSizer2);
+	FlexGridSizer2->Fit(CoroPanel);
+	FlexGridSizer2->SetSizeHints(CoroPanel);
 	NodeRangePanel = new wxPanel(FaceTypeChoice, ID_PANEL6, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("ID_PANEL6"));
 	FlexGridSizer5 = new wxFlexGridSizer(0, 2, 0, 0);
 	FlexGridSizer5->AddGrowableCol(1);
@@ -248,6 +250,8 @@ ModelFaceDialog::ModelFaceDialog(wxWindow* parent, OutputManager* outputManager,
 	FlexGridSizer9->Add(NodeRangeGrid, 1, wxALL|wxEXPAND, 0);
 	FlexGridSizer5->Add(FlexGridSizer9, 1, wxALL|wxEXPAND, 0);
 	NodeRangePanel->SetSizer(FlexGridSizer5);
+	FlexGridSizer5->Fit(NodeRangePanel);
+	FlexGridSizer5->SetSizeHints(NodeRangePanel);
 	Matrix = new wxPanel(FaceTypeChoice, ID_PANEL3, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("ID_PANEL3"));
 	FlexGridSizer3 = new wxFlexGridSizer(0, 2, 0, 0);
 	FlexGridSizer3->AddGrowableCol(1);
@@ -295,6 +299,8 @@ ModelFaceDialog::ModelFaceDialog(wxWindow* parent, OutputManager* outputManager,
 	FlexGridSizer10->Add(MatrixModelsGrid, 1, wxALL|wxEXPAND, 0);
 	FlexGridSizer3->Add(FlexGridSizer10, 1, wxALL|wxEXPAND, 0);
 	Matrix->SetSizer(FlexGridSizer3);
+	FlexGridSizer3->Fit(Matrix);
+	FlexGridSizer3->SetSizeHints(Matrix);
 	FaceTypeChoice->AddPage(CoroPanel, _("Single Nodes"), false);
 	FaceTypeChoice->AddPage(NodeRangePanel, _("Node Ranges"), false);
 	FaceTypeChoice->AddPage(Matrix, _("Matrix"), false);
@@ -305,47 +311,52 @@ ModelFaceDialog::ModelFaceDialog(wxWindow* parent, OutputManager* outputManager,
 	StdDialogButtonSizer1->Realize();
 	FlexGridSizer4->Add(StdDialogButtonSizer1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	Panel3->SetSizer(FlexGridSizer4);
+	FlexGridSizer4->Fit(Panel3);
+	FlexGridSizer4->SetSizeHints(Panel3);
 	ModelPreviewPanelLocation = new wxPanel(SplitterWindow1, ID_PANEL1, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("ID_PANEL1"));
 	PreviewSizer = new wxFlexGridSizer(1, 1, 0, 0);
 	PreviewSizer->AddGrowableCol(0);
 	PreviewSizer->AddGrowableRow(0);
 	ModelPreviewPanelLocation->SetSizer(PreviewSizer);
+	PreviewSizer->Fit(ModelPreviewPanelLocation);
+	PreviewSizer->SetSizeHints(ModelPreviewPanelLocation);
 	SplitterWindow1->SplitVertically(Panel3, ModelPreviewPanelLocation);
 	FlexGridSizer1->Add(SplitterWindow1, 0, wxEXPAND, 0);
 	SetSizer(FlexGridSizer1);
+	FlexGridSizer1->Fit(this);
 	FlexGridSizer1->SetSizeHints(this);
 
 	Connect(ID_CHOICE3, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ModelFaceDialog::OnMatrixNameChoiceSelect);
-	Connect(ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnButtonMatrixAddClicked);
-	Connect(ID_BUTTON_IMPORT, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnButtonImportClick);
-	Connect(ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnButtonMatrixDeleteClick);
-	Panel_SingleNode->Connect(wxEVT_PAINT, (wxObjectEventFunction)&ModelFaceDialog::Paint, NULL, this);
-	Connect(ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnCustomColorCheckboxClick);
-	Connect(ID_GRID_COROFACES, wxEVT_GRID_CELL_LEFT_CLICK, (wxObjectEventFunction)&ModelFaceDialog::OnSingleNodeGridCellLeftClick);
-	Connect(ID_GRID_COROFACES, wxEVT_GRID_CELL_LEFT_DCLICK, (wxObjectEventFunction)&ModelFaceDialog::OnSingleNodeGridCellLeftDClick);
-	Connect(ID_GRID_COROFACES, wxEVT_GRID_CELL_CHANGED, (wxObjectEventFunction)&ModelFaceDialog::OnSingleNodeGridCellChange);
-	Connect(ID_GRID_COROFACES, wxEVT_GRID_SELECT_CELL, (wxObjectEventFunction)&ModelFaceDialog::OnSingleNodeGridCellSelect);
-	SingleNodeGrid->Connect(wxEVT_SIZE, (wxObjectEventFunction)&ModelFaceDialog::OnSingleNodeGridResize, NULL, this);
-	Panel_NodeRanges->Connect(wxEVT_PAINT, (wxObjectEventFunction)&ModelFaceDialog::Paint, NULL, this);
-	Connect(ID_CHECKBOX2, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnCustomColorCheckboxClick);
-	Connect(ID_CHECKBOX3, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnCheckBox_OutputToLightsClick);
-	Connect(ID_GRID3, wxEVT_GRID_CELL_LEFT_CLICK, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridCellLeftClick);
-	Connect(ID_GRID3, wxEVT_GRID_CELL_RIGHT_CLICK, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridCellRightClick);
-	Connect(ID_GRID3, wxEVT_GRID_CELL_LEFT_DCLICK, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridCellLeftDClick);
-	Connect(ID_GRID3, wxEVT_GRID_LABEL_LEFT_DCLICK, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridLabelLeftDClick);
-	Connect(ID_GRID3, wxEVT_GRID_CELL_CHANGED, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridCellChange);
-	Connect(ID_GRID3, wxEVT_GRID_SELECT_CELL, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridCellSelect);
-	NodeRangeGrid->Connect(wxEVT_SIZE, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridResize, NULL, this);
-	Panel_Matrix->Connect(wxEVT_PAINT, (wxObjectEventFunction)&ModelFaceDialog::Paint, NULL, this);
-	Connect(ID_CHOICE2, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ModelFaceDialog::OnMatricImagePlacementChoiceSelect);
-	Connect(ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnButton_DownloadImagesClick);
-	Connect(ID_GRID1, wxEVT_GRID_CELL_LEFT_CLICK, (wxObjectEventFunction)&ModelFaceDialog::OnMatrixModelsGridCellLeftClick1);
-	Connect(ID_GRID1, wxEVT_GRID_CELL_LEFT_DCLICK, (wxObjectEventFunction)&ModelFaceDialog::OnMatrixModelsGridCellLeftClick);
-	Connect(ID_GRID1, wxEVT_GRID_LABEL_LEFT_DCLICK, (wxObjectEventFunction)&ModelFaceDialog::OnMatrixModelsGridLabelLeftDClick);
-	Connect(ID_GRID1, wxEVT_GRID_CELL_CHANGED, (wxObjectEventFunction)&ModelFaceDialog::OnMatrixModelsGridCellChange);
-	Connect(ID_GRID1, wxEVT_GRID_SELECT_CELL, (wxObjectEventFunction)&ModelFaceDialog::OnMatrixModelsGridCellSelect);
-	MatrixModelsGrid->Connect(wxEVT_SIZE, (wxObjectEventFunction)&ModelFaceDialog::OnMatrixModelsGridResize, NULL, this);
-	Connect(ID_CHOICEBOOK1, wxEVT_COMMAND_CHOICEBOOK_PAGE_CHANGED, (wxObjectEventFunction)&ModelFaceDialog::OnFaceTypeChoicePageChanged);
+    Connect(ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnButtonMatrixAddClicked);
+    Connect(ID_BUTTON_IMPORT, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnButtonImportClick);
+    Connect(ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnButtonMatrixDeleteClick);
+    Panel_SingleNode->Connect(wxEVT_PAINT, (wxObjectEventFunction)&ModelFaceDialog::Paint, NULL, this);
+    Connect(ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnCustomColorCheckboxClick);
+    Connect(ID_GRID_COROFACES, wxEVT_GRID_CELL_LEFT_CLICK, (wxObjectEventFunction)&ModelFaceDialog::OnSingleNodeGridCellLeftClick);
+    Connect(ID_GRID_COROFACES, wxEVT_GRID_CELL_LEFT_DCLICK, (wxObjectEventFunction)&ModelFaceDialog::OnSingleNodeGridCellLeftDClick);
+    Connect(ID_GRID_COROFACES, wxEVT_GRID_CELL_CHANGED, (wxObjectEventFunction)&ModelFaceDialog::OnSingleNodeGridCellChange);
+    Connect(ID_GRID_COROFACES, wxEVT_GRID_SELECT_CELL, (wxObjectEventFunction)&ModelFaceDialog::OnSingleNodeGridCellSelect);
+    SingleNodeGrid->Connect(wxEVT_SIZE, (wxObjectEventFunction)&ModelFaceDialog::OnSingleNodeGridResize, NULL, this);
+    Panel_NodeRanges->Connect(wxEVT_PAINT, (wxObjectEventFunction)&ModelFaceDialog::Paint, NULL, this);
+    Connect(ID_CHECKBOX2, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnCustomColorCheckboxClick);
+    Connect(ID_CHECKBOX3, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnCheckBox_OutputToLightsClick);
+    Connect(ID_GRID3, wxEVT_GRID_CELL_LEFT_CLICK, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridCellLeftClick);
+    Connect(ID_GRID3, wxEVT_GRID_CELL_RIGHT_CLICK, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridCellRightClick);
+    Connect(ID_GRID3, wxEVT_GRID_CELL_LEFT_DCLICK, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridCellLeftDClick);
+    Connect(ID_GRID3, wxEVT_GRID_LABEL_LEFT_DCLICK, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridLabelLeftDClick);
+    Connect(ID_GRID3, wxEVT_GRID_CELL_CHANGED, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridCellChange);
+    Connect(ID_GRID3, wxEVT_GRID_SELECT_CELL, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridCellSelect);
+    NodeRangeGrid->Connect(wxEVT_SIZE, (wxObjectEventFunction)&ModelFaceDialog::OnNodeRangeGridResize, NULL, this);
+    Panel_Matrix->Connect(wxEVT_PAINT, (wxObjectEventFunction)&ModelFaceDialog::Paint, NULL, this);
+    Connect(ID_CHOICE2, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ModelFaceDialog::OnMatricImagePlacementChoiceSelect);
+    Connect(ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelFaceDialog::OnButton_DownloadImagesClick);
+    Connect(ID_GRID1, wxEVT_GRID_CELL_LEFT_CLICK, (wxObjectEventFunction)&ModelFaceDialog::OnMatrixModelsGridCellLeftClick1);
+    Connect(ID_GRID1, wxEVT_GRID_CELL_LEFT_DCLICK, (wxObjectEventFunction)&ModelFaceDialog::OnMatrixModelsGridCellLeftClick);
+    Connect(ID_GRID1, wxEVT_GRID_LABEL_LEFT_DCLICK, (wxObjectEventFunction)&ModelFaceDialog::OnMatrixModelsGridLabelLeftDClick);
+    Connect(ID_GRID1, wxEVT_GRID_CELL_CHANGED, (wxObjectEventFunction)&ModelFaceDialog::OnMatrixModelsGridCellChange);
+    Connect(ID_GRID1, wxEVT_GRID_SELECT_CELL, (wxObjectEventFunction)&ModelFaceDialog::OnMatrixModelsGridCellSelect);
+    MatrixModelsGrid->Connect(wxEVT_SIZE, (wxObjectEventFunction)&ModelFaceDialog::OnMatrixModelsGridResize, NULL, this);
+    Connect(ID_CHOICEBOOK1, wxEVT_COMMAND_CHOICEBOOK_PAGE_CHANGED, (wxObjectEventFunction)&ModelFaceDialog::OnFaceTypeChoicePageChanged);
 	//*)
 
     model = nullptr;
@@ -463,6 +474,15 @@ void ModelFaceDialog::SetFaceInfo(Model *cls, std::map< std::string, std::map<st
     }
 
     UpdatePreview("", *wxWHITE);
+    std::list<std::string> warnings = cls->CheckModelSettings();
+    if (!warnings.empty()) {
+        std::string warningsStr;
+        for (const auto& warning : warnings) {
+            warningsStr += warning + "\n";
+        }
+        // Show the concatenated warnings in a wxMessageBox
+        wxMessageBox(wxString(warningsStr), "Warnings", wxOK | wxICON_WARNING);
+    }
 }
 
 void ModelFaceDialog::GetFaceInfo(std::map< std::string, std::map<std::string, std::string> > &finfo) {


### PR DESCRIPTION
Warn users prior to making changes in the face submodels of potential problems with the model itself. #2403
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/0271ebfb-cdc2-4bef-b590-47b8cf0df82c)
