### PR TITLE
Keybindings to increase and decrease speed along with next and prior

### DIFF
--- a/xLights/KeyBindings.cpp
+++ b/xLights/KeyBindings.cpp
@@ -124,6 +124,8 @@ static  std::vector<std::pair<std::string, KBSCOPE>> KeyBindingTypes =
     { "AUDIO_S_1_4_SPEED", KBSCOPE::Sequence },
     { "PRIOR_TAG", KBSCOPE::Sequence },
     { "NEXT_TAG", KBSCOPE::Sequence },
+    { "PLAY_PRIOR_TAG", KBSCOPE::Sequence },
+    { "PLAY_NEXT_TAG", KBSCOPE::Sequence },
     { "MODEL_TOGGLE", KBSCOPE::Sequence },
     { "MODEL_DISABLE", KBSCOPE::Sequence },
     { "MODEL_ENABLE", KBSCOPE::Sequence },
@@ -141,7 +143,9 @@ static  std::vector<std::pair<std::string, KBSCOPE>> KeyBindingTypes =
     { "SELECT_TIMING_7", KBSCOPE::Sequence },
     { "SELECT_TIMING_8", KBSCOPE::Sequence },
     { "SELECT_TIMING_9", KBSCOPE::Sequence },
-    { "SELECT_NO_TIMING", KBSCOPE::Sequence }
+    { "SELECT_NO_TIMING", KBSCOPE::Sequence },
+    { "INCREASE_SPEED", KBSCOPE::Sequence },
+    { "DECREASE_SPEED", KBSCOPE::Sequence }
 };
 
 static  std::vector<std::pair<std::string, std::string>> keyBindingTips = {
@@ -241,6 +245,8 @@ static  std::vector<std::pair<std::string, std::string>> keyBindingTips = {
     { "AUDIO_S_1_4_SPEED", "Playback audio at 1/4 speed." },
     { "PRIOR_TAG", "Jump to prior audio tag." },
     { "NEXT_TAG", "Jump to next audio tag." },
+    { "PLAY_PRIOR_TAG", "Play from prior audio tag." },
+    { "PLAY_NEXT_TAG", "Play from next audio tag." },
     { "MODEL_SUBMODELS", "Edit model submodels." },
     { "MODEL_FACES", "Edit model faces." },
     { "MODEL_STATES", "Edit model states." },
@@ -262,7 +268,9 @@ static  std::vector<std::pair<std::string, std::string>> keyBindingTips = {
     { "SELECT_TIMING_7", "Select seventh timing." },
     { "SELECT_TIMING_8", "Select eighth timing." },
     { "SELECT_TIMING_9", "Select ninth timing." },
-    { "SELECT_NO_TIMING", "Select no timing tracks." }
+    { "SELECT_NO_TIMING", "Select no timing tracks." },
+    { "INCREASE_SPEED", "Increase speed." },
+    { "DECREASE_SPEED", "Decrease speed." }
 };
 
 const std::vector<KeyBinding> DefaultBindings =
@@ -298,6 +306,8 @@ const std::vector<KeyBinding> DefaultBindings =
     KeyBinding("", true, "AUDIO_S_1_4_SPEED", true, true),
     KeyBinding("", true, "PRIOR_TAG", true, true),
     KeyBinding("", true, "NEXT_TAG", true, true),
+    KeyBinding("", true, "INCREASE_SPEED", true, true),
+    KeyBinding("", true, "DECREASE_SPEED", true, true),
 
     KeyBinding("s", false, "SAVE_CURRENT_TAB", true),
     KeyBinding("", true, "SAVE_SEQUENCE", true),
@@ -466,6 +476,7 @@ KeyBinding::KeyBinding(wxKeyCode k, bool disabled, const std::string& type, bool
     _id = __nextid++;
 
     log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+    logger_base.debug(">>>>testing");
 
     wxASSERT(KeyBindingTypes.size() > 0); // this can fail if someone reorders the constant creation so catch it
     auto it = std::find_if(begin(KeyBindingTypes), end(KeyBindingTypes), [type](const auto& kbt) { return kbt.first == type; });
@@ -478,6 +489,7 @@ KeyBinding::KeyBinding(wxKeyCode k, bool disabled, const std::string& type, bool
     } else {
         _scope = it->second;
     }
+    logger_base.debug(">>>>testing 2");
     auto it2 = std::find_if(begin(keyBindingTips), end(keyBindingTips), [type](const auto& kbt) { return kbt.first == type; });
     if (it2 != keyBindingTips.end()) {
         _tip = it2->second;

--- a/xLights/models/ImageModel.cpp
+++ b/xLights/models/ImageModel.cpp
@@ -256,7 +256,7 @@ void ImageModel::DisplayEffectOnWindow(ModelPreview* preview, double pointSize)
                 int maxBrightness = 0;
                 if (drawColor) {
                     // Color Image mode selected. Convert image to grayscale image so custom color can be applied later
-                    for (int x = 0; x < img.GetWidth(); x++) { // dwe
+                    for (int x = 0; x < img.GetWidth(); x++) {
                         for (int y = 0; y < img.GetHeight(); y++) {
                             int r = img.GetRed(x, y);
                             int g = img.GetGreen(x, y);

--- a/xLights/sequencer/MainSequencer.cpp
+++ b/xLights/sequencer/MainSequencer.cpp
@@ -679,6 +679,24 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
             }
             else if (type == "INSERT_LAYER_ABOVE") {
                 PanelEffectGrid->InsertEffectLayerAbove();
+            } else if (type == "INCREASE_SPEED") {
+                float t = mSequenceElements->GetXLightsFrame()->GetPlaySpeed();
+                mSequenceElements->GetXLightsFrame()->SetPlaySpeedTo(t + 0.25);
+                mSequenceElements->GetXLightsFrame()->SetStatusText(wxString::Format("Speed now set %.2f ", t + 0.25));
+            } else if (type == "DECREASE_SPEED") {
+                float t = mSequenceElements->GetXLightsFrame()->GetPlaySpeed();
+                if (t > 0.50) {
+                    mSequenceElements->GetXLightsFrame()->SetPlaySpeedTo(t - 0.25);
+                    mSequenceElements->GetXLightsFrame()->SetStatusText(wxString::Format("Speed now set %.2f ", t - 0.25));
+                }
+            } else if (type == "PLAY_PRIOR_TAG") {
+                logger_base.debug("play prior tag");
+                wxCommandEvent playEvent(EVT_SEQUENCE_PRIOR_TAG);
+                wxPostEvent(mSequenceElements->GetXLightsFrame(), playEvent);
+            } else if (type == "PLAY_NEXT_TAG") {
+                logger_base.debug("play next tag");
+                wxCommandEvent playEvent(EVT_SEQUENCE_NEXT_TAG);
+                wxPostEvent(mSequenceElements->GetXLightsFrame(), playEvent);
             }
             else if (type == "AUDIO_FULL_SPEED") {
                 mSequenceElements->GetXLightsFrame()->SetPlaySpeedTo(1.0);

--- a/xLights/sequencer/TimeLine.cpp
+++ b/xLights/sequencer/TimeLine.cpp
@@ -194,6 +194,35 @@ void TimeLine::GoToTag(int tag)
     }
 }
 
+int TimeLine::GetNextTag(int pos) {
+    int end = GetTimeLength();
+    int next = end;
+
+    for (const auto& it : _tagPositions) {
+        if (it != -1) {
+            if (it > pos && it < next) {
+                next = it;
+            }
+        }
+    }
+
+    return next;
+}
+
+int TimeLine::GetPriorTag(int pos) {
+    int prior = 0;
+
+    for (const auto& it : _tagPositions) {
+        if (it != -1) {
+            if (it < pos && it > prior) {
+                prior = it;
+            }
+        }
+    }
+
+    return prior;
+}
+
 int TimeLine::GetTagPosition(int tag)
 {
     // update it if it is outside the sequence

--- a/xLights/sequencer/TimeLine.h
+++ b/xLights/sequencer/TimeLine.h
@@ -121,6 +121,8 @@ public:
     void GoToTag(int tag);
     void GoToPriorTag();
     void GoToNextTag();
+    int GetPriorTag(int pos);
+    int GetNextTag(int pos);
     int GetTagPosition(int tag);
     void SetTagPosition(int tag, int position , bool flag = true );
     void ClearTags();

--- a/xLights/sequencer/tabSequencer.cpp
+++ b/xLights/sequencer/tabSequencer.cpp
@@ -1973,6 +1973,84 @@ void xLightsFrame::SequenceFForward10(wxCommandEvent& event)
     mainSequencer->UpdateTimeDisplay(current_play_time, _fps);
 }
 
+void xLightsFrame::SequencePriorTag(wxCommandEvent& event) {
+    if (CurrentSeqXmlFile == nullptr)
+        return;
+
+    int current_play_time;
+    if (CurrentSeqXmlFile->GetSequenceType() == "Media" && CurrentSeqXmlFile->GetMedia() != nullptr) {
+        current_play_time = CurrentSeqXmlFile->GetMedia()->Tell();
+    } else {
+        wxTimeSpan ts = wxDateTime::UNow() - starttime;
+        long curtime = ts.GetMilliseconds().ToLong();
+        int msec;
+        if (playAnimation) {
+            msec = curtime * playSpeed;
+        } else {
+            msec = curtime;
+        }
+        current_play_time = (playStartTime + msec - playStartMS);
+    }
+
+    long origtime = current_play_time;
+    current_play_time = mainSequencer->PanelTimeLine->GetPriorTag(origtime - 500);
+
+    int end_ms = CurrentSeqXmlFile->GetSequenceDurationMS();
+    if (current_play_time > end_ms)
+        current_play_time = end_ms;
+
+    if (CurrentSeqXmlFile->GetSequenceType() == "Media") {
+        if (CurrentSeqXmlFile->GetMedia() != nullptr) {
+            CurrentSeqXmlFile->GetMedia()->Seek(current_play_time);
+        }
+    } else {
+        starttime += wxTimeSpan(0, 0, (origtime - current_play_time) / 1000, (origtime - current_play_time) % 1000);
+    }
+
+    mainSequencer->PanelWaveForm->UpdatePlayMarker();
+    mainSequencer->PanelEffectGrid->ForceRefresh();
+    mainSequencer->UpdateTimeDisplay(current_play_time, _fps);
+}
+
+void xLightsFrame::SequenceNextTag(wxCommandEvent& event) {
+    if (CurrentSeqXmlFile == nullptr)
+        return;
+
+    int current_play_time;
+    if (CurrentSeqXmlFile->GetSequenceType() == "Media" && CurrentSeqXmlFile->GetMedia() != nullptr) {
+        current_play_time = CurrentSeqXmlFile->GetMedia()->Tell();
+    } else {
+        wxTimeSpan ts = wxDateTime::UNow() - starttime;
+        long curtime = ts.GetMilliseconds().ToLong();
+        int msec;
+        if (playAnimation) {
+            msec = curtime * playSpeed;
+        } else {
+            msec = curtime;
+        }
+
+        current_play_time = (playStartTime + msec - playStartMS);
+    }
+
+    long origtime = current_play_time;
+    current_play_time = mainSequencer->PanelTimeLine->GetNextTag(origtime);
+    int end_ms = CurrentSeqXmlFile->GetSequenceDurationMS();
+    if (current_play_time > end_ms)
+        current_play_time = end_ms;
+
+    if (CurrentSeqXmlFile->GetSequenceType() == "Media") {
+        if (CurrentSeqXmlFile->GetMedia() != nullptr) {
+            CurrentSeqXmlFile->GetMedia()->Seek(current_play_time);
+        }
+    } else {
+        starttime += wxTimeSpan(0, 0, (origtime - current_play_time) / 1000, (origtime - current_play_time) % 1000);
+    }
+
+    mainSequencer->PanelWaveForm->UpdatePlayMarker();
+    mainSequencer->PanelEffectGrid->ForceRefresh();
+    mainSequencer->UpdateTimeDisplay(current_play_time, _fps);
+}
+
 void xLightsFrame::SequenceSeekTo(wxCommandEvent& event)
 {
     if (CurrentSeqXmlFile == nullptr) return;

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -399,6 +399,8 @@ wxDEFINE_EVENT(EVT_SEQUENCE_FIRST_FRAME, wxCommandEvent);
 wxDEFINE_EVENT(EVT_SEQUENCE_LAST_FRAME, wxCommandEvent);
 wxDEFINE_EVENT(EVT_SEQUENCE_REWIND10, wxCommandEvent);
 wxDEFINE_EVENT(EVT_SEQUENCE_FFORWARD10, wxCommandEvent);
+wxDEFINE_EVENT(EVT_SEQUENCE_PRIOR_TAG, wxCommandEvent);
+wxDEFINE_EVENT(EVT_SEQUENCE_NEXT_TAG, wxCommandEvent);
 wxDEFINE_EVENT(EVT_SEQUENCE_SEEKTO, wxCommandEvent);
 wxDEFINE_EVENT(EVT_SEQUENCE_REPLAY_SECTION, wxCommandEvent);
 wxDEFINE_EVENT(EVT_SHOW_DISPLAY_ELEMENTS, wxCommandEvent);
@@ -455,6 +457,8 @@ EVT_COMMAND(wxID_ANY, EVT_SEQUENCE_FIRST_FRAME, xLightsFrame::SequenceFirstFrame
 EVT_COMMAND(wxID_ANY, EVT_SEQUENCE_LAST_FRAME, xLightsFrame::SequenceLastFrame)
 EVT_COMMAND(wxID_ANY, EVT_SEQUENCE_REWIND10, xLightsFrame::SequenceRewind10)
 EVT_COMMAND(wxID_ANY, EVT_SEQUENCE_FFORWARD10, xLightsFrame::SequenceFForward10)
+EVT_COMMAND(wxID_ANY, EVT_SEQUENCE_PRIOR_TAG, xLightsFrame::SequencePriorTag)
+EVT_COMMAND(wxID_ANY, EVT_SEQUENCE_NEXT_TAG, xLightsFrame::SequenceNextTag)
 EVT_COMMAND(wxID_ANY, EVT_SEQUENCE_SEEKTO, xLightsFrame::SequenceSeekTo)
 EVT_COMMAND(wxID_ANY, EVT_SEQUENCE_REPLAY_SECTION, xLightsFrame::SequenceReplaySection)
 EVT_COMMAND(wxID_ANY, EVT_TOGGLE_PLAY, xLightsFrame::TogglePlay)
@@ -3531,6 +3535,10 @@ void xLightsFrame::SetGridNodeValues(bool b)
     mGridNodeValues = b;
     mainSequencer->PanelEffectGrid->SetEffectNodeValues(mGridNodeValues);
     mainSequencer->PanelEffectGrid->Refresh();
+}
+
+float xLightsFrame::GetPlaySpeed() {
+    return playSpeed;
 }
 
 void xLightsFrame::SetPlaySpeedTo(float speed)

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -175,6 +175,8 @@ wxDECLARE_EVENT(EVT_SEQUENCE_FIRST_FRAME, wxCommandEvent);
 wxDECLARE_EVENT(EVT_SEQUENCE_LAST_FRAME, wxCommandEvent);
 wxDECLARE_EVENT(EVT_SEQUENCE_REWIND10, wxCommandEvent);
 wxDECLARE_EVENT(EVT_SEQUENCE_FFORWARD10, wxCommandEvent);
+wxDECLARE_EVENT(EVT_SEQUENCE_NEXT_TAG, wxCommandEvent);
+wxDECLARE_EVENT(EVT_SEQUENCE_PRIOR_TAG, wxCommandEvent);
 wxDECLARE_EVENT(EVT_SEQUENCE_SEEKTO, wxCommandEvent);
 wxDECLARE_EVENT(EVT_SEQUENCE_REPLAY_SECTION, wxCommandEvent);
 wxDECLARE_EVENT(EVT_SHOW_DISPLAY_ELEMENTS, wxCommandEvent);
@@ -464,6 +466,7 @@ public:
     void SuspendRender(bool suspend) { _suspendRender = suspend; }
     bool IsRenderSuspended() const { return _suspendRender; }
     void SetPlaySpeedTo(float speed);
+    float GetPlaySpeed();
 
     //(*Handlers(xLightsFrame)
     void OnQuit(wxCommandEvent& event);
@@ -1800,6 +1803,8 @@ private:
     void SequenceRewind10(wxCommandEvent& event);
     void SequenceFForward10(wxCommandEvent& event);
     void SequenceSeekTo(wxCommandEvent& event);
+    void SequencePriorTag(wxCommandEvent& event);
+    void SequenceNextTag(wxCommandEvent& event);
     void SequenceReplaySection(wxCommandEvent& event);
     void TogglePlay(wxCommandEvent& event);
     void ExportModel(wxCommandEvent& event);


### PR DESCRIPTION
#4704 key bindings to increase / decrease speeds rather then just the current set speeds.
Also key bindings to jump to prior or next tags while doing the playback.