### PR TITLE
Dedup FPPs using UUID and prioritize the configured IP (resolved)

### DIFF
--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -3906,6 +3906,7 @@ void FPP::MapToFPPInstances(Discovery &discovery, std::list<FPP*> &instances, Ou
                 setIfEmpty(fpp->controllerVendor, res->vendor);
                 setIfEmpty(fpp->controllerModel, res->model);
                 setIfEmpty(fpp->controllerVariant, res->variant);
+
                 setIfEmpty(fpp->minorVersion, res->minorVersion);
                 setIfEmpty(fpp->patchVersion, res->patchVersion);
                 setIfEmpty(fpp->majorVersion, res->majorVersion);

--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -3186,7 +3186,7 @@ static void ProcessFPPSystems(Discovery &discovery, const std::string &systemsSt
         std::string hostName = system[HostNameKey].IsNull() ? "" : ToUTF8(system[HostNameKey].AsString());
         std::string uuid = system.HasMember("uuid") ? ToUTF8(system["uuid"].AsString()) : (system.HasMember("UUID") ? ToUTF8(system["UUID"].AsString()) : "");
         
-        logger_base.info("Processing ip: %s   host: %s    uuid: %s", address.c_str(), hostName.c_str(), uuid.c_str());
+        //logger_base.info("Processing ip: %s   host: %s    uuid: %s", address.c_str(), hostName.c_str(), uuid.c_str());
         if (!uuid.empty()) {
             fppDiscInfo.insert({ hostName, address, uuid });
         }
@@ -3329,11 +3329,6 @@ static void ProcessFPPSystems(Discovery &discovery, const std::string &systemsSt
                 });
             }
        }
-        //for (const auto& [ip, hostAnduuid] : fppDiscInfo) {
-       for (const auto& info : fppDiscInfo) {
-            //logger_base.info("IP: %s, HostName: %s, UUID: %s", info.hostname.ToStdString().c_str(), hostAnduuid.first.ToStdString().c_str(), hostAnduuid.second.ToStdString().c_str());
-           logger_base.info("HostName: %s, UUID: %s, IP: %s", info.hostname.c_str(), info.uuid.c_str(), info.ip.c_str());
-        }
    }
 }
 static void ProcessFPPProxies(Discovery &discovery, const std::string &ip, const std::string &proxies) {
@@ -3572,8 +3567,8 @@ static void ProcessFPPPingPacket(Discovery &discovery, uint8_t *buffer,int len) 
         snprintf(ip, sizeof(ip), "%d.%d.%d.%d", (int)buffer[15], (int)buffer[16], (int)buffer[17], (int)buffer[18]);
         //printf("Ping %s\n", ip);
         if (strcmp(ip, "0.0.0.0")) {
-            static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
-            logger_base.info("FPP Discovery - Received Ping response from %s", ip);
+            //static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+            //logger_base.info("FPP Discovery - Received Ping response from %s", ip);
             AddTraceMessage("Received UDP result " + std::string(ip));
 
             //we found a system!!!
@@ -3837,17 +3832,32 @@ inline void setIfEmpty(uint32_t &val, uint32_t nv) {
 
 void FPP::MapToFPPInstances(Discovery &discovery, std::list<FPP*> &instances, OutputManager* outputManager) {
     static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+    std::unordered_set<std::string> configuredIPs;
+    for (auto& it : discovery.GetOutputManager()->GetControllers()) {
+		auto c = dynamic_cast<ControllerEthernet*>(it);
+            configuredIPs.insert(c->GetResolvedIP());
+	}
     for (auto res : discovery.GetResults()) {
         if (::supportedForFPPConnect(res, outputManager)) {
-            logger_base.info("FPP Discovery - Found Supported FPP Instance: %s (h: %s)(p: %s)(r: %s)", res->ip.c_str(), res->hostname.c_str(), res->proxy.c_str(), res->ranges.c_str());
+            logger_base.info("FPP Discovery - Found Supported FPP Instance: %s (u: %s)(h: %s)(p: %s)(r: %s)", res->ip.c_str(), res->uuid.c_str(), res->hostname.c_str(), res->proxy.c_str(), res->ranges.c_str());
             FPP *fpp = nullptr;
+            bool skipit = false;
 
             for (auto f : instances) {
                 if (f->ipAddress == res->ip) {
                     fpp = f;
                 }
+                if (!res->uuid.empty() && f->uuid == res->uuid) {
+                    if (configuredIPs.count(res->ip) > 0) {
+                        logger_base.info("FPP Discovery - Found Configured IP - %s for the same UUID - %s. Going to use this instead.", res->ip.c_str(), res->uuid.c_str());
+                        fpp = f;
+                    } else {
+                        skipit = true;
+                    }
+                }
             }
-            if (fpp == nullptr) {
+
+            if (!skipit && fpp == nullptr) {
                 FPP *fpp = new FPP(res->ip, res->proxy, res->pixelControllerType);
                 fpp->ipAddress = res->ip;//not needed, in constructor
                 fpp->hostName = res->hostname;
@@ -3878,7 +3888,8 @@ void FPP::MapToFPPInstances(Discovery &discovery, std::list<FPP*> &instances, Ou
                     fpp->capeInfo = res->extraData["cape"];
                 }
                 instances.push_back(fpp);
-            } else {
+            } else if (!skipit) {
+                fpp->ipAddress = res->ip;
                 setIfEmpty(fpp->proxy, res->proxy);
                 setIfEmpty(fpp->hostName, res->hostname);
                 setIfEmpty(fpp->uuid, res->uuid);
@@ -3895,7 +3906,6 @@ void FPP::MapToFPPInstances(Discovery &discovery, std::list<FPP*> &instances, Ou
                 setIfEmpty(fpp->controllerVendor, res->vendor);
                 setIfEmpty(fpp->controllerModel, res->model);
                 setIfEmpty(fpp->controllerVariant, res->variant);
-
                 setIfEmpty(fpp->minorVersion, res->minorVersion);
                 setIfEmpty(fpp->patchVersion, res->patchVersion);
                 setIfEmpty(fpp->majorVersion, res->majorVersion);

--- a/xLights/controllers/FPP.h
+++ b/xLights/controllers/FPP.h
@@ -59,6 +59,8 @@ class FPP : public BaseController
 
     std::string proxy;
     std::set<std::string> proxies;
+    bool isaProxy = false;
+    bool solePlayer = false;
 
     std::string username;
     std::string password;

--- a/xLights/controllers/FPPConnectDialog.cpp
+++ b/xLights/controllers/FPPConnectDialog.cpp
@@ -620,9 +620,14 @@ void FPPConnectDialog::PopulateFPPInstanceList(wxProgressDialog *prgs) {
             Choice1->Append(_("Proxied"));
             Choice1->SetSelection(0);
             FPPInstanceSizer->Add(Choice1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 1);
-
+            if (inst->solePlayer) {
+				SetChoiceValueIndex(UDP_COL + rowStr, 1);
+			} else if (inst->isaProxy) {
+				SetChoiceValueIndex(UDP_COL + rowStr, 2);
+			}
             wxCheckBox* CheckBoxProxy = new wxCheckBox(FPPInstanceList, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, PROXY_COL + rowStr);
             FPPInstanceSizer->Add(CheckBoxProxy, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 1);
+			CheckBoxProxy->SetValue(inst->isaProxy);
 
             //playlist combo box
             if (StartsWith(inst->mode, "player")) {
@@ -1553,13 +1558,36 @@ void FPPConnectDialog::SaveSettings(bool onlyInsts)
         std::string rowStr = std::to_string(row);
         wxString keyPostfx = (inst->uuid.empty() ? inst->ipAddress : inst->uuid);
         keyPostfx = Fixitup(keyPostfx);
-        config->Write("FPPConnectUpload_" + keyPostfx, GetCheckValue(CHECK_COL + rowStr));
-        config->Write("FPPConnectUploadMedia_" + keyPostfx, GetCheckValue(MEDIA_COL + rowStr));
-        config->Write("FPPConnectUploadFSEQType_" + keyPostfx, GetChoiceValueIndex(FSEQ_COL + rowStr));
-        config->Write("FPPConnectUploadModels_" + keyPostfx, GetChoiceValueIndex(MODELS_COL + rowStr));
-        config->Write("FPPConnectUploadUDPOut_" + keyPostfx, GetChoiceValueIndex(UDP_COL + rowStr));
-        config->Write("FPPConnectUploadPixelOut_" + keyPostfx, GetCheckValue(UPLOAD_CONTROLLER_COL + rowStr));
-        config->Write("FPPConnectUploadProxy_" + keyPostfx, GetCheckValue(PROXY_COL + rowStr));
+        bool bval;
+        int lval;
+        // only save the settings if they are different from defaults, or if previously changed and saved - this will help new users with auto setting up UPD & proxy
+        if (GetCheckValue(CHECK_COL + rowStr) != false || config->Read("FPPConnectUpload_" + Fixitup(inst->uuid), &bval)) {
+            config->Write("FPPConnectUpload_" + keyPostfx, GetCheckValue(CHECK_COL + rowStr));
+        }
+        if (GetCheckValue(MEDIA_COL + rowStr) != false || config->Read("FPPConnectUploadMedia_" + Fixitup(inst->uuid), &bval)) {
+            config->Write("FPPConnectUploadMedia_" + keyPostfx, GetCheckValue(MEDIA_COL + rowStr));
+        }
+        if (inst->fppType == FPP_TYPE::FPP && inst->supportedForFPPConnect()) {
+            if (GetChoiceValueIndex(FSEQ_COL + rowStr) != 2 || config->Read("FPPConnectUploadFSEQType_" + Fixitup(inst->uuid), &lval)) {
+                config->Write("FPPConnectUploadFSEQType_" + keyPostfx, GetChoiceValueIndex(FSEQ_COL + rowStr));
+            }
+        } else if (inst->fppType == FPP_TYPE::FALCONV4V5) {
+            if (GetChoiceValueIndex(FSEQ_COL + rowStr) != 2 || config->Read("FPPConnectUploadFSEQType_" + Fixitup(inst->uuid), &lval)) {
+                config->Write("FPPConnectUploadFSEQType_" + keyPostfx, GetChoiceValueIndex(FSEQ_COL + rowStr));
+            }
+        }
+        if (GetChoiceValueIndex(MODELS_COL + rowStr) != 0 || config->Read("FPPConnectUploadModels_" + Fixitup(inst->uuid), &lval)) {
+            config->Write("FPPConnectUploadModels_" + keyPostfx, GetChoiceValueIndex(MODELS_COL + rowStr));
+        }
+        if (GetChoiceValueIndex(UDP_COL + rowStr) > 0 || config->Read("FPPConnectUploadUDPOut_" + Fixitup(inst->uuid), &lval)) {
+            config->Write("FPPConnectUploadUDPOut_" + keyPostfx, GetChoiceValueIndex(UDP_COL + rowStr));
+        }
+        if (GetCheckValue(UPLOAD_CONTROLLER_COL + rowStr) != false || config->Read("FPPConnectUploadPixelOut_" + Fixitup(inst->uuid), &bval)) {
+            config->Write("FPPConnectUploadPixelOut_" + keyPostfx, GetCheckValue(UPLOAD_CONTROLLER_COL + rowStr));
+        }
+        if (GetCheckValue(PROXY_COL + rowStr) != false || config->Read("FPPConnectUploadProxy_" + Fixitup(inst->uuid), &bval)) {
+            config->Write("FPPConnectUploadProxy_" + keyPostfx, GetCheckValue(PROXY_COL + rowStr));
+        }
         row++;
     }
     config->Flush();

--- a/xLights/controllers/FPPConnectDialog.cpp
+++ b/xLights/controllers/FPPConnectDialog.cpp
@@ -689,7 +689,7 @@ void FPPConnectDialog::PopulateFPPInstanceList(wxProgressDialog *prgs) {
     ApplySavedHostSettings();
 
     FPPInstanceList->FitInside();
-    FPPInstanceList->SetScrollRate(10, 10);
+    FPPInstanceList->SetScrollRate(100, 100);
     FPPInstanceList->ShowScrollbars(wxSHOW_SB_ALWAYS, wxSHOW_SB_ALWAYS);
     FPPInstanceList->Thaw();
 }


### PR DESCRIPTION
Somehow users get the colorlight card IP (169) listed in FPPConnect - think from IPv6.
Also, sometimes, they get the show-network IP listed
This will stop it by using the UUID to dedup and use the configured IPs

Added logic to set UDP->Proxied and turn on Proxy if controller is configured as a proxy for either another controller or global proxy. If there's only one player in FPP connect and there are active controllers configured, UDP will be set to All
To make sure this works for new users as they add/change controllers, options will not change if they are the default and there isn't already a saved registry entry. 

Speed up the Scrolling int he FPP Connect window for those that lave a large number of controllers listed.