### PR TITLE
[enh] Custom Model - improvements to Node starts for Individual Strings

### DIFF
--- a/xLights/models/CustomModel.h
+++ b/xLights/models/CustomModel.h
@@ -91,6 +91,7 @@ class CustomModel : public ModelWithScreenLocation<BoxedScreenLocation>
             return wxString::Format(wxT("String%i"), idx + 1).ToStdString();  // a space between "String" and "%i" breaks the start channels listed in Indiv Start Chans
         }
         std::string ComputeStringStartNode(int x) const;
+        bool ComputeFurtherStringStartNodesFromString(int x) const;
         int GetCustomNodeStringNumber(int node) const;
 
         int _depth = 1;


### PR DESCRIPTION
A common troubleshooting issue in the zoom room is when splitting custom models into individual strings, the user often has to update all of the numbers manually.
The intention behind this addition is to make this process easier for the user to implement.

### Current Behavior
When the user checks "Indiv Start Nodes", it will evenly break up the amount of nodes evenly per string. This is pretty uncommon when people are connecting nodes to lights, especially on models with node counts that aren't easily divisible by 50 or 100.

### Changed Behavior

- With this change, nothing is auto calculated by default. When a user checks "Indiv Start Nodes", the strings are auto populated to 0 counts. Then the user enters the starting pixel for the 2nd String. After that happens, the code auto calculated the node count, and propagates that count as far down the string counts as it can.
- Strings with 0 counts are highlighted in red to indicate to the user a setup issue.
- An error dialog was added if the user attempts to add string counts out of order.
- As before, if a user unchecks the box, and then rechecks the box, it will reset the starting node count per string. In this case, it resets all the node start counts to 0 instead of evenly dividing it again, allowing the user to start over if they make a mistake.

![Screenshot 2024-09-06 at 10 08 53 AM](https://github.com/user-attachments/assets/528ce4b4-fe73-42ce-b0ae-faa1c63aef18)
![Screenshot 2024-09-06 at 10 09 36 AM](https://github.com/user-attachments/assets/2992c7de-f67d-442f-af41-66e783a50e71)
![Screenshot 2024-09-06 at 10 09 46 AM](https://github.com/user-attachments/assets/16d32c59-3073-4f9e-a150-ae026bcf07ea)
![Screenshot 2024-09-06 at 10 09 07 AM](https://github.com/user-attachments/assets/42b0ecf3-574d-4c54-9e9e-a4899340e2ec)
