### PR TITLE
Escape the Ampersand in an xlights model export #5017

### DIFF
--- a/xLights/models/CustomModel.cpp
+++ b/xLights/models/CustomModel.cpp
@@ -1705,6 +1705,7 @@ void CustomModel::ExportXlightsModel()
     }
     wxString state = SerialiseState();
     if (state != "") {
+        state.Replace("&", "&amp;", true);
         f.Write(state);
     }
     wxString submodel = SerialiseSubmodel();

--- a/xLights/models/CustomModel.cpp
+++ b/xLights/models/CustomModel.cpp
@@ -1705,7 +1705,6 @@ void CustomModel::ExportXlightsModel()
     }
     wxString state = SerialiseState();
     if (state != "") {
-        state.Replace("&", "&amp;", true);
         f.Write(state);
     }
     wxString submodel = SerialiseSubmodel();

--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -2543,6 +2543,7 @@ wxString Model::SerialiseFace() const
             }
             res += "/>\n";
         }
+        res.Replace("&", "&amp;", true);
     }
 
     return res;
@@ -2685,6 +2686,7 @@ wxString Model::SerialiseState() const
             }
             res += "/>\n";
         }
+        res.Replace("&", "&amp;", true);
     }
 
     return res;


### PR DESCRIPTION
Wasn't practical to handle it on the import of the bad file. Also using the existing strings XMLSafe function was too aggressive and would change all the quotes, left and right angle brackets etc. #5017