### PR TITLE
Check that timing track name doesnt conflict with models #2785

### DIFF
--- a/xLights/sequencer/RowHeading.cpp
+++ b/xLights/sequencer/RowHeading.cpp
@@ -693,14 +693,19 @@ void RowHeading::OnLayerPopup(wxCommandEvent& event)
                 } else if (selected_timing == "Empty") {
                     bool first = true;
                     wxTextEntryDialog te(this, "Enter a name for the timing track", wxGetTextFromUserPromptStr, selected_timing);
+                    selected_timing = RemoveUnsafeXmlChars(selected_timing);
                     OptimiseDialogPosition(&te);
-                    while (first || xml_file->TimingAlreadyExists(selected_timing, mSequenceElements->GetXLightsFrame()) || selected_timing == "") {
+                    while (first || 
+                           xml_file->TimingAlreadyExists(selected_timing, mSequenceElements->GetXLightsFrame()) || 
+                           xml_file->TimingMatchesModelName(selected_timing, mSequenceElements->GetXLightsFrame()) ||
+                           selected_timing == "") {
                         first = false;
 
                         auto base = selected_timing;
 
                         int suffix = 2;
-                        while (xml_file->TimingAlreadyExists(selected_timing, mSequenceElements->GetXLightsFrame())) {
+                        while (xml_file->TimingAlreadyExists(selected_timing, mSequenceElements->GetXLightsFrame()) ||
+                               xml_file->TimingMatchesModelName(selected_timing, mSequenceElements->GetXLightsFrame())) {
                             selected_timing = wxString::Format("%s_%d", base, suffix++);
                         }
 

--- a/xLights/xLightsXmlFile.cpp
+++ b/xLights/xLightsXmlFile.cpp
@@ -2888,6 +2888,16 @@ bool xLightsXmlFile::TimingAlreadyExists(const std::string & section, xLightsFra
     return false;
 }
 
+bool xLightsXmlFile::TimingMatchesModelName(const std::string& section, xLightsFrame* xLightsParent) {
+    if (sequence_loaded) {
+        SequenceElements& mSequenceElements = xLightsParent->GetSequenceElements();
+        if (mSequenceElements.ElementExists(section)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void xLightsXmlFile::AddNewTimingSection(const std::string& filename, xLightsFrame* xLightsParent,
                                          std::vector<int>& starts, std::vector<int>& ends, std::vector<std::string>& labels)
 {

--- a/xLights/xLightsXmlFile.h
+++ b/xLights/xLightsXmlFile.h
@@ -127,6 +127,7 @@ public:
     void DeleteTimingSection(const std::string& section);
     void SetTimingSectionName(const std::string& section, const std::string& name);
     bool TimingAlreadyExists(const std::string& section, xLightsFrame* xLightsParent);
+    bool TimingMatchesModelName(const std::string& section, xLightsFrame* xLightsParent);
     wxArrayString GetTimingList() const
     {
         return timing_list;


### PR DESCRIPTION
If a timing track is named the same as a model, it is hidden. Checks were in place to catch a rename but were not done on the initial Add Timing track option. #2785