### PR TITLE
Add middle mouse to pan sequencer #4593

### DIFF
--- a/xLights/sequencer/EffectsGrid.h
+++ b/xLights/sequencer/EffectsGrid.h
@@ -202,6 +202,8 @@ public:
     }
 
 protected:
+    bool m_wheel_down = false;
+    int m_previous_mouse_x = 0;
 
 private:
     Effect* GetEffectAtRowAndTime(int row, int ms,int &index, HitLocation &selectionType);
@@ -218,6 +220,8 @@ private:
 	void rightClick(wxMouseEvent& event);
 	void mouseLeftDClick(wxMouseEvent& event);
 	void mouseLeftWindow(wxMouseEvent& event);
+    void mouseMiddleDown(wxMouseEvent& event);
+    void mouseMiddleUp(wxMouseEvent& event);
     void OnLostMouseCapture(wxMouseCaptureLostEvent& event);
 	void keyPressed(wxKeyEvent& event);
 	void keyReleased(wxKeyEvent& event);

--- a/xLights/sequencer/EffectsGrid.h
+++ b/xLights/sequencer/EffectsGrid.h
@@ -213,18 +213,18 @@ private:
     void CreateEffectForFile(int x, int y, const std::string& effectName, const std::string& filename);
     void render(wxPaintEvent& evt);
     void magnify(wxMouseEvent& event);
-	void mouseMoved(wxMouseEvent& event);
-	void mouseDown(wxMouseEvent& event);
-	void mouseWheelMoved(wxMouseEvent& event);
-	void mouseReleased(wxMouseEvent& event);
-	void rightClick(wxMouseEvent& event);
-	void mouseLeftDClick(wxMouseEvent& event);
-	void mouseLeftWindow(wxMouseEvent& event);
+    void mouseMoved(wxMouseEvent& event);
+    void mouseDown(wxMouseEvent& event);
+    void mouseWheelMoved(wxMouseEvent& event);
+    void mouseReleased(wxMouseEvent& event);
+    void rightClick(wxMouseEvent& event);
+    void mouseLeftDClick(wxMouseEvent& event);
+    void mouseLeftWindow(wxMouseEvent& event);
     void mouseMiddleDown(wxMouseEvent& event);
     void mouseMiddleUp(wxMouseEvent& event);
     void OnLostMouseCapture(wxMouseCaptureLostEvent& event);
-	void keyPressed(wxKeyEvent& event);
-	void keyReleased(wxKeyEvent& event);
+    void keyPressed(wxKeyEvent& event);
+    void keyReleased(wxKeyEvent& event);
 
     void CreateEffectIconTextures(xlGraphicsContext *ctx);
     void SetRCToolTip();


### PR DESCRIPTION
With a sequence open, on the sequence panel add the ability to middle click, hold and pan to move the sequence window. #4593 