### PR TITLE
Add preference to override color highlighting #3446

### DIFF
--- a/xLights/ColorManager.cpp
+++ b/xLights/ColorManager.cpp
@@ -101,6 +101,24 @@ void ColorManager::RestoreSnapshot()
 	}
 }
 
+wxColor ColorManager::CyanOrBlueOverride() {
+    const xlColor* color = ColorManager::instance()->GetColorPtr(ColorManager::COLOR_TEXT_HIGHLIGHTED);
+    if (color->asWxColor() == *wxBLACK) {
+        return CyanOrBlue();
+    } else {
+        return color->asWxColor();
+    }
+}
+
+wxColor ColorManager::LightOrMediumGreyOverride() {
+    const xlColor* color = ColorManager::instance()->GetColorPtr(ColorManager::COLOR_TEXT_UNSELECTED);
+    if (color->asWxColor() == *wxBLACK) {
+        return LightOrMediumGrey();
+    } else {
+        return color->asWxColor();
+    }
+}
+
 void ColorManager::SetNewColor(std::string name, xlColor& color)
 {
     std::string color_name = name;
@@ -208,7 +226,7 @@ void ColorManager::Load(wxXmlNode* colors_node)
 {
 	if (colors_node != nullptr)
 	{
-        colors.clear();
+        ResetDefaults();
         for (wxXmlNode* c = colors_node->GetChildren(); c != nullptr; c = c->GetNext())
         {
             std::string name = c->GetName().ToStdString();

--- a/xLights/ColorManager.h
+++ b/xLights/ColorManager.h
@@ -58,6 +58,8 @@ class ColorManager
             COLOR_EFFECT_SELECTED_DISABLED,
             COLOR_REFERENCE_EFFECT_DISABLED,
             COLOR_WAVEFORM_MOUSE_MARKER,
+            COLOR_TEXT_UNSELECTED,
+            COLOR_TEXT_HIGHLIGHTED,
             NUM_COLORS
         };
 
@@ -108,6 +110,8 @@ class ColorManager
 
         void Save(wxXmlDocument* doc);
         void Load(wxXmlNode* colors_node);
+        wxColor CyanOrBlueOverride();
+        wxColor LightOrMediumGreyOverride();
 
         void SetDirty();
 
@@ -150,7 +154,9 @@ class ColorManager
             { ColorManager::ColorNames::COLOR_EFFECT_SELECTED_DISABLED, "EffectSelectedDisabled", "Selected Disabled Effects", xlColor(200, 200, 64), ColorManager::ColorCategory::COLOR_CAT_EFFECT_GRID },
 
             { ColorManager::ColorNames::COLOR_REFERENCE_EFFECT_DISABLED, "ReferenceEffectDisabled", "Disabled Reference Effect", xlColor(255, 255, 127), ColorManager::ColorCategory::COLOR_CAT_EFFECT_GRID },
-            { ColorManager::ColorNames::COLOR_WAVEFORM_MOUSE_MARKER, "WaveformMouseMarker", "Waveform Mouse Marker", xlColor(0, 0, 255), ColorManager::ColorCategory::COLOR_CAT_EFFECT_GRID }
+            { ColorManager::ColorNames::COLOR_WAVEFORM_MOUSE_MARKER, "WaveformMouseMarker", "Waveform Mouse Marker", xlColor(0, 0, 255), ColorManager::ColorCategory::COLOR_CAT_EFFECT_GRID },
+            { ColorManager::ColorNames::COLOR_TEXT_UNSELECTED, "TextUnselected", "Unselected Text", xlLIGHT_GREY, ColorManager::ColorCategory::COLOR_CAT_LAYOUT_TAB },
+            { ColorManager::ColorNames::COLOR_TEXT_HIGHLIGHTED, "TextHighlighted", "Highlighted Text", xlBLUE, ColorManager::ColorCategory::COLOR_CAT_LAYOUT_TAB }
         };
 
     protected:

--- a/xLights/xLightsImportChannelMapDialog.cpp
+++ b/xLights/xLightsImportChannelMapDialog.cpp
@@ -24,6 +24,7 @@
 #include "xLightsMain.h"
 #include "models/Model.h"
 #include "models/ModelGroup.h"
+#include "ColorManager.h"
 #include "UtilFunctions.h"
 #include "ExternalHooks.h"
 #include "MediaImportOptionsDialog.h"
@@ -181,7 +182,7 @@ bool xLightsImportTreeModel::GetAttr(const wxDataViewItem &item, unsigned int co
     }
 
     if (node->IsGroup()) {
-            attr.SetColour(CyanOrBlue());
+        attr.SetColour(ColorManager::instance()->CyanOrBlueOverride());
         set = true;
     }
 
@@ -923,7 +924,7 @@ void xLightsImportChannelMapDialog::PopulateAvailable(bool ccr)
 
             // If importing from xsqPkg flag known groups by color like is currently done in mapped list
             if (m->type == "ModelGroup") {
-                ListCtrl_Available->SetItemTextColour(j, CyanOrBlue());
+                ListCtrl_Available->SetItemTextColour(j, ColorManager::instance()->CyanOrBlueOverride());
             }
             j++;
         }
@@ -2235,13 +2236,13 @@ void xLightsImportChannelMapDialog::MarkUsed()
             // not used
             ImportChannel* im = GetImportChannel(ListCtrl_Available->GetItemText(i).ToStdString());
             if (im != nullptr && im->type == "ModelGroup") {
-                ListCtrl_Available->SetItemTextColour(i, CyanOrBlue());
+                ListCtrl_Available->SetItemTextColour(i, ColorManager::instance()->CyanOrBlueOverride());
             } else {
                 ListCtrl_Available->SetItemTextColour(i, wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT));
             }
         } else {
             //used
-            ListCtrl_Available->SetItemTextColour(i, LightOrMediumGrey());
+            ListCtrl_Available->SetItemTextColour(i, ColorManager::instance()->LightOrMediumGreyOverride());
         }
     }
     ListCtrl_Available->Thaw();


### PR DESCRIPTION
The preference can be used to override the cyan/blue color in lists and another to override the grey/med grey. #3446 
Using a local function so as not to touch the utilfunction. Note there are other places this could be substituted in (cyanorblue) but they seem less likely to cause issues. No changes required for users, only if they want to override the normal.