### PR TITLE
Fix: Moving Head Effect - Selecting None won't reset effects

### DIFF
--- a/xLights/effects/MovingHeadPanel.cpp
+++ b/xLights/effects/MovingHeadPanel.cpp
@@ -1616,7 +1616,6 @@ void MovingHeadPanel::OnButton_NoneClick(wxCommandEvent& event)
 {
     UncheckAllFixtures();
     UpdateColorPanel();
-    OnButton_ResetToDefaultClick(event);
 }
 
 void MovingHeadPanel::OnButton_EvensClick(wxCommandEvent& event)


### PR DESCRIPTION
A bug was introducted recently where if you select None of the moving head effect when it is on a group, it will also reset the effects that was on all the moving heads.  The buttons are for easily selecting and deselecting the heads, not resetting.