### PR TITLE
#4633 Address the crashes with groups of submodels

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -1518,7 +1518,7 @@ void LayoutPanel::UpdateModelsForPreview(const std::string &group, LayoutGroup* 
                         }
                         if (m->DisplayAs == "SubModel") {
                             if (mark_selected) {
-                                prev_models.push_back(m);  // setting this causes exception when prev_models render finds a submodel
+                              //  prev_models.push_back(m);  // setting this causes exception when prev_models render finds a submodel
                             }
                         }
                         else if (m->DisplayAs == "ModelGroup") {


### PR DESCRIPTION
Don't put submodels to the models vector and can cause a render assert and a crash with the layout preview refresh.