### PR TITLE
Fix for the Channel row of the property grid not having its limits updated

### DIFF
--- a/xLights/TabSetup.cpp
+++ b/xLights/TabSetup.cpp
@@ -1760,7 +1760,7 @@ void xLightsFrame::SetControllersProperties(bool rebuildPropGrid) {
                 Controllers_PropertyEditor->Clear();
                 controller->AddProperties(Controllers_PropertyEditor, &AllModels, expandProperties);
             }
-            controller->UpdateProperties(Controllers_PropertyEditor, &AllModels, expandProperties);
+            controller->UpdateProperties(Controllers_PropertyEditor, &AllModels, expandProperties, &_outputModelManager);
 
             if (controller->IsFromBase()) {
                 Controllers_PropertyEditor->SetToolTip("This model comes from the base folder and its properties cannot be edited.");

--- a/xLights/outputs/Controller.cpp
+++ b/xLights/outputs/Controller.cpp
@@ -765,7 +765,7 @@ void Controller::AddVariants(wxPGProperty* p) {
 }
 
 
-void Controller::UpdateProperties(wxPropertyGrid* propertyGrid, ModelManager* modelManager, std::list<wxPGProperty*>& expandProperties) {
+void Controller::UpdateProperties(wxPropertyGrid* propertyGrid, ModelManager* modelManager, std::list<wxPGProperty*>& expandProperties, OutputModelManager* outputModelManager) {
     
     wxPGProperty* p = propertyGrid->GetProperty("ControllerName");
     if (p) p->SetValue(GetName());

--- a/xLights/outputs/Controller.h
+++ b/xLights/outputs/Controller.h
@@ -301,7 +301,7 @@ public:
         void AddModels(wxPGProperty* property, wxPGProperty* vp);
         void AddVariants(wxPGProperty* property);
 
-        virtual void UpdateProperties(wxPropertyGrid* propertyGrid, ModelManager* modelManager, std::list<wxPGProperty*>& expandProperties);
+        virtual void UpdateProperties(wxPropertyGrid* propertyGrid, ModelManager* modelManager, std::list<wxPGProperty*>& expandProperties, OutputModelManager* outputModelManager);
         virtual void AddProperties(wxPropertyGrid* propertyGrid, ModelManager* modelManager, std::list<wxPGProperty*>& expandProperties);
 	    virtual bool HandlePropertyEvent(wxPropertyGridEvent& event, OutputModelManager* outputModelManager);
         virtual void ValidateProperties(OutputManager* om, wxPropertyGrid* propGrid) const;

--- a/xLights/outputs/ControllerEthernet.cpp
+++ b/xLights/outputs/ControllerEthernet.cpp
@@ -255,23 +255,6 @@ std::string ControllerEthernet::GetResolvedIP(bool forceResolve) const {
     return _resolvedIp;
 }
 
-void ControllerEthernet::SetProtocolAndRebuildProperties(const std::string& protocol, wxPropertyGrid* grid, OutputModelManager* outputModelManager) {
-    if (_outputs.size() > 0) {
-        _outputs.front()->RemoveProperties(grid);
-    }
-    SetProtocol(protocol);
-
-    if (_outputs.size() > 0) {
-        std::list<wxPGProperty*> expandProperties;
-        auto before = grid->GetProperty("Managed");
-        _outputs.front()->AddProperties(grid, before, this, AllSameSize(), expandProperties);
-    }
-    outputModelManager->AddASAPWork(OutputModelManager::WORK_NETWORK_CHANGE, "ControllerEthernet::HandlePropertyEvent::Protocol");
-    outputModelManager->AddASAPWork(OutputModelManager::WORK_NETWORK_CHANNELSCHANGE, "ControllerEthernet::HandlePropertyEvent::Protocol", nullptr);
-    outputModelManager->AddASAPWork(OutputModelManager::WORK_UPDATE_NETWORK_LIST, "ControllerEthernet::HandlePropertyEvent::Protocol", nullptr);
-    outputModelManager->AddLayoutTabWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "ControllerEthernet::HandlePropertyEvent::Protocol", nullptr);
-}
-
 void ControllerEthernet::SetProtocol(const std::string& protocol) {
 
     int totchannels = GetChannels();
@@ -1412,6 +1395,23 @@ void ControllerEthernet::ValidateProperties(OutputManager* om, wxPropertyGrid* p
             p->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX));
         }
     }
+}
+
+void ControllerEthernet::SetProtocolAndRebuildProperties(const std::string& protocol, wxPropertyGrid* grid, OutputModelManager* outputModelManager) {
+    if (_outputs.size() > 0) {
+        _outputs.front()->RemoveProperties(grid);
+    }
+    SetProtocol(protocol);
+
+    if (_outputs.size() > 0) {
+        std::list<wxPGProperty*> expandProperties;
+        auto before = grid->GetProperty("Managed");
+        _outputs.front()->AddProperties(grid, before, this, AllSameSize(), expandProperties);
+    }
+    outputModelManager->AddASAPWork(OutputModelManager::WORK_NETWORK_CHANGE, "ControllerEthernet::HandlePropertyEvent::Protocol");
+    outputModelManager->AddASAPWork(OutputModelManager::WORK_NETWORK_CHANNELSCHANGE, "ControllerEthernet::HandlePropertyEvent::Protocol", nullptr);
+    outputModelManager->AddASAPWork(OutputModelManager::WORK_UPDATE_NETWORK_LIST, "ControllerEthernet::HandlePropertyEvent::Protocol", nullptr);
+    outputModelManager->AddLayoutTabWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "ControllerEthernet::HandlePropertyEvent::Protocol", nullptr);
 }
 #endif
 

--- a/xLights/outputs/ControllerEthernet.h
+++ b/xLights/outputs/ControllerEthernet.h
@@ -25,6 +25,9 @@ class Output;
 // An ethernet controller sends data to a unique IP address
 class ControllerEthernet : public Controller
 {
+private:
+    void SetProtocolAndRebuildProperties(const std::string& protocol, wxPropertyGrid* grid, OutputModelManager* outputModelManager);
+
 protected:
 
 #pragma region Property Choices
@@ -163,7 +166,7 @@ public:
     #ifndef EXCLUDENETWORKUI
         bool SupportsUniversePerString() const;
     
-        virtual void UpdateProperties(wxPropertyGrid* propertyGrid, ModelManager* modelManager, std::list<wxPGProperty*>& expandProperties) override;
+        virtual void UpdateProperties(wxPropertyGrid* propertyGrid, ModelManager* modelManager, std::list<wxPGProperty*>& expandProperties, OutputModelManager* outputModelManager) override;
         virtual void AddProperties(wxPropertyGrid* propertyGrid, ModelManager* modelManager, std::list<wxPGProperty*>& expandProperties) override;
         virtual bool HandlePropertyEvent(wxPropertyGridEvent & event, OutputModelManager * outputModelManager) override;
         virtual void ValidateProperties(OutputManager* om, wxPropertyGrid* propGrid) const override;


### PR DESCRIPTION
Fix for the Channel row of the property grid not having its limits updated when the protocol automatically switches to Twinkly

Repro:
1) Add a new Ethernet controller
2) Set Vendor to Twinkly
3) Set Model to Cluster (notice this also updates the Protocol to 'Twinkly') 4) Untick Auto Size
5) Change 'Channels' to 1200.
Notice that when you defocus the Channels property (eg by selecting another property), it will revert back to 510.

Workaround: After step 3, switch to a different controller and back, to rebuild the property grid.

This happened because Twinkly controllers only have one protocol available, and this protocol is auto-selected (by ControllerEthernet::UpdateProperties), but in doing so by-passes the normal handler that would rebuild the property grid in response. I've fixed this by reusing the same logic that triggers in the property grid event handler, which rebuilds the property grid.