### PR TITLE
Fix Fade on 'Head and Tail' fade type for certain layer blendings

### DIFF
--- a/xLights/effects/SingleStrandEffect.cpp
+++ b/xLights/effects/SingleStrandEffect.cpp
@@ -722,19 +722,25 @@ void SingleStrandEffect::draw_chase(RenderBuffer& buffer,
                             } else {
                                 color.alpha = 255.0 * ((2 * i +1 - max_chase_width)) / max_chase_width;
                             }
-                            
                         }
+
                     } else {   // head tail not alpha 
                         HSVValue hsv1 = color.asHSV();
-                        if (i > middle_chase_index) {
-                            hsv1.value = orig_v - ((max_chase_width - (2.0 * i + 1.0)) / max_chase_width);
+
+                        if (i <= middle_chase_index) {
+                            hsv1.value = orig_v * (1.0 - (2.0 * i) / max_chase_width);
                         } else {
-                            hsv1.value = ((max_chase_width - (2.0 * i)) / (max_chase_width));
+                            hsv1.value = orig_v * ((2.0 * (i - middle_chase_index)) / max_chase_width);
                         }
- 
+
+                        if (hsv1.value > orig_v) {
+                            hsv1.value = orig_v;
+                        }
+
                         if (hsv1.value < 0.0) {
                             hsv1.value = 0.0;
                         }
+
                         color = hsv1;
                     }
                 } else if (Fade_Type == "Middle") {


### PR DESCRIPTION
There is currently a bug on the Head and Tail fade type on Single Strand when you use another layer blending besides normal.
Here you can see I selected 1 color only from the orange palette, I set the fade type to Head and Tail and then I set the Layer blending to Effect 1 (you can use many others like additive etc)
![BeforeFix](https://github.com/user-attachments/assets/60bf4fe2-effa-4e28-8a39-20d1bebdf011)

Here is the same after the fix.
![AfterFix](https://github.com/user-attachments/assets/77125b6b-82a5-4850-9d1e-077b4649fa8f)
