### PR TITLE
ExperienceLights support for Remote/Standalone modes

### DIFF
--- a/xLights/controllers/Experience.h
+++ b/xLights/controllers/Experience.h
@@ -36,6 +36,7 @@ class Experience : public BaseController
     int _numberOfRemoteOutputs{ 0 };
     int _numberOfSerialOutputs{ 0 };
     bool _has_efuses{ false };
+    std::string _opMode = "ddp";
 
 #pragma endregion
 


### PR DESCRIPTION
Added support for Remote and Standalone modes

[fixed previous logic issue with switching between DDP/E1.31 - xLights  wins to configure the channels and Operating_Mode is put back in Remote/StandAlsone