### PR TITLE
Update lua script and code to allow lowdef or forced highdef video #3437

### DIFF
--- a/scripts/RenderExportModel.lua
+++ b/scripts/RenderExportModel.lua
@@ -1,22 +1,90 @@
--- Script to Export Model MP4 for Selected Model. 
-
-properties2 = {}
-properties2['groups'] = "false"
-
-models_str = RunCommand('getModels', properties2)
-models = models_str['models']
-
-sel_model = PromptSelection(models,'Select Model')
-
-RunCommand('renderAll', {})
+--
+-- 
+-- Select Model and Sequences to have them rendered and exported to mp4 files
+-- This uses the force highdef rendering if set
+--
+local FILE_DELIMITER  = "\\"
 
 properties = {}
-properties['model'] = sel_model
-properties['format'] = 'avicompressed'
-properties['filename'] = sel_model .. ".mp4"
-Log(properties['filename'])
-Log(properties['model'])
+properties['groups'] = "false"
 
-result = RunCommand('exportModel', properties)
-Log(result['msg'])
+models_str = RunCommand('getModels', properties)
+models = models_str['models']
+sel_model = PromptSelection(models,'Select Model')
 
+sel_compress = PromptSelection({'Yes','No'},'Compressed MP4?')
+
+seqs,sel_highdef = PromptSequences()
+
+-- Function to check if a folder exists
+function folderExists(path)
+	Log("Checking folderExists(): "..path)
+	if type(path)~="string" then return false end
+	res = os.rename(path,path)
+	return res
+end
+
+for i,seq in ipairs(seqs) do 
+    properties = {}
+    properties['seq'] = seq
+	properties['promptIssues'] = 'false'
+    result = RunCommand('openSequence', properties)
+	Log("SequenceName: "..result['seq'])
+
+	fullSequenceName = result['fullseq']
+	Log("FullSeqName: "..fullSequenceName)
+	
+	lastSeparatorIndex = fullSequenceName:find("[\\/]([^\\/]*)$")
+	sequenceRenderingLocation = fullSequenceName:sub(1,lastSeparatorIndex -1)
+	Log("sequenceRenderingLocation: "..sequenceRenderingLocation)
+		
+	media = string.gsub(result['media'],".*\\","")
+	if media == "" then 
+		media = "export"
+	end
+	mediaFile = string.gsub(media,"%.mp%d","") .. ".mp4"
+	Log("MediaFile: "..mediaFile)
+
+	newFileName = sequenceRenderingLocation..FILE_DELIMITER..sel_model..FILE_DELIMITER..mediaFile
+	--folder location of export video
+	local folderPath = sequenceRenderingLocation..FILE_DELIMITER..sel_model
+	
+	-- Check if the folder exists
+	if not folderExists(folderPath) then
+		-- Folder doesn't exist, so create it
+		local success, errorMessage = os.execute("mkdir " .. folderPath)
+
+		if success then
+			Log("The folder '"..sel_model.."' has been created at: " .. folderPath)
+		else
+			Log("Failed to create the folder '"..sel_model.."': " .. errorMessage)
+		end
+	else
+		Log("The folder '"..sel_model.."' already exists at: " .. folderPath)
+	end
+			
+    properties = {}
+	properties['model'] = sel_model
+	if sel_compress == "Yes" then
+		Log("Compressed")
+		properties['format'] = 'avicompressed'
+	else
+		Log("Uncompressed")
+		properties['format'] = 'mp4uncompressed'
+	end
+	properties['filename'] = newFileName
+	properties['highdef'] = tostring(sel_highdef)
+	
+	Log ("Export Model: "..sel_model)
+	Log ("Export File: "..newFileName)
+	Log ("Force HighDef: "..tostring(sel_highdef))
+	
+	result = RunCommand('exportModelWithRender', properties)
+	Log("Export Result: "..result['msg'])
+	
+	properties = {}
+	properties['quiet'] = 'true'
+	properties['force'] = 'true'	
+    result = RunCommand('closeSequence', {})
+    Log("Status: "..result['msg'])
+end

--- a/xLights/BatchRenderDialog.cpp
+++ b/xLights/BatchRenderDialog.cpp
@@ -136,6 +136,7 @@ BatchRenderDialog::BatchRenderDialog(wxWindow* parent)
     FlexGridSizer1->SetSizeHints(this);
 
     SetEscapeId(Button_Cancel->GetId());
+    Button_Ok->SetDefault();
     ValidateWindow();
 }
 

--- a/xLights/TabSetup.cpp
+++ b/xLights/TabSetup.cpp
@@ -1941,7 +1941,7 @@ int xLightsFrame::GetSelectedControllerCount() const {
 
 void xLightsFrame::OnListItemSelectedControllers(wxListEvent& event)
 {
-    if (!inInitialize) { // dwe
+    if (!inInitialize) {
         SetControllersProperties();
     }
 

--- a/xLights/automation/xLightsAutomations.cpp
+++ b/xLights/automation/xLightsAutomations.cpp
@@ -613,16 +613,17 @@ bool xLightsFrame::ProcessAutomation(std::vector<std::string> &paths,
 
         auto ld = _lowDefinitionRender;
         auto highdef = params["highdef"];
+        auto model = params["model"];
+
+        if (AllModels.GetModel(model) == nullptr) {
+            return sendResponse("Unknown model.", "msg", 503, false);
+        }
+
         if (highdef == "true" && _lowDefinitionRender) {
             // override definition
             _lowDefinitionRender = false;
-            _outputModelManager.AddImmediateWork(OutputModelManager::WORK_RELOAD_MODEL_FROM_XML, "Automation::exportModelWithRender");
+            _outputModelManager.AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "Automation::exportModelWithRender");
             _outputModelManager.AddImmediateWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "Automation::exportModelWithRender");
-        }
-
-        auto model = params["model"];
-        if (AllModels.GetModel(model) == nullptr) {
-            return sendResponse("Unknown model.", "msg", 503, false);
         }
 
         auto filename = params["filename"];
@@ -657,7 +658,7 @@ bool xLightsFrame::ProcessAutomation(std::vector<std::string> &paths,
         if (DoExportModel(0, 0, model, filename, format, true)) {
             if (ld != _lowDefinitionRender) {
                 _lowDefinitionRender = ld;
-                _outputModelManager.AddImmediateWork(OutputModelManager::WORK_RELOAD_MODEL_FROM_XML, "Automation::exportModelWithRender");
+                _outputModelManager.AddImmediateWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "Automation::exportModelWithRender");  // Restore the models back to prior
                 _outputModelManager.AddImmediateWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "Automation::exportModelWithRender");
             }
             return sendResponse("Model exported.", "msg", 200, false);


### PR DESCRIPTION
Allow via the existing force highdef checkbox to render and export the model video. This can be used to export highdev videos for virtual matrixes and such. #3437
Also includes an updated RenderExportModel lua script.
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/d878041b-2c54-4f82-9aa0-9abe2e447f44)
