### PR TITLE
Add sACN/ArtNet support for ILightThat controller

### DIFF
--- a/controllers/ilightthat.xcontroller
+++ b/controllers/ilightthat.xcontroller
@@ -8,6 +8,7 @@
         <MaxPixelPortChannels>2250</MaxPixelPortChannels>
         <AllInputUniversesMustBeSameSize/>
         <UniversesMustBeSequential/>
+        <AllInputUniversesMustBe510/>
         <SupportsAutoLayout/>
         <PixelProtocols>
             <Protocol>ws2811</Protocol>
@@ -15,6 +16,8 @@
         <SerialProtocols/>
         <InputProtocols>
             <Protocol>ddp</Protocol>
+            <Protocol>artnet</Protocol>
+            <Protocol>e131</Protocol>
         </InputProtocols>
         <ConfigDriver>ILightThat</ConfigDriver>
     </AbstractVariant>

--- a/xLights/controllers/ILightThat.cpp
+++ b/xLights/controllers/ILightThat.cpp
@@ -63,6 +63,25 @@ bool ILightThat::SetOutputs(ModelManager* allmodels, OutputManager* outputManage
     static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
     logger_base.debug("ILightThat Outputs Upload: Uploading to %s", (const char*)_ip.c_str());
 
+    std::unordered_map<std::string, int> model_test_cols = {};
+    std::string const json = GetURL("/settings");
+    if (!json.empty()) {
+        wxJSONValue jsonVal;
+        wxJSONReader reader;
+
+        reader.Parse(json, &jsonVal);
+        if (jsonVal["ports"].IsArray()) {
+            for (int i = 0; i < jsonVal["ports"].Size(); i++) {
+                for (int j = 0; j < jsonVal["ports"][i]["models"].Size(); j++) {
+                    wxJSONValue model = jsonVal["ports"][i]["models"][j];
+                    if (model.HasMember("test_colour")) {
+                        model_test_cols[model["name"].AsString()] = model["test_colour"].AsInt();
+                    }
+                }
+            }
+        }
+    }
+
     std::string check;
     UDController cud(controller, outputManager, allmodels, false);
     auto rules = ControllerCaps::GetControllerConfig(controller);
@@ -72,6 +91,8 @@ bool ILightThat::SetOutputs(ModelManager* allmodels, OutputManager* outputManage
         wxJSONValue outputConfig = new wxJSONValue();
         int first_channel = cud.GetFirstOutput()->GetStartChannel();
         outputConfig["start_address"] = first_channel;
+        outputConfig["start_universe"] = cud.GetFirstOutput()->GetUniverse();
+        outputConfig["channels_per_universe"] = 510;
         //GetOutputConfig(outputConfig);
         for (int x = 0; x < cud.GetMaxPixelPort(); x++) {
             UDControllerPort* port = cud.GetControllerPixelPort(x + 1);
@@ -87,6 +108,14 @@ bool ILightThat::SetOutputs(ModelManager* allmodels, OutputManager* outputManage
                     brightness = 100;
                 }
                 
+                if (model_test_cols.find(model->GetName()) == model_test_cols.end()) {
+                    outputConfig["ports"][x]["models"][i]["test_colour"] = 0x00ff0000;
+                }
+                else
+                {
+                    outputConfig["ports"][x]["models"][i]["test_colour"] = model_test_cols.find(model->GetName())->second;
+                }
+
                 outputConfig["ports"][x]["models"][i]["brightness"] = brightness;
                 outputConfig["ports"][x]["models"][i]["start"] = (model->GetStartChannel() - port->GetFirstModel()->GetStartChannel()) / 3;
                 outputConfig["ports"][x]["models"][i]["num_pixels"] = ((model->GetEndChannel() - model->GetStartChannel()) + 1) / 3;


### PR DESCRIPTION
Also cache and restore test colour for models, so they're not lost whenever we push config from xLights.