### PR TITLE
Reverse the layers in Tree 3d Custom Model Export #4233

### DIFF
--- a/xLights/models/TreeModel.cpp
+++ b/xLights/models/TreeModel.cpp
@@ -603,7 +603,7 @@ void TreeModel::ExportAsCustomXModel3D() const
     for (auto& n : Nodes) {
         int xx = SCALE_FACTOR_3D * w * (n->Coords[0].screenX - minx) / w;
         int yy = (SCALE_FACTOR_3D * h) - (SCALE_FACTOR_3D * h * (n->Coords[0].screenY - miny) / h);
-        int zz = SCALE_FACTOR_3D * d * (n->Coords[0].screenZ - minz) / d;
+        int zz = SCALE_FACTOR_3D * d * (maxz - n->Coords[0].screenZ) / d;
         wxASSERT(xx >= 0 && xx < SCALE_FACTOR_3D * w + 1);
         wxASSERT(yy >= 0 && yy < SCALE_FACTOR_3D * h + 1);
         wxASSERT(zz >= 0 && zz < SCALE_FACTOR_3D * d + 1);


### PR DESCRIPTION
When exporting a 3d custom model of a tree, the resulting file would be front/back flipped. This corrects that. #4233 
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/f4e2b446-147f-4870-aa5b-22f1a55adc44)
