### PR TITLE
Add the generate node names ability to the New Moving Head Model #4693

### DIFF
--- a/xLights/models/DMX/DmxMovingHeadAdv.cpp
+++ b/xLights/models/DMX/DmxMovingHeadAdv.cpp
@@ -1044,3 +1044,25 @@ void DmxMovingHeadAdv::Draw3DBeam(xlVertexColorAccumulator* tvac, xlColor beam_c
         }
     }
 }
+
+std::vector<std::string> DmxMovingHeadAdv::GenerateNodeNames() const {
+    std::vector<std::string> names = DmxModel::GenerateNodeNames();
+
+    if (0 != shutter_channel && shutter_channel < names.size()) {
+        names[shutter_channel - 1] = "Shutter";
+    }
+    if (0 != pan_motor->GetChannelCoarse() && pan_motor->GetChannelCoarse() < names.size()) {
+        names[pan_motor->GetChannelCoarse() - 1] = "Pan";
+    }
+    if (0 != tilt_motor->GetChannelCoarse() && tilt_motor->GetChannelCoarse() < names.size()) {
+        names[tilt_motor->GetChannelCoarse() - 1] = "Tilt";
+    }
+    if (0 != pan_motor->GetChannelFine() && pan_motor->GetChannelFine() < names.size()) {
+        names[pan_motor->GetChannelFine() - 1] = "Pan Fine";
+    }
+    if (0 != tilt_motor->GetChannelFine() && tilt_motor->GetChannelFine() < names.size()) {
+        names[tilt_motor->GetChannelFine() - 1] = "Tilt Fine";
+    }
+
+    return names;
+}

--- a/xLights/models/DMX/DmxMovingHeadAdv.h
+++ b/xLights/models/DMX/DmxMovingHeadAdv.h
@@ -40,6 +40,7 @@ class DmxMovingHeadAdv : public DmxMovingHeadComm, public DmxDimmerAbility
 
         int GetNumMotors() const { return NUM_MOTORS; }
         DmxMotor* GetAxis(int num) { return num == 1 ? tilt_motor.get() : pan_motor.get(); }
+        [[nodiscard]] std::vector<std::string> GenerateNodeNames() const override;
 
         DmxMotorBase* GetPanMotor() const override { return pan_motor.get(); }
         DmxMotorBase* GetTiltMotor() const override { return tilt_motor.get(); }


### PR DESCRIPTION
In the strand node names you can click the generate node names to populate the channels. This was added for the new moving head model #4693