### PR TITLE
[enh] changing the background colors for dark mode in the Node Layout dialog. [4792]

### DIFF
--- a/xLights/models/CubeModel.cpp
+++ b/xLights/models/CubeModel.cpp
@@ -1198,7 +1198,8 @@ std::string CubeModel::ChannelLayoutHtml(OutputManager* outputManager)
             int string = index / nodesPerString + 1;
             int nodenum = index % nodesPerString + 1;
             wxString bgcolor = string % 2 == 1 ? "#ADD8E6" : "#90EE90";
-
+            if( IsDarkMode() )
+                bgcolor = string % 2 == 1 ? "#3f7c85" : "#962B09";
             html += wxString::Format("<td bgcolor='" + bgcolor + "'>n%ds%d</td>", nodenum, string);
         }
         html += "</tr>";

--- a/xLights/models/CustomModel.cpp
+++ b/xLights/models/CustomModel.cpp
@@ -1256,7 +1256,11 @@ std::string CustomModel::ChannelLayoutHtml(OutputManager* outputManager) {
                     wxString value = _data[l][r][c];
                     if (!value.IsEmpty() && value != "0") {
                         if (_strings == 1) {
-                            html += wxString::Format("<td bgcolor='#ADD8E6'>n%s</td>", value);
+                            if( IsDarkMode() ) {
+                                html += wxString::Format("<td bgcolor='#962B09'>n%s</td>", value);
+                            } else {
+                                html += wxString::Format("<td bgcolor='#ADD8E6'>n%s</td>", value);
+                            }
                         }
                         else {
                             int string = GetCustomNodeStringNumber(wxAtoi(value));
@@ -1264,19 +1268,19 @@ std::string CustomModel::ChannelLayoutHtml(OutputManager* outputManager) {
                             switch (string % 4)
                             {
                             case 0:
-                                bgcolor = "#eed1a4"; // yellow
+                                bgcolor = IsDarkMode() ? "#7a577a" : "#eed1a4"; // purple / yellow
                                 break;
                             case 1:
-                                bgcolor = "#8aa2bb"; // blue
+                                bgcolor = IsDarkMode() ? "#3f7c85" : "#8aa2bb"; // teal / blue
                                 break;
                             case 2:
-                                bgcolor = "#ec9396"; // red
+                                bgcolor = IsDarkMode() ? "#520120" : "#ec9396"; // maroon / red
                                 break;
                             case 3:
-                                bgcolor = "#86d0c3"; // green
+                                bgcolor = IsDarkMode() ? "#08403e" : "#86d0c3"; // dark teal / green
                                 break;
                             }
-                            html += wxString::Format("<td bgcolor='" + bgcolor + "'>n%ss%d</td>", value, string);
+                            html += wxString::Format("<td bgcolor='" + bgcolor + "'>n%ss%d</td>",value, string);
                         }
                     }
                     else {

--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -5182,6 +5182,8 @@ std::string Model::ChannelLayoutHtml(OutputManager* outputManager)
                 } else {
                     int s = Nodes[n - 1]->StringNum + 1;
                     wxString bgcolor = (s % 2 == 1) ? "#ADD8E6" : "#90EE90";
+                    if( IsDarkMode() )
+                        bgcolor = (s % 2 == 1) ? "#3F7C85" : "#962B09";
                     while (n > NodesPerString()) {
                         n -= NodesPerString();
                     }


### PR DESCRIPTION
https://github.com/xLightsSequencer/xLights/issues/4792

Added a new set of background colors to handle a white font from dark mode. This should allow for easier readability of the layout.

I'm not great at accessibility, so I hope these colors are still distinguishable by those that are colorblind.

Example colors:
![Screenshot 2024-09-06 at 12 36 39 PM](https://github.com/user-attachments/assets/719da239-bdab-464b-94eb-07fd38d44e0c)
