### PR TITLE
Show Set Center Point dialog for all groups #4537

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -1527,7 +1527,7 @@ void LayoutPanel::UpdateModelsForPreview(const std::string &group, LayoutGroup* 
                         }
                         if (m->DisplayAs == "SubModel") {
                             if (mark_selected) {
-                                prev_models.push_back(m);
+                                prev_models.push_back(m);  // setting this causes exception when prev_models render finds a submodel
                             }
                         }
                         else if (m->DisplayAs == "ModelGroup") {
@@ -4632,7 +4632,7 @@ void LayoutPanel::OnPreviewRightDown(wxMouseEvent& event)
 
     int selectedObjectCnt = editing_models ? ModelsSelectedCount() : ViewObjectsSelectedCount();
 
-    if (selectedObjectCnt > 1)
+    if (editing_models && selectedTreeModels.size() > 1 && selectedTreeGroups.size() == 0)
     {
         wxMenu* mnuBulkEdit = new wxMenu();
         AddBulkEditOptionsToMenu(mnuBulkEdit);
@@ -4655,15 +4655,14 @@ void LayoutPanel::OnPreviewRightDown(wxMouseEvent& event)
         mnu.Append(ID_PREVIEW_DISTRIBUTE, "Distribute", mnuDistribute, "");
         mnu.Append(ID_PREVIEW_RESIZE, "Resize", mnuResize, "");
         mnu.AppendSeparator();
-        
-        if (!is_3d) {
-            auto mg = GetSelectedModelGroup();
-            if (xlights->AllModels.IsModelValid(mg)) {
-                mnu.Append(ID_SET_CENTER_OFFSET, _("Set Center Offset Here"));
-                mnu.AppendSeparator();
-                m_previous_mouse_x = event.GetX();
-                m_previous_mouse_y = event.GetY();
-            }
+    }
+    if (!is_3d && selectedTreeGroups.size() == 1 && selectedTreeModels.size() == 0 && selectedTreeSubModels.size() == 0) {
+        auto mg = GetSelectedModelGroup();
+        if (xlights->AllModels.IsModelValid(mg)) {
+            mnu.Append(ID_SET_CENTER_OFFSET, _("Set Center Offset Here"));
+            mnu.AppendSeparator();
+            m_previous_mouse_x = event.GetX();
+            m_previous_mouse_y = event.GetY();
         }
     }
 


### PR DESCRIPTION
The right click menu option was not showing under some circumstances. Note that I also flagged a potential issue with adding submodels to the previous models list. I found that commenting it out would not trigger this assert flag - but was uncertain of other potential downstream issues, so I left that code as is.
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/1bfefd3e-e35e-4fbe-929a-5c4aa9adf708)
![image](https://github.com/xLightsSequencer/xLights/assets/4643499/1843e64c-0152-4519-ac45-8fc2f682f0d6)
