### PR TITLE
Adding additional fade types to single strand effect and tool tips.

### DIFF
--- a/xLights/Color.h
+++ b/xLights/Color.h
@@ -233,6 +233,20 @@ public:
         return xlColor((uint8_t)dr, (uint8_t)dg, (uint8_t)db);
     }
     
+        /** Blend this color onto the background **/
+    xlColor Blend(const xlColor& bc) const {
+      
+        int r = (red + bc.red) / 2;
+        int g = (green+ bc.green) / 2;
+        int b = (blue + bc.blue) / 2;
+        return xlColor(r, g, b);
+    }
+
+    /** Blend this color onto the background **/
+    xlColor ChannelMax(const xlColor& bc) const {
+        return xlColor(std::max(red,bc.red),std::max(green,bc.green),std::max(blue,bc.blue));
+    }
+    
     /** AlphaBlend the fg color onto this color **/
     void AlphaBlendForgroundOnto(const xlColor &fc) {
         if (fc.alpha == 0) return;

--- a/xLights/effects/SingleStrandEffect.cpp
+++ b/xLights/effects/SingleStrandEffect.cpp
@@ -703,8 +703,7 @@ void SingleStrandEffect::draw_chase(RenderBuffer& buffer,
                         color.alpha = 255.0 * (max_chase_width - i + 1.0) / max_chase_width;
                     } else {
                         HSVValue hsv1 = color.asHSV();
-                        // new reverse value (brightnesss fade) take the orignal brightness - itself (min value) + the fraction of the width going to bright
-                        hsv1.value = orig_v - orig_v + ((max_chase_width - (i + 1.0)) / max_chase_width);
+                        hsv1.value = ((max_chase_width - (i + 1.0)) / max_chase_width);
                         if (hsv1.value < 0.0) {
                             hsv1.value = 0.0;
                         }
@@ -736,7 +735,7 @@ void SingleStrandEffect::draw_chase(RenderBuffer& buffer,
                             if (i > middle_chase_index) {
                                 hsv1.value = orig_v - ((max_chase_width - (2.0 * i + 1.0)) / max_chase_width);
                             } else {
-                                hsv1.value = orig_v - orig_v + ((max_chase_width - (2.0 * i )) / ( max_chase_width));
+                                hsv1.value = ((max_chase_width - (2.0 * i)) / (max_chase_width));
                             }
  
                         if (hsv1.value < 0.0) {
@@ -770,7 +769,7 @@ void SingleStrandEffect::draw_chase(RenderBuffer& buffer,
                     } else {  // middle not alpha blend
                         HSVValue hsv1 = color.asHSV();
                         if (i > middle_chase_index) {
-                            hsv1.value = orig_v - orig_v + ((max_chase_width - (i + 1.0)) / (.5 * max_chase_width));
+                            hsv1.value = ((max_chase_width - (i + 1.0)) / (.5 * max_chase_width));
                         } else {
                             hsv1.value = orig_v - ((max_chase_width - (2.0 * i + 1.0)) / max_chase_width);
                         }
@@ -800,9 +799,10 @@ void SingleStrandEffect::draw_chase(RenderBuffer& buffer,
                                     int a = color.alpha;
                                     color = color.AlphaBlend(c);
                                     color.alpha = c.alpha > a ? c.alpha : a;
-
                                 } else {
-                                    if (Fade_Type == "Middle" || Fade_Type == "From Tail") {
+                                    // only blend new fade types for hsv types to allow for backward compatabilty 
+                                    // overcomes leading black on bounce effects overriding trailing brightness
+                                    if (Fade_Type == "Middle" || Fade_Type == "From Tail" || Fade_Type == "Head and Tail") {
                                         color = color.ChannelMax(c);
                                     }
                                 }
@@ -823,9 +823,11 @@ void SingleStrandEffect::draw_chase(RenderBuffer& buffer,
                                     color = color.AlphaBlend(c);
                                     color.alpha = c.alpha > a ? c.alpha : a;
                                 } else {
-                                    if (Fade_Type == "Middle" || Fade_Type == "From Tail") {
+                                    // only blend new fade types for hsv types to allow for backward compatabilty
+                                    // overcomes leading black on bounce effects overriding trailing brightness
+                                    if (Fade_Type == "Middle" || Fade_Type == "From Tail" || Fade_Type == "Head and Tail") {
                                         color = color.ChannelMax(c);
-                                    }
+                                   }
                                 }
                             }
                         }

--- a/xLights/effects/SingleStrandEffect.cpp
+++ b/xLights/effects/SingleStrandEffect.cpp
@@ -105,16 +105,32 @@ void SingleStrandEffect::SetDefaultParameters()
     SetSliderValue(sp->Slider_FX_Intensity, 128);
     SetSliderValue(sp->Slider_FX_Speed, 128);
 
-    SetCheckBoxValue(sp->CheckBox_Chase_3dFade1, false);
+    SetChoiceValue(sp->Choice_Fade_Type, "None");
     SetCheckBoxValue(sp->CheckBox_Chase_Group_All, false);
 }
 
 bool SingleStrandEffect::needToAdjustSettings(const std::string& version) {
     // give the base class a chance to adjust any settings
-    return RenderableEffect::needToAdjustSettings(version) || IsVersionOlder("2024.05", version);
+    return RenderableEffect::needToAdjustSettings(version) || IsVersionOlder("2024.15", version);
 }
 
 void SingleStrandEffect::adjustSettings(const std::string& version, Effect* effect, bool removeDefaults) {
+    if (IsVersionOlder("2024.15", version)) {
+        SettingsMap& settings = effect->GetSettings();
+        bool Three_dfade_checked = settings.GetBool("E_CHECKBOX_Chase_3dFade1", false);
+
+        if (Three_dfade_checked) {
+            settings["E_CHOICE_Fade_Type"] = "From Head";
+            settings.erase("E_CHECKBOX_Chase_3dFade1");
+        }
+
+        bool Three_dfade_unchecked = settings.GetBool("E_CHECKBOX_Chase_3dFade1", true);
+        if (!Three_dfade_unchecked) {
+            settings["E_CHOICE_Fade_Type"] = "None";
+            settings.erase("E_CHECKBOX_Chase_3dFade1");
+        }
+    }
+    
     if (IsVersionOlder("2024.05", version)) {
         std::string mn = effect->GetParentEffectLayer()->GetParentElement()->GetFullName();
         if (mn.find("/") != std::string::npos) {
@@ -178,7 +194,7 @@ void SingleStrandEffect::Render(Effect* effect, const SettingsMap& SettingsMap, 
                                 GetValueCurveInt("Number_Chases", 1, SettingsMap, eff_pos, SINGLESTRAND_CHASES_MIN, SINGLESTRAND_CHASES_MAX, buffer.GetStartTimeMS(), buffer.GetEndTimeMS()),
                                 GetValueCurveInt("Color_Mix1", 10, SettingsMap, eff_pos, SINGLESTRAND_COLOURMIX_MIN, SINGLESTRAND_COLOURMIX_MAX, buffer.GetStartTimeMS(), buffer.GetEndTimeMS()),
                                 SettingsMap.Get("CHOICE_Chase_Type1", "Left-Right"),
-                                SettingsMap.GetBool("CHECKBOX_Chase_3dFade1", false),
+                                SettingsMap.Get("CHOICE_Fade_Type", "None"),
                                 SettingsMap.GetBool("CHECKBOX_Chase_Group_All", false),
                                 GetValueCurveDouble("Chase_Rotations", 1.0, SettingsMap, eff_pos, SINGLESTRAND_ROTATIONS_MIN, SINGLESTRAND_ROTATIONS_MAX, buffer.GetStartTimeMS(), buffer.GetEndTimeMS(), SINGLESTRAND_ROTATIONS_DIVISOR),
                                 GetValueCurveDouble("Chase_Offset", 0.0, SettingsMap, eff_pos, SINGLESTRAND_OFFSET_MIN, SINGLESTRAND_OFFSET_MAX, buffer.GetStartTimeMS(), buffer.GetEndTimeMS(), SINGLESTRAND_OFFSET_DIVISOR));
@@ -362,7 +378,8 @@ int mapChaseType(const std::string &Chase_Type) {
 void SingleStrandEffect::RenderSingleStrandChase(RenderBuffer& buffer, Effect* eff,
     const std::string & ColorSchemeName, int Number_Chases, int chaseSize,
     const std::string &Chase_Type1,
-    bool Chase_Fade3d1, bool Chase_Group_All,
+    const std::string &Fade_Type,
+    bool Chase_Group_All,
     float chaseSpeed, float offset)
 {
     int ColorScheme = "Palette" == ColorSchemeName;
@@ -512,28 +529,28 @@ void SingleStrandEffect::RenderSingleStrandChase(RenderBuffer& buffer, Effect* e
             x = chase * dx + startState - scaledChaseWidth; // L-R
         }
 
-        draw_chase(buffer, DoubleEnd ? width - x - 1 * scaledChaseWidth : x, Chase_Group_All, ColorScheme, Number_Chases, AutoReverse, width, chaseSize, Chase_Fade3d1, bool(ChaseDirection) != DoubleEnd, Mirror); // Turn pixel on
+        draw_chase(buffer, DoubleEnd ? width - x - 1 * scaledChaseWidth : x, Chase_Group_All, ColorScheme, Number_Chases, AutoReverse, width, chaseSize, Fade_Type, bool(ChaseDirection) != DoubleEnd, Mirror); // Turn pixel on
         if (Dual_Chases) {
-            draw_chase(buffer, DoubleEnd ? x - 1 * scaledChaseWidth : x, Chase_Group_All, ColorScheme, Number_Chases, AutoReverse, width, chaseSize, Chase_Fade3d1, bool(ChaseDirection) == DoubleEnd, Mirror);
+            draw_chase(buffer, DoubleEnd ? x - 1 * scaledChaseWidth : x, Chase_Group_All, ColorScheme, Number_Chases, AutoReverse, width, chaseSize, Fade_Type, bool(ChaseDirection) == DoubleEnd, Mirror);
         }
     }
     buffer.CopyPixelsToDisplayListX(eff, 0, 0, chaseSize);
 }
 
-void SingleStrandEffect::draw_chase(RenderBuffer &buffer,
-    int x, bool GroupAll,
-    int ColorScheme,
-    int Number_Chases,
-    bool AutoReverse,
-    int width,
-    int Chase_Width,
-    bool Chase_Fade3d1,
-    int ChaseDirection,
-    bool mirror)
-{
+void SingleStrandEffect::draw_chase(RenderBuffer& buffer,
+                                    int x, bool GroupAll,
+                                    int ColorScheme,
+                                    int Number_Chases,
+                                    bool AutoReverse,
+                                    int width,
+                                    int Chase_Width,
+                                    const std::string& Fade_Type,
+                                    int ChaseDirection,
+                                    bool mirror) {
     size_t colorcnt = buffer.GetColorCount();
 
     int max_chase_width = width * Chase_Width / 100.0;
+    int middle_chase_index = 0; 
     if (max_chase_width < 1) max_chase_width = 1;
 
     wxASSERT(Number_Chases != 0);
@@ -602,6 +619,13 @@ void SingleStrandEffect::draw_chase(RenderBuffer &buffer,
     }
 
     if (max_chase_width >= 1) {
+        if (Fade_Type != "None") {
+            if (max_chase_width % 2 == 0) {
+                middle_chase_index = (max_chase_width / 2) - 1.0;
+            } else{
+                middle_chase_index = (max_chase_width / 2.0);
+            }
+        }
         for (int i = 0; i < max_chase_width; i++) {
             xlColor color;
             if (ColorScheme == 0) {
@@ -661,13 +685,99 @@ void SingleStrandEffect::draw_chase(RenderBuffer &buffer,
                     }
                 }
 
-                if (Chase_Fade3d1) {
+                if (Fade_Type == "None") {
+                } else if (Fade_Type == "From Head") { /// 3d fade
                     if (buffer.allowAlpha) {
                         color.alpha = 255.0 * (i + 1.0) / max_chase_width;
                     } else {
                         HSVValue hsv1 = color.asHSV();
                         hsv1.value = orig_v - ((max_chase_width - (i + 1.0)) / max_chase_width); // fades data down over chase width
-                        if (hsv1.value < 0.0) hsv1.value = 0.0;
+                        if (hsv1.value < 0.0) {
+                            hsv1.value = 0.0;
+                        }
+                        color = hsv1;
+                    }
+                } else if (Fade_Type == "From Tail") {
+                    if (buffer.allowAlpha) {
+                        // reverse the fade black to white
+                        color.alpha = 255.0 * (max_chase_width - i + 1.0) / max_chase_width;
+                    } else {
+                        HSVValue hsv1 = color.asHSV();
+                        // new reverse value (brightnesss fade) take the orignal brightness - itself (min value) + the fraction of the width going to bright
+                        hsv1.value = orig_v - orig_v + ((max_chase_width - (i + 1.0)) / max_chase_width);
+                        if (hsv1.value < 0.0) {
+                            hsv1.value = 0.0;
+                        }
+                        color = hsv1;
+                    }
+                } else if (Fade_Type == "Head and Tail") {
+                    if (buffer.allowAlpha) {
+
+                        if (i <= middle_chase_index) {
+                            // first half of the string
+                                color.alpha = 255.0 * ((max_chase_width - (2.0 * i) + 0.0)) / max_chase_width;
+                            
+
+                        } else {
+                            // second half of the string
+                            if (  ((2.0 * i + 1.0 - max_chase_width) / max_chase_width) > 1.0 ) {
+                                    color.alpha = 255.0;
+                            } else {
+                                color.alpha = 255.0 * ((2 * i +1 - max_chase_width)) / max_chase_width;
+                            }
+                            
+                        }
+                        if (i == i ) {
+                            color.alpha = color.alpha;
+                        }
+
+                    } else {   // head tail not alpha 
+                        HSVValue hsv1 = color.asHSV();
+                            if (i > middle_chase_index) {
+                                hsv1.value = orig_v - ((max_chase_width - (2.0 * i + 1.0)) / max_chase_width);
+                            } else {
+                                hsv1.value = orig_v - orig_v + ((max_chase_width - (2.0 * i )) / ( max_chase_width));
+                            }
+ 
+                        if (hsv1.value < 0.0) {
+                            hsv1.value = 0.0;
+                        }
+                        color = hsv1;
+                    }
+                } else if (Fade_Type == "Middle") {
+                    if (buffer.allowAlpha) {
+
+                        if (i >= middle_chase_index) {
+                            // second half of the string
+                            if ((((max_chase_width - (i) + 0.0)) / (.5 * max_chase_width)) > 1) {
+                                color.alpha = 255.0;
+                            } else {
+                                color.alpha = 255.0 * ((max_chase_width - (i) + 0.0)) / (.5 * max_chase_width);
+                            }
+
+                        } else {
+                            // first half of the string
+                            if (((i + 1 - max_chase_width) / (.5 * max_chase_width)) > 1) {
+                                color.alpha = 255.0;
+                            } else {
+                                color.alpha = 255.0 * ((i + 1 - max_chase_width)) / (.5 * max_chase_width);
+                            }
+                        }
+                        if (i == i) {
+                            color.alpha = color.alpha;
+                        }
+
+                    } else {  // middle not alpha blend
+                        HSVValue hsv1 = color.asHSV();
+                        if (i > middle_chase_index) {
+                            hsv1.value = orig_v - orig_v + ((max_chase_width - (i + 1.0)) / (.5 * max_chase_width));
+                        } else {
+                            hsv1.value = orig_v - ((max_chase_width - (2.0 * i + 1.0)) / max_chase_width);
+                        }
+
+                        if (hsv1.value < 0.0) {
+                            hsv1.value = 0.0;
+                        }
                         color = hsv1;
                     }
                 }
@@ -677,18 +787,25 @@ void SingleStrandEffect::draw_chase(RenderBuffer &buffer,
                         int y = 0;
                         int mirrorx = buffer.BufferWi*buffer.BufferHt - new_x - 1;
                         int mirrory = 0;
-                        
+
                         y += new_x / buffer.BufferWi;
                         new_x = new_x % buffer.BufferWi;
                         mirrory += mirrorx / buffer.BufferWi;
                         mirrorx = mirrorx % buffer.BufferWi;
-                        if (Chase_Fade3d1) {
+                        if (Fade_Type != "None") {
                             xlColor c;
                             buffer.GetPixel(new_x, y, c);
                             if (c != xlBLACK) {
-                                int a = color.alpha;
-                                color = color.AlphaBlend(c);
-                                color.alpha = c.alpha > a ? c.alpha : a;
+                                if (buffer.allowAlpha) {
+                                    int a = color.alpha;
+                                    color = color.AlphaBlend(c);
+                                    color.alpha = c.alpha > a ? c.alpha : a;
+
+                                } else {
+                                    if (Fade_Type == "Middle" || Fade_Type == "From Tail") {
+                                        color = color.ChannelMax(c);
+                                    }
+                                }
                             }
                         }
 
@@ -697,13 +814,19 @@ void SingleStrandEffect::draw_chase(RenderBuffer &buffer,
                             buffer.SetPixel(mirrorx, mirrory, color); // Turn pixel on
                         }
                     } else {
-                        if (Chase_Fade3d1) {
+                        if (Fade_Type != "None") {
                             xlColor c;
                             buffer.GetPixel(new_x, 0, c);
                             if (c != xlBLACK) {
-                                int a = color.alpha;
-                                color = color.AlphaBlend(c);
-                                color.alpha = c.alpha > a ? c.alpha : a;
+                                if (buffer.allowAlpha) {
+                                    int a = color.alpha;
+                                    color = color.AlphaBlend(c);
+                                    color.alpha = c.alpha > a ? c.alpha : a;
+                                } else {
+                                    if (Fade_Type == "Middle" || Fade_Type == "From Tail") {
+                                        color = color.ChannelMax(c);
+                                    }
+                                }
                             }
                         }
                         for (int y = 0; y < buffer.BufferHt; y++) {
@@ -718,4 +841,3 @@ void SingleStrandEffect::draw_chase(RenderBuffer &buffer,
         }
     }
 }
-

--- a/xLights/effects/SingleStrandEffect.h
+++ b/xLights/effects/SingleStrandEffect.h
@@ -100,12 +100,12 @@ private:
     void RenderSingleStrandChase(RenderBuffer& buffer, Effect* eff,
                                  const std::string& ColorScheme, int Number_Chases, int chaseSize,
                                  const std::string& Chase_Type1,
-                                 bool Chase_3dFade1, bool Chase_Group_All,
+                                 const std::string& Fade_Type, bool Chase_Group_All,
                                  float chaseSpeed, float offset);
     void RenderSingleStrandSkips(RenderBuffer& buffer, Effect* eff, int Skips_BandSize,
                                  int Skips_SkipSize, int Skips_StartPos, const std::string& Skips_Direction, int advances);
     void RenderSingleStrandFX(RenderBuffer& buffer, Effect* eff, int intensity, int speed, const std::string& fx, const std::string& palette);
     void draw_chase(RenderBuffer& buffer,
                     int x, bool group, int ColorScheme, int Number_Chases, bool autoReverse, int width,
-                    int Color_Mix1, bool Chase_Fade3d1, int ChaseDirection, bool mirror);
+                    int Color_Mix1, const std::string& Fade_Type, int ChaseDirection, bool mirror);
 };

--- a/xLights/effects/SingleStrandPanel.cpp
+++ b/xLights/effects/SingleStrandPanel.cpp
@@ -58,8 +58,9 @@ const long SingleStrandPanel::ID_BITMAPBUTTON_SLIDER_Chase_Offset = wxNewId();
 const long SingleStrandPanel::ID_STATICTEXT_Chase_Type1 = wxNewId();
 const long SingleStrandPanel::ID_CHOICE_Chase_Type1 = wxNewId();
 const long SingleStrandPanel::ID_BITMAPBUTTON_CHOICE_Chase_Type1 = wxNewId();
-const long SingleStrandPanel::ID_CHECKBOX_Chase_3dFade1 = wxNewId();
-const long SingleStrandPanel::ID_BITMAPBUTTON_CHECKBOX_Chase_3dFade1 = wxNewId();
+const long SingleStrandPanel::ID_STATICTEXT6 = wxNewId();
+const long SingleStrandPanel::ID_CHOICE_Fade_Type = wxNewId();
+const long SingleStrandPanel::ID_BITMAPBUTTON_CHOICE_Fade_Type = wxNewId();
 const long SingleStrandPanel::ID_CHECKBOX_Chase_Group_All = wxNewId();
 const long SingleStrandPanel::ID_BITMAPBUTTON_CHECKBOX_Chase_Group_All = wxNewId();
 const long SingleStrandPanel::ID_PANEL3 = wxNewId();
@@ -150,6 +151,7 @@ SingleStrandPanel::SingleStrandPanel(wxWindow* parent) : xlEffectPanel(parent)
 	BitmapButton_SingleStrand_Colors->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
 	FlexGridSizer24->Add(BitmapButton_SingleStrand_Colors, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText60 = new wxStaticText(Panel1, ID_STATICTEXT_Number_Chases, _("Number Chases"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Number_Chases"));
+	StaticText60->SetToolTip(_("Number of chases within the string, may overlap if chase size is greater than can fit."));
 	FlexGridSizer24->Add(StaticText60, 1, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
 	FlexGridSizer1 = new wxFlexGridSizer(0, 2, 0, 0);
 	FlexGridSizer1->AddGrowableCol(0);
@@ -166,6 +168,7 @@ SingleStrandPanel::SingleStrandPanel(wxWindow* parent) : xlEffectPanel(parent)
 	BitmapButton_Number_Chases->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
 	FlexGridSizer24->Add(BitmapButton_Number_Chases, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
 	StaticText9 = new wxStaticText(Panel1, ID_STATICTEXT_Color_Mix1, _("Chase Size"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_Color_Mix1"));
+	StaticText9->SetToolTip(_("Size of the effect in percentage of the string, will overlap if the number of chases are larger than can fit.  3 chases + > 33.3 percent = overlap"));
 	FlexGridSizer24->Add(StaticText9, 1, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
 	FlexGridSizer2 = new wxFlexGridSizer(0, 2, 0, 0);
 	FlexGridSizer2->AddGrowableCol(0);
@@ -196,12 +199,13 @@ SingleStrandPanel::SingleStrandPanel(wxWindow* parent) : xlEffectPanel(parent)
 	BitmapButton_ChaseRotations->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
 	FlexGridSizer24->Add(BitmapButton_ChaseRotations, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 1);
 	StaticText5 = new wxStaticText(Panel1, ID_STATICTEXT5, _("Offset"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT5"));
+	StaticText5->SetToolTip(_("Offset by the percentage of the string, will loop > +/- 100"));
 	FlexGridSizer24->Add(StaticText5, 1, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
 	FlexGridSizer7 = new wxFlexGridSizer(0, 2, 0, 0);
 	FlexGridSizer7->AddGrowableCol(0);
 	Slider_Chase_Offset = new BulkEditSliderF1(Panel1, IDD_SLIDER_Chase_Offset, 0, -5000, 5000, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("IDD_SLIDER_Chase_Offset"));
 	FlexGridSizer7->Add(Slider_Chase_Offset, 1, wxALL|wxEXPAND, 2);
-    BitmapButton_Chase_OffsetVC = new BulkEditValueCurveButton(Panel1, ID_VALUECURVE_Chase_Offset, GetValueCurveNotSelectedBitmap(), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW | wxBORDER_NONE, wxDefaultValidator, _T("ID_VALUECURVE_Chase_Offset"));
+	BitmapButton_Chase_OffsetVC = new BulkEditValueCurveButton(Panel1, ID_VALUECURVE_Chase_Offset, GetValueCurveNotSelectedBitmap(), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW | wxBORDER_NONE, wxDefaultValidator, _T("ID_VALUECURVE_Chase_Offset"));
 	FlexGridSizer7->Add(BitmapButton_Chase_OffsetVC, 1, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
 	FlexGridSizer24->Add(FlexGridSizer7, 1, wxALL|wxEXPAND, 0);
 	TextCtrl_ChaseOffset = new BulkEditTextCtrlF1(Panel1, ID_TEXTCTRL_Chase_Offset, _("0.0"), wxDefaultPosition, wxDLG_UNIT(Panel1,wxSize(30,-1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_Chase_Offset"));
@@ -233,14 +237,20 @@ SingleStrandPanel::SingleStrandPanel(wxWindow* parent) : xlEffectPanel(parent)
 	BitmapButton_Chase_Type1 = new xlLockButton(Panel1, ID_BITMAPBUTTON_CHOICE_Chase_Type1, wxNullBitmap, wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_CHOICE_Chase_Type1"));
 	BitmapButton_Chase_Type1->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
 	FlexGridSizer24->Add(BitmapButton_Chase_Type1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
+	StaticText6 = new wxStaticText(Panel1, ID_STATICTEXT6, _("Fade"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT6"));
+	StaticText6->SetToolTip(_("From Head - Brightest at the start, From Tail - Brightest and the end, Head and Tail - Brightest at both ends, Middle - Brightest in the middle"));
+	FlexGridSizer24->Add(StaticText6, 1, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
+	Choice_Fade_Type = new BulkEditChoice(Panel1, ID_CHOICE_Fade_Type, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_Fade_Type"));
+	Choice_Fade_Type->SetSelection( Choice_Fade_Type->Append(_("None")) );
+	Choice_Fade_Type->Append(_("From Head"));
+	Choice_Fade_Type->Append(_("From Tail"));
+	Choice_Fade_Type->Append(_("Head and Tail"));
+	Choice_Fade_Type->Append(_("Middle"));
+	FlexGridSizer24->Add(Choice_Fade_Type, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 2);
 	FlexGridSizer24->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	CheckBox_Chase_3dFade1 = new BulkEditCheckBox(Panel1, ID_CHECKBOX_Chase_3dFade1, _("3d Fade"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_Chase_3dFade1"));
-	CheckBox_Chase_3dFade1->SetValue(false);
-	FlexGridSizer24->Add(CheckBox_Chase_3dFade1, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
-	FlexGridSizer24->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	BitmapButton_Chase_3dFade1 = new xlLockButton(Panel1, ID_BITMAPBUTTON_CHECKBOX_Chase_3dFade1, wxNullBitmap, wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_CHECKBOX_Chase_3dFade1"));
-	BitmapButton_Chase_3dFade1->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
-	FlexGridSizer24->Add(BitmapButton_Chase_3dFade1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
+	BitmapButton_Choice_Fade_Type = new xlLockButton(Panel1, ID_BITMAPBUTTON_CHOICE_Fade_Type, wxNullBitmap, wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_CHOICE_Fade_Type"));
+	BitmapButton_Choice_Fade_Type->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNHIGHLIGHT));
+	FlexGridSizer24->Add(BitmapButton_Choice_Fade_Type, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
 	FlexGridSizer24->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	CheckBox_Chase_Group_All = new BulkEditCheckBox(Panel1, ID_CHECKBOX_Chase_Group_All, _("Group All Strands"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_Chase_Group_All"));
 	CheckBox_Chase_Group_All->SetValue(false);
@@ -376,9 +386,6 @@ SingleStrandPanel::SingleStrandPanel(wxWindow* parent) : xlEffectPanel(parent)
 	Connect(ID_BITMAPBUTTON_CHOICE_SingleStrand_Colors,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SingleStrandPanel::OnLockButtonClick);
 	Connect(ID_BITMAPBUTTON_SLIDER_Number_Chases,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SingleStrandPanel::OnLockButtonClick);
 	Connect(ID_VALUECURVE_Color_Mix1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SingleStrandPanel::OnVCButtonClick);
-	Connect(ID_BITMAPBUTTON_SLIDER_Color_Mix1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SingleStrandPanel::OnLockButtonClick);
-	Connect(ID_BITMAPBUTTON_CHOICE_Chase_Type1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SingleStrandPanel::OnLockButtonClick);
-	Connect(ID_BITMAPBUTTON_CHECKBOX_Chase_3dFade1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SingleStrandPanel::OnLockButtonClick);
 	Connect(ID_BITMAPBUTTON_CHECKBOX_Chase_Group_All,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SingleStrandPanel::OnLockButtonClick);
 	Connect(ID_BITMAPBUTTON_SLIDER_Skips_BandSize,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SingleStrandPanel::OnLockButtonClick);
 	Connect(ID_BITMAPBUTTON_SLIDER_Skips_SkipSize,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SingleStrandPanel::OnLockButtonClick);
@@ -386,7 +393,10 @@ SingleStrandPanel::SingleStrandPanel(wxWindow* parent) : xlEffectPanel(parent)
 	Connect(ID_BITMAPBUTTON_SLIDER_Skips_Advance,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SingleStrandPanel::OnLockButtonClick);
 	Connect(ID_BITMAPBUTTON_CHOICE_Skips_Direction,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&SingleStrandPanel::OnLockButtonClick);
 	//*)
-
+    Connect(ID_BITMAPBUTTON_SLIDER_Color_Mix1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SingleStrandPanel::OnLockButtonClick);
+    Connect(ID_BITMAPBUTTON_CHOICE_Chase_Type1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SingleStrandPanel::OnLockButtonClick);
+    Connect(ID_BITMAPBUTTON_CHOICE_Fade_Type, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SingleStrandPanel::OnLockButtonClick);
+   
     Connect(ID_VALUECURVE_Chase_Rotations, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SingleStrandPanel::OnVCButtonClick);
     Connect(ID_VALUECURVE_Number_Chases, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SingleStrandPanel::OnVCButtonClick);
     Connect(ID_VALUECURVE_Chase_Offset, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SingleStrandPanel::OnVCButtonClick);

--- a/xLights/effects/SingleStrandPanel.h
+++ b/xLights/effects/SingleStrandPanel.h
@@ -35,10 +35,10 @@ class SingleStrandPanel: public xlEffectPanel
 		virtual void ValidateWindow() override;
 
 		//(*Declarations(SingleStrandPanel)
-		BulkEditCheckBox* CheckBox_Chase_3dFade1;
 		BulkEditCheckBox* CheckBox_Chase_Group_All;
 		BulkEditChoice* Choice_Chase_Type1;
 		BulkEditChoice* Choice_FX_Palette;
+		BulkEditChoice* Choice_Fade_Type;
 		BulkEditChoice* Choice_SingleStrand_Colors;
 		BulkEditChoice* Choice_SingleStrand_FX;
 		BulkEditChoice* Choice_Skips_Direction;
@@ -77,12 +77,13 @@ class SingleStrandPanel: public xlEffectPanel
 		wxStaticText* StaticText5;
 		wxStaticText* StaticText60;
 		wxStaticText* StaticText61;
+		wxStaticText* StaticText6;
 		wxStaticText* StaticText9;
 		xlLockButton* BitmapButton_ChaseRotations;
-		xlLockButton* BitmapButton_Chase_3dFade1;
 		xlLockButton* BitmapButton_Chase_Group_All;
 		xlLockButton* BitmapButton_Chase_Offset;
 		xlLockButton* BitmapButton_Chase_Type1;
+		xlLockButton* BitmapButton_Choice_Fade_Type;
 		xlLockButton* BitmapButton_Color_Mix1;
 		xlLockButton* BitmapButton_Number_Chases;
 		xlLockButton* BitmapButton_SingleStrand_Colors;
@@ -122,8 +123,9 @@ class SingleStrandPanel: public xlEffectPanel
 		static const long ID_STATICTEXT_Chase_Type1;
 		static const long ID_CHOICE_Chase_Type1;
 		static const long ID_BITMAPBUTTON_CHOICE_Chase_Type1;
-		static const long ID_CHECKBOX_Chase_3dFade1;
-		static const long ID_BITMAPBUTTON_CHECKBOX_Chase_3dFade1;
+		static const long ID_STATICTEXT6;
+		static const long ID_CHOICE_Fade_Type;
+		static const long ID_BITMAPBUTTON_CHOICE_Fade_Type;
 		static const long ID_CHECKBOX_Chase_Group_All;
 		static const long ID_BITMAPBUTTON_CHECKBOX_Chase_Group_All;
 		static const long ID_PANEL3;

--- a/xLights/wxsmith/SingleStrandPanel.wxs
+++ b/xLights/wxsmith/SingleStrandPanel.wxs
@@ -51,6 +51,7 @@
 								<object class="sizeritem">
 									<object class="wxStaticText" name="ID_STATICTEXT_Number_Chases" variable="StaticText60" member="yes">
 										<label>Number Chases</label>
+										<tooltip>Number of chases within the string, may overlap if chase size is greater than can fit.</tooltip>
 									</object>
 									<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
 									<border>5</border>
@@ -108,6 +109,7 @@
 								<object class="sizeritem">
 									<object class="wxStaticText" name="ID_STATICTEXT_Color_Mix1" variable="StaticText9" member="yes">
 										<label>Chase Size</label>
+										<tooltip>Size of the effect in percentage of the string, will overlap if the number of chases are larger than can fit.  3 chases + &gt; 33.3 percent = overlap</tooltip>
 									</object>
 									<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
 									<border>5</border>
@@ -154,7 +156,6 @@
 										<size>14,14</size>
 										<bg>wxSYS_COLOUR_BTNHIGHLIGHT</bg>
 										<style>wxBU_AUTODRAW|wxBORDER_NONE</style>
-										<handler function="OnLockButtonClick" entry="EVT_BUTTON" />
 									</object>
 									<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 									<border>2</border>
@@ -217,6 +218,7 @@
 								<object class="sizeritem">
 									<object class="wxStaticText" name="ID_STATICTEXT5" variable="StaticText5" member="yes">
 										<label>Offset</label>
+										<tooltip>Offset by the percentage of the string, will loop &gt; +/- 100</tooltip>
 									</object>
 									<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
 									<border>5</border>
@@ -310,9 +312,32 @@
 										<size>14,14</size>
 										<bg>wxSYS_COLOUR_BTNHIGHLIGHT</bg>
 										<style>wxBU_AUTODRAW|wxBORDER_NONE</style>
-										<handler function="OnLockButtonClick" entry="EVT_BUTTON" />
 									</object>
 									<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+									<border>2</border>
+									<option>1</option>
+								</object>
+								<object class="sizeritem">
+									<object class="wxStaticText" name="ID_STATICTEXT6" variable="StaticText6" member="yes">
+										<label>Fade</label>
+										<tooltip>From Head - Brightest at the start, From Tail - Brightest and the end, Head and Tail - Brightest at both ends, Middle - Brightest in the middle</tooltip>
+									</object>
+									<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+									<border>5</border>
+									<option>1</option>
+								</object>
+								<object class="sizeritem">
+									<object class="wxChoice" name="ID_CHOICE_Fade_Type" subclass="BulkEditChoice" variable="Choice_Fade_Type" member="yes">
+										<content>
+											<item>None</item>
+											<item>From Head</item>
+											<item>From Tail</item>
+											<item>Head and Tail</item>
+											<item>Middle</item>
+										</content>
+										<selection>0</selection>
+									</object>
+									<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
 									<border>2</border>
 									<option>1</option>
 								</object>
@@ -322,24 +347,10 @@
 									<option>1</option>
 								</object>
 								<object class="sizeritem">
-									<object class="wxCheckBox" name="ID_CHECKBOX_Chase_3dFade1" subclass="BulkEditCheckBox" variable="CheckBox_Chase_3dFade1" member="yes">
-										<label>3d Fade</label>
-									</object>
-									<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
-									<border>5</border>
-									<option>1</option>
-								</object>
-								<object class="spacer">
-									<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
-									<border>5</border>
-									<option>1</option>
-								</object>
-								<object class="sizeritem">
-									<object class="wxBitmapButton" name="ID_BITMAPBUTTON_CHECKBOX_Chase_3dFade1" subclass="xlLockButton" variable="BitmapButton_Chase_3dFade1" member="yes">
+									<object class="wxBitmapButton" name="ID_BITMAPBUTTON_CHOICE_Fade_Type" subclass="xlLockButton" variable="BitmapButton_Choice_Fade_Type" member="yes">
 										<size>14,14</size>
 										<bg>wxSYS_COLOUR_BTNHIGHLIGHT</bg>
 										<style>wxBU_AUTODRAW|wxBORDER_NONE</style>
-										<handler function="OnLockButtonClick" entry="EVT_BUTTON" />
 									</object>
 									<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 									<border>2</border>


### PR DESCRIPTION
changed 3d fade checkbox to choice, to include 'From head' old 3d fade, from tail reverse of 3d fade, head and tail bright at the ends, and middle bright in the middle. Also added tool tip text for Single Strand panel. 