### PR TITLE
Reduced render time for bars by 60-80%, by caching IsSpatial

### DIFF
--- a/xLights/effects/BarsEffect.cpp
+++ b/xLights/effects/BarsEffect.cpp
@@ -214,11 +214,15 @@ void BarsEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBu
                 }
                 color = hsv;
             }
+
+            const bool isSpatialColor = buffer.palette.IsSpatial(colorIdx); // Cache the spatial color check, as it's expensive to do for every pixel
+
             switch (direction) {
             case 1:
                 // down
                 for (int x = 0; x < buffer.BufferWi; ++x) {
-                    GetSpatialColor(color, colorIdx, (float)x / (float)buffer.BufferWi, (float)(n % barHt) / (float)barHt, buffer, gradient, highlightColor, highlight, show3D, barHt, n, pct, color2);
+                    if (isSpatialColor)
+                        GetSpatialColor(color, colorIdx, (float)x / (float)buffer.BufferWi, (float)(n % barHt) / (float)barHt, buffer, gradient, highlightColor, highlight, show3D, barHt, n, pct, color2);
                     buffer.SetPixel(x, y, color);
                 }
                 break;
@@ -226,7 +230,8 @@ void BarsEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBu
                 // expand
                 if (y <= newCenter) {
                     for (int x = 0; x < buffer.BufferWi; ++x) {
-                        GetSpatialColor(color, colorIdx, (float)x / (float)buffer.BufferWi, (float)(n % barHt) / (float)barHt, buffer, gradient, highlightColor, highlight, show3D, barHt, n, pct, color2);
+                        if (isSpatialColor)
+                            GetSpatialColor(color, colorIdx, (float)x / (float)buffer.BufferWi, (float)(n % barHt) / (float)barHt, buffer, gradient, highlightColor, highlight, show3D, barHt, n, pct, color2);
                         buffer.SetPixel(x, y, color);
                         buffer.SetPixel(x, newCenter + (newCenter - y), color);
                     }
@@ -236,7 +241,8 @@ void BarsEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBu
                 // compress
                 if (y >= newCenter) {
                     for (int x = 0; x < buffer.BufferWi; ++x) {
-                        GetSpatialColor(color, colorIdx, (float)x / (float)buffer.BufferWi, (float)(n % barHt) / (float)barHt, buffer, gradient, highlightColor, highlight, show3D, barHt, n, pct, color2);
+                        if (isSpatialColor)
+                            GetSpatialColor(color, colorIdx, (float)x / (float)buffer.BufferWi, (float)(n % barHt) / (float)barHt, buffer, gradient, highlightColor, highlight, show3D, barHt, n, pct, color2);
                         buffer.SetPixel(x, y, color);
                         buffer.SetPixel(x, newCenter + (newCenter - y), color);
                     }
@@ -245,7 +251,8 @@ void BarsEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBu
             default:
                 // up
                 for (int x = 0; x < buffer.BufferWi; ++x) {
-                    GetSpatialColor(color, colorIdx, (float)x / (float)buffer.BufferWi, 1.0 - (float)(n % barHt) / (float)barHt, buffer, gradient, highlightColor, highlight, show3D, barHt, n, pct, color2);
+                    if (isSpatialColor)
+                        GetSpatialColor(color, colorIdx, (float)x / (float)buffer.BufferWi, 1.0 - (float)(n % barHt) / (float)barHt, buffer, gradient, highlightColor, highlight, show3D, barHt, n, pct, color2);
                     buffer.SetPixel(x, buffer.BufferHt - y - 1, color);
                 }
                 break;
@@ -357,11 +364,15 @@ void BarsEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBu
                     hsv.value *= double(barWi - n % barWi - 1) / barWi;
                 color = hsv;
             }
+
+            const bool isSpatialColor = buffer.palette.IsSpatial(colorIdx); // Cache the spatial color check, as it's expensive to do for every pixel
+
             switch (direction) {
             case 5:
                 // right
                 for (int y = 0; y < buffer.BufferHt; ++y) {
-                    GetSpatialColor(color, colorIdx, 1.0 - pct, (double)y / (double)buffer.BufferHt, buffer, gradient, highlightColor, highlight, show3D, barWi, n, pct, color2);
+                    if (isSpatialColor)
+                        GetSpatialColor(color, colorIdx, 1.0 - pct, (double)y / (double)buffer.BufferHt, buffer, gradient, highlightColor, highlight, show3D, barWi, n, pct, color2);
                     buffer.SetPixel(buffer.BufferWi - x - 1, y, color);
                 }
                 break;
@@ -369,7 +380,8 @@ void BarsEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBu
                 // H-expand
                 if (x <= newCenter) {
                     for (int y = 0; y < buffer.BufferHt; ++y) {
-                        GetSpatialColor(color, colorIdx, pct, (double)y / (double)buffer.BufferHt, buffer, gradient, highlightColor, highlight, show3D, barWi, n, pct, color2);
+                        if (isSpatialColor)
+                            GetSpatialColor(color, colorIdx, pct, (double)y / (double)buffer.BufferHt, buffer, gradient, highlightColor, highlight, show3D, barWi, n, pct, color2);
                         buffer.SetPixel(x, y, color);
                         buffer.SetPixel(newCenter + (newCenter - x), y, color);
                     }
@@ -379,7 +391,8 @@ void BarsEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBu
                 // H-compress
                 if (x >= newCenter) {
                     for (int y = 0; y < buffer.BufferHt; ++y) {
-                        GetSpatialColor(color, colorIdx, pct, (double)y / (double)buffer.BufferHt, buffer, gradient, highlightColor, highlight, show3D, barWi, n, pct, color2);
+                        if (isSpatialColor)
+                            GetSpatialColor(color, colorIdx, pct, (double)y / (double)buffer.BufferHt, buffer, gradient, highlightColor, highlight, show3D, barWi, n, pct, color2);
                         buffer.SetPixel(x, y, color);
                         buffer.SetPixel(newCenter + (newCenter - x), y, color);
                     }
@@ -388,7 +401,8 @@ void BarsEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBu
             default:
                 // left
                 for (int y = 0; y < buffer.BufferHt; ++y) {
-                    GetSpatialColor(color, colorIdx, pct, (double)y / (double)buffer.BufferHt, buffer, gradient, highlightColor, highlight, show3D, barWi, n, pct, color2);
+                    if (isSpatialColor)
+                        GetSpatialColor(color, colorIdx, pct, (double)y / (double)buffer.BufferHt, buffer, gradient, highlightColor, highlight, show3D, barWi, n, pct, color2);
                     buffer.SetPixel(x, y, color);
                 }
                 break;


### PR DESCRIPTION
In my profiling, `GetSpatialColor` represents 33% of the time spent inside `BarsEffect::Render`, just checking `buffer.palette.IsSpatial(colorIdx)` for every pixel. If you're not using spatial colors, this time is pure wastage. The optimiser can't see deep enough to know that it can cache `IsSpatial`, so I've done it manually. Despite expecting a saving of only 33%, it's actually more like 60%, because skipping the `GetSpatialColor` function call also skips all of the maths done to build its parameters, such as `(float)x / (float)buffer.BufferWi`, and `(float)(n % barHt) / (float)barHt`.

5.878s -> 2.184s for my test sequence, that is one bars effect with 3 colours, across all channels.

More savings could undoubtedly be had by performing this same optimisation on other effects.