### PR TITLE
Write Effects to Temp for NAS

### DIFF
--- a/xLights/TabSequence.cpp
+++ b/xLights/TabSequence.cpp
@@ -706,7 +706,7 @@ bool xLightsFrame::SaveEffectsFile(bool backup)
     viewpoint_mgr.Save(&EffectsXml);
 
     wxFileName effectsFile;
-    effectsFile.AssignDir(CurrentDir);
+    effectsFile.AssignDir(wxFileName::GetTempDir());
     if (backup) {
         effectsFile.SetFullName(_(XLIGHTS_RGBEFFECTS_FILE_BACKUP));
     } else {
@@ -725,6 +725,9 @@ bool xLightsFrame::SaveEffectsFile(bool backup)
     if (!backup) {
 #ifndef __WXOSX__
         SaveModelsFile();
+	wxFileName efFinal = effectsFile;
+	efFinal.Assign(CurrentDir, effectsFile.GetName(), effectsFile.GetExt());
+	wxRenameFile(effectsFile.GetFullPath(), efFinal.GetFullPath());
 #endif
         UnsavedRgbEffectsChanges = false;
     }


### PR DESCRIPTION
When rgbeffects is on a NAS and we save a new version, because of the line by line save, it takes a very long time to save. Saving it to the local OS temp folder and then renaming it to the show folder, seems to address this slowwwwwnesssss