### PR TITLE
[ILightThat Controllers] Fix colour order inheritance issue

### DIFF
--- a/xLights/controllers/ILightThat.cpp
+++ b/xLights/controllers/ILightThat.cpp
@@ -134,6 +134,10 @@ bool ILightThat::SetOutputs(ModelManager* allmodels, OutputManager* outputManage
                 if (colorOrder != "unknown") {
                     outputConfig["ports"][x]["models"][i]["colour_order"] = colorOrder;
                 }
+                else
+                {
+                    outputConfig["ports"][x]["models"][i]["colour_order"] = std::string("RGB");
+                }
                 i++;
             }
         }


### PR DESCRIPTION
Fix a minor issue when changing the order of props without explicitly set colour orders.