### PR TITLE
Reduced the time it takes to resize the Custom Model grid when importing a model

### DIFF
--- a/xLights/CustomModelDialog.cpp
+++ b/xLights/CustomModelDialog.cpp
@@ -2878,14 +2878,14 @@ void CustomModelDialog::AddPage()
     grid->EnableDragGridSize(false);
     grid->EnableDragRowSize(false);
 
-    while (grid->GetNumberCols() < WidthSpin->GetValue())
-    {
-        grid->AppendCols();
+    int numColsToAdd = WidthSpin->GetValue() - grid->GetNumberCols();
+    if (numColsToAdd > 0) {
+        grid->AppendCols(numColsToAdd);
     }
 
-    while (grid->GetNumberRows() < HeightSpin->GetValue())
-    {
-        grid->AppendRows();
+    int numRowsToAdd = HeightSpin->GetValue() - grid->GetNumberRows();
+    if (numRowsToAdd > 0) {
+        grid->AppendRows(numRowsToAdd);
     }
 
     auto renderer = new wxModelGridCellRenderer(bkg_image, *grid);


### PR DESCRIPTION
Adding rows and columns in one go is much quicker than adding them one at a time, as wx spends most of the op time calculating scrollbar metrics.

In my example, 74 cols x 39 rows x 12 pages, this was a 1.5s operation. Reduced to 0.6s.