### PR TITLE
#4601 Fix JSON & ZigZag parameters for PixLite E4-S v1.5 firmware

### DIFF
--- a/xLights/controllers/Pixlite16.cpp
+++ b/xLights/controllers/Pixlite16.cpp
@@ -1129,7 +1129,7 @@ bool Pixlite16::GetMK3Config()
 
     if (_mk3APIVersion != "") {
         std::string request = "{\"req\":\"configRead\",\"id\":1,\"params\":{\"path\":[\"\"]}}";
-        _mk3Config = Curl::HTTPSPost("http://" + _ip + "/" + _mk3APIVersion, request, "", "", "application/json");
+        _mk3Config = Curl::HTTPSPost("http://" + _ip + "/" + _mk3APIVersion, request, "", "", "JSON");
 
         wxJSONValue jsonVal;
         wxJSONReader reader;
@@ -1192,7 +1192,7 @@ bool Pixlite16::GetMK3Config()
             }
 
             request = "{\"req\":\"constantRead\",\"id\":1,\"params\":{\"path\":[\"\"]}}";
-            _mk3Constants = Curl::HTTPSPost("http://" + _ip + "/" + _mk3APIVersion, request, "", "", "application/json");
+            _mk3Constants = Curl::HTTPSPost("http://" + _ip + "/" + _mk3APIVersion, request, "", "", "JSON");
 
             return true;
         }
@@ -1532,7 +1532,7 @@ bool Pixlite16::SendMk3Config(bool logresult) const
 
     logger_base.debug(request);
 
-    auto res = Curl::HTTPSPost("http://" + _ip + "/" + _mk3APIVersion, request, "", "", "application/json");
+    auto res = Curl::HTTPSPost("http://" + _ip + "/" + _mk3APIVersion, request, "", "", "JSON");
 
     logger_base.debug(res);
 
@@ -1806,7 +1806,7 @@ bool Pixlite16::SetOutputs(ModelManager* allmodels, OutputManager* outputManager
                 _config._outputGrouping[pp - 1] = std::max(1, port->GetFirstModel()->GetGroupCount(1));
                 _config._outputBrightness[pp - 1] = port->GetFirstModel()->GetBrightness(100);
                 _config._outputColourOrder[pp - 1] = EncodeColourOrder(port->GetFirstModel()->GetColourOrder("RGB"));
-                _config._outputZigZag[pp - 1] = port->GetFirstModel()->GetZigZag(0);
+                _config._outputZigZag[pp - 1] = port->GetFirstModel()->GetZigZag(1);
                 if (port->GetFirstModel()->GetDirection("Forward") == "Reverse") {
                     _config._outputReverse[pp - 1] = 1;
                 }


### PR DESCRIPTION
Fixes issue in #4601 - ZigZag must be specified in the range of 1-50 in the new firmware versions; and requires JSON format. 
Untested changes put in by Keith didn't work on the MIME type.