### PR TITLE
update URL to fixed shader for Mac - Twin Rays

### DIFF
--- a/download/shaders.xml
+++ b/download/shaders.xml
@@ -1059,9 +1059,9 @@
 	</shader>
 	<shader>	
 		<name>Twin Rays</name>
-		<id>5e7a80297c113618206debee</id>
-		<link>https://www.interactiveshaderformat.com/sketches/5e7a80297c113618206debee</link>
-		<download>https://www.interactiveshaderformat.com/sketches/5e7a80297c113618206debee/download</download>
+		<id>6716a86f2e035b001b56f461</id>
+		<link>https://www.interactiveshaderformat.com/sketches/6716a86f2e035b001b56f461</link>
+		<download>https://www.interactiveshaderformat.com/sketches/6716a86f2e035b001b56f461/download</download>
 		<image>https://res.cloudinary.com/hrlz5rsqo/image/upload/c_fill,h_250,w_360/quxll9orxfoqoqodkgsi</image>
 		<rating>3</rating>
 	</shader>


### PR DESCRIPTION
Fix for https://github.com/xLightsSequencer/xLights/issues/4908 (thanks @dkulp )

Created a fork of the existing shader on isf.video and added the correct constructor. Named the shader xLights - Twin Rays