### PR TITLE
Enable the Hw Video Decoding dropdown #4479

### DIFF
--- a/xLights/preferences/OtherSettingsPanel.cpp
+++ b/xLights/preferences/OtherSettingsPanel.cpp
@@ -280,6 +280,12 @@ void OtherSettingsPanel::OnControlChanged(wxCommandEvent& event)
 {
     if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
         TransferDataFromWindow();
+    } else {
+#ifdef __WXMSW__
+        frame->SetHardwareVideoRenderer(HardwareVideoRenderChoice->GetSelection());
+        HardwareVideoRenderChoice->Enable(HardwareVideoDecodingCheckBox->IsChecked());
+#endif
+        return;
     }
 }
 


### PR DESCRIPTION
After enabling checkbox, enable the dropdown. Is there a better way of doing this? Currently it only would enable it after clicking the OK and leaving the panel. Drawback here is you could have come in with it enabled, change the dropdown but cancel - it would still apply the change to the dropdown. Not perfect but not much risk either.