### PR TITLE
Set format on Audio when using Prepare Audio #4611

### DIFF
--- a/xLights/AudioManager.cpp
+++ b/xLights/AudioManager.cpp
@@ -3344,7 +3344,7 @@ bool AudioManager::CreateAudioFile(const std::vector<float>& left, const std::ve
     codecContext->channel_layout = AV_CH_LAYOUT_STEREO;
 
     AVFormatContext* formatContext;
-    avformat_alloc_output_context2( &formatContext, nullptr, nullptr, targetFile.c_str() );
+    avformat_alloc_output_context2(&formatContext, nullptr, "wav", targetFile.c_str());
     if (formatContext == nullptr)
     {
         logger_base.error("  Error opening output-context");


### PR DESCRIPTION
Seems the update to ffmpeg now requires this parameter to be set. This is used when processing an .rpp (reaper) file to edit an audio file. (Used in a prior xLights Around The World sequence) #4611 