### PR TITLE
Fix submodel node updates when changing to new submodel choice #2954

### DIFF
--- a/xLights/SubModelsDialog.cpp
+++ b/xLights/SubModelsDialog.cpp
@@ -937,6 +937,10 @@ void SubModelsDialog::OnNodesGridCellChange(wxGridEvent& event)
 {
     log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
 
+    if (!shouldProcessGridCellChanged) {
+        shouldProcessGridCellChanged = true;
+        return;
+    }
     int r = event.GetRow();
     SubModelInfo* sm = GetSubModelInfo(GetSelectedName());
     if (sm != nullptr)
@@ -963,6 +967,7 @@ void SubModelsDialog::OnNodesGridCellChange(wxGridEvent& event)
 
 void SubModelsDialog::OnNodesGridCellSelect(wxGridEvent& event)
 {
+    shouldProcessGridCellChanged = true;
     SelectRow(event.GetRow());
     ValidateWindow();
 }
@@ -1163,6 +1168,7 @@ void SubModelsDialog::OnButton_ReverseNodesClick(wxCommandEvent& event)
 
 void SubModelsDialog::OnListCtrl_SubModelsItemSelect(wxListEvent& event)
 {
+    shouldProcessGridCellChanged = false;
     if (ListCtrl_SubModels->GetSelectedItemCount() == 1)
     {
         Select(GetSelectedName());

--- a/xLights/SubModelsDialog.h
+++ b/xLights/SubModelsDialog.h
@@ -378,6 +378,7 @@ private:
 
     void OnDrop(wxCommandEvent& event);
     //void OnGridChar(wxKeyEvent& event);
+    bool shouldProcessGridCellChanged = true;
 
     DECLARE_EVENT_TABLE()
 };

--- a/xLights/TabSetup.cpp
+++ b/xLights/TabSetup.cpp
@@ -1449,7 +1449,6 @@ void xLightsFrame::InitialiseControllersTab(bool rebuildPropGrid) {
         Connect(ID_List_Controllers, wxEVT_RIGHT_DOWN, (wxObjectEventFunction)&xLightsFrame::OnListControllersRClick);
         Connect(ID_List_Controllers, wxEVT_LIST_COL_CLICK, (wxObjectEventFunction)&xLightsFrame::OnListControllersColClick);
         Connect(ID_List_Controllers, wxEVT_LIST_ITEM_RIGHT_CLICK, (wxObjectEventFunction)&xLightsFrame::OnListControllersItemRClick);
-        Connect(ID_List_Controllers, wxEVT_LIST_ITEM_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnListItemSelectedControllers);
         Connect(ID_List_Controllers, wxEVT_LIST_ITEM_DESELECTED, (wxObjectEventFunction)&xLightsFrame::OnListItemDeselectedControllers);
         Connect(ID_List_Controllers, wxEVT_LIST_BEGIN_DRAG, (wxObjectEventFunction)&xLightsFrame::OnListItemBeginDragControllers);
         Connect(ID_List_Controllers, wxEVT_LIST_ITEM_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnListItemSelectedControllers);
@@ -1942,7 +1941,7 @@ int xLightsFrame::GetSelectedControllerCount() const {
 
 void xLightsFrame::OnListItemSelectedControllers(wxListEvent& event)
 {
-    if (!inInitialize) {
+    if (!inInitialize) { // dwe
         SetControllersProperties();
     }
 


### PR DESCRIPTION
After changing nodes in a submodel, if you clicked on a new submodel, it would improperly assign those changes to the new submodel choice. This correct that. It acts more like xlights that you must enter enter or tab out of the box to accept that node update (or click on something other than a new submodel selection). #2954