### PR TITLE
Add copy model including submodels right click option #4196

### DIFF
--- a/xLights/sequencer/EffectsGrid.cpp
+++ b/xLights/sequencer/EffectsGrid.cpp
@@ -6755,7 +6755,7 @@ void EffectsGrid::CutModelEffects(int row_number, bool allLayers) {
     }
 }
 
-void EffectsGrid::CopyModelEffects(int row_number, bool allLayers) {
+void EffectsGrid::CopyModelEffects(int row_number, bool allLayers, bool incSubModels) {
     if (!allLayers) {
         mSequenceElements->UnSelectAllEffects();
         EffectLayer* effectLayer = mSequenceElements->GetVisibleEffectLayer(row_number);
@@ -6782,6 +6782,25 @@ void EffectsGrid::CopyModelEffects(int row_number, bool allLayers) {
         mSequenceElements->UnSelectAllEffects();
         for (int i = 0; i < e->GetEffectLayerCount(); i++) {
             e->GetEffectLayer(i)->SelectAllEffects();
+        }
+        if (incSubModels) {
+            ModelElement* me = dynamic_cast<ModelElement*>(e);
+            if (me == nullptr) {
+                SubModelElement* se = dynamic_cast<SubModelElement*>(e);
+                me = se->GetModelElement();
+            }
+            if (me != nullptr) {
+                for (size_t s = 0; s < me->GetSubModelCount(); ++s) {
+                    auto se = me->GetSubModel(s);
+                    if (se != nullptr) {
+                        for (int i = 0; i < se->GetEffectLayerCount(); ++i) {
+                            if (se->GetEffectLayer(i)->GetEffectCount() > 0) {
+                                se->GetEffectLayer(i)->SelectAllEffects();
+                            }
+                        }
+                    }
+                }
+            }
         }
         ((MainSequencer*)mParent)->CopySelectedEffects();
         mSequenceElements->UnSelectAllEffects();

--- a/xLights/sequencer/EffectsGrid.h
+++ b/xLights/sequencer/EffectsGrid.h
@@ -128,7 +128,7 @@ public:
     void SetEffectsTiming();
     void ProcessDroppedEffect(Effect* effect);
     void CutModelEffects(int row_number, bool allLayers);
-    void CopyModelEffects(int row_number, bool allLayers);
+    void CopyModelEffects(int row_number, bool allLayers, bool incSubModels = false);
     void PasteModelEffects(int row_number, bool allLayers);
     Effect* GetSelectedEffect() const;
     int GetSelectedEffectCount(const std::string& effectName) const;

--- a/xLights/sequencer/RowHeading.cpp
+++ b/xLights/sequencer/RowHeading.cpp
@@ -71,6 +71,7 @@ const long RowHeading::ID_ROW_MNU_CUT_ROW = wxNewId();
 const long RowHeading::ID_ROW_MNU_CUT_MODEL = wxNewId();
 const long RowHeading::ID_ROW_MNU_COPY_ROW = wxNewId();
 const long RowHeading::ID_ROW_MNU_COPY_MODEL = wxNewId();
+const long RowHeading::ID_ROW_MNU_COPY_MODEL_INCL_SUBMODELS = wxNewId();
 const long RowHeading::ID_ROW_MNU_PASTE_ROW = wxNewId();
 const long RowHeading::ID_ROW_MNU_PASTE_MODEL = wxNewId();
 const long RowHeading::ID_ROW_MNU_RENDERENABLE_MODEL = wxNewId();
@@ -435,6 +436,7 @@ void RowHeading::rightClick( wxMouseEvent& event)
                 modelMenu->Append(ID_ROW_MNU_CUT_MODEL, "Cut Effects");
                 rowMenu->Append(ID_ROW_MNU_COPY_ROW, "Copy Effects");
                 modelMenu->Append(ID_ROW_MNU_COPY_MODEL, "Copy Effects");
+                modelMenu->Append(ID_ROW_MNU_COPY_MODEL_INCL_SUBMODELS, "Copy Effects incl SubModels");
                 wxMenuItem* menu_paste = rowMenu->Append(ID_ROW_MNU_PASTE_ROW, "Paste Effects");
                 wxMenuItem* menu_pastem = modelMenu->Append(ID_ROW_MNU_PASTE_MODEL, "Paste Effects");
                 if (!mCanPaste) {
@@ -1023,6 +1025,12 @@ void RowHeading::OnLayerPopup(wxCommandEvent& event)
         wxCommandEvent copyRowEvent(EVT_COPY_MODEL_EFFECTS);
         copyRowEvent.SetInt(mSelectedRow);
         copyRowEvent.SetString("All");
+        wxPostEvent(GetParent(), copyRowEvent);
+        mCanPaste = true;
+    } else if (id == ID_ROW_MNU_COPY_MODEL_INCL_SUBMODELS) {
+        wxCommandEvent copyRowEvent(EVT_COPY_MODEL_EFFECTS);
+        copyRowEvent.SetInt(mSelectedRow);
+        copyRowEvent.SetString("AllInclSub");
         wxPostEvent(GetParent(), copyRowEvent);
         mCanPaste = true;
     } else if (id == ID_ROW_MNU_DELETE_ROW_EFFECTS) {

--- a/xLights/sequencer/RowHeading.h
+++ b/xLights/sequencer/RowHeading.h
@@ -104,6 +104,7 @@ private:
     static const long ID_ROW_MNU_CUT_MODEL;
     static const long ID_ROW_MNU_COPY_ROW;
     static const long ID_ROW_MNU_COPY_MODEL;
+    static const long ID_ROW_MNU_COPY_MODEL_INCL_SUBMODELS;
     static const long ID_ROW_MNU_PASTE_ROW;
     static const long ID_ROW_MNU_PASTE_MODEL;
     static const long ID_ROW_MNU_RENDERENABLE_ALL;

--- a/xLights/sequencer/tabSequencer.cpp
+++ b/xLights/sequencer/tabSequencer.cpp
@@ -1493,7 +1493,7 @@ void xLightsFrame::CutModelEffects(wxCommandEvent& event)
 
 void xLightsFrame::CopyModelEffects(wxCommandEvent& event)
 {
-    mainSequencer->PanelEffectGrid->CopyModelEffects(event.GetInt(), event.GetString() == "All");
+    mainSequencer->PanelEffectGrid->CopyModelEffects(event.GetInt(), event.GetString().StartsWith("All"), event.GetString() == "AllInclSub");
 }
 
 void xLightsFrame::PasteModelEffects(wxCommandEvent& event)


### PR DESCRIPTION
For larger props with many submodels, this new right click option will select and copy all those effects so they can be pasted to another model. Like other cut n paste options, it assumes you have the layers and sequence setup to accept the paste correctly. #4196 