### PR TITLE
Include last render date on Batch Render #4901

### DIFF
--- a/xLights/BatchRenderDialog.h
+++ b/xLights/BatchRenderDialog.h
@@ -87,7 +87,8 @@ protected:
 		void OnInit(wxInitDialogEvent& event);
 		//*)
 
-		void DisplayDateModified(std::string const& fileName, wxTreeListItem& index) const;
+        void DisplayDateModified(std::string const& fileName, wxTreeListItem& index) const;
+        void DisplayDateRendered(std::string const& fileName, wxTreeListItem& item) const;
 
         void ValidateWindow();
         uint32_t UpdateCount();


### PR DESCRIPTION
Include the date of the fseq file if found, either in the showfolder or the prefernce FSEQFolder. #4901
Sorting is available as well.
![image](https://github.com/user-attachments/assets/9fa2fd39-fee9-41a4-a252-fac058509073)
