### PR TITLE
Allow UTF8 characters in song and filename #4515

### DIFF
--- a/xLights/AudioManager.cpp
+++ b/xLights/AudioManager.cpp
@@ -26,6 +26,7 @@
 #include "../xSchedule/md5.h"
 #include "ExternalHooks.h"
 #include "Parallel.h"
+#include "UtilFunctions.h"
 
 extern "C"
 {
@@ -2096,7 +2097,7 @@ int AudioManager::OpenMediaFile()
     #endif
 
 	AVFormatContext* formatContext = nullptr;
-	int res = avformat_open_input(&formatContext, _audio_file.c_str(), nullptr, nullptr);
+	int res = avformat_open_input(&formatContext, ToUTF8(_audio_file).c_str(), nullptr, nullptr);
 	if (res != 0)
 	{
 		logger_base.error("avformat_open_input Error opening the file %s => %d.", (const char *) _audio_file.c_str(), res);

--- a/xLights/controllers/FPPConnectDialog.cpp
+++ b/xLights/controllers/FPPConnectDialog.cpp
@@ -658,7 +658,7 @@ void FPPConnectDialog::LoadSequencesFromFolder(wxString dir) const
                         case SP_XmlPullEvent::eCData:
                             if (isMedia) {
                                 SP_XmlCDataEvent * stagEvent = (SP_XmlCDataEvent*)event;
-                                mediaName = wxString::FromAscii(stagEvent->getText()).ToStdString();
+                                mediaName = FromUTF8(stagEvent->getText());
                                 done = true;
                             }
                             break;

--- a/xLights/xLightsXmlFile.cpp
+++ b/xLights/xLightsXmlFile.cpp
@@ -1141,7 +1141,7 @@ bool xLightsXmlFile::LoadSequence(const wxString& ShowDir, bool ignore_audio, co
                             audio = nullptr;
                         }
                         if (::FileExists(mf) && mf.IsFileReadable()) {
-                            mediaFileName = ToUTF8(media_file);
+                            mediaFileName = media_file.ToStdString();
                         }
                         else {
                             if (!::FileExists(mf)) {


### PR DESCRIPTION
Just use UTF8 when it reads the audio and fpp connect. This appears to work BUT it needs to be changed/handled on the FPP side. It uploads using the UTF8. Works on load and sequence settings. Need to be confirmed on MAC OS.
#4515 
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/0af2f244-d15c-4735-90b1-6bd0f1499d55)
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/6914712d-3a38-437a-ab90-4eb6d9a2c797)
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/443dd37d-7de2-49eb-b648-194f236ee7a4)
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/27320986-6096-4556-a56a-26b487eeccf4)
TODO:
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/a1de7533-85b4-475e-a119-b0ae0eb0cf45)

