### PR TITLE
Handle missing model type on Base Folder creation #4441

### DIFF
--- a/xLights/models/ModelManager.cpp
+++ b/xLights/models/ModelManager.cpp
@@ -1363,6 +1363,9 @@ Model* ModelManager::CreateModel(wxXmlNode* node, int previewW, int previewH, bo
         return grp;
     }
     std::string type = node->GetAttribute("DisplayAs").ToStdString();
+    if (type.empty()) {
+        if (Lower(node->GetName().ToStdString()) == "custommodel") type = "Custom";
+    }
 
     // Upgrade older DMX models
     if (type == "DMX") {


### PR DESCRIPTION
When creating a base show folder it throws a warning that it cant determine the type of the model. It appears to be a slightly different format of xml and hence needs this little change to handle that situation #4441 