### PR TITLE
Add option to add new model to the same groups #4494

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -7054,6 +7054,29 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
 						lastModelName = name;
 					}
 
+                    if (wxMessageBox("Should I add model to the same group(s) as the original?", "Add to groups?", wxICON_QUESTION | wxYES_NO) == wxYES) {
+                        Model* sourcemodel = xlights->GetModel(this->selectedBaseObject->name);
+                        auto inmodelGroups = sourcemodel->GetModelManager().GetGroupsContainingModel(sourcemodel);
+                        for (const auto& grp : inmodelGroups) {
+                            Model* addToGroup = xlights->GetModel(grp);
+                            if (!addToGroup->IsFromBase()) {
+                                wxXmlNode* node = addToGroup->GetModelXml();
+                                wxArrayString groupModels = wxSplit(node->GetAttribute("models", ""), ',');
+                                int groupItems = groupModels.GetCount();    //we'll keep adding items, keep inital count
+                                for (int i = 0; i < groupItems; i++) {
+                                    if (groupModels[i].StartsWith(selectedBaseObject->name)) {
+                                        wxString addnew = groupModels[i];
+                                        addnew.Replace(selectedBaseObject->name, name);
+                                        groupModels.Add(addnew);
+                                    }
+                                }
+                                wxString xmlModels = wxJoin(groupModels, ',');
+                                node->DeleteAttribute("models");
+                                node->AddAttribute("models", xmlModels);
+                            }
+                        }
+                    }
+
                     //SelectBaseObject(name);
                     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::DoPaste");
                     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "LayoutPanel::DoPaste");


### PR DESCRIPTION
Prompts users if they want to add the newly copy/paste model to the same group(s) as the original model