### PR TITLE
Allow Individual Start Nodes to Circle and Star

### DIFF
--- a/xLights/controllers/ControllerUploadData.cpp
+++ b/xLights/controllers/ControllerUploadData.cpp
@@ -76,7 +76,11 @@ UDControllerPortModel::UDControllerPortModel(Model* m, Controller* controller, O
     }
     else {
         _startChannel = _model->GetStringStartChan(string) + 1;
-        _endChannel = _startChannel + _model->NodesPerString(string) * _model->GetChanCountPerNode() - 1;
+        if ((string + 1) == _model->GetParm1()) { // last custom string; zero indexed vs parm1
+            _endChannel = _model->GetLastChannel()+1;
+        } else {
+            _endChannel = _model->GetStringStartChan(string+1);
+          }
     }
 
     Output* o = nullptr;

--- a/xLights/models/CircleModel.cpp
+++ b/xLights/models/CircleModel.cpp
@@ -78,6 +78,7 @@ void CircleModel::InitModel()
     if (GetLayerSizeCount() == 1) {
         SetLayerSize(0, parm1 * parm2);
     }
+    totalNodes = (int)GetLayerSizesTotalNodes();
 
     if (ModelXml->HasAttribute("InsideOut")) {
         insideOut = wxAtoi(ModelXml->GetAttribute("InsideOut"));
@@ -109,11 +110,56 @@ void CircleModel::AddTypeProperties(wxPropertyGridInterface* grid, OutputManager
     p->SetEditor("SpinCtrl");
     p->SetHelpString("This is typically the number of connections from the prop to your controller.");
 
+    if (parm1 == 1) {
+        // cant set start node
+    } else {
+        wxString nm = StartNodeAttrName(0);
+        bool hasIndiv = ModelXml->HasAttribute(nm);
+
+        p = grid->Append(new wxBoolProperty("Indiv Start Nodes", "ModelIndividualStartNodes", hasIndiv));
+        p->SetAttribute("UseCheckbox", true);
+
+        wxPGProperty* psn = grid->AppendIn(p, new wxUIntProperty(nm, nm, wxAtoi(ModelXml->GetAttribute(nm, "1"))));
+        psn->SetAttribute("Min", 1);
+        psn->SetAttribute("Max", (int)GetNodeCount());
+        psn->SetEditor("SpinCtrl");
+
+        if (hasIndiv) {
+            int c = parm1;
+            for (int x = 0; x < c; ++x) {
+                nm = StartNodeAttrName(x);
+                std::string val = ModelXml->GetAttribute(nm, "").ToStdString();
+                if (val.empty()) {
+                    val = ComputeStringStartNode(x);
+                    ModelXml->DeleteAttribute(nm);
+                    ModelXml->AddAttribute(nm, val);
+                }
+                int v = wxAtoi(val);
+                if (v < 1) v = 1;
+                if (v > NodesPerString()) v = NodesPerString();
+                if (x == 0) {
+                    psn->SetValue(v);
+                } else {
+                    grid->AppendIn(p, new wxUIntProperty(nm, nm, v));
+                }
+            }
+        } else {
+            psn->Enable(false);
+        }
+    }
+    
+    p = grid->Append(new wxStringProperty("Total Nodes", "TotalNodes", wxString::Format("%d", totalNodes)));
+    p->SetHelpString("Total Nodes for this model");
+    p->SetTextColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+    p->ChangeFlag(wxPGPropertyFlags::ReadOnly, true);
+
     if (SingleNode) {
         p = grid->Append(new wxUIntProperty("Lights/String", "CircleLightCount", parm2));
         p->SetAttribute("Min", 1);
         p->SetAttribute("Max", 2000);
         p->SetEditor("SpinCtrl");
+        p->SetTextColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+        p->ChangeFlag(wxPGPropertyFlags::Hidden, true);
     }
     else {
         p = grid->Append(new wxUIntProperty("Nodes/String", "CircleLightCount", parm2));
@@ -121,6 +167,8 @@ void CircleModel::AddTypeProperties(wxPropertyGridInterface* grid, OutputManager
         p->SetAttribute("Max", 2000);
         p->SetEditor("SpinCtrl");
         p->SetHelpString("This is typically the total number of pixels per #String.");
+        p->SetTextColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+        p->ChangeFlag(wxPGPropertyFlags::Hidden, true);
     }
 
     p = grid->Append(new wxUIntProperty("Center %", "CircleCenterPercent", parm3));
@@ -143,8 +191,18 @@ void CircleModel::AddTypeProperties(wxPropertyGridInterface* grid, OutputManager
 int CircleModel::OnPropertyGridChange(wxPropertyGridInterface* grid, wxPropertyGridEvent& event)
 {
     if ("CircleStringCount" == event.GetPropertyName()) {
+        int prvVal = wxAtoi(ModelXml->GetAttribute("parm1"));   //we never removed old custom strings.. now we do if/when you reduce the ports
+        int newVal = event.GetPropertyValue().GetLong();
+        if (newVal < prvVal) {
+            for (int i = newVal; i < prvVal; i++) {
+                wxString nm = StartNodeAttrName(i);
+                ModelXml->DeleteAttribute(nm);
+            }
+        }
         ModelXml->DeleteAttribute("parm1");
-        ModelXml->AddAttribute("parm1", wxString::Format("%d", (int)event.GetPropertyValue().GetLong()));
+        ModelXml->AddAttribute("parm1", wxString::Format("%d", newVal));
+        ModelXml->DeleteAttribute("parm2");
+        ModelXml->AddAttribute("parm2", wxString::Format("%d", (int)GetLayerSizesTotalNodes() / newVal));
         //AdjustStringProperties(grid, parm1);
         IncrementChangeCount();
         AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "CircleModel::OnPropertyGridChange::CircleStringCount");
@@ -183,17 +241,52 @@ int CircleModel::OnPropertyGridChange(wxPropertyGridInterface* grid, wxPropertyG
         ModelXml->DeleteAttribute("Dir");
         ModelXml->DeleteAttribute("StartSide");
         ModelXml->DeleteAttribute("InsideOut");
-
         int v = event.GetValue().GetLong();
         ModelXml->AddAttribute("Dir", v & 0x1 ? "L" : "R");
         ModelXml->AddAttribute("StartSide", v < 4 ? "T" : "B");
         ModelXml->AddAttribute("InsideOut", v & 0x2 ? "1" : "0");
-
         IncrementChangeCount();
         AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "CircleModel::OnPropertyGridChange::CircleStart");
         AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "CircleModel::OnPropertyGridChange::CircleStart");
         AddASAPWork(OutputModelManager::WORK_RELOAD_MODEL_FROM_XML, "CircleModel::OnPropertyGridChange::CircleStart");
         AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "CircleModel::OnPropertyGridChange::CircleLayerSizes");
+        return 0;
+    } else if (event.GetPropertyName() == "ModelIndividualStartNodes") {
+        bool hasIndiv = parm1>1;
+        for (int x = 0; x < parm1; x++) {
+            wxString nm = StartNodeAttrName(x);
+            ModelXml->DeleteAttribute(nm);
+        }
+        if (hasIndiv) {
+            for (int x = 0; x < parm1; x++) {
+                wxString nm = StartNodeAttrName(x);
+                ModelXml->AddAttribute(nm, ComputeStringStartNode(x));
+            }
+        }
+        IncrementChangeCount();
+        AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "CircleModel::OnPropertyGridChange::ModelIndividualStartNodes");
+        AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "CircleModel::OnPropertyGridChange::ModelIndividualStartNodes");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_MODEL_FROM_XML, "CircleModel::OnPropertyGridChange::ModelIndividualStartNodes");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_MODELLIST, "CircleModel::OnPropertyGridChange::ModelIndividualStartNodes");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "CircleModel::OnPropertyGridChange::ModelIndividualStartNodes");
+        AddASAPWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "CircleModel::OnPropertyGridChange::ModelIndividualStartNodes");
+        return 0;
+    } else if (event.GetPropertyName().StartsWith("ModelIndividualStartNodes.Strings")) {
+        wxString s = event.GetPropertyName().substr(strlen("ModelIndividualStartNodes.Strings"));
+        int string = wxAtoi(s);
+        wxString nm = StartNodeAttrName(string - 1);
+        int value = event.GetValue().GetInteger();
+        if (value < 1) value = 1;
+        if (value > NodesPerString()) value = NodesPerString();
+        ModelXml->DeleteAttribute(nm);
+        ModelXml->AddAttribute(nm, wxString::Format("%d", value));
+        IncrementChangeCount();
+        AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "CircleModel::OnPropertyGridChange::ModelIndividualStartNodes2");
+        AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "CircleModel::OnPropertyGridChange::ModelIndividualStartNodes2");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_MODEL_FROM_XML, "CircleModel::OnPropertyGridChange::ModelIndividualStartNodes2");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_MODELLIST, "CircleModel::OnPropertyGridChange::ModelIndividualStartNodes2");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "CircleModel::OnPropertyGridChange::ModelIndividualStartNodes2");
+        AddASAPWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "CircleModel::OnPropertyGridChange::ModelIndividualStartNodes2");
         return 0;
     }
 
@@ -213,7 +306,7 @@ int CircleModel::maxSize() {
 void CircleModel::InitCircle()
 {
     int maxLights = 0;
-    int numLights = parm1 * parm2;
+    int numLights = totalNodes;
     int cnt = 0;
 
     if (GetLayerSizeCount() == 0) {
@@ -236,7 +329,8 @@ void CircleModel::InitCircle()
         }
     }
 
-    SetNodeCount(parm1, parm2, rgbOrder);
+    SetNodeCount(1, totalNodes, rgbOrder);
+
     SetBufferSize(GetLayerSizeCount(), maxLights);
     int LastStringNum = -1;
     int chan = 0;
@@ -276,6 +370,18 @@ void CircleModel::InitCircle()
             node++;
         }
         nodesToMap -= loop_count;
+    }
+
+    if (GetParm1() > 1) {       //this is only needed to get a visialisation of the strings in NodeView. Can easily be ignored.
+        Nodes[0]->StringNum = 0;
+        std::vector<int> result(stringStartChan.size(), -1);
+        result = stringStartChan;
+        std::transform(result.begin(), result.end(), result.begin(), [](int x) { return std::max(x - 1,0); });
+        result.push_back(Nodes[Nodes.size() - 1]->ActChan + 1);
+        for (int i = 1; i < Nodes.size(); ++i) {
+            auto it = std::lower_bound(result.begin(), result.end(), Nodes[i]->ActChan);
+            if (it != result.end()) Nodes[i]->StringNum = std::distance(result.begin(), it)-1;
+        }
     }
 }
 
@@ -436,12 +542,11 @@ void CircleModel::ImportXlightsModel(wxXmlNode* root, xLightsFrame* xlights, flo
     }
 }
 
-void CircleModel::OnLayerSizesChange(bool countChanged)
-{
-    // if string count is 1 then adjust nodes per string to match sum of nodes
-    if (parm1 == 1 && GetLayerSizeCount() > 0) {
+void CircleModel::OnLayerSizesChange(bool countChanged) {
+    if (GetLayerSizeCount() > 0) {
         ModelXml->DeleteAttribute("parm2");
-        ModelXml->AddAttribute("parm2", wxString::Format("%d", (int)GetLayerSizesTotalNodes()));
+        ModelXml->AddAttribute("parm2", wxString::Format("%d", (int)GetLayerSizesTotalNodes()/parm1));
+        totalNodes = (int)GetLayerSizesTotalNodes();
         AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "CircleModel::OnLayerSizesChange");
         AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "CircleModel::OnLayerSizesChange");
         AddASAPWork(OutputModelManager::WORK_RELOAD_MODEL_FROM_XML, "CircleModel::OnLayerSizesChange");
@@ -450,5 +555,26 @@ void CircleModel::OnLayerSizesChange(bool countChanged)
         AddASAPWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "CircleModel::OnLayerSizesChange");
         AddASAPWork(OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS, "CircleModel::OnLayerSizesChange");
         AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "CircleModel::OnLayerSizesChange");
+    }
+}
+
+std::string CircleModel::ComputeStringStartNode(int x) const {
+    if (x == 0)  return "1";
+
+    int strings = GetNumPhysicalStrings();
+    int nodes = GetNodeCount();
+    float nodesPerString = (float)nodes / (float)strings;
+
+    return std::to_string((int)(x * nodesPerString + 1));
+}
+
+int CircleModel::NodesPerString() const {
+    int nodes = GetChanCount() / std::max(GetChanCountPerNode(), 1);
+    int ts = GetSmartTs();
+
+    if (ts <= 1) {
+        return nodes;
+    } else {
+        return nodes * ts;
     }
 }

--- a/xLights/models/CircleModel.h
+++ b/xLights/models/CircleModel.h
@@ -35,6 +35,9 @@ class CircleModel : public ModelWithScreenLocation<BoxedScreenLocation>
         virtual bool ModelSupportsLayerSizes() const override { return true; }
         virtual void OnLayerSizesChange(bool countChanged) override;
 
+        virtual int NodesPerString() const override;
+        bool SupportsChangingStringCount() const override { return true; };
+
     protected:
         virtual void InitModel() override;
         
@@ -45,4 +48,8 @@ class CircleModel : public ModelWithScreenLocation<BoxedScreenLocation>
         int maxSize();
 
         bool insideOut = false;
+
+        int totalNodes = 0;
+        static std::string StartNodeAttrName(int idx) { return wxString::Format(wxT("Strings%i"), idx + 1).ToStdString(); }
+        std::string ComputeStringStartNode(int x) const;
 };

--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -3099,7 +3099,24 @@ void Model::SetFromXml(wxXmlNode* ModelNode, bool zb)
     size_t NumberOfStrings = HasOneString(DisplayAs) ? 1 : parm1;
     int ChannelsPerString = CalcCannelsPerString();
 
-    SetStringStartChannels(zeroBased, NumberOfStrings, StartChannel, ChannelsPerString);
+    if (ModelNode->GetAttribute("TotalNodes") != NULL) {
+        std::vector<int> customStartNodes{};
+        for (auto i = 1; i <= NumberOfStrings; i++) {
+
+            auto foo = ModelNode->GetAttribute(wxString::Format(wxT("Strings%i"), i).ToStdString(), "-1");
+
+            if (i == 1) {
+                customStartNodes.push_back(StartChannel - 1);
+            } else if (wxAtoi(ModelNode->GetAttribute(wxString::Format(wxT("Strings%i"), i).ToStdString(), "-1")) == -1 ) {
+                customStartNodes.push_back(wxAtoi(ModelNode->GetAttribute("parm2", "1")) * (i-1) * 3 + StartChannel - 1);
+            } else {
+                customStartNodes.push_back((wxAtoi(ModelNode->GetAttribute(wxString::Format(wxT("Strings%i"), i).ToStdString(), "1"))-1) * 3 + StartChannel-1);
+            }
+        }
+        SetStringStartChannels(zeroBased, customStartNodes);
+    } else {
+        SetStringStartChannels(zeroBased, NumberOfStrings, StartChannel, ChannelsPerString);
+    }
     GetModelScreenLocation().Read(ModelNode);
 
     InitModel();
@@ -3353,6 +3370,12 @@ void Model::SetStringStartChannels(bool zeroBased, int NumberOfStrings, int Star
     }
 }
 
+void Model::SetStringStartChannels(int StartChannel, std::vector<int> customStartNodes) {
+    stringStartChan.clear();
+    stringStartChan.resize(customStartNodes.size());
+    stringStartChan = customStartNodes;
+}
+
 int Model::FindNodeAtXY(int bufx, int bufy)
 {
     for (int i = 0; i < Nodes.size(); ++i) {
@@ -3581,7 +3604,7 @@ std::string Model::GetFirstChannelInStartChannelFormat(OutputManager* outputMana
 }
 
 uint32_t Model::GetLastChannel() const
-{
+{    
     uint32_t LastChan = 0;
     size_t NodeCount = GetNodeCount();
     for (size_t idx = 0; idx < NodeCount; ++idx) {
@@ -4377,20 +4400,18 @@ void Model::AddLayerSizeProperty(wxPropertyGridInterface* grid)
     psn->SetAttribute("Max", 100);
     psn->SetEditor("SpinCtrl");
 
-    if (GetLayerSizeCount() > 1) {
-        for (int i = 0; i < GetLayerSizeCount(); ++i) {
-            wxString id = wxString::Format("Layer%d", i);
-            wxString nm = wxString::Format("Layer %d", i + 1);
-            if (i == 0)
-                nm = "Inside";
-            else if (i == GetLayerSizeCount() - 1)
-                nm = "Outside";
+    for (int i = 0; i < GetLayerSizeCount(); ++i) {         //Always show Layers since we're using this to get the node counts
+        wxString id = wxString::Format("Layer%d", i);
+        wxString nm = wxString::Format("Layer %d", i + 1);
+        if (i == 0)
+            nm = "Inside";
+        else if (i == GetLayerSizeCount() - 1)
+            nm = "Outside";
 
-            wxPGProperty* pls = grid->AppendIn(psn, new wxUIntProperty(nm, id, GetLayerSize(i)));
-            pls->SetAttribute("Min", 1);
-            pls->SetAttribute("Max", 1000);
-            pls->SetEditor("SpinCtrl");
-        }
+        wxPGProperty* pls = grid->AppendIn(psn, new wxUIntProperty(nm, id, GetLayerSize(i)));
+        pls->SetAttribute("Min", 1);
+        pls->SetAttribute("Max", 1000);
+        pls->SetEditor("SpinCtrl");
     }
 }
 

--- a/xLights/models/Model.h
+++ b/xLights/models/Model.h
@@ -290,6 +290,7 @@ protected:
     virtual void InitModel();
     virtual int CalcCannelsPerString();
     virtual void SetStringStartChannels(bool zeroBased, int NumberOfStrings, int StartChannel, int ChannelsPerString);
+    virtual void SetStringStartChannels(int StartChannel, std::vector<int> customStartNodes);
     void RecalcStartChannels();
 
     void SetBufferSize(int NewHt, int NewWi);

--- a/xLights/models/StarModel.cpp
+++ b/xLights/models/StarModel.cpp
@@ -254,7 +254,6 @@ void StarModel::InitModel()
     innerPercent = wxAtoi(ModelXml->GetAttribute("starCenterPercent", "-1"));
 
     if (parm3 < 2) parm3 = 2; // need at least 2 arms
-    SetNodeCount(parm1, parm2, rgbOrder);
 
     // Found a problem where a user had multiple layer sizes but just 1 string and set to RGB dumb string type.
     // I think the commented out code would fix this but I am not sure it would work in all situations.
@@ -272,14 +271,14 @@ void StarModel::InitModel()
     // each layer is then applied inside the prior one by some factor
     // the radius of the outer circle starts are bufferWi / 2
 
-    int numlights = parm1 * parm2;
-    if (numlights == 0) return;
     if (GetLayerSizeCount() == 0) {
         SetLayerSizeCount(1);
     }
     if (GetLayerSizeCount() == 1) {
-        SetLayerSize(0, numlights);
+        SetLayerSize(0, parm1 * parm2);
     }
+    totalNodes = (int)GetLayerSizesTotalNodes();
+    SetNodeCount(1, totalNodes, rgbOrder);
 
     int maxLightsOnLayer = 0;
     for (int l = 0; l < GetLayerSizeCount(); l++) {
@@ -378,8 +377,8 @@ void StarModel::InitModel()
 
                 while (curPos < segEndLen && currentNode < endNodeForLayer) {
 
-                    int currentString = currentNode / parm2;
-                    int nodeInString = currentNode % parm2;
+                    int currentString = currentNode / totalNodes;
+                    int nodeInString = currentNode % totalNodes;
                     if (nodeInString == 0 && currentString < GetNumStrings()) {
                         chan = stringStartChan[currentString];
                     }
@@ -416,8 +415,8 @@ void StarModel::InitModel()
 
         // handle any left over nodes
         for (int n = currentNode; n < Nodes.size(); n++) {
-            int currentString = n / parm2;
-            int nodeInString = n % parm2;
+            int currentString = n / totalNodes;
+            int nodeInString = n % totalNodes;
             if (nodeInString == 0) {
                 chan = stringStartChan[currentString];
             }
@@ -510,6 +509,19 @@ void StarModel::InitModel()
             innerRadius = outerRadius / starRatio;
         }
     }
+
+    if (GetParm1() > 1) { // this is only needed to get a visialisation of the strings in NodeView. Can easily be ignored.
+        Nodes[0]->StringNum = 0;
+        std::vector<int> result(stringStartChan.size(), -1);
+        result = stringStartChan;
+        std::transform(result.begin(), result.end(), result.begin(), [](int x) { return std::max(x - 1,0); });
+        result.push_back(Nodes[Nodes.size() - 1]->ActChan + 1);
+        for (int i = 1; i < Nodes.size(); ++i) {
+            auto it = std::lower_bound(result.begin(), result.end(), Nodes[i]->ActChan);
+            if (it != result.end()) Nodes[i]->StringNum = std::distance(result.begin(), it) - 1;
+        }
+    }
+
     GetModelScreenLocation().SetRenderSize(BufferWi, BufferHt, GetModelScreenLocation().GetRenderDp());
     screenLocation.RenderDp = 10.0f;  // give the bounding box a little depth
 }
@@ -539,17 +551,66 @@ void StarModel::AddTypeProperties(wxPropertyGridInterface* grid, OutputManager* 
     p->SetEditor("SpinCtrl");
     p->SetHelpString("This is typically the number of connections from the prop to your controller.");
 
+    if (parm1 == 1) {
+        // cant set start node
+    } else {
+        wxString nm = StartNodeAttrName(0);
+        bool hasIndiv = ModelXml->HasAttribute(nm);
+
+        p = grid->Append(new wxBoolProperty("Indiv Start Nodes", "ModelIndividualStartNodes", hasIndiv));
+        p->SetAttribute("UseCheckbox", true);
+
+        wxPGProperty* psn = grid->AppendIn(p, new wxUIntProperty(nm, nm, wxAtoi(ModelXml->GetAttribute(nm, "1"))));
+        psn->SetAttribute("Min", 1);
+        psn->SetAttribute("Max", (int)GetNodeCount());
+        psn->SetEditor("SpinCtrl");
+
+        if (hasIndiv) {
+            int c = parm1;
+            for (int x = 0; x < c; ++x) {
+                nm = StartNodeAttrName(x);
+                std::string val = ModelXml->GetAttribute(nm, "").ToStdString();
+                if (val.empty()) {
+                    val = ComputeStringStartNode(x);
+                    ModelXml->DeleteAttribute(nm);
+                    ModelXml->AddAttribute(nm, val);
+                }
+                int v = wxAtoi(val);
+                if (v < 1)
+                    v = 1;
+                if (v > NodesPerString())
+                    v = NodesPerString();
+                if (x == 0) {
+                    psn->SetValue(v);
+                } else {
+                    grid->AppendIn(p, new wxUIntProperty(nm, nm, v));
+                }
+            }
+        } else {
+            psn->Enable(false);
+        }
+    }
+
+    p = grid->Append(new wxStringProperty("Total Nodes", "TotalNodes", wxString::Format("%d", totalNodes)));
+    p->SetHelpString("Total Nodes for this model");
+    p->SetTextColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+    p->ChangeFlag(wxPGPropertyFlags::ReadOnly, true);
+
     if (SingleNode) {
         p = grid->Append(new wxUIntProperty("Lights/String", "StarLightCount", parm2));
         p->SetAttribute("Min", 1);
         p->SetAttribute("Max", 10000);
         p->SetEditor("SpinCtrl");
+        p->SetTextColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+        p->ChangeFlag(wxPGPropertyFlags::Hidden, true);
     } else {
         p = grid->Append(new wxUIntProperty("Nodes/String", "StarLightCount", parm2));
         p->SetAttribute("Min", 1);
         p->SetAttribute("Max", 10000);
         p->SetEditor("SpinCtrl");
         p->SetHelpString("This is typically the total number of pixels per #String.");
+        p->SetTextColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+        p->ChangeFlag(wxPGPropertyFlags::Hidden, true);
     }
 
     p = grid->Append(new wxUIntProperty("# Points", "StarStrandCount", parm3));
@@ -584,8 +645,18 @@ void StarModel::AddTypeProperties(wxPropertyGridInterface* grid, OutputManager* 
 int StarModel::OnPropertyGridChange(wxPropertyGridInterface* grid, wxPropertyGridEvent& event)
 {
     if ("StarStringCount" == event.GetPropertyName()) {
+        int prvVal = wxAtoi(ModelXml->GetAttribute("parm1")); // we never removed old custom strings.. now we do if/when you reduce the ports
+        int newVal = event.GetPropertyValue().GetLong();
+        if (newVal < prvVal) {
+            for (int i = newVal; i < prvVal; i++) {
+                wxString nm = StartNodeAttrName(i);
+                ModelXml->DeleteAttribute(nm);
+            }
+        }
         ModelXml->DeleteAttribute("parm1");
-        ModelXml->AddAttribute("parm1", wxString::Format("%d", (int)event.GetPropertyValue().GetLong()));
+        ModelXml->AddAttribute("parm1", wxString::Format("%d", newVal));
+        ModelXml->DeleteAttribute("parm2");
+        ModelXml->AddAttribute("parm2", wxString::Format("%d", (int)GetLayerSizesTotalNodes() / newVal));
         //AdjustStringProperties(grid, parm1);
         IncrementChangeCount();
         AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "StarModel::OnPropertyGridChange::StarStringCount");
@@ -647,6 +718,45 @@ int StarModel::OnPropertyGridChange(wxPropertyGridInterface* grid, wxPropertyGri
         AddASAPWork(OutputModelManager::WORK_RELOAD_MODEL_FROM_XML, "StarModel::OnPropertyGridChange::StarRatio");
         AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "StarModel::OnPropertyGridChange::StarRatio");
         return 0;
+    } else if (event.GetPropertyName() == "ModelIndividualStartNodes") {
+        bool hasIndiv = parm1 > 1;
+        for (int x = 0; x < parm1; x++) {
+            wxString nm = StartNodeAttrName(x);
+            ModelXml->DeleteAttribute(nm);
+        }
+        if (hasIndiv) {
+            for (int x = 0; x < parm1; x++) {
+                wxString nm = StartNodeAttrName(x);
+                ModelXml->AddAttribute(nm, ComputeStringStartNode(x));
+            }
+        }
+        IncrementChangeCount();
+        AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "StarModel::OnPropertyGridChange::ModelIndividualStartNodes");
+        AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "StarModel::OnPropertyGridChange::ModelIndividualStartNodes");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_MODEL_FROM_XML, "StarModel::OnPropertyGridChange::ModelIndividualStartNodes");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_MODELLIST, "StarModel::OnPropertyGridChange::ModelIndividualStartNodes");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "StarModel::OnPropertyGridChange::ModelIndividualStartNodes");
+        AddASAPWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "StarModel::OnPropertyGridChange::ModelIndividualStartNodes");
+        return 0;
+    } else if (event.GetPropertyName().StartsWith("ModelIndividualStartNodes.Strings")) {
+        wxString s = event.GetPropertyName().substr(strlen("ModelIndividualStartNodes.Strings"));
+        int string = wxAtoi(s);
+        wxString nm = StartNodeAttrName(string - 1);
+        int value = event.GetValue().GetInteger();
+        if (value < 1)
+            value = 1;
+        if (value > NodesPerString())
+            value = NodesPerString();
+        ModelXml->DeleteAttribute(nm);
+        ModelXml->AddAttribute(nm, wxString::Format("%d", value));
+        IncrementChangeCount();
+        AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "StarModel::OnPropertyGridChange::ModelIndividualStartNodes2");
+        AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "StarModel::OnPropertyGridChange::ModelIndividualStartNodes2");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_MODEL_FROM_XML, "StarModel::OnPropertyGridChange::ModelIndividualStartNodes2");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_MODELLIST, "StarModel::OnPropertyGridChange::ModelIndividualStartNodes2");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "StarModel::OnPropertyGridChange::ModelIndividualStartNodes2");
+        AddASAPWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "StarModel::OnPropertyGridChange::ModelIndividualStartNodes2");
+        return 0;
     }
 
     return Model::OnPropertyGridChange(grid, event);
@@ -655,9 +765,10 @@ int StarModel::OnPropertyGridChange(wxPropertyGridInterface* grid, wxPropertyGri
 void StarModel::OnLayerSizesChange(bool countChanged)
 {
     // if string count is 1 then adjust nodes per string to match sum of nodes
-    if (parm1 == 1) {
+    if (GetLayerSizeCount() > 0) {
         ModelXml->DeleteAttribute("parm2");
-        ModelXml->AddAttribute("parm2", wxString::Format("%d", (int)GetLayerSizesTotalNodes()));
+        ModelXml->AddAttribute("parm2", wxString::Format("%d", (int)GetLayerSizesTotalNodes()/parm1));
+        totalNodes = (int)GetLayerSizesTotalNodes();
         IncrementChangeCount();
         AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "StarModel::OnLayerSizesChange");
         AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "StarModel::OnLayerSizesChange");
@@ -813,5 +924,25 @@ void StarModel::ImportXlightsModel(wxXmlNode* root, xLightsFrame* xlights, float
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "StarModel::ImportXlightsModel");
     } else {
         DisplayError("Failure loading Star model file.");
+    }
+}
+std::string StarModel::ComputeStringStartNode(int x) const {
+    if (x == 0) return "1";
+
+    int strings = GetNumPhysicalStrings();
+    int nodes = GetNodeCount();
+    float nodesPerString = (float)nodes / (float)strings;
+
+    return std::to_string((int)(x * nodesPerString + 1));
+}
+
+int StarModel::NodesPerString() const {
+    int nodes = GetChanCount() / std::max(GetChanCountPerNode(), 1);
+    int ts = GetSmartTs();
+
+    if (ts <= 1) {
+        return nodes;
+    } else {
+        return nodes * ts;
     }
 }

--- a/xLights/models/StarModel.h
+++ b/xLights/models/StarModel.h
@@ -29,9 +29,7 @@ class StarModel : public ModelWithScreenLocation<BoxedScreenLocation>
         virtual int MapToNodeIndex(int strand, int node) const override;
         virtual int GetMappedStrand(int strand) const override;
 
-        int GetStarSize(int starLayer) const {
-            return GetLayerSize(starLayer);
-        }
+        int GetStarSize(int starLayer) const { return GetLayerSize(starLayer); }
         virtual int GetNumStrands() const override;
         virtual bool AllNodesAllocated() const override;
 
@@ -44,6 +42,9 @@ class StarModel : public ModelWithScreenLocation<BoxedScreenLocation>
 
         virtual bool ModelSupportsLayerSizes() const override { return true; }
         virtual void OnLayerSizesChange(bool countChanged) override;
+
+        virtual int NodesPerString() const override;
+        bool SupportsChangingStringCount() const override { return true; };
 
     protected:
         static std::vector<std::string> STAR_BUFFER_STYLES;
@@ -59,4 +60,7 @@ class StarModel : public ModelWithScreenLocation<BoxedScreenLocation>
         // The ratio between the inner start and outer star radius (if more than 1 layer)
         int innerPercent = -1;
         std::string _starStartLocation = "Bottom Ctr-CW";
+        int totalNodes = 0;
+        static std::string StartNodeAttrName(int idx) { return wxString::Format(wxT("Strings%i"), idx + 1).ToStdString(); }
+        std::string ComputeStringStartNode(int x) const;
 };


### PR DESCRIPTION
There will be part 2 for the Matrix

There's a new read only Attribute, TotalNodes, that's the sum of all layers. Node counts comes from that sum
Added logic (best it can do for abckwars support) to set parm1/parm2 based on any changes to layers and ports
Allow user to enter nodes for a single layer -> since that's where the total nodes come from