### PR TITLE
Fix issue with replacing models/groups and duplicates #4625

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -6893,7 +6893,7 @@ void LayoutPanel::ReplaceModel()
         xlights->AllModels.RenameInListOnly(modelToReplaceItWith->GetName(), dlg.GetStringSelection().ToStdString());
         modelToReplaceItWith->Rename(dlg.GetStringSelection().ToStdString());
         xlights->AllModels.Delete("Iamgoingtodeletethismodel");
-        // xlights->ReplaceModelWithModelFixGroups(rmn, riw);           // no need to rename since replacing already has the original model name in groups
+        xlights->ReplaceModelWithModelFixGroups(rmn, riw);
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "ReplaceModel", nullptr, nullptr, dlg.GetStringSelection().ToStdString());
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "ReplaceModel");
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS, "ReplaceModel");

--- a/xLights/models/ModelGroup.cpp
+++ b/xLights/models/ModelGroup.cpp
@@ -925,6 +925,14 @@ bool ModelGroup::ModelRenamed(const std::string &oldName, const std::string &new
 
     if (RemoveDuplicates()) {
         changed = true;
+        wxString oss;
+        for (size_t i = 0; i < modelNames.size(); ++i) {
+            oss << modelNames[i];
+            if (i < modelNames.size() - 1) {
+                oss << ",";
+            }
+        }
+        newVal = oss;
     }
 
     if (changed) {


### PR DESCRIPTION
RemovedDuplicated updated modelNames but wasn't used. Old vewVal was still being passed. Now we're updating newVal after Dedeup detected