### PR TITLE
Add support for default port gamma with Genius controllers

### DIFF
--- a/controllers/experience.xcontroller
+++ b/controllers/experience.xcontroller
@@ -19,6 +19,7 @@
 		<SupportsAutoLayout/>
 		<SupportsFullxLightsControl/>
 		<SupportsDefaultBrightness/>
+		<SupportsDefaultGamma/>
 		<PreferredInputProtocol>DDP</PreferredInputProtocol>
 		<PixelProtocols>
 			<Protocol>ws2811</Protocol>

--- a/xLights/controllers/Experience.cpp
+++ b/xLights/controllers/Experience.cpp
@@ -238,6 +238,7 @@ bool Experience::SetOutputs(ModelManager* allmodels, OutputManager* outputManage
 
     bool const fullControl = rules->SupportsFullxLightsControl() && controller->IsFullxLightsControl();
     int const defaultBrightness = EncodeBrightness(controller->GetDefaultBrightnessUnderFullControl());
+    int const defaultGamma = EncodeGamma(controller->GetDefaultGammaUnderFullControl());
 
     bool const has_eFuses = Lower(rules->GetCustomPropertyByPath("eFuses", "false")) == "true";
     logger_base.info("Initializing Pixel Output Information.");
@@ -282,6 +283,8 @@ bool Experience::SetOutputs(ModelManager* allmodels, OutputManager* outputManage
                 }
                 if (pvs->_gammaSet) {
                     vs["g"] = EncodeGamma(pvs->_gamma);
+                } else if (fullControl) {
+                    vs["g"] = defaultGamma;
                 }
                 if (pvs->_brightnessSet) {
                     vs["b"] = EncodeBrightness(pvs->_brightness);
@@ -345,6 +348,8 @@ bool Experience::SetOutputs(ModelManager* allmodels, OutputManager* outputManage
                         }
                         if (pvs->_gammaSet) {
                             vs["g"] = EncodeGamma(pvs->_gamma);
+                        } else if (fullControl) {
+                            vs["g"] = defaultGamma;
                         }
                         if (pvs->_brightnessSet) {
                             vs["b"] = EncodeBrightness(pvs->_brightness);


### PR DESCRIPTION
Pretty simple change. Was implemented in FPP-based controllers, but found it missing in Experience controllers. Tested on MacOS 15.0 arm64 with Genius Pro 16.