### PR TITLE
Re-resolve host names on ctrl click or Test if ctrl wasn't on at boot

### DIFF
--- a/xLights/outputs/ControllerEthernet.cpp
+++ b/xLights/outputs/ControllerEthernet.cpp
@@ -720,6 +720,16 @@ void ControllerEthernet::VMVChanged(wxPropertyGrid *grid)
 
 Output::PINGSTATE ControllerEthernet::Ping() {
 
+    if (hasAlpha(_resolvedIp)) {
+        for (auto& it : GetOutputs()) { // Get the actual IPOutput object
+            IPOutput* ipOutput = dynamic_cast<IPOutput*>(it);
+            if (ipOutput) {
+                ipOutput->SetIP(this->GetResolvedIP(), true, true); // Re-resolve IP
+                ip_utils::waitForAllToResolve();
+                _resolvedIp = it->GetResolvedIP();
+            }
+        }
+    }
     if (GetResolvedIP(false) == "MULTICAST") {
         _lastPingResult = Output::PINGSTATE::PING_UNAVAILABLE;
     } else if (_outputs.size() > 0) {

--- a/xLights/outputs/OutputManager.cpp
+++ b/xLights/outputs/OutputManager.cpp
@@ -15,6 +15,7 @@
 #include <wx/filename.h>
 #include <wx/dir.h>
 
+#include "IPOutput.h"
 #include "OutputManager.h"
 #include "ControllerEthernet.h"
 #include "ControllerNull.h"
@@ -29,7 +30,8 @@
 #include "TestPreset.h"
 #include "../Parallel.h"
 #include "../UtilFunctions.h"
-#include "../utils/ip_utils.h"
+#include "utils/ip_utils.h"
+#include <wx/regex.h>
 
 #include <numeric>
 
@@ -1162,6 +1164,13 @@ bool OutputManager::StartOutput() {
         // make sure global FPP proxy is up to date ...
         it->SetGlobalFPPProxyIP(_globalFPPProxy);
         it->SetGlobalForceLocalIP(_globalForceLocalIP);
+
+        //try to refresh in case ctrl was turned on after xlights started
+        if (hasAlpha(it->GetResolvedIP())) {
+            IPOutput* ipOutput = dynamic_cast<IPOutput*>(it);
+            if (ipOutput) ipOutput->SetIP(it->GetResolvedIP(), true, true);
+            ip_utils::waitForAllToResolve();
+        }
 
         bool preok = ok;
         ok = it->Open() && ok;

--- a/xLights/utils/ip_utils.cpp
+++ b/xLights/utils/ip_utils.cpp
@@ -201,7 +201,10 @@ namespace ip_utils
         std::unique_lock<std::mutex> lock(__resolvedIPMapLock);
         std::string resolvedIp = __resolvedIPMap[ip];
         lock.unlock();
-        if (resolvedIp.empty()) {
+        if (resolvedIp.empty() || hasAlpha(ip)) {
+        std::string resolvedIp = __resolvedIPMap[ip];
+            if (hasAlpha(ip))
+                __resolvedIPMap.erase(ip);
             ResolveJob *job = new ResolveJob(ip, func);
             RESOLVE_POOL.PushJob(job);
         } else {

--- a/xLights/utils/string_utils.h
+++ b/xLights/utils/string_utils.h
@@ -93,10 +93,13 @@ extern const wxString xlEMPTY_WXSTRING;
         return in.find(contains) != std::wstring::npos;
     }
 
-    inline bool hasAlpha(const std::string& str) noexcept 
-    {
-        std::regex pattern("[a-zA-Z]");
-        return std::regex_search(str, pattern);
+    inline bool hasAlpha(const std::string& s) {
+        for (auto c : s) {
+            if (std::isalpha(c)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     inline std::string StripAllBut(const std::string& in, const std::string& but)

--- a/xLights/utils/string_utils.h
+++ b/xLights/utils/string_utils.h
@@ -13,6 +13,7 @@
 #include <numeric>
 #include <string>
 #include <vector>
+#include <regex>
 
 #include <wx/string.h>
 
@@ -90,6 +91,12 @@ extern const wxString xlEMPTY_WXSTRING;
     inline bool Contains(const std::wstring& in, const std::wstring& contains) noexcept
     {
         return in.find(contains) != std::wstring::npos;
+    }
+
+    inline bool hasAlpha(const std::string& str) noexcept 
+    {
+        std::regex pattern("[a-zA-Z]");
+        return std::regex_search(str, pattern);
     }
 
     inline std::string StripAllBut(const std::string& in, const std::string& but)


### PR DESCRIPTION
Currently if using hostnames for the ctrls and if they weren't on when xlights started, the ctrl status LedPing won't update and you also get an error when doing Tools -> Test since it can't ping the ctrls. We'll now force a re-resolve if _resolvedIp has characters ie: was never actually resolved.
There may be a bit more to do for FPPConnect, but in my testing that also works now.