### PR TITLE
Flag in Visualizer when Group Count puts you over the Pixel limit #3577

### DIFF
--- a/xLights/controllers/ControllerUploadData.h
+++ b/xLights/controllers/ControllerUploadData.h
@@ -236,6 +236,7 @@ class UDControllerPort
     int32_t GetStartChannel() const;
 	int32_t GetEndChannel() const;
 	int32_t Channels() const;
+    int32_t EffectiveChannels(std::string vendor) const;
 
     int GetUniverse() const;
     int GetUniverseStartChannel() const;

--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -7142,7 +7142,7 @@ void Model::SetControllerColorOrder(wxString const& color)
 
 void Model::SetControllerGroupCount(int grouping)
 {
-    if (grouping == wxAtoi(GetControllerConnection()->GetAttribute("groupCount", "1"))) {
+    if (grouping == wxAtoi(GetControllerConnection()->GetAttribute("groupCount", "0"))) {
         return;
     }
     GetControllerConnection()->DeleteAttribute("groupCount");


### PR DESCRIPTION
Specifically for Falcon (and coded as such) if a group count is set on the port it is used for all the remaining models on the port. This has the potential to put you over the pixel limit for the port. An upload would fail, this PR finds that issue and flags it in the visualizer. Also the right click to set the group count was altered to let you reset it back to 1 as needed. Previously it would ignore the attempt to set it to 1 - since that is normally just the default setting.
Q: Is Falcon the only one (that has virtual strings and group count) that does it this way? I didnt see anything in xcontroller that I could use either. #3577 
Note I didnt see an easy way to code #4315 (for group count) without getting it real messy.