### PR TITLE
Fix Single Strand Fade type: Head and Tail for all blending types.

### DIFF
--- a/xLights/effects/SingleStrandEffect.cpp
+++ b/xLights/effects/SingleStrandEffect.cpp
@@ -726,15 +726,21 @@ void SingleStrandEffect::draw_chase(RenderBuffer& buffer,
                         }
                     } else {   // head tail not alpha 
                         HSVValue hsv1 = color.asHSV();
-                        if (i > middle_chase_index) {
-                            hsv1.value = orig_v - ((max_chase_width - (2.0 * i + 1.0)) / max_chase_width);
+
+                        if (i <= middle_chase_index) {
+                            hsv1.value = orig_v * (1.0 - (2.0 * i) / max_chase_width);
                         } else {
-                            hsv1.value = ((max_chase_width - (2.0 * i)) / (max_chase_width));
+                            hsv1.value = orig_v * ((2.0 * (i - middle_chase_index)) / max_chase_width);
                         }
- 
+
+                        if (hsv1.value > orig_v) {
+                            hsv1.value = orig_v;
+                        }
+
                         if (hsv1.value < 0.0) {
                             hsv1.value = 0.0;
                         }
+
                         color = hsv1;
                     }
                 } else if (Fade_Type == "Middle") {


### PR DESCRIPTION
Currently, you place a single strand on a matrix.  Pick Purple or Orange as the color and have a fade type of Head and Tail, you can see it looks correct -> once you change the layer blending to something else like Effect 1 or Adative .. you can observe the colors are incorrect.

This will fix it.