### PR TITLE
Patch to re-allow states on submodels

### DIFF
--- a/xLights/sequencer/tabSequencer.cpp
+++ b/xLights/sequencer/tabSequencer.cpp
@@ -1221,9 +1221,15 @@ void xLightsFrame::SelectedEffectChanged(SelectedEffectChangedEvent& event)
                     effect->SetEffectIndex(effectManager.GetEffectIndex(effectName));
                     resetStrings = true;
                 }
-                SetEffectControls(effect->GetParentEffectLayer()->GetParentElement()->GetFullName(),
-                    effect->GetEffectName(), effect->GetSettings(), effect->GetPaletteMap(),
-                    !event.isNew);
+                if (effect->GetEffectName() == "State") { // special case to allow States to function at submodel level
+                    SetEffectControls(effect->GetParentEffectLayer()->GetParentElement()->GetModelName(),
+                                      effect->GetEffectName(), effect->GetSettings(), effect->GetPaletteMap(),
+                                      !event.isNew);
+                } else {
+                    SetEffectControls(effect->GetParentEffectLayer()->GetParentElement()->GetFullName(),
+                                      effect->GetEffectName(), effect->GetSettings(), effect->GetPaletteMap(),
+                                      !event.isNew);
+                }
                 selectedEffectString = GetEffectTextFromWindows(selectedEffectPalette);
                 selectedEffect = effect;
 


### PR DESCRIPTION
temp solution to reallow states on submoldes. 

Layering doesn't work for what we are trying to do here.
This is with layer.. note dimmer state is not applied...
![image](https://github.com/xLightsSequencer/xLights/assets/23619433/2e2095fe-0097-46b6-8552-625f7f470e17)

vs with this change and allowing states on sm
 
![image](https://github.com/xLightsSequencer/xLights/assets/23619433/0471b45f-4f1e-44fd-bb04-65097546a657)
