### PR TITLE
Increase the max buffer wi and ht #4717

### DIFF
--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -4225,13 +4225,13 @@ void Model::InitRenderBufferNodes(const std::string& tp, const std::string& came
         logger_base.warn("Model::InitRenderBufferNodes BufferWi was 0 ... overridden to be 1.");
         bufferWi = 1;
     }
-    if (bufferHt > 10000) {
-        logger_base.warn("Model::InitRenderBufferNodes BufferHt was overly large ... overridden to be 10000.");
-        bufferHt = 10000;
+    if (bufferHt > 100000) {
+        logger_base.warn("Model::InitRenderBufferNodes BufferHt was overly large ... overridden to be 100000.");
+        bufferHt = 100000;
     }
-    if (bufferWi > 10000) {
-        logger_base.warn("Model::InitRenderBufferNodes BufferWi was overly large ... overridden to be 10000.");
-        bufferWi = 10000;
+    if (bufferWi > 100000) {
+        logger_base.warn("Model::InitRenderBufferNodes BufferWi was overly large ... overridden to be 100000.");
+        bufferWi = 100000;
     }
 
     ApplyTransform(transform, newNodes, bufferWi, bufferHt);

--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -4225,7 +4225,7 @@ void Model::InitRenderBufferNodes(const std::string& tp, const std::string& came
         logger_base.warn("Model::InitRenderBufferNodes BufferWi was 0 ... overridden to be 1.");
         bufferWi = 1;
     }
-    if (bufferWi * bufferHt > 21000000) {
+    if (bufferWi * bufferHt > 2100000) {
         if (bufferHt > 100000) {
             logger_base.warn("Model::InitRenderBufferNodes BufferHt was overly large ... overridden to be 100000.");
             bufferHt = 100000;

--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -4225,13 +4225,15 @@ void Model::InitRenderBufferNodes(const std::string& tp, const std::string& came
         logger_base.warn("Model::InitRenderBufferNodes BufferWi was 0 ... overridden to be 1.");
         bufferWi = 1;
     }
-    if (bufferHt > 100000) {
-        logger_base.warn("Model::InitRenderBufferNodes BufferHt was overly large ... overridden to be 100000.");
-        bufferHt = 100000;
-    }
-    if (bufferWi > 100000) {
-        logger_base.warn("Model::InitRenderBufferNodes BufferWi was overly large ... overridden to be 100000.");
-        bufferWi = 100000;
+    if (bufferWi * bufferHt > 21000000) {
+        if (bufferHt > 100000) {
+            logger_base.warn("Model::InitRenderBufferNodes BufferHt was overly large ... overridden to be 100000.");
+            bufferHt = 100000;
+        }
+        if (bufferWi > 100000) {
+            logger_base.warn("Model::InitRenderBufferNodes BufferWi was overly large ... overridden to be 100000.");
+            bufferWi = 100000;
+        }
     }
 
     ApplyTransform(transform, newNodes, bufferWi, bufferHt);


### PR DESCRIPTION
The group incl VM, is being processed as a single line and hence the buffer width is overly large. Any ideas why this isn't processed as a per preview?
```
    } else if (type == SINGLE_LINE) {
        bufferHt = 1;
        bufferWi = newNodes.size();
        int cnt = 0;
        for (int x = firstNode; x < newNodes.size(); ++x) {
             ... etc ...
        }
```