### PR TITLE
Text Effect - Add Center function for XLFonts and No Repeat.

### DIFF
--- a/xLights/effects/TextEffect.cpp
+++ b/xLights/effects/TextEffect.cpp
@@ -539,6 +539,7 @@ void TextEffect::Render(Effect *effect, const SettingsMap &SettingsMap, RenderBu
                        SettingsMap["FONTPICKER_Text_Font"],
                        TextEffectDirectionsIndex(SettingsMap["CHOICE_Text_Dir"]),
                        wxAtoi(SettingsMap["CHECKBOX_TextToCenter"]),
+                       wxAtoi(SettingsMap["CHECKBOX_TextNoRepeat"]),
                        TextEffectsIndex(SettingsMap["CHOICE_Text_Effect"]),
                        TextCountDownIndex(SettingsMap["CHOICE_Text_Count"]),
                        wxAtoi(SettingsMap.Get("TEXTCTRL_Text_Speed", "10")),
@@ -905,7 +906,7 @@ wxImage *TextEffect::RenderTextLine(RenderBuffer &buffer,
                                     const wxString& Line_orig,
                                     const std::string &fontString,
                                     int dir,
-                                    bool center, int Effect, int Countdown, int tspeed,
+                                    bool center, bool norepeat, int Effect, int Countdown, int tspeed,
                                     int startx, int starty, int endx, int endy,
                                     bool isPixelBased, bool perWord) const
 {
@@ -951,11 +952,6 @@ wxImage *TextEffect::RenderTextLine(RenderBuffer &buffer,
     wxSize textsize = GetMultiLineTextExtent(dc, msg, cache, fontString, fontSet);
     int extra_left = IsGoingLeft(dir)? textsize.x - GetMultiLineTextExtent(dc, wxString(msg).Trim(false), cache, fontString, fontSet).x: 0; //CAUTION: trim() alters object, so make a copy first
     int extra_right = IsGoingRight(dir)? textsize.x - GetMultiLineTextExtent(dc, wxString(msg).Trim(true), cache, fontString, fontSet).x: 0;
-    int extra_down = IsGoingDown(dir)? textsize.y - GetMultiLineTextExtent(dc, StripRight(msg, "\n"), cache, fontString, fontSet).y: 0;
-    int extra_up = IsGoingUp(dir)? textsize.y - GetMultiLineTextExtent(dc, StripLeft(msg, "\n"), cache, fontString, fontSet).y: 0;
-    //    debug(1, "size %d lstrip %d, rstrip %d, = %d, %d, text %s", dc.GetMultiLineTextExtent(msg).y, dc.GetMultiLineTextExtent(StripLeft(msg, "\n")).y, dc.GetMultiLineTextExtent(StripRight(msg, "\n")).y, extra_down, extra_up, (const char*)StripLeft(msg, "\n"));
-    int lineh = GetMultiLineTextExtent(dc, "X", cache, fontString, fontSet).y;
-    //    wxString debmsg = msg; debmsg.Replace("\n","\\n", true);
     int xoffset=0;
     int yoffset=0;
 
@@ -1024,38 +1020,71 @@ wxImage *TextEffect::RenderTextLine(RenderBuffer &buffer,
                 rect.Offset(ex, ey);
             }
                 break;
-            case TEXTDIR_LEFT:
-                //           debug(1, "l2r[%d] center? %d, xlim/16 %d, state %d, xofs %d, extra l %d r %d, text %s", idx, center, xlimit/16, state, center? std::max((int)(xlimit/16 - state /*% xlimit*/ /8), -extra_left/2): xlimit/16 - state % xlimit/8, extra_left, extra_right, (const char*)msg);
-                // rect.Offset(center? std::max((int)(xlimit/16 - state /*% xlimit*/ /8), -extra_left/2): xlimit/16 - state % xlimit/8, OffsetTop);
+            case TEXTDIR_LEFT: // OS FONTS
                 {                
                     int state8 = state / 8;
                     if (state8 < 0) state8 += 32768;
                     if (state > 2000000)
                         state = state + 0;
-                    rect.Offset(center ? std::max((int)(xlimit / 16 - state8), -extra_left / 2) : xlimit / 16 - state % xlimit / 8, OffsetTop);
+                    if (norepeat && !center && state > xlimit) {
+                        rect.Offset(-xlimit, OffsetTop);
+                    } else {
+                        rect.Offset(center ? std::max((int)(xlimit / 16 - state8), -extra_left/2) : xlimit/16 - state % xlimit/8, OffsetTop);
+                    }
                 }
                 break; // left, optionally stop at center
-            case TEXTDIR_RIGHT:
-                rect.Offset(center? std::min((int)(state /*% xlimit*/ /8 - xlimit/16), extra_right/2): state % xlimit/8 - xlimit/16, OffsetTop);
+            case TEXTDIR_RIGHT: 
+                if (norepeat && !center && state > xlimit) {
+                    rect.Offset(xlimit, OffsetTop);
+                } else {
+                    rect.Offset(center ? std::min((int)(state /*% xlimit*/ / 8 - xlimit/16), extra_right/2) : state % xlimit/8 - xlimit/16, OffsetTop);
+                }
                 break; // right, optionally stop at center
             case TEXTDIR_UP:
-                rect.Offset(OffsetLeft, center? std::max((int)(ylimit/16 - state /*% ylimit*/ /8), lineh/2 - extra_up/2): ylimit/16 - state % ylimit/8);
+                if (norepeat && !center && state > ylimit) {
+                    rect.Offset(OffsetLeft, -ylimit);
+                } else {
+                    rect.Offset(OffsetLeft, center ? std::max((int)(ylimit/16 - state /*% ylimit*/ /8), 0): ylimit/16 - state % ylimit/8);
+                }
                 break; // up, optionally stop at center
-            case TEXTDIR_DOWN:
-                //            debug(1, "t2b[%d] center? %d, totht %d, ylimit %d, extra u %d d %d, lineh %d, text %s => yofs min(%d - %d, %d + %d)", idx, center, totheight, ylimit, extra_up, extra_down, lineh, (const char*)debmsg, state /*% ylimit*/ /8, ylimit/16, -lineh/2, extra_down/2);
-                rect.Offset(OffsetLeft, center? std::min((int)(state /*% ylimit*/ /8 - ylimit/16), -lineh/2 + extra_down/2): state % ylimit/8 - ylimit/16);
+            case TEXTDIR_DOWN:;
+                if (norepeat && !center && state > ylimit) {
+                    rect.Offset(OffsetLeft, ylimit);
+                } else {
+                    rect.Offset(OffsetLeft, center ? std::min((int)(state /*% ylimit*/ /8 - ylimit/16), 0) : state % ylimit/8 - ylimit/16);
+                }
                 break; // down, optionally stop at center
             case TEXTDIR_UPLEFT:
-                rect.Offset(center? std::max((int)(xlimit/16 - state /*% xlimit*/ /8), -extra_left/2): xlimit/16 - state % xlimit/8, center? std::max((int)(ylimit/16 - state /*% ylimit*/ /8), lineh/2 - extra_up/2): ylimit/16 - state % ylimit/8);
+                if (norepeat && !center && (state > ylimit || state > xlimit)) {
+                    rect.Offset(-xlimit, -ylimit);
+                } else {
+                    rect.Offset(center ? std::max((int)(xlimit/16 - state /*% xlimit*/ /8) + startx, 0): xlimit/16 - state % xlimit/8 + startx, 
+                                center ? std::max((int)(ylimit/16 - state /*% ylimit*/ /8) - starty, 0): ylimit/16 - state % ylimit/8 - starty);
+                }
                 break; // up-left, optionally stop at center
             case TEXTDIR_DOWNLEFT:
-                rect.Offset(center? std::max((int)(xlimit/16 - state /*% xlimit*/ /8), -extra_left/2): xlimit/16 - state % xlimit/8, center? std::min((int)(state /*% ylimit*/ /8 - ylimit/16), -lineh/2 + extra_down/2): state % ylimit/8 - ylimit/16);
+                if (norepeat && !center && (state > ylimit || state > xlimit)) {
+                    rect.Offset(-xlimit, ylimit);
+                } else {
+                    rect.Offset(center ? std::max((int)(xlimit/16 - state /*% xlimit*/ /8) + startx, 0): xlimit/16 - state % xlimit/8 + startx,
+                                center ? std::min((int)(state /*% ylimit*/ /8 - ylimit/16) + starty, 0): state % ylimit/8 - ylimit/16 + starty);
+                }
                 break; // down-left, optionally stop at center
             case TEXTDIR_UPRIGHT:
-                rect.Offset(center? std::min((int)(state /*% xlimit*/ /8 - xlimit/16), extra_right/2): state % xlimit/8 - xlimit/16, center? std::max((int)(ylimit/16 - state /*% ylimit*/ /8), lineh/2 - extra_up/2): ylimit/16 - state % ylimit/8);
+                if (norepeat && !center && (state > ylimit || state > xlimit)) {
+                    rect.Offset(xlimit, -ylimit);
+                } else {
+                    rect.Offset(center ? std::min((int)(state /*% xlimit*/ /8 - xlimit/16) - startx, 0): state % xlimit/8 - xlimit/16 - startx,
+                                center ? std::max((int)(ylimit/16 - state /*% ylimit*/ /8) - starty, 0): ylimit/16 - state % ylimit/8 - starty);
+                }
                 break; // up-right, optionally stop at center
             case TEXTDIR_DOWNRIGHT:
-                rect.Offset(center? std::min((int)(state /*% xlimit*/ /8 - xlimit/16), extra_right/2): state % xlimit/8 - xlimit/16, center? std::min((int)(state /*% ylimit*/ /8 - ylimit/16), -lineh/2 + extra_down/2): state % ylimit/8 - ylimit/16);
+                if (norepeat && !center && (state > ylimit || state > xlimit)) {
+                    rect.Offset(xlimit, ylimit);
+                } else {
+                    rect.Offset(center ? std::min((int)(state /*% xlimit*/ /8 - xlimit/16) - startx, 0): state % xlimit/8 - xlimit/16 - startx,
+                                center ? std::min((int)(state /*% ylimit*/ /8 - ylimit/16) + starty, 0): state % ylimit/8 - ylimit/16 + starty);
+                }
                 break; // down-right, optionally stop at center
             case TEXTDIR_WAVEY_LRUPDOWN:
                 if (center) //does to-center make sense with this one?
@@ -1681,7 +1710,8 @@ void TextEffect::AddMotions(int& OffsetLeft, int& OffsetTop, const SettingsMap& 
     int ylimit = totheight * 8 + 1;
 
     TextDirection dir = TextEffectDirectionsIndex(settings["CHOICE_Text_Dir"]);
-    //int center = wxAtoi(settings["CHECKBOX_TextToCenter"]);  // not implemented yet - hoping to switch to value curves anyways
+    int center = wxAtoi(settings["CHECKBOX_TextToCenter"]);
+    int norepeat = wxAtoi(settings["CHECKBOX_TextNoRepeat"]);
 
     switch (dir) {
     case TEXTDIR_VECTOR:
@@ -1697,33 +1727,62 @@ void TextEffect::AddMotions(int& OffsetLeft, int& OffsetTop, const SettingsMap& 
         OffsetTop += (ey - OffsetTop) * position;
     }
     break;
-    case TEXTDIR_LEFT:
-        OffsetLeft = buffer.BufferWi - state % (xlimit + buffer.BufferWi) / 8 + PreOffsetLeft + txtwidth / 2;
+    case TEXTDIR_LEFT: // XL FONTS REALLY
+        OffsetLeft = center ? std::max(buffer.BufferWi - (state / 8) + PreOffsetLeft + (txtwidth / 2),0):
+                                        (buffer.BufferWi - (state % (xlimit + buffer.BufferWi)) / 8) + PreOffsetLeft + (txtwidth / 2);
+        if (norepeat && !center && state > (buffer.BufferWi + PreOffsetLeft + txtwidth) * 8) {
+            OffsetLeft = -(buffer.BufferWi + PreOffsetLeft + txtwidth);
+        }
         break; // left
     case TEXTDIR_RIGHT:
-        OffsetLeft = state % xlimit / 8 - txtwidth + PreOffsetLeft;
+        OffsetLeft = center ? std::min(state / 8 - txtwidth + PreOffsetLeft, 0) : (state % xlimit / 8 - txtwidth + PreOffsetLeft);
+        if (norepeat && !center && state > xlimit) {
+            OffsetLeft = xlimit + PreOffsetLeft;
+        }
         break; // right
     case TEXTDIR_UP:
-        OffsetTop = buffer.BufferHt - state % ylimit / 8 - PreOffsetTop;
+        OffsetTop = center ? std::max(buffer.BufferHt - state / 8 - PreOffsetTop, 0) : (buffer.BufferHt - state % ylimit / 8 - PreOffsetTop);
+        if (norepeat && !center && state > ylimit) {
+            OffsetTop = -ylimit;
+        }
         break; // up
     case TEXTDIR_DOWN:
-        OffsetTop = state % ylimit / 8 - txtheight - PreOffsetTop;
+        OffsetTop = center ? std::min(state / 8 - (buffer.BufferHt / 2) - PreOffsetTop, 0):(state % ylimit / 8 - (buffer.BufferHt / 2) - PreOffsetTop);
+        if (norepeat && !center && state > (ylimit - (buffer.BufferHt / 2))) {
+            OffsetTop = ylimit;
+        }
         break; // down
     case TEXTDIR_UPLEFT:
-        OffsetLeft = buffer.BufferWi - state % xlimit / 8 + PreOffsetLeft;
-        OffsetTop = buffer.BufferHt - state % ylimit / 8 - PreOffsetTop;
+        OffsetLeft = center ? std::max(buffer.BufferWi - state / 8 + PreOffsetLeft,0):(buffer.BufferWi - state % xlimit / 8 + PreOffsetLeft);
+        OffsetTop = center ? std::max(buffer.BufferHt - state / 8 - PreOffsetTop,0):(buffer.BufferHt - state % ylimit / 8 - PreOffsetTop);
+        if (norepeat && !center && (state > ylimit || state > xlimit)) {
+                OffsetTop = -ylimit;
+                OffsetLeft= -xlimit;
+        }
         break; // up-left
     case TEXTDIR_DOWNLEFT:
-        OffsetLeft = buffer.BufferWi - state % xlimit / 8 + PreOffsetLeft;
-        OffsetTop = state % ylimit / 8 - txtheight - PreOffsetTop;
+        OffsetLeft = center ? std::max(buffer.BufferWi - state / 8 + PreOffsetLeft, 0) :(buffer.BufferWi - state % xlimit / 8 + PreOffsetLeft);
+        OffsetTop = center ? std::min(state / 8 - txtheight - PreOffsetTop,0):(state % ylimit / 8 - txtheight - PreOffsetTop);
+        if (norepeat && !center && (state > (ylimit - (buffer.BufferHt / 2)) || state > (buffer.BufferWi + PreOffsetLeft + txtwidth) * 8)) {
+            OffsetLeft = -(buffer.BufferWi + PreOffsetLeft + txtwidth);
+            OffsetTop = ylimit;
+        }
         break; // down-left
     case TEXTDIR_UPRIGHT:
-        OffsetLeft = state % xlimit / 8 - txtwidth + PreOffsetLeft;
-        OffsetTop = buffer.BufferHt - state % ylimit / 8 - PreOffsetTop;
+        OffsetLeft = center ? std::min(state / 8 - txtwidth + PreOffsetLeft,0):(state % xlimit / 8 - txtwidth + PreOffsetLeft);
+        OffsetTop = center ? std::max(buffer.BufferHt - state / 8 - PreOffsetTop, 0) : (buffer.BufferHt - state % ylimit / 8 - PreOffsetTop);
+        if (norepeat && !center && (state > ylimit || state > xlimit)) {
+            OffsetLeft = xlimit + PreOffsetLeft;
+            OffsetTop = -ylimit;
+        }
         break; // up-right
     case TEXTDIR_DOWNRIGHT:
-        OffsetLeft = state % xlimit / 8 - txtwidth + PreOffsetLeft;
-        OffsetTop = state % ylimit / 8 - txtheight - PreOffsetTop;
+        OffsetLeft = center ? std::min(state / 8 - txtwidth + PreOffsetLeft, 0) : (state % xlimit / 8 - txtwidth + PreOffsetLeft);
+        OffsetTop = center ? std::min(state / 8 - txtheight - PreOffsetTop, 0) : (state % ylimit / 8 - txtheight - PreOffsetTop);
+        if (norepeat && !center && (state > ylimit || state > (buffer.BufferWi + PreOffsetLeft + txtwidth) * 8)) {
+            OffsetLeft = -(buffer.BufferWi + PreOffsetLeft + txtwidth);
+            OffsetTop = -ylimit;
+        }
         break; // down-right
     case TEXTDIR_WAVEY_LRUPDOWN:
         OffsetLeft = xlimit / 16 - state % xlimit / 8;

--- a/xLights/effects/TextEffect.h
+++ b/xLights/effects/TextEffect.h
@@ -55,7 +55,7 @@ private:
         const wxString& Line_orig,
         const std::string& fontString,
         int dir,
-        bool center, int Effect, int Countdown, int tspeed,
+        bool center, bool norepeat, int Effect, int Countdown, int tspeed,
         int startx, int starty, int endx, int endy,
         bool isPixelBased, bool perWord) const;
     void RenderXLText(Effect* effect, const SettingsMap& settings, RenderBuffer& buffer);

--- a/xLights/effects/TextPanel.cpp
+++ b/xLights/effects/TextPanel.cpp
@@ -48,6 +48,7 @@ const long TextPanel::ID_STATICTEXT_Text_Dir = wxNewId();
 const long TextPanel::ID_CHOICE_Text_Dir = wxNewId();
 const long TextPanel::ID_BITMAPBUTTON_CHOICE_Text_Dir = wxNewId();
 const long TextPanel::ID_CHECKBOX_TextToCenter = wxNewId();
+const long TextPanel::ID_CHECKBOX_TextNoRepeat = wxNewId();
 const long TextPanel::ID_BITMAPBUTTON_TextToCenter = wxNewId();
 const long TextPanel::ID_STATICTEXT_Text_Speed = wxNewId();
 const long TextPanel::IDD_SLIDER_Text_Speed = wxNewId();
@@ -107,7 +108,6 @@ void xlTextFilePickerCtrl::ValidateControl()
 TextPanel::TextPanel(wxWindow* parent) : xlEffectPanel(parent)
 {
 	//(*Initialize(TextPanel)
-	BulkEditCheckBox* CheckBox_TextToCenter;
 	BulkEditFontPicker* FontPickerCtrl;
 	BulkEditTextCtrl* TextCtrl72;
 	BulkEditTextCtrl* TextCtrl91;
@@ -170,7 +170,7 @@ TextPanel::TextPanel(wxWindow* parent) : xlEffectPanel(parent)
 	FlexGridSizer119->Add(BitmapButton1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	StaticText78 = new wxStaticText(Panel_Text1, ID_STATICTEXT_Text_Dir, _("Movement"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Text_Dir"));
 	FlexGridSizer119->Add(StaticText78, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
-	FlexGridSizer48 = new wxFlexGridSizer(0, 3, 0, 0);
+	FlexGridSizer48 = new wxFlexGridSizer(0, 4, 0, 0);
 	Choice_Text_Dir = new BulkEditChoice(Panel_Text1, ID_CHOICE_Text_Dir, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_Text_Dir"));
 	Choice_Text_Dir->SetSelection( Choice_Text_Dir->Append(_("none")) );
 	Choice_Text_Dir->Append(_("left"));
@@ -191,7 +191,11 @@ TextPanel::TextPanel(wxWindow* parent) : xlEffectPanel(parent)
 	CheckBox_TextToCenter = new BulkEditCheckBox(Panel_Text1, ID_CHECKBOX_TextToCenter, _("C"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_TextToCenter"));
 	CheckBox_TextToCenter->SetValue(false);
 	CheckBox_TextToCenter->SetToolTip(_("Move to center and stop"));
-	FlexGridSizer48->Add(CheckBox_TextToCenter, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer48->Add(CheckBox_TextToCenter, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
+	CheckBox_NoRepeat = new BulkEditCheckBox(Panel_Text1, ID_CHECKBOX_TextNoRepeat, _("NoRep"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_TextNoRepeat"));
+	CheckBox_NoRepeat->SetValue(false);
+	CheckBox_NoRepeat->SetToolTip(_("Do not cycle the text."));
+	FlexGridSizer48->Add(CheckBox_NoRepeat, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
 	FlexGridSizer119->Add(FlexGridSizer48, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 1);
 	BitmapButton_TextToCenter = new xlLockButton(Panel_Text1, ID_BITMAPBUTTON_TextToCenter, wxNullBitmap, wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_TextToCenter"));
 	BitmapButton_TextToCenter->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
@@ -321,6 +325,7 @@ TextPanel::TextPanel(wxWindow* parent) : xlEffectPanel(parent)
 	Connect(ID_CHOICE_Text_LyricTrack,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&TextPanel::OnChoice_LyricTrackSelect);
 	Connect(ID_BITMAPBUTTON_FONTPICKER_Text_Font,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&TextPanel::OnLockButtonClick);
 	Connect(ID_BITMAPBUTTON1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&TextPanel::OnLockButtonClick);
+	Connect(ID_CHOICE_Text_Dir,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&TextPanel::OnChoice_Text_DirSelect);
 	Connect(ID_BITMAPBUTTON_CHOICE_Text_Dir,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&TextPanel::OnLockButtonClick);
 	Connect(ID_BITMAPBUTTON_TextToCenter,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&TextPanel::OnLockButtonClick);
 	Connect(ID_BITMAPBUTTON_Text_Speed,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&TextPanel::OnLockButtonClick);
@@ -358,6 +363,13 @@ void TextPanel::OnFilePickerCtrl1FileChanged(wxFileDirPickerEvent& event)
 
 void TextPanel::ValidateWindow()
 {
+    if (Choice_Text_Dir->GetStringSelection() == "none") {
+        CheckBox_TextToCenter->Disable();
+        CheckBox_NoRepeat->Disable();
+    } else {
+        CheckBox_TextToCenter->Enable();
+        CheckBox_NoRepeat->Enable();
+    }
     TextCtrl_Text->Enable();
     if (TextCtrl_Text->GetValue() != "")
     {
@@ -390,6 +402,11 @@ void TextPanel::OnTextCtrl_TextText(wxCommandEvent& event)
 }
 
 void TextPanel::OnChoice_LyricTrackSelect(wxCommandEvent& event)
+{
+    ValidateWindow();
+}
+
+void TextPanel::OnChoice_Text_DirSelect(wxCommandEvent& event)
 {
     ValidateWindow();
 }

--- a/xLights/effects/TextPanel.h
+++ b/xLights/effects/TextPanel.h
@@ -62,6 +62,8 @@ class TextPanel: public xlEffectPanel
 		virtual void ValidateWindow() override;
 
 		//(*Declarations(TextPanel)
+		BulkEditCheckBox* CheckBox_NoRepeat;
+		BulkEditCheckBox* CheckBox_TextToCenter;
 		BulkEditCheckBox* CheckBox_Text_Color_PerWord;
 		BulkEditCheckBox* CheckBox_Text_PixelOffsets;
 		BulkEditChoice* Choice_Text_Count;
@@ -118,6 +120,7 @@ class TextPanel: public xlEffectPanel
 		static const long ID_CHOICE_Text_Dir;
 		static const long ID_BITMAPBUTTON_CHOICE_Text_Dir;
 		static const long ID_CHECKBOX_TextToCenter;
+		static const long ID_CHECKBOX_TextNoRepeat;
 		static const long ID_BITMAPBUTTON_TextToCenter;
 		static const long ID_STATICTEXT_Text_Speed;
 		static const long IDD_SLIDER_Text_Speed;
@@ -156,6 +159,7 @@ class TextPanel: public xlEffectPanel
 		void OnFilePickerCtrl1FileChanged(wxFileDirPickerEvent& event);
 		void OnTextCtrl_TextText(wxCommandEvent& event);
 		void OnChoice_LyricTrackSelect(wxCommandEvent& event);
+		void OnChoice_Text_DirSelect(wxCommandEvent& event);
 		//*)
 
 		DECLARE_EVENT_TABLE()

--- a/xLights/wxsmith/TextPanel.wxs
+++ b/xLights/wxsmith/TextPanel.wxs
@@ -143,7 +143,7 @@
 								</object>
 								<object class="sizeritem">
 									<object class="wxFlexGridSizer" variable="FlexGridSizer48" member="no">
-										<cols>3</cols>
+										<cols>4</cols>
 										<object class="sizeritem">
 											<object class="wxChoice" name="ID_CHOICE_Text_Dir" subclass="BulkEditChoice" variable="Choice_Text_Dir" member="yes">
 												<content>
@@ -161,6 +161,7 @@
 													<item>word-flip</item>
 												</content>
 												<selection>0</selection>
+												<handler function="OnChoice_Text_DirSelect" entry="EVT_CHOICE" />
 											</object>
 											<flag>wxALL|wxEXPAND</flag>
 											<border>2</border>
@@ -178,12 +179,20 @@
 											<option>1</option>
 										</object>
 										<object class="sizeritem">
-											<object class="wxCheckBox" name="ID_CHECKBOX_TextToCenter" subclass="BulkEditCheckBox" variable="CheckBox_TextToCenter" member="no">
+											<object class="wxCheckBox" name="ID_CHECKBOX_TextToCenter" subclass="BulkEditCheckBox" variable="CheckBox_TextToCenter" member="yes">
 												<label>C</label>
 												<tooltip>Move to center and stop</tooltip>
 											</object>
 											<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
-											<border>5</border>
+											<border>2</border>
+											<option>1</option>
+										</object>
+										<object class="sizeritem">
+											<object class="wxCheckBox" name="ID_CHECKBOX_TextNoRepeat" subclass="BulkEditCheckBox" variable="CheckBox_NoRepeat" member="yes">
+												<label>NoRep</label>
+												<tooltip>Do not cycle the text.</tooltip>
+											</object>
+											<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 											<option>1</option>
 										</object>
 									</object>


### PR DESCRIPTION
The text effect never implemented the Center function for XL Fonts (only OS fonts). I also added a no repeat option so if you scroll, it will only scroll once. No longer do you have to try and time the effect to make something appear just once.