### PR TITLE
Use the rotation if set in Tree to show model preview correctly #3231

### DIFF
--- a/xLights/models/TreeModel.cpp
+++ b/xLights/models/TreeModel.cpp
@@ -170,10 +170,10 @@ void TreeModel::SetTreeCoord(long degrees)
                 double xt = topradius * sin(angle);
                 double zb = radius * cos(angle);
                 double zt = topradius * cos(angle);
-                double yb = ybot;
-                double yt = ytop;
-                // double yb = ybot - perspective * radius * cos(angle);
-                // double yt = ytop - perspective * topradius * cos(angle);
+                //double yb = ybot;
+                //double yt = ytop;
+                double yb = ybot - perspective * radius * cos(angle);
+                double yt = ytop - perspective * topradius * cos(angle);
                 double posOnString = 0.5;
                 if (BufferHt > 1) {
                     posOnString = yPos[bufferY] / (double)(BufferHt - 1.0);


### PR DESCRIPTION
This is an old bug .. @dkulp @AzGilrock  I simply removed the comments and re-enabled the code from late 2018 - when the bug was introduced. I went back and found 2019.01 was the first time it broke.
Either of you know the history here? It seems to work just fine with this re-enabled code.
#3231 
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/3e0e1ef1-0b22-43ef-8ea2-4da87e890d38)
@keithsw1111 adding keith here as he commented on the bug ticket.
PR that did the change.
https://github.com/xLightsSequencer/xLights/commit/3f63e274d780dffef99b55a16631d7306354be07