### PR TITLE
Update RemoteFalcon.h to add playlistIndex to sync playlists request body

### DIFF
--- a/xSchedule/RemoteFalcon/RemoteFalcon.h
+++ b/xSchedule/RemoteFalcon/RemoteFalcon.h
@@ -101,8 +101,8 @@ class RemoteFalcon
                             body += ",";
                         }
 
-                        body += wxString::Format("{\"playlistName\":\"" + val["steps"][i]["name"].AsString() + "\",\"playlistDuration\":%d}",
-                            wxAtoi(val["steps"][i]["lengthms"].AsString()) / 1000);
+                        body += wxString::Format("{\"playlistName\":\"" + val["steps"][i]["name"].AsString() + "\",\"playlistIndex\":%d, \"playlistDuration\":%d}",
+                            (i+1), wxAtoi(val["steps"][i]["lengthms"].AsString()) / 1000);
                     }
                 }
             }


### PR DESCRIPTION
Add playlistIndex to sequences sync for Remote Falcon plugin.

Sequence index was -1 for all synced sequences since it wasn't part of the request. Added to request body so each sequence has a valid index (used for specific sequence styling).

![image](https://github.com/user-attachments/assets/92f99e0a-2dd0-4fb3-8e8e-ac338f062e0e)
