### PR TITLE
Bug fix to fill the tag correctly #4839

### DIFF
--- a/xLights/KeyBindings.cpp
+++ b/xLights/KeyBindings.cpp
@@ -476,7 +476,6 @@ KeyBinding::KeyBinding(wxKeyCode k, bool disabled, const std::string& type, bool
     _id = __nextid++;
 
     log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
-    logger_base.debug(">>>>testing");
 
     wxASSERT(KeyBindingTypes.size() > 0); // this can fail if someone reorders the constant creation so catch it
     auto it = std::find_if(begin(KeyBindingTypes), end(KeyBindingTypes), [type](const auto& kbt) { return kbt.first == type; });
@@ -489,7 +488,6 @@ KeyBinding::KeyBinding(wxKeyCode k, bool disabled, const std::string& type, bool
     } else {
         _scope = it->second;
     }
-    logger_base.debug(">>>>testing 2");
     auto it2 = std::find_if(begin(keyBindingTips), end(keyBindingTips), [type](const auto& kbt) { return kbt.first == type; });
     if (it2 != keyBindingTips.end()) {
         _tip = it2->second;

--- a/xLights/sequencer/TimeLine.cpp
+++ b/xLights/sequencer/TimeLine.cpp
@@ -1049,17 +1049,18 @@ void TimeLine::render( wxDC& dc ) {
 
 void TimeLine::DrawTag(wxDC& dc, int tag, int position, int y_bottom)
 {
-    const wxPen* pen_black = wxBLUE_PEN;
+    dc.SetPen(*wxBLUE_PEN);
+    dc.SetBrush(*wxLIGHT_GREY_BRUSH);
 
-    dc.SetPen(*pen_black);
-    dc.DrawLine(position-5, y_bottom - 1, position+5, y_bottom -1);
-    dc.DrawLine(position-5, y_bottom - 1, position-5, y_bottom - 12);
-    dc.DrawLine(position+5, y_bottom - 1, position+5, y_bottom - 12);
-    dc.DrawLine(position-5, y_bottom - 12, position, y_bottom - 15);
-    dc.DrawLine(position+5, y_bottom - 12, position, y_bottom - 15);
-#ifndef __LINUX__
-    dc.FloodFill(position, y_bottom - 6, *wxLIGHT_GREY);
-#endif
+    wxPoint points[5];
+    points[0] = wxPoint(position+5, y_bottom -1);
+    points[1] = wxPoint(position-5, y_bottom - 1);
+    points[2] = wxPoint(position-5, y_bottom - 12);
+    points[3] = wxPoint(position,   y_bottom - 15);
+    points[4] = wxPoint(position+5, y_bottom - 12);
+
+    dc.DrawPolygon(5, points, 0,0, wxWINDING_RULE);
+    dc.SetBrush(*wxBLACK_BRUSH);
     dc.DrawLabel(wxString::Format("%i", tag), wxRect(position - 4, y_bottom - 13, 10, 13), wxALIGN_CENTRE_HORIZONTAL | wxALIGN_CENTRE_VERTICAL);
 }
 


### PR DESCRIPTION
Remove the use of the floodfill that was throwing an error and not working. Now using a polygon #4839
![image](https://github.com/user-attachments/assets/b42b4523-14b8-4c50-a87f-c18568590c9f)
(please verify on mac)