### PR TITLE
Exit upload if the sd card is cancelled #4998

### DIFF
--- a/xLights/controllers/HinksPixExportDialog.cpp
+++ b/xLights/controllers/HinksPixExportDialog.cpp
@@ -1004,6 +1004,8 @@ void HinksPixExportDialog::OnButton_ExportClick(wxCommandEvent& /*event*/) {
             wxDirDialog dlg(this, "Select SD Directory for " + hix->GetName(), drive, wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
             if (dlg.ShowModal() == wxID_OK) {
                 drive = dlg.GetPath();
+            } else {
+                continue;
             }
             if (!ObtainAccessToURL(drive)) {
                 errorMsg = wxString::Format("Could not obtain write access for '%s'", drive);


### PR DESCRIPTION
If one cancels from selecting and SD card directory it exits the file creation.
@computergeek1507 Scott - I cant test this to see if it does what I intend. Can you confirm?
#4998 