### PR TITLE
#4605 Optionally retain the effect duration when duplicating an effect

### DIFF
--- a/xLights/DuplicateDialog.cpp
+++ b/xLights/DuplicateDialog.cpp
@@ -22,6 +22,7 @@
 const long DuplicateDialog::ID_SPINCTRL_COUNT = wxNewId();
 const long DuplicateDialog::ID_STATICTEXT2 = wxNewId();
 const long DuplicateDialog::ID_SPINCTRL_GAP = wxNewId();
+const long DuplicateDialog::ID_CHECKBOX_RetainDur = wxNewId();
 const long DuplicateDialog::ID_BUTTON_OK = wxNewId();
 const long DuplicateDialog::ID_BUTTON_CLOSE = wxNewId();
 //*)
@@ -42,29 +43,37 @@ DuplicateDialog::DuplicateDialog(wxWindow* parent, wxWindowID id, const wxPoint&
     BoxSizer1 = new wxBoxSizer(wxVERTICAL);
     FlexGridSizer2 = new wxFlexGridSizer(0, 2, 0, 0);
     StaticText1 = new wxStaticText(this, wxID_ANY, _("Count:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
-    FlexGridSizer2->Add(StaticText1, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 5);
+    FlexGridSizer2->Add(StaticText1, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
     SpinCtrl_Count = new wxSpinCtrl(this, ID_SPINCTRL_COUNT, _T("1"), wxDefaultPosition, wxDefaultSize, 0, 1, 100, 1, _T("ID_SPINCTRL_COUNT"));
     SpinCtrl_Count->SetValue(_T("1"));
-    FlexGridSizer2->Add(SpinCtrl_Count, 1, wxALL | wxEXPAND, 5);
+    FlexGridSizer2->Add(SpinCtrl_Count, 1, wxALL|wxEXPAND, 5);
     StaticText2 = new wxStaticText(this, ID_STATICTEXT2, _("Gap:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT2"));
-    FlexGridSizer2->Add(StaticText2, 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 5);
+    FlexGridSizer2->Add(StaticText2, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
     SpinCtrl_Gap = new wxSpinCtrl(this, ID_SPINCTRL_GAP, _T("0"), wxDefaultPosition, wxDefaultSize, 0, 0, 100, 0, _T("ID_SPINCTRL_GAP"));
     SpinCtrl_Gap->SetValue(_T("0"));
-    FlexGridSizer2->Add(SpinCtrl_Gap, 1, wxALL | wxEXPAND, 5);
-    BoxSizer1->Add(FlexGridSizer2, 1, wxALL | wxEXPAND, 5);
+    FlexGridSizer2->Add(SpinCtrl_Gap, 1, wxALL|wxEXPAND, 5);
+    StaticText3 = new wxStaticText(this, wxID_ANY, _("Retain Duration:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+    FlexGridSizer2->Add(StaticText3, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    Checkbox_Retain_Duration = new wxCheckBox(this, ID_CHECKBOX_RetainDur, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_RetainDur"));
+    Checkbox_Retain_Duration->SetValue(false);
+    Checkbox_Retain_Duration->SetToolTip(_("Paste by Cell will retain the duration of the original effect"));
+    FlexGridSizer2->Add(Checkbox_Retain_Duration, 1, wxALL, 5);
+    BoxSizer1->Add(FlexGridSizer2, 1, wxALL|wxEXPAND, 5);
     BoxSizer2 = new wxBoxSizer(wxHORIZONTAL);
     Button_Ok = new wxButton(this, ID_BUTTON_OK, _("Ok"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_OK"));
-    BoxSizer2->Add(Button_Ok, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 5);
+    Button_Ok->SetDefault();
+    BoxSizer2->Add(Button_Ok, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
     Button_Close = new wxButton(this, ID_BUTTON_CLOSE, _("Close"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_CLOSE"));
-    BoxSizer2->Add(Button_Close, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 5);
-    BoxSizer1->Add(BoxSizer2, 0, wxALL | wxEXPAND, 5);
+    BoxSizer2->Add(Button_Close, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    BoxSizer1->Add(BoxSizer2, 0, wxALL|wxEXPAND, 5);
     SetSizer(BoxSizer1);
     BoxSizer1->Fit(this);
     BoxSizer1->SetSizeHints(this);
 
-    Connect(ID_BUTTON_OK, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&DuplicateDialog::OnButton_OkClick);
-    Connect(ID_BUTTON_CLOSE, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&DuplicateDialog::OnButton_CloseClick);
+    Connect(ID_BUTTON_OK,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&DuplicateDialog::OnButton_OkClick);
+    Connect(ID_BUTTON_CLOSE,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&DuplicateDialog::OnButton_CloseClick);
     //*)
+
     wxConfigBase* config = wxConfigBase::Get();
     if (config != nullptr) {
         int count { 1 };

--- a/xLights/DuplicateDialog.h
+++ b/xLights/DuplicateDialog.h
@@ -12,6 +12,7 @@
 
 //(*Headers(DuplicateDialog)
 #include <wx/button.h>
+#include <wx/checkbox.h>
 #include <wx/dialog.h>
 #include <wx/sizer.h>
 #include <wx/spinctrl.h>
@@ -28,10 +29,12 @@ class DuplicateDialog: public wxDialog
 		//(*Declarations(DuplicateDialog)
 		wxButton* Button_Close;
 		wxButton* Button_Ok;
+		wxCheckBox* Checkbox_Retain_Duration;
 		wxSpinCtrl* SpinCtrl_Count;
 		wxSpinCtrl* SpinCtrl_Gap;
 		wxStaticText* StaticText1;
 		wxStaticText* StaticText2;
+		wxStaticText* StaticText3;
 		//*)
 
         int GetCount() const
@@ -42,6 +45,9 @@ class DuplicateDialog: public wxDialog
         {
             return SpinCtrl_Gap->GetValue();
         }
+        int GetRetainDuration() const {
+            return Checkbox_Retain_Duration->GetValue();
+        }
 
 	protected:
 
@@ -49,6 +55,7 @@ class DuplicateDialog: public wxDialog
 		static const long ID_SPINCTRL_COUNT;
 		static const long ID_STATICTEXT2;
 		static const long ID_SPINCTRL_GAP;
+		static const long ID_CHECKBOX_RetainDur;
 		static const long ID_BUTTON_OK;
 		static const long ID_BUTTON_CLOSE;
 		//*)

--- a/xLights/sequencer/EffectsGrid.cpp
+++ b/xLights/sequencer/EffectsGrid.cpp
@@ -7001,6 +7001,10 @@ void EffectsGrid::DuplicateSelectedEffects()
                 if (tel == nullptr) {
                     return;
                 }
+                long start = mSelectedEffect->GetStartTimeMS();
+                long end = mSelectedEffect->GetEndTimeMS();
+                long length = end - start;
+
                 long startCol = tel->GetEffectByTime(mSelectedEffect->GetStartTimeMS())->GetID() + 2;
                 if (mSelectedEffect->GetStartTimeMS() == 0) {//first timing mark in the zero column, and second timing mark has start column of 0 too
                     startCol--;
@@ -7012,7 +7016,12 @@ void EffectsGrid::DuplicateSelectedEffects()
                     Effect* eff = tel->GetEffect(startCol);
                     if (nullptr != eff) {
                         long newstart = mTimeline->RoundToMultipleOfPeriod(eff->GetStartTimeMS(), mSequenceElements->GetFrequency());
-                        long newEnd = mTimeline->RoundToMultipleOfPeriod(eff->GetEndTimeMS(), mSequenceElements->GetFrequency());
+                        long newEnd;
+                        if (dialog.GetRetainDuration()) {
+                            newEnd = mTimeline->RoundToMultipleOfPeriod(newstart + length, mSequenceElements->GetFrequency());
+                        } else {
+                            newEnd = mTimeline->RoundToMultipleOfPeriod(eff->GetEndTimeMS(), mSequenceElements->GetFrequency());
+                        }
                         if (!el->HasEffectsInTimeRange(newstart, newEnd)) {
                             Effect* newef = el->AddEffect(0, xlights->GetEffectManager().GetEffectName(mSelectedEffect->GetEffectIndex()), mSelectedEffect->GetSettingsAsString(), mSelectedEffect->GetPaletteAsString(), newstart, newEnd, EFFECT_SELECTED, false);
                             mSequenceElements->get_undo_mgr().CaptureAddedEffect(el->GetParentElement()->GetName(), el->GetIndex(), newef->GetID());

--- a/xLights/wxsmith/DuplicateDialog.wxs
+++ b/xLights/wxsmith/DuplicateDialog.wxs
@@ -41,6 +41,22 @@
 						<border>5</border>
 						<option>1</option>
 					</object>
+					<object class="sizeritem">
+						<object class="wxStaticText" name="wxID_ANY" variable="StaticText3" member="yes">
+							<label>Retain Duration:</label>
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxCheckBox" name="ID_CHECKBOX_RetainDur" variable="Checkbox_Retain_Duration" member="yes">
+							<tooltip>Paste by Cell will retain the duration of the original effect</tooltip>
+						</object>
+						<flag>wxALL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
 				</object>
 				<flag>wxALL|wxEXPAND</flag>
 				<border>5</border>


### PR DESCRIPTION
In the right click duplicate effect menu, a new checkbox (@computergeek1507) will optionally make the duplicated effects retain the same effect length rather then expand the effect to the max between the timing marks. This is good, for example, to create a shockwave of .5s at each of the various timing marks.