### PR TITLE
Resize the buffer if it is not the right size #4574

### DIFF
--- a/xLights/effects/FireEffect.cpp
+++ b/xLights/effects/FireEffect.cpp
@@ -239,7 +239,7 @@ void FireEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBu
     FireRenderCache* cache = GetCache(buffer, id);
 
     float mod_state = 4.0;
-    if (buffer.needToInit) {
+    if (buffer.needToInit || (maxMHt * maxMWi) != cache->FireBuffer.size()) {
         buffer.needToInit = false;
         cache->FireBuffer.resize(maxMHt * maxMWi);
         for (size_t i = 0; i < cache->FireBuffer.size(); ++i) {


### PR DESCRIPTION
This is more of a workaround - not clear why the buffer would come in the wrong size here - seems like it was created at a different layer perhaps incorrectly?
Note too that "mod_state" on lines 241 and 249 is dead code and could be removed.
