### PR TITLE
Fix issue with miss-identification of Falcon boards in FPP connect.

### DIFF
--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -3608,8 +3608,7 @@ static bool supportedForFPPConnect(DiscoveredData* res, OutputManager* outputMan
         return res->majorVersion >= 4 && res->mode == "remote";
     }
 
-    if (res->typeId == 0x88 || res->typeId == 0x89 ||
-        res->typeId == 0x90 || res->typeId == 0x91) {
+    if ((res->typeId >= 0x80) && (res->typeId <= 0x83)) {
         // F16V4 / F48V4 / F16V5 / F48V5
         return res->mode != "bridge";
     }
@@ -3714,8 +3713,7 @@ void FPP::MapToFPPInstances(Discovery &discovery, std::list<FPP*> &instances, Ou
 void FPP::TypeIDtoControllerType(int typeId, FPP* inst) {
     if (typeId < 0x80) {
         inst->fppType = FPP_TYPE::FPP;
-    } else if (typeId == 0x88 || typeId == 0x89 ||
-               typeId == 0x90 || typeId == 0x91) {
+    } else if (typeId >= 0x80 && typeId <= 0x83) {
         inst->fppType = FPP_TYPE::FALCONV4V5;
     } else if (typeId == 0xC2 || typeId == 0xC3) {
         inst->fppType = FPP_TYPE::ESPIXELSTICK;


### PR DESCRIPTION
Falcon.cpp has ModelDecode as below, which is correct based on what ip/status.xml returns (ie: <p>130</p> for F16V5.
However FPPConnect was looking at the 88-91 range vs 80-93 to set up a Falcon V4or V5 board.
case 128:
    model = 16;
    version = 4;
    break;
case 129:
    model = 48;
    version = 4;
    break;
case 130:
    model = 16;
    version = 5;
    break;
case 131:
    model = 48;
    version = 5;
    break;