### PR TITLE
Ruse existing shader files when doing a File Cleanup #4181

### DIFF
--- a/xLights/effects/ShaderEffect.cpp
+++ b/xLights/effects/ShaderEffect.cpp
@@ -238,7 +238,7 @@ bool ShaderEffect::CleanupFileLocations(xLightsFrame* frame, SettingsMap& Settin
     {
         if (!frame->IsInShowFolder(file))
         {
-            SettingsMap["E_0FILEPICKERCTRL_IFS"] = frame->MoveToShowFolder(file, wxString(wxFileName::GetPathSeparator()) + "Shaders");
+            SettingsMap["E_0FILEPICKERCTRL_IFS"] = frame->MoveToShowFolder(file, wxString(wxFileName::GetPathSeparator()) + "Shaders", true);
             rc = true;
         }
     }

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -7606,7 +7606,7 @@ bool xLightsFrame::FilesMatch(const std::string& file1, const std::string& file2
     return (memcmp(buf1, buf2, sizeof(buf1)) == 0);
 }
 
-std::string xLightsFrame::MoveToShowFolder(const std::string& file, const std::string& subdirectory)
+std::string xLightsFrame::MoveToShowFolder(const std::string& file, const std::string& subdirectory, const bool reuse)
 {
     log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
     wxFileName fn(file);
@@ -7633,13 +7633,15 @@ std::string xLightsFrame::MoveToShowFolder(const std::string& file, const std::s
     target += fn.GetFullName();
 
     int i = 1;
-    while (FileExists(target) && !FilesMatch(file, target)) {
+    while (FileExists(target) && !FilesMatch(file, target) && !reuse) {
         target = dir + wxFileName::GetPathSeparator() + fn.GetName() + "_" + wxString::Format("%d", i++) + "." + fn.GetExt();
     }
 
     if (!FileExists(target)) {
         logger_base.debug("Copying file %s to %s.", (const char*)file.c_str(), (const char*)target.c_str());
         wxCopyFile(file, target, false);
+    } else if (reuse) {
+        logger_base.debug("Reusing file %s for %s.", (const char*)target.c_str(), (const char*)file.c_str());
     }
 
     return target.ToStdString();

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -1888,7 +1888,7 @@ public:
     MainSequencer* GetMainSequencer() const { return mainSequencer; }
     wxString GetSeqXmlFileName();
 
-    std::string MoveToShowFolder(const std::string& file, const std::string& subdirectory);
+    std::string MoveToShowFolder(const std::string& file, const std::string& subdirectory, const bool reuse = false);
     bool IsInShowFolder(const std::string & file) const;
     bool FilesMatch(const std::string & file1, const std::string & file2) const;
     ColorPanel* GetColorPanel() const { return colorPanel; }


### PR DESCRIPTION
Unlike images and videos, we can be fairly certain a pre-existing copy of a shader with the same name is the same code as the one  found elsewhere on a persons file system. So simply point to that existing copy rather than creating multiple copies of it. #4181