### PR TITLE
xschedule build fails - assuming std or wxwidgets?

### DIFF
--- a/include/xs_brightness_down.xpm
+++ b/include/xs_brightness_down.xpm
@@ -1,8 +1,9 @@
 /* XPM */
-static char * xs_brightness_down[] = {
+static const char *xs_brightness_down[] = {
 "32 32 2 1",
 " 	c None",
 ".	c #6AC259",
+/* pixels */
 "                                ",
 "                                ",
 "                                ",

--- a/include/xs_brightness_up.xpm
+++ b/include/xs_brightness_up.xpm
@@ -1,8 +1,9 @@
 /* XPM */
-static char * xs_brightness_up[] = {
+static const char *xs_brightness_up[] = {
 "32 32 2 1",
 " 	c None",
 ".	c #6AC259",
+/* pixels */
 "                                ",
 "               ..               ",
 "               ..               ",


### PR DESCRIPTION
Not sure why this is needed but I compared to the others that were working.