### PR TITLE
Add preference to override color highlighting #3446

### DIFF
--- a/xLights/ColorManager.cpp
+++ b/xLights/ColorManager.cpp
@@ -208,7 +208,7 @@ void ColorManager::Load(wxXmlNode* colors_node)
 {
 	if (colors_node != nullptr)
 	{
-        colors.clear();
+        ResetDefaults();
         for (wxXmlNode* c = colors_node->GetChildren(); c != nullptr; c = c->GetNext())
         {
             std::string name = c->GetName().ToStdString();

--- a/xLights/ColorManager.h
+++ b/xLights/ColorManager.h
@@ -104,7 +104,7 @@ class ColorManager
         void SetNewColor(std::string name, xlColor& color);
         xlColor GetColor(ColorNames name);
         const xlColor* GetColorPtr(ColorNames name);
-  
+ 
         void Snapshot();
         void RestoreSnapshot();
 

--- a/xLights/ColorManager.h
+++ b/xLights/ColorManager.h
@@ -104,7 +104,7 @@ class ColorManager
         void SetNewColor(std::string name, xlColor& color);
         xlColor GetColor(ColorNames name);
         const xlColor* GetColorPtr(ColorNames name);
- 
+
         void Snapshot();
         void RestoreSnapshot();
 

--- a/xLights/ColorManager.h
+++ b/xLights/ColorManager.h
@@ -58,6 +58,8 @@ class ColorManager
             COLOR_EFFECT_SELECTED_DISABLED,
             COLOR_REFERENCE_EFFECT_DISABLED,
             COLOR_WAVEFORM_MOUSE_MARKER,
+            COLOR_TEXT_UNSELECTED,
+            COLOR_TEXT_HIGHLIGHTED,
             NUM_COLORS
         };
 
@@ -102,7 +104,7 @@ class ColorManager
         void SetNewColor(std::string name, xlColor& color);
         xlColor GetColor(ColorNames name);
         const xlColor* GetColorPtr(ColorNames name);
-
+  
         void Snapshot();
         void RestoreSnapshot();
 
@@ -150,7 +152,9 @@ class ColorManager
             { ColorManager::ColorNames::COLOR_EFFECT_SELECTED_DISABLED, "EffectSelectedDisabled", "Selected Disabled Effects", xlColor(200, 200, 64), ColorManager::ColorCategory::COLOR_CAT_EFFECT_GRID },
 
             { ColorManager::ColorNames::COLOR_REFERENCE_EFFECT_DISABLED, "ReferenceEffectDisabled", "Disabled Reference Effect", xlColor(255, 255, 127), ColorManager::ColorCategory::COLOR_CAT_EFFECT_GRID },
-            { ColorManager::ColorNames::COLOR_WAVEFORM_MOUSE_MARKER, "WaveformMouseMarker", "Waveform Mouse Marker", xlColor(0, 0, 255), ColorManager::ColorCategory::COLOR_CAT_EFFECT_GRID }
+            { ColorManager::ColorNames::COLOR_WAVEFORM_MOUSE_MARKER, "WaveformMouseMarker", "Waveform Mouse Marker", xlColor(0, 0, 255), ColorManager::ColorCategory::COLOR_CAT_EFFECT_GRID },
+            { ColorManager::ColorNames::COLOR_TEXT_UNSELECTED, "TextUnselected", "Unselected Text", xlLIGHT_GREY, ColorManager::ColorCategory::COLOR_CAT_LAYOUT_TAB },
+            { ColorManager::ColorNames::COLOR_TEXT_HIGHLIGHTED, "TextHighlighted", "Highlighted Text", xlBLUE, ColorManager::ColorCategory::COLOR_CAT_LAYOUT_TAB }
         };
 
     protected:

--- a/xLights/UtilFunctions.cpp
+++ b/xLights/UtilFunctions.cpp
@@ -24,6 +24,7 @@
 #include <time.h>
 #include <thread>
 
+#include "ColorManager.h"
 #include "UtilFunctions.h"
 #include "xLightsVersion.h"
 #include "ExternalHooks.h"
@@ -1394,22 +1395,35 @@ void DumpBinary(uint8_t* buffer, size_t sz)
 
 wxColor CyanOrBlue()
 {
-    if (IsDarkMode()) {
-        // In Dark Mode blue is hard to read
-        return *wxCYAN;
+    // if the color is set use that .. otherwise default to the usual
+    auto color = ColorManager::instance()->GetColorPtr(ColorManager::COLOR_TEXT_HIGHLIGHTED);
+    if (color->asWxColor() == *wxBLACK) {
+        if (IsDarkMode()) {
+            // In Dark Mode blue is hard to read
+            return *wxCYAN;
+        } else {
+            return *wxBLUE;
+        }
     } else {
-        return *wxBLUE;
+        return color->asWxColor();
     }
 }
+
 wxColor LightOrMediumGrey()
 {
-    if (IsDarkMode()) {
-        static const wxColor medGray(128, 128, 128);
-        return medGray;
+    auto color = ColorManager::instance()->GetColorPtr(ColorManager::COLOR_TEXT_UNSELECTED);
+    if (color->asWxColor() == *wxBLACK) {
+        if (IsDarkMode()) {
+            static const wxColor medGray(128, 128, 128);
+            return medGray;
+        } else {
+            return *wxLIGHT_GREY;
+        }
     } else {
-        return *wxLIGHT_GREY;
+        return color->asWxColor();
     }
 }
+
 void CleanupIpAddress(wxString& IpAddr)
 {
     static wxRegEx leadingzero1("(^0+)(?:[1-9]|0\\.)", wxRE_ADVANCED);

--- a/xLights/UtilFunctions.cpp
+++ b/xLights/UtilFunctions.cpp
@@ -1396,7 +1396,7 @@ void DumpBinary(uint8_t* buffer, size_t sz)
 wxColor CyanOrBlue()
 {
     // if the color is set use that .. otherwise default to the usual
-    auto color = ColorManager::instance()->GetColorPtr(ColorManager::COLOR_TEXT_HIGHLIGHTED);
+    const xlColor* color = ColorManager::instance()->GetColorPtr(ColorManager::COLOR_TEXT_HIGHLIGHTED);
     if (color->asWxColor() == *wxBLACK) {
         if (IsDarkMode()) {
             // In Dark Mode blue is hard to read
@@ -1411,7 +1411,7 @@ wxColor CyanOrBlue()
 
 wxColor LightOrMediumGrey()
 {
-    auto color = ColorManager::instance()->GetColorPtr(ColorManager::COLOR_TEXT_UNSELECTED);
+    const xlColor* color = ColorManager::instance()->GetColorPtr(ColorManager::COLOR_TEXT_UNSELECTED);
     if (color->asWxColor() == *wxBLACK) {
         if (IsDarkMode()) {
             static const wxColor medGray(128, 128, 128);


### PR DESCRIPTION
The preference can be used to override the cyan/blue color in lists and another to override the grey/med grey. #3446