### PR TITLE
Fix:  Bar highlight color for all layer blending options

### DIFF
--- a/xLights/effects/BarsEffect.cpp
+++ b/xLights/effects/BarsEffect.cpp
@@ -352,7 +352,7 @@ void BarsEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBu
                     buffer.Get2ColorBlend(colorIdx, color2, pct, color);
                 HSVValue hsv = color.asHSV();
                 if (highlight && n % barWi == 0)
-                    hsv.saturation = 0.0;
+                    hsv = highlightColor.asHSV();
                 if (show3D)
                     hsv.value *= double(barWi - n % barWi - 1) / barWi;
                 color = hsv;


### PR DESCRIPTION
The new highlight color for the bars effects which I previously added had a bug where if you pick other layer blending options it doesn't respect the color selected and makes it white.  This line was missed and it should work correctly now.