### PR TITLE
Issue #4675 - Support the ability to set the alias behavior for renaming models

### DIFF
--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -549,10 +549,14 @@ void Model::Rename(std::string const& newName)
     ModelXml->DeleteAttribute("name");
     ModelXml->AddAttribute("name", name);
 
-    if (oldname != "" && newName != "Iamgoingtodeletethismodel") {
+    if (oldname != "" && newName != "Iamgoingtodeletethismodel" && modelManager.GetXLightsFrame()->GetRenameModelAliasPromptBehavior() == "Always Prompt" ) {
         if (wxMessageBox("Would you like to save the old name as an alias for this prop. This could be useful if you have sequences already sequenced against this prop using the old name.", "Save old name as alias", wxYES_NO | wxICON_QUESTION, GetModelManager().GetXLightsFrame()) == wxYES) {
             AddAlias("oldname:" + oldname);
         }
+    }
+    
+    if( modelManager.GetXLightsFrame()->GetRenameModelAliasPromptBehavior() == "Always Yes" ) {
+        AddAlias("oldname:" + oldname);
     }
 }
 

--- a/xLights/preferences/OtherSettingsPanel.cpp
+++ b/xLights/preferences/OtherSettingsPanel.cpp
@@ -81,7 +81,7 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     wxStaticBoxSizer* StaticBoxSizer3;
     wxStaticText* StaticText1;
 
-    Create(parent, wxID_ANY, wxDefaultPosition, wxSize(603,310), wxTAB_TRAVERSAL, _T("wxID_ANY"));
+    Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("wxID_ANY"));
     GridBagSizer1 = new wxGridBagSizer(0, 0);
     FlexGridSizer4 = new wxFlexGridSizer(0, 2, 0, 0);
     StaticText2 = new wxStaticText(this, ID_STATICTEXT1, _("Link save:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT1"));

--- a/xLights/preferences/OtherSettingsPanel.cpp
+++ b/xLights/preferences/OtherSettingsPanel.cpp
@@ -33,27 +33,29 @@ extern bool isMetalComputeSupported();
 #endif
 
 //(*IdInit(OtherSettingsPanel)
-const long OtherSettingsPanel::ID_STATICTEXT1 = wxNewId();
-const long OtherSettingsPanel::ID_CHOICE1 = wxNewId();
-const long OtherSettingsPanel::ID_CHECKBOX1 = wxNewId();
-const long OtherSettingsPanel::ID_CHOICE4 = wxNewId();
-const long OtherSettingsPanel::ID_CHECKBOX7 = wxNewId();
-const long OtherSettingsPanel::ID_STATICTEXT3 = wxNewId();
-const long OtherSettingsPanel::ID_CHOICE_CODEC = wxNewId();
-const long OtherSettingsPanel::ID_STATICTEXT5 = wxNewId();
-const long OtherSettingsPanel::ID_SPINCTRLDOUBLE_BITRATE = wxNewId();
-const long OtherSettingsPanel::ID_CHECKBOX2 = wxNewId();
-const long OtherSettingsPanel::ID_CHECKBOX3 = wxNewId();
-const long OtherSettingsPanel::ID_CHECKBOX4 = wxNewId();
-const long OtherSettingsPanel::ID_CHECKBOX6 = wxNewId();
-const long OtherSettingsPanel::ID_CHECKBOX5 = wxNewId();
-const long OtherSettingsPanel::ID_STATICTEXT4 = wxNewId();
-const long OtherSettingsPanel::ID_CHOICE3 = wxNewId();
-const long OtherSettingsPanel::ID_CHECKBOX8 = wxNewId();
-const long OtherSettingsPanel::ID_STATICTEXT2 = wxNewId();
-const long OtherSettingsPanel::ID_CHOICE2 = wxNewId();
-const long OtherSettingsPanel::ID_TEXTCTRL1 = wxNewId();
-const long OtherSettingsPanel::ID_CHECKBOX9 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_STATICTEXT1 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHOICE1 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHECKBOX1 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHOICE4 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHECKBOX7 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_STATICTEXT3 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHOICE_CODEC = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_STATICTEXT5 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_SPINCTRLDOUBLE_BITRATE = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHECKBOX2 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHECKBOX3 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHECKBOX4 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHECKBOX6 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHECKBOX5 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_STATICTEXT4 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHOICE3 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHECKBOX8 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_STATICTEXT2 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHOICE2 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_STATICTEXT6 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHOICE_ALIASPROMPT = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_TEXTCTRL1 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHECKBOX9 = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(OtherSettingsPanel,wxPanel)
@@ -71,6 +73,7 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     wxFlexGridSizer* FlexGridSizer4;
     wxFlexGridSizer* FlexGridSizer5;
     wxFlexGridSizer* FlexGridSizer6;
+    wxFlexGridSizer* FlexGridSizer7;
     wxGridBagSizer* GridBagSizer1;
     wxGridBagSizer* GridBagSizer2;
     wxStaticBoxSizer* StaticBoxSizer1;
@@ -78,7 +81,7 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     wxStaticBoxSizer* StaticBoxSizer3;
     wxStaticText* StaticText1;
 
-    Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("wxID_ANY"));
+    Create(parent, wxID_ANY, wxDefaultPosition, wxSize(603,310), wxTAB_TRAVERSAL, _T("wxID_ANY"));
     GridBagSizer1 = new wxGridBagSizer(0, 0);
     FlexGridSizer4 = new wxFlexGridSizer(0, 2, 0, 0);
     StaticText2 = new wxStaticText(this, ID_STATICTEXT1, _("Link save:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT1"));
@@ -141,7 +144,7 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     GridBagSizer1->Add(CheckBox_PurgeDownloadCache, wxGBPosition(5, 0), wxDefaultSpan, wxALL|wxEXPAND, 5);
     CheckBox_IgnoreVendorModelRecommendations = new wxCheckBox(this, ID_CHECKBOX5, _("Ignore vendor model recommendations"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX5"));
     CheckBox_IgnoreVendorModelRecommendations->SetValue(false);
-    GridBagSizer1->Add(CheckBox_IgnoreVendorModelRecommendations, wxGBPosition(8, 0), wxDefaultSpan, wxALL|wxEXPAND, 5);
+    GridBagSizer1->Add(CheckBox_IgnoreVendorModelRecommendations, wxGBPosition(9, 0), wxDefaultSpan, wxALL|wxEXPAND, 5);
     StaticBoxSizer3 = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Tip Of The Day"));
     FlexGridSizer2 = new wxFlexGridSizer(0, 2, 0, 0);
     StaticText5 = new wxStaticText(this, ID_STATICTEXT4, _("Minimum Tip Level"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT4"));
@@ -167,6 +170,15 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     Choice_LinkControllerUpload->Append(_("Inputs and Outputs"));
     FlexGridSizer5->Add(Choice_LinkControllerUpload, 1, wxALL|wxEXPAND, 5);
     GridBagSizer1->Add(FlexGridSizer5, wxGBPosition(7, 0), wxDefaultSpan, wxALL|wxEXPAND, 0);
+    FlexGridSizer7 = new wxFlexGridSizer(0, 2, 0, 0);
+    StaticText7 = new wxStaticText(this, ID_STATICTEXT6, _("Model renaming alias behavior"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT6"));
+    FlexGridSizer7->Add(StaticText7, 1, wxALL|wxEXPAND, 5);
+    Choice_AliasPromptBehavior = new wxChoice(this, ID_CHOICE_ALIASPROMPT, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_ALIASPROMPT"));
+    Choice_AliasPromptBehavior->SetSelection( Choice_AliasPromptBehavior->Append(_("Always Prompt")) );
+    Choice_AliasPromptBehavior->Append(_("Always Yes"));
+    Choice_AliasPromptBehavior->Append(_("Always No"));
+    FlexGridSizer7->Add(Choice_AliasPromptBehavior, 1, wxALL|wxEXPAND, 5);
+    GridBagSizer1->Add(FlexGridSizer7, wxGBPosition(8, 0), wxDefaultSpan, wxALL|wxEXPAND, 0);
     FlexGridSizer6 = new wxFlexGridSizer(0, 2, 0, 0);
     StaticText1 = new wxStaticText(this, wxID_ANY, _("eMail Address:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
     FlexGridSizer6->Add(StaticText1, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
@@ -178,27 +190,26 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     GPURenderCheckbox->SetToolTip(_("Some effects can be rendered on the GPU if this is enabled."));
     GridBagSizer1->Add(GPURenderCheckbox, wxGBPosition(2, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
     SetSizer(GridBagSizer1);
-    GridBagSizer1->Fit(this);
-    GridBagSizer1->SetSizeHints(this);
 
-    Connect(ID_CHOICE1,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_CHECKBOX1,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_CHOICE4,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_CHECKBOX7,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_CHOICE_CODEC,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_SPINCTRLDOUBLE_BITRATE,wxEVT_SPINCTRLDOUBLE,(wxObjectEventFunction)&OtherSettingsPanel::OnSpinCtrlDoubleBitrateChange);
-    Connect(ID_CHECKBOX2,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_CHECKBOX3,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_CHECKBOX4,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_CHECKBOX6,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_CHECKBOX5,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_CHOICE3,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_CHECKBOX8,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_CHOICE2,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_TEXTCTRL1,wxEVT_COMMAND_TEXT_UPDATED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_TEXTCTRL1,wxEVT_COMMAND_TEXT_ENTER,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(ID_CHECKBOX9,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
-    Connect(wxEVT_PAINT,(wxObjectEventFunction)&OtherSettingsPanel::OnPaint);
+    Connect(ID_CHOICE1, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHOICE4, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHECKBOX7, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHOICE_CODEC, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_SPINCTRLDOUBLE_BITRATE, wxEVT_SPINCTRLDOUBLE, (wxObjectEventFunction)&OtherSettingsPanel::OnSpinCtrlDoubleBitrateChange);
+    Connect(ID_CHECKBOX2, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHECKBOX3, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHECKBOX4, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHECKBOX6, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHECKBOX5, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHOICE3, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHECKBOX8, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHOICE2, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHOICE_ALIASPROMPT, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_TEXTCTRL1, wxEVT_COMMAND_TEXT_UPDATED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_TEXTCTRL1, wxEVT_COMMAND_TEXT_ENTER, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHECKBOX9, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(wxEVT_PAINT, (wxObjectEventFunction)&OtherSettingsPanel::OnPaint);
     //*)
 
 #ifdef __LINUX__
@@ -239,6 +250,7 @@ bool OtherSettingsPanel::TransferDataFromWindow() {
     frame->SetUserEMAIL(eMailTextControl->GetValue());
 	frame->SetLinkedSave(Choice_LinkSave->GetStringSelection());
 	frame->SetLinkedControllerUpload(Choice_LinkControllerUpload->GetStringSelection());
+    frame->SetRenameModelAliasPromptBehavior(Choice_AliasPromptBehavior->GetStringSelection());
 	frame->SetPromptBatchRenderIssues(CheckBox_BatchRenderPromptIssues->GetValue());
 	frame->SetIgnoreVendorModelRecommendations(CheckBox_IgnoreVendorModelRecommendations->GetValue());
 	frame->SetPurgeDownloadCacheOnStart(CheckBox_PurgeDownloadCache->GetValue());
@@ -262,6 +274,7 @@ bool OtherSettingsPanel::TransferDataToWindow() {
     eMailTextControl->ChangeValue(frame->UserEMAIL());
 	Choice_LinkSave->SetStringSelection(frame->GetLinkedSave());
 	Choice_LinkControllerUpload->SetStringSelection(frame->GetLinkedControllerUpload());
+    Choice_AliasPromptBehavior->SetStringSelection(frame->GetRenameModelAliasPromptBehavior());
 	CheckBox_BatchRenderPromptIssues->SetValue(frame->GetPromptBatchRenderIssues());
 	CheckBox_IgnoreVendorModelRecommendations->SetValue(frame->GetIgnoreVendorModelRecommendations());
 	CheckBox_PurgeDownloadCache->SetValue(frame->GetPurgeDownloadCacheOnStart());

--- a/xLights/preferences/OtherSettingsPanel.h
+++ b/xLights/preferences/OtherSettingsPanel.h
@@ -43,6 +43,7 @@ class OtherSettingsPanel: public wxPanel
 		wxCheckBox* HardwareVideoDecodingCheckBox;
 		wxCheckBox* ShaderCheckbox;
 		wxChoice* ChoiceCodec;
+		wxChoice* Choice_AliasPromptBehavior;
 		wxChoice* Choice_LinkControllerUpload;
 		wxChoice* Choice_LinkSave;
 		wxChoice* Choice_MinTipLevel;
@@ -53,6 +54,7 @@ class OtherSettingsPanel: public wxPanel
 		wxStaticText* StaticText4;
 		wxStaticText* StaticText5;
 		wxStaticText* StaticText6;
+		wxStaticText* StaticText7;
 		wxTextCtrl* eMailTextControl;
 		//*)
 
@@ -62,27 +64,29 @@ class OtherSettingsPanel: public wxPanel
 	protected:
 
 		//(*Identifiers(OtherSettingsPanel)
-		static const long ID_STATICTEXT1;
-		static const long ID_CHOICE1;
-		static const long ID_CHECKBOX1;
-		static const long ID_CHOICE4;
-		static const long ID_CHECKBOX7;
-		static const long ID_STATICTEXT3;
-		static const long ID_CHOICE_CODEC;
-		static const long ID_STATICTEXT5;
-		static const long ID_SPINCTRLDOUBLE_BITRATE;
-		static const long ID_CHECKBOX2;
-		static const long ID_CHECKBOX3;
-		static const long ID_CHECKBOX4;
-		static const long ID_CHECKBOX6;
-		static const long ID_CHECKBOX5;
-		static const long ID_STATICTEXT4;
-		static const long ID_CHOICE3;
-		static const long ID_CHECKBOX8;
-		static const long ID_STATICTEXT2;
-		static const long ID_CHOICE2;
-		static const long ID_TEXTCTRL1;
-		static const long ID_CHECKBOX9;
+		static const wxWindowID ID_STATICTEXT1;
+		static const wxWindowID ID_CHOICE1;
+		static const wxWindowID ID_CHECKBOX1;
+		static const wxWindowID ID_CHOICE4;
+		static const wxWindowID ID_CHECKBOX7;
+		static const wxWindowID ID_STATICTEXT3;
+		static const wxWindowID ID_CHOICE_CODEC;
+		static const wxWindowID ID_STATICTEXT5;
+		static const wxWindowID ID_SPINCTRLDOUBLE_BITRATE;
+		static const wxWindowID ID_CHECKBOX2;
+		static const wxWindowID ID_CHECKBOX3;
+		static const wxWindowID ID_CHECKBOX4;
+		static const wxWindowID ID_CHECKBOX6;
+		static const wxWindowID ID_CHECKBOX5;
+		static const wxWindowID ID_STATICTEXT4;
+		static const wxWindowID ID_CHOICE3;
+		static const wxWindowID ID_CHECKBOX8;
+		static const wxWindowID ID_STATICTEXT2;
+		static const wxWindowID ID_CHOICE2;
+		static const wxWindowID ID_STATICTEXT6;
+		static const wxWindowID ID_CHOICE_ALIASPROMPT;
+		static const wxWindowID ID_TEXTCTRL1;
+		static const wxWindowID ID_CHECKBOX9;
 		//*)
 
 	private:

--- a/xLights/wxsmith/OtherSettingsPanel.wxs
+++ b/xLights/wxsmith/OtherSettingsPanel.wxs
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <wxsmith>
 	<object class="wxPanel" name="OtherSettingsPanel">
-		<size>603,310</size>
 		<id_arg>0</id_arg>
 		<handler function="OnPaint" entry="EVT_PAINT" />
 		<object class="wxGridBagSizer" variable="GridBagSizer1" member="no">

--- a/xLights/wxsmith/OtherSettingsPanel.wxs
+++ b/xLights/wxsmith/OtherSettingsPanel.wxs
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <wxsmith>
 	<object class="wxPanel" name="OtherSettingsPanel">
+		<size>603,310</size>
 		<id_arg>0</id_arg>
 		<handler function="OnPaint" entry="EVT_PAINT" />
 		<object class="wxGridBagSizer" variable="GridBagSizer1" member="no">
@@ -208,7 +209,7 @@
 					<handler function="OnControlChanged" entry="EVT_CHECKBOX" />
 				</object>
 				<col>0</col>
-				<row>8</row>
+				<row>9</row>
 				<flag>wxALL|wxEXPAND</flag>
 				<border>5</border>
 				<option>1</option>
@@ -296,6 +297,37 @@
 				</object>
 				<col>0</col>
 				<row>7</row>
+				<flag>wxALL|wxEXPAND</flag>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxFlexGridSizer" variable="FlexGridSizer7" member="no">
+					<cols>2</cols>
+					<object class="sizeritem">
+						<object class="wxStaticText" name="ID_STATICTEXT6" variable="StaticText7" member="yes">
+							<label>Model reanaming alias behavior:</label>
+						</object>
+						<flag>wxALL|wxEXPAND</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxChoice" name="ID_CHOICE_ALIASPROMPT" variable="Choice_AliasPromptBehavior" member="yes">
+							<content>
+								<item>Always Prompt</item>
+								<item>Always Yes</item>
+								<item>Always No</item>
+							</content>
+							<selection>0</selection>
+							<handler function="OnControlChanged" entry="EVT_CHOICE" />
+						</object>
+						<flag>wxALL|wxEXPAND</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<col>0</col>
+				<row>8</row>
 				<flag>wxALL|wxEXPAND</flag>
 				<option>1</option>
 			</object>

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -2046,6 +2046,9 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
 
     config->Read("xLightsLinkedControllerUpload", &_linkedControllerUpload, "Inputs and Outputs");
     logger_base.debug("Linked controller upload: %s.", (const char*)_linkedControllerUpload.c_str());
+    
+    config->Read("xLightsModelRename", &_aliasRenameBehavior, "Always Prompt");
+    logger_base.debug("Model Rename Behavior: %s.", (const char*)_aliasRenameBehavior.c_str());
 
     std::thread th([this]() {
         try {
@@ -9911,6 +9914,16 @@ void xLightsFrame::SetLinkedControllerUpload(const wxString& e)
     config->Write("xLightsLinkedControllerUpload", _linkedControllerUpload);
     config->Flush();
     logger_base.info("Linked controller upload set to %s", (const char*)_linkedControllerUpload.c_str());
+}
+
+void xLightsFrame::SetRenameModelAliasPromptBehavior(const wxString& e)
+{
+    static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+    _aliasRenameBehavior = e;
+    wxConfigBase* config = wxConfigBase::Get();
+    config->Write("xLightsModelRename", _aliasRenameBehavior);
+    config->Flush();
+    logger_base.info("Rename Alias Prompt Behavior set to %s", (const char*)_aliasRenameBehavior.c_str());
 }
 
 void xLightsFrame::CollectUserEmail()

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -383,6 +383,7 @@ public:
     wxString _userEmail;
     wxString _linkedSave = "None";
     wxString _linkedControllerUpload = "None";
+    wxString _aliasRenameBehavior = "Always Prompt";
     static wxString CurrentDir; //expose current folder name -DJ
     static wxString FseqDir; //expose current fseq name
     static wxString PlaybackMarker; //keep track of where we are within grid -DJ
@@ -1215,6 +1216,9 @@ public:
 
     const wxString& GetLinkedControllerUpload() const { return _linkedControllerUpload; }
     void SetLinkedControllerUpload(const wxString& e);
+    
+    const wxString& GetRenameModelAliasPromptBehavior() const { return _aliasRenameBehavior; }
+    void SetRenameModelAliasPromptBehavior(const wxString& e);
 
     int SaveFSEQVersion() const { return _fseqVersion; }
     void SetSaveFSEQVersion(int i) { _fseqVersion = i; }


### PR DESCRIPTION
(Fixing link to branch from original PR)

For Issue https://github.com/xLightsSequencer/xLights/issues/4675

Added the ability to set the behavior for alias setting on renaming models. The default is the current behavior. The user can set "Always Yes" or "Always No" per their preference, or leave it to always prompt.