### PR TITLE
Fix total nodes tooltip for groups #4481

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -5845,14 +5845,14 @@ std::vector<Model *> LayoutPanel::GetSelectedModelsFromGroup(wxTreeListItem grou
 }
 
 // The will return unique selected models for edit, useful when groups are also selected in model tree
-std::vector<Model*> LayoutPanel::GetSelectedModelsForEdit() {
+std::vector<Model*> LayoutPanel::GetSelectedModelsForEdit(bool incSubModels) {
     std::vector<Model*> modelsForEdit;
 
     for (const auto& groupItem : selectedTreeGroups) {
         std::vector<Model*> groupModels = GetSelectedModelsFromGroup(groupItem);
         for (Model* model: groupModels) {
             if (std::find(modelsForEdit.begin(), modelsForEdit.end(), model) == modelsForEdit.end()) {
-                if (model->GetDisplayAs() != "SubModel") {
+                if (model->GetDisplayAs() != "SubModel" || incSubModels) {
                     modelsForEdit.push_back(model);
                 }
             }
@@ -9072,7 +9072,6 @@ int LayoutPanel::calculateNodeCountOfSelected()
     int totalNodeCount = 0;
     std::vector<Model*> modelsProcessed;
     //We can break the selected groups into their components for processing. GetSelectedModelsForEdit already does this, even though we aren't editing. We can reuse that logic. This gives us all models, so I want to split this back up into models and submodels
-    std::vector<Model*> modelsToProcess = GetSelectedModelsForEdit();
     std::vector<Model*> selectedModels;
     std::vector<Model*> selectedSubModels;
     
@@ -9084,7 +9083,7 @@ int LayoutPanel::calculateNodeCountOfSelected()
     }
     
     //Now parse the group elements into their perspective groups for processing
-    std::vector<Model*> sgModels = GetSelectedModelsForEdit();
+    std::vector<Model*> sgModels = GetSelectedModelsForEdit(true);
     for (const auto& item : sgModels){
         if (item->GetDisplayAs() == "SubModel") {
             selectedSubModels.push_back(item);

--- a/xLights/LayoutPanel.h
+++ b/xLights/LayoutPanel.h
@@ -384,7 +384,7 @@ class LayoutPanel: public wxPanel
         Model* GetModelFromTreeItem(wxTreeListItem treeItem);
         wxTreeListItem GetTreeItemFromModel(Model* model);
         std::vector<Model*> GetSelectedModelsFromGroup(wxTreeListItem groupItem, bool nested = true);
-        std::vector<Model*> GetSelectedModelsForEdit();
+        std::vector<Model*> GetSelectedModelsForEdit(bool incSubModels = false);
         void SetTreeModelSelected(Model* model, bool isPrimary);
         void SetTreeGroupModelsSelected(Model* model, bool isPrimary);
         void SetTreeSubModelSelected(Model* model, bool isPrimary);


### PR DESCRIPTION
The code was ignoring submodels when calculating the total nodes in the layout tooltip for groups.
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/4df52bd7-a0d6-4b93-aebe-10e32c911a2a)

