### PR TITLE
Handle duplicate model/sub-models names in groups when replacing a model

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -6890,7 +6890,7 @@ void LayoutPanel::ReplaceModel()
         xlights->AllModels.RenameInListOnly(modelToReplaceItWith->GetName(), dlg.GetStringSelection().ToStdString());
         modelToReplaceItWith->Rename(dlg.GetStringSelection().ToStdString());
         xlights->AllModels.Delete("Iamgoingtodeletethismodel");
-        xlights->ReplaceModelWithModelFixGroups(rmn, riw);
+        // xlights->ReplaceModelWithModelFixGroups(rmn, riw);           // no need to rename since replacing already has the original model name in groups
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "ReplaceModel", nullptr, nullptr, dlg.GetStringSelection().ToStdString());
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "ReplaceModel");
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS, "ReplaceModel");


### PR DESCRIPTION
When replacing a model with a model, the original model remains in groups but the new model gets renamed and also stays in hte group, thus resulting in M/S-M being in groups twice.