### PR TITLE
Alllow export/import for all models nad submodels #4520

### DIFF
--- a/xLights/EditAliasesDialog.cpp
+++ b/xLights/EditAliasesDialog.cpp
@@ -31,7 +31,7 @@ EditAliasesDialog::EditAliasesDialog(wxWindow* parent, Model* m, wxWindowID id, 
 	FlexGridSizer1 = new wxFlexGridSizer(0, 2, 0, 0);
 	FlexGridSizer1->AddGrowableCol(0);
 	FlexGridSizer1->AddGrowableRow(0);
-	ListBoxAliases = new wxListBox(this, ID_LISTBOX1, wxDefaultPosition, wxDefaultSize, 0, 0, wxLB_SINGLE|wxLB_SORT, wxDefaultValidator, _T("ID_LISTBOX1"));
+	ListBoxAliases = new wxListBox(this, ID_LISTBOX1, wxDefaultPosition, wxDefaultSize, 0, 0, wxLB_SINGLE, wxDefaultValidator, _T("ID_LISTBOX1"));
 	FlexGridSizer1->Add(ListBoxAliases, 1, wxALL|wxEXPAND, 5);
 	FlexGridSizer2 = new wxFlexGridSizer(0, 1, 0, 0);
 	ButtonAdd = new wxButton(this, ID_BUTTON1, _("Add"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON1"));

--- a/xLights/EditSubmodelAliasesDialog.cpp
+++ b/xLights/EditSubmodelAliasesDialog.cpp
@@ -43,7 +43,7 @@ EditSubmodelAliasesDialog::EditSubmodelAliasesDialog(wxWindow* parent, Model* m,
     FlexGridSizer1 = new wxFlexGridSizer(0, 2, 0, 0);
     FlexGridSizer1->AddGrowableCol(0);
     FlexGridSizer1->AddGrowableRow(0);
-    ListBoxAliases = new wxListBox(this, ID_LISTBOX1, wxDefaultPosition, wxDefaultSize, 0, 0, wxLB_SINGLE|wxLB_SORT, wxDefaultValidator, _T("ID_LISTBOX1"));
+    ListBoxAliases = new wxListBox(this, ID_LISTBOX1, wxDefaultPosition, wxDefaultSize, 0, 0, wxLB_SINGLE, wxDefaultValidator, _T("ID_LISTBOX1"));
     FlexGridSizer1->Add(ListBoxAliases, 1, wxALL|wxEXPAND, 5);
     FlexGridSizer2 = new wxFlexGridSizer(0, 1, 0, 0);
     ButtonAdd = new wxButton(this, ID_BUTTON1, _("Add"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON1"));

--- a/xLights/models/ArchesModel.cpp
+++ b/xLights/models/ArchesModel.cpp
@@ -603,7 +603,10 @@ void ArchesModel::ExportXlightsModel()
     f.Write(wxString::Format("ZigZag=\"%s\" ", zz));
     f.Write(ExportSuperStringColors());
     f.Write(" >\n");
-
+    wxString aliases = SerialiseAliases();
+    if (aliases != "") {
+        f.Write(aliases);
+    }
     wxString groups = SerialiseGroups();
     if (groups != "") {
         f.Write(groups);

--- a/xLights/models/CircleModel.cpp
+++ b/xLights/models/CircleModel.cpp
@@ -354,7 +354,10 @@ void CircleModel::ExportXlightsModel()
     f.Write(wxString::Format("SourceVersion=\"%s\" ", v));
     f.Write(ExportSuperStringColors());
     f.Write(" >\n");
-
+    wxString aliases = SerialiseAliases();
+    if (aliases != "") {
+        f.Write(aliases);
+    }
     wxString state = SerialiseState();
     if (state != "") {
         f.Write(state);

--- a/xLights/models/CubeModel.cpp
+++ b/xLights/models/CubeModel.cpp
@@ -1035,6 +1035,10 @@ void CubeModel::ExportXlightsModel()
     f.Write(wxString::Format("StrandsPerLayer=\"%s\" ", s4));
     f.Write(ExportSuperStringColors());
     f.Write(" >\n");
+    wxString aliases = SerialiseAliases();
+    if (aliases != "") {
+        f.Write(aliases);
+    }
     wxString groups = SerialiseGroups();
     if (groups != "") {
         f.Write(groups);

--- a/xLights/models/CustomModel.cpp
+++ b/xLights/models/CustomModel.cpp
@@ -1456,6 +1456,10 @@ void CustomModel::ExportXlightsModel()
     f.Write(wxString::Format("SourceVersion=\"%s\" ", v));
     f.Write(ExportSuperStringColors());
     f.Write(" >\n");
+    wxString aliases = SerialiseAliases();
+    if (aliases != "") {
+        f.Write(aliases);
+    }
     wxString face = SerialiseFace();
     if (face != "") {
         f.Write(face);

--- a/xLights/models/MatrixModel.cpp
+++ b/xLights/models/MatrixModel.cpp
@@ -641,6 +641,10 @@ void MatrixModel::ExportXlightsModel()
     f.Write(wxString::Format("LowDefinition=\"%s\" ", ld));
     f.Write(ExportSuperStringColors());
     f.Write(" >\n");
+    wxString aliases = SerialiseAliases();
+    if (aliases != "") {
+        f.Write(aliases);
+    }
     wxString state = SerialiseState();
     if (state != "")
     {

--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -2332,6 +2332,27 @@ void Model::AddState(wxXmlNode* n)
     UpdateStateInfoNodes();
 }
 
+void Model::AddModelAliases(wxXmlNode* n) {
+    // can't be sure of the order of tags in xml and we don't want to ask twice, so setup breadcrumbs to ensure a single prompt
+    if (importAliases == false) {
+        if (skipImportAliases != true) {
+            if (wxMessageBox("Should I import aliases from the base model?", "Import Aliases?", wxICON_QUESTION | wxYES_NO) == wxYES) {
+                importAliases = true;
+            } else {
+                skipImportAliases = true;
+            }
+        }
+    }
+    if (importAliases == true) {
+        std::list<std::string> aliases;
+        for (auto a = n->GetChildren(); a != nullptr; a = a->GetNext()) {
+            aliases.push_back(a->GetAttribute("name"));
+        }
+        SetAliases(aliases);
+    }
+}
+
+
 void Model::ImportShadowModels(wxXmlNode* n, xLightsFrame* xlights)
 {
     static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
@@ -2393,7 +2414,35 @@ void Model::AddSubmodel(wxXmlNode* n)
     for (auto a = n->GetAttributes(); a != nullptr; a = a->GetNext()) {
         f->AddAttribute(a->GetName(), a->GetValue());
     }
-}
+
+    // can't be sure of the order of tags in xml and we don't want to ask twice, so setup breadcrumbs to ensure a single prompt
+    if (importAliases == false) {
+        if (skipImportAliases != true) {
+            if (wxMessageBox("Should I import aliases from the base model?", "Import Aliases?", wxICON_QUESTION | wxYES_NO) == wxYES) {
+                importAliases = true;
+            } else {
+                skipImportAliases = true;
+            }
+        }
+    }
+    if (importAliases == true) {
+        std::list<std::string> smaliases;
+        for (auto a = n->GetChildren(); a != nullptr; a = a->GetNext()) {
+             if (a->GetName() == "Aliases") {
+                 for (auto sma = a->GetChildren(); sma != nullptr; sma = sma->GetNext()) {
+                     smaliases.push_back(sma->GetAttribute("name"));
+                 }
+                 wxXmlNode* smf = new wxXmlNode(wxXML_ELEMENT_NODE, "Aliases");
+                 for (const auto& it : smaliases) {
+                     auto smn = new wxXmlNode(wxXmlNodeType::wxXML_ELEMENT_NODE, "alias");
+                     smn->AddAttribute("name", Lower(it));
+                     smf->AddChild(smn);
+                 }
+                 f->AddChild(smf);
+             }
+         }
+     }
+ }
 
 wxString Model::SerialiseFace() const
 {
@@ -5850,11 +5899,14 @@ void Model::ImportModelChildren(wxXmlNode* root, xLightsFrame* xlights, wxString
 {
     bool merge = false;
     bool showPopup = true;
+    importAliases = 0;
     for (wxXmlNode* n = root->GetChildren(); n != nullptr; n = n->GetNext()) {
         if (n->GetName() == "stateInfo") {
             AddState(n);
         } else if (n->GetName() == "subModel") {
             AddSubmodel(n);
+        } else if (n->GetName() == "Aliases") {
+            AddModelAliases(n);
         } else if (n->GetName() == "faceInfo") {
             AddFace(n);
         } else if (n->GetName() == "ControllerConnection") {
@@ -6614,6 +6666,27 @@ wxString Model::SerialiseSubmodel() const
     }
 
     return res;
+}
+
+wxString Model::SerialiseAliases() const {
+    wxString alias = "";
+
+    wxXmlNode* root = GetModelXml();
+    wxXmlNode* child = root->GetChildren();
+    while (child != nullptr) {
+        if (child->GetName() == "Aliases") {
+            wxXmlDocument new_doc;
+            new_doc.SetRoot(new wxXmlNode(*child));
+            wxStringOutputStream stream;
+            new_doc.Save(stream);
+            wxString s = stream.GetString();
+            s = s.SubString(s.Find("\n") + 1, s.Length()); // skip over xml format header
+            alias += s;
+        }
+        child = child->GetNext();
+    }
+
+    return alias;
 }
 
 wxString Model::CreateBufferAsSubmodel() const

--- a/xLights/models/Model.h
+++ b/xLights/models/Model.h
@@ -189,10 +189,14 @@ public:
     void AddFace(wxXmlNode* n);
     void AddState(wxXmlNode* n);
     void AddSubmodel(wxXmlNode* n);
+    void AddModelAliases(wxXmlNode* n);
     void ImportShadowModels(wxXmlNode* n, xLightsFrame* xlights);
 
     wxString SerialiseSubmodel() const;
+    wxString SerialiseAliases() const;
     virtual wxString CreateBufferAsSubmodel() const;
+    bool importAliases = false;
+    bool skipImportAliases = false;
 
     std::map<std::string, std::map<std::string, std::string>> GetDimmingInfo() const;
     virtual std::list<std::string> CheckModelSettings() override;

--- a/xLights/models/MultiPointModel.cpp
+++ b/xLights/models/MultiPointModel.cpp
@@ -552,6 +552,10 @@ void MultiPointModel::ExportXlightsModel()
     f.Write(wxString::Format("SourceVersion=\"%s\" ", v));
     f.Write(ExportSuperStringColors());
     f.Write(" >\n");
+    wxString aliases = SerialiseAliases();
+    if (aliases != "") {
+        f.Write(aliases);
+    }
     wxString state = SerialiseState();
     if (state != "") {
         f.Write(state);

--- a/xLights/models/PolyLineModel.cpp
+++ b/xLights/models/PolyLineModel.cpp
@@ -1540,6 +1540,10 @@ void PolyLineModel::ExportXlightsModel()
     f.Write(wxString::Format("SourceVersion=\"%s\" ", v));
     f.Write(ExportSuperStringColors());
     f.Write(" >\n");
+    wxString aliases = SerialiseAliases();
+    if (aliases != "") {
+        f.Write(aliases);
+    }
     wxString state = SerialiseState();
     if (state != "") {
         f.Write(state);

--- a/xLights/models/SphereModel.cpp
+++ b/xLights/models/SphereModel.cpp
@@ -202,6 +202,10 @@ void SphereModel::ExportXlightsModel()
     f.Write(wxString::Format("SourceVersion=\"%s\" ", v));
     f.Write(ExportSuperStringColors());
     f.Write(" >\n");
+    wxString aliases = SerialiseAliases();
+    if (aliases != "") {
+        f.Write(aliases);
+    }
     wxString state = SerialiseState();
     if (state != "")
     {

--- a/xLights/models/StarModel.cpp
+++ b/xLights/models/StarModel.cpp
@@ -717,6 +717,10 @@ void StarModel::ExportXlightsModel()
     f.Write(wxString::Format("SourceVersion=\"%s\" ", v));
     f.Write(ExportSuperStringColors());
     f.Write(" >\n");
+    wxString aliases = SerialiseAliases();
+    if (aliases != "") {
+        f.Write(aliases);
+    }
     wxString groups = SerialiseGroups();
     if (groups != "") {
         f.Write(groups);

--- a/xLights/models/SubModel.cpp
+++ b/xLights/models/SubModel.cpp
@@ -385,7 +385,7 @@ void SubModel::AddProperties(wxPropertyGridInterface* grid, OutputManager* outpu
             sma += it;
             smacr += it;
         }
-        p = grid->Append(new wxStringProperty("Sub-model Aliases", "SMA", sma));
+        p = grid->Append(new wxStringProperty("SubModel Aliases", "SMA", sma));
         p->SetHelpString(smacr);
         p->SetTextColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
         p->ChangeFlag(wxPGPropertyFlags::ReadOnly, true);

--- a/xLights/models/TreeModel.cpp
+++ b/xLights/models/TreeModel.cpp
@@ -456,6 +456,10 @@ void TreeModel::ExportXlightsModel()
     f.Write(wxString::Format("SourceVersion=\"%s\" ", v));
     f.Write(ExportSuperStringColors());
     f.Write(" >\n");
+    wxString aliases = SerialiseAliases();
+    if (aliases != "") {
+        f.Write(aliases);
+    }
     wxString state = SerialiseState();
     if (state != "")
     {

--- a/xLights/wxsmith/EditAliasesDialog.wxs
+++ b/xLights/wxsmith/EditAliasesDialog.wxs
@@ -11,7 +11,7 @@
 			<object class="sizeritem">
 				<object class="wxListBox" name="ID_LISTBOX1" variable="ListBoxAliases" member="yes">
 					<default>-1</default>
-					<style>wxLB_SINGLE|wxLB_SORT</style>
+					<style>wxLB_SINGLE</style>
 					<handler function="OnListBoxAliasesSelect" entry="EVT_LISTBOX" />
 				</object>
 				<flag>wxALL|wxEXPAND</flag>

--- a/xLights/wxsmith/EditSubmodelAliasesDialog.wxs
+++ b/xLights/wxsmith/EditSubmodelAliasesDialog.wxs
@@ -11,7 +11,7 @@
 			<object class="sizeritem">
 				<object class="wxListBox" name="ID_LISTBOX1" variable="ListBoxAliases" member="yes">
 					<default>-1</default>
-					<style>wxLB_SINGLE|wxLB_SORT</style>
+					<style>wxLB_SINGLE</style>
 					<handler function="OnListBoxAliasesSelect" entry="EVT_LISTBOX" />
 				</object>
 				<flag>wxALL|wxEXPAND</flag>


### PR DESCRIPTION
Currently only groups can be exported/imported. THis allows all models and submodels to be exported and optionally (prompt) imported.
Also, remove sort of aliases to keep history
Clean up submodel panel naming convention