### PR TITLE
[Enhancement] Ability to default "Keep Channel Numbers" for Controller Variants

### DIFF
--- a/controllers/espixelstick.xcontroller
+++ b/controllers/espixelstick.xcontroller
@@ -11,6 +11,7 @@
 			<AllInputUniversesMustBeSameSize/>
 			<UniversesMustBeSequential/>
 			<SupportsAutoLayout/>
+            <DDPStartsAtOne/>
 			<PixelProtocols>
 				<Protocol>ws2811</Protocol>
 				<Protocol>gece</Protocol>
@@ -36,6 +37,7 @@
         <AllInputUniversesMustBeSameSize/>
         <UniversesMustBeSequential/>
         <SupportsAutoLayout/>
+        <DDPStartsAtOne/>
         <SupportsPixelPortEndNullPixels/>
         <NeedsDDPInputUpload/>
         <InputProtocols>

--- a/controllers/wled.xcontroller
+++ b/controllers/wled.xcontroller
@@ -11,6 +11,7 @@
         <AllInputUniversesMustBeSameSize/>
         <UniversesMustBeSequential/>
         <SupportsAutoLayout/>
+        <DDPStartsAtOne/>
         <SupportsMultipleSimultaneousOutputProtocols/>
         <PixelProtocols>
             <Protocol>ws2811</Protocol>

--- a/xLights/controllers/ControllerCaps.cpp
+++ b/xLights/controllers/ControllerCaps.cpp
@@ -386,6 +386,10 @@ bool ControllerCaps::SupportsAutoUpload() const {
     return DoesXmlNodeExist(_config, "SupportsAutoUpload");
 }
 
+bool ControllerCaps::DDPStartsAtOne() const {
+    return DoesXmlNodeExist(_config, "DDPStartsAtOne");
+}
+
 bool ControllerCaps::SupportsUniversePerString() const
 {
     return DoesXmlNodeExist(_config, "SupportsUniversePerString");

--- a/xLights/controllers/ControllerCaps.h
+++ b/xLights/controllers/ControllerCaps.h
@@ -72,6 +72,7 @@ public:
     bool SupportsRemotes() const;
     bool SupportsAutoLayout() const;
     bool SupportsAutoUpload() const;
+    bool DDPStartsAtOne() const;
     bool SupportsUniversePerString() const;
     bool SupportsMultipleSimultaneousOutputProtocols() const;
     bool SupportsMultipleSimultaneousInputProtocols() const;

--- a/xLights/outputs/ControllerEthernet.cpp
+++ b/xLights/outputs/ControllerEthernet.cpp
@@ -273,6 +273,11 @@ void ControllerEthernet::SetProtocol(const std::string& protocol) {
                 ddpo->SetId(_outputManager->UniqueId());
             }
             SetId(ddpo->GetId());
+            
+            auto c = ControllerCaps::GetControllerConfig(_vendor, _model, _variant);
+            if( c && c->DDPStartsAtOne() )
+                ddpo->SetKeepChannelNumber(false);
+            
         } else if (_type == OUTPUT_TWINKLY) {
             auto to = new TwinklyOutput();
             _outputs.push_back(to);


### PR DESCRIPTION
There were some questions about this in the zoom room recently where for the DDP protocol, "Keep Channel Numbers" needs to be unchecked. However, this is not something we can configure via .xcontroller configs. 

Added the ability to do this via .xcontroller configs for AbstractVariants. It was not easily understood how I could do this at a vendor level, but if I'm just missing something, please point me in the right direction and I'll update the code. A side effect is that a user can choose a Vendor, then switch to DDP, and the checkbox will be checked. Then when the user selects a Variant, the box remains checked. Again, if I'm missing something obvious, please point me and I'll update it.

I also added the config update for WLED and ESPixelStick as the code prompts the user to disabled this, and zoom room lurking confirms this. There was recent discussion that "Minleon" may also require this, however I cannot confirm this, but perhaps someone else can (and make the update accordingly).

Thanks!