### PR TITLE
Add preference to hide/size the Group Crosshair #4885

### DIFF
--- a/xLights/ModelPreview.cpp
+++ b/xLights/ModelPreview.cpp
@@ -674,6 +674,7 @@ void ModelPreview::DrawGroupCentre(float x, float y)
 {
     auto acc = solidProgram->getAccumulator();
     int start = acc->getCount();
+    int crosshairChoice = xlights->GetCrosshairSize();
 
     float factor = 1;
     if (!Is3D()) {
@@ -688,9 +689,30 @@ void ModelPreview::DrawGroupCentre(float x, float y)
         float center_width = std::max(CENTER_MARK_WIDTH, CENTER_MARK_WIDTH * zoom * rs);
         factor = center_width * 0.40; // adjust this for ideal size.
         factor = MIN(MAX(factor, 1), 10); // sanity check
+        switch (crosshairChoice) {
+        case 0:
+            factor *= 1.25;
+            break;
+        case 1:
+            // No changes needed
+            break;
+        case 2:
+            factor *= 0.5;
+            break;
+        case 3:
+            factor *= 0.20;
+            break;
+        case 4:
+            factor = 0;
+            break;
+        default:
+            break;
+        }
     }
-    acc->AddRectAsTriangles(x - 20.5 * factor, y - 1.5 * factor, x + 20.5 * factor, y + 1.5 * factor, xlREDTRANSLUCENT);
-    acc->AddRectAsTriangles(x - 1.5 * factor, y - 20.5 * factor, x + 1.5 * factor, y + 20.5 * factor, xlREDTRANSLUCENT);
+    if (factor > 0) {
+        acc->AddRectAsTriangles(x - 20.5 * factor, y - 1.5 * factor, x + 20.5 * factor, y + 1.5 * factor, xlREDTRANSLUCENT);
+        acc->AddRectAsTriangles(x - 1.5 * factor, y - 20.5 * factor, x + 1.5 * factor, y + 20.5 * factor, xlREDTRANSLUCENT);
+    }
 
     int end = acc->getCount();
     solidProgram->addStep([start, end, this, acc](xlGraphicsContext* ctx) {
@@ -1110,7 +1132,7 @@ float ModelPreview::GetCameraZoomForHandles() const
 
 int ModelPreview::GetHandleScale() const
 {
-    return xlights->GetModelHandleScale();
+    return xlights->GetModelHandleSize();
 }
 
 void ModelPreview::SetZoomDelta(float delta)

--- a/xLights/preferences/ViewSettingsPanel.cpp
+++ b/xLights/preferences/ViewSettingsPanel.cpp
@@ -24,16 +24,17 @@
 #include <wx/preferences.h>
 
 //(*IdInit(ViewSettingsPanel)
-const long ViewSettingsPanel::ID_CHOICE3 = wxNewId();
-const long ViewSettingsPanel::ID_CHOICE4 = wxNewId();
-const long ViewSettingsPanel::ID_CHOICE5 = wxNewId();
-const long ViewSettingsPanel::ID_CHECKBOX1 = wxNewId();
-const long ViewSettingsPanel::ID_CHECKBOX2 = wxNewId();
-const long ViewSettingsPanel::ID_CHECKBOX5 = wxNewId();
-const long ViewSettingsPanel::ID_CHECKBOX3 = wxNewId();
-const long ViewSettingsPanel::ID_CHOICE_TIMELINEZOOMING = wxNewId();
-const long ViewSettingsPanel::ID_CHECKBOX4 = wxNewId();
-const long ViewSettingsPanel::ID_CHECKBOX_ZoomMethod = wxNewId();
+const wxWindowID ViewSettingsPanel::ID_CHOICE3 = wxNewId();
+const wxWindowID ViewSettingsPanel::ID_CHOICE4 = wxNewId();
+const wxWindowID ViewSettingsPanel::ID_CHOICE5 = wxNewId();
+const wxWindowID ViewSettingsPanel::ID_CHECKBOX1 = wxNewId();
+const wxWindowID ViewSettingsPanel::ID_CHECKBOX2 = wxNewId();
+const wxWindowID ViewSettingsPanel::ID_CHECKBOX5 = wxNewId();
+const wxWindowID ViewSettingsPanel::ID_CHECKBOX3 = wxNewId();
+const wxWindowID ViewSettingsPanel::ID_CHOICE_TIMELINEZOOMING = wxNewId();
+const wxWindowID ViewSettingsPanel::ID_CHECKBOX4 = wxNewId();
+const wxWindowID ViewSettingsPanel::ID_CHECKBOX_ZoomMethod = wxNewId();
+const wxWindowID ViewSettingsPanel::ID_CHOICE_CROSSHAIRSIZE = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(ViewSettingsPanel, wxPanel)
@@ -47,6 +48,7 @@ ViewSettingsPanel::ViewSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWindow
     //(*Initialize(ViewSettingsPanel)
     wxGridBagSizer* GridBagSizer1;
     wxStaticText* StaticText1;
+    wxStaticText* StaticText2;
     wxStaticText* StaticText4;
     wxStaticText* StaticText5;
     wxStaticText* StaticText6;
@@ -60,7 +62,7 @@ ViewSettingsPanel::ViewSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWindow
     ToolIconSizeChoice->SetSelection( ToolIconSizeChoice->Append(_("Medium")) );
     ToolIconSizeChoice->Append(_("Large"));
     ToolIconSizeChoice->Append(_("Extra Large"));
-    GridBagSizer1->Add(ToolIconSizeChoice, wxGBPosition(0, 1), wxDefaultSpan, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    GridBagSizer1->Add(ToolIconSizeChoice, wxGBPosition(0, 1), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
     StaticText4 = new wxStaticText(this, wxID_ANY, _("Model Handle Size"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
     GridBagSizer1->Add(StaticText4, wxGBPosition(1, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
     ModelHandleSizeChoice = new wxChoice(this, ID_CHOICE4, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE4"));
@@ -86,7 +88,7 @@ ViewSettingsPanel::ViewSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWindow
     GridBagSizer1->Add(CheckBox_DisableKeyAcceleration, wxGBPosition(9, 0), wxDefaultSpan, wxALL|wxEXPAND, 5);
     CheckBox_BaseShowFolder = new wxCheckBox(this, ID_CHECKBOX3, _("Enable Base Show Folder Settings"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX3"));
     CheckBox_BaseShowFolder->SetValue(false);
-    GridBagSizer1->Add(CheckBox_BaseShowFolder, wxGBPosition(5, 0), wxDefaultSpan, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    GridBagSizer1->Add(CheckBox_BaseShowFolder, wxGBPosition(5, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
     StaticText6 = new wxStaticText(this, wxID_ANY, _("Timeline Zooming"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
     GridBagSizer1->Add(StaticText6, wxGBPosition(6, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
     Choice_TimelineZooming = new wxChoice(this, ID_CHOICE_TIMELINEZOOMING, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_TIMELINEZOOMING"));
@@ -99,19 +101,28 @@ ViewSettingsPanel::ViewSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWindow
     CheckBox_ZoomMethod = new wxCheckBox(this, ID_CHECKBOX_ZoomMethod, _("Zoom To Cursor"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_ZoomMethod"));
     CheckBox_ZoomMethod->SetValue(true);
     GridBagSizer1->Add(CheckBox_ZoomMethod, wxGBPosition(8, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    StaticText2 = new wxStaticText(this, wxID_ANY, _("Group Center Crosshair Size"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+    GridBagSizer1->Add(StaticText2, wxGBPosition(10, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    CrosshairSizeChoice = new wxChoice(this, ID_CHOICE_CROSSHAIRSIZE, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_CROSSHAIRSIZE"));
+    CrosshairSizeChoice->Append(_("Large"));
+    CrosshairSizeChoice->SetSelection( CrosshairSizeChoice->Append(_("Normal")) );
+    CrosshairSizeChoice->Append(_("Small"));
+    CrosshairSizeChoice->Append(_("Tiny"));
+    CrosshairSizeChoice->Append(_("None"));
+    CrosshairSizeChoice->SetToolTip(_("Control the size of the crosshair for group centering"));
+    GridBagSizer1->Add(CrosshairSizeChoice, wxGBPosition(10, 1), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
     SetSizer(GridBagSizer1);
-    GridBagSizer1->Fit(this);
-    GridBagSizer1->SetSizeHints(this);
 
-    Connect(ID_CHOICE3,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&ViewSettingsPanel::OnToolIconSizeChoiceSelect);
-    Connect(ID_CHOICE4,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&ViewSettingsPanel::OnModelHandleSizeChoiceSelect);
-    Connect(ID_CHOICE5,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&ViewSettingsPanel::OnEffectAssistChoiceSelect);
-    Connect(ID_CHECKBOX1,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&ViewSettingsPanel::OnPlayControlsCheckBoxClick);
-    Connect(ID_CHECKBOX2,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&ViewSettingsPanel::OnHousePreviewCheckBoxClick);
-    Connect(ID_CHECKBOX3,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&ViewSettingsPanel::OnCheckBox_BaseShowFolderClick);
-    Connect(ID_CHOICE_TIMELINEZOOMING,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&ViewSettingsPanel::OnChoice_TimelineZoomingSelect);
-    Connect(ID_CHECKBOX4,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&ViewSettingsPanel::OnPresetPreviewCheckBoxClick);
-    Connect(ID_CHECKBOX_ZoomMethod,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&ViewSettingsPanel::OnCheckBox_ZoomMethodClick);
+    Connect(ID_CHOICE3, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ViewSettingsPanel::OnToolIconSizeChoiceSelect);
+    Connect(ID_CHOICE4, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ViewSettingsPanel::OnModelHandleSizeChoiceSelect);
+    Connect(ID_CHOICE5, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ViewSettingsPanel::OnEffectAssistChoiceSelect);
+    Connect(ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ViewSettingsPanel::OnPlayControlsCheckBoxClick);
+    Connect(ID_CHECKBOX2, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ViewSettingsPanel::OnHousePreviewCheckBoxClick);
+    Connect(ID_CHECKBOX3, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ViewSettingsPanel::OnCheckBox_BaseShowFolderClick);
+    Connect(ID_CHOICE_TIMELINEZOOMING, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ViewSettingsPanel::OnChoice_TimelineZoomingSelect);
+    Connect(ID_CHECKBOX4, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ViewSettingsPanel::OnPresetPreviewCheckBoxClick);
+    Connect(ID_CHECKBOX_ZoomMethod, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ViewSettingsPanel::OnCheckBox_ZoomMethodClick);
+    Connect(ID_CHOICE_CROSSHAIRSIZE, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ViewSettingsPanel::OnCrosshairSizeChoiceSelect);
     //*)
 
 #ifdef _MSC_VER
@@ -135,7 +146,8 @@ bool ViewSettingsPanel::TransferDataToWindow()
         i = 0;
     }
     EffectAssistChoice->SetSelection(i);
-    ModelHandleSizeChoice->SetSelection(frame->ModelHandleSize());
+    ModelHandleSizeChoice->SetSelection(frame->GetModelHandleSize());
+    CrosshairSizeChoice->SetSelection(frame->GetCrosshairSize());
     int ts = frame->ToolIconSize();
     switch (ts) {
     case 48:
@@ -161,6 +173,7 @@ bool ViewSettingsPanel::TransferDataToWindow()
 bool ViewSettingsPanel::TransferDataFromWindow()
 {
     frame->SetModelHandleSize(ModelHandleSizeChoice->GetSelection());
+    frame->SetCrosshairSize(CrosshairSizeChoice->GetSelection());
     frame->SetEffectAssistMode(EffectAssistChoice->GetSelection());
     frame->SetPlayControlsOnPreview(PlayControlsCheckBox->IsChecked());
     frame->SetAutoShowHousePreview(HousePreviewCheckBox->IsChecked());
@@ -267,6 +280,13 @@ void ViewSettingsPanel::OnCheckBox_ZoomMethodClick(wxCommandEvent& event)
 }
 
 void ViewSettingsPanel::OnCheckBox_DisableKeyAccelerationClick(wxCommandEvent& event)
+{
+    if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
+        TransferDataFromWindow();
+    }
+}
+
+void ViewSettingsPanel::OnCrosshairSizeChoiceSelect(wxCommandEvent& event)
 {
     if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
         TransferDataFromWindow();

--- a/xLights/preferences/ViewSettingsPanel.h
+++ b/xLights/preferences/ViewSettingsPanel.h
@@ -34,6 +34,7 @@ class ViewSettingsPanel: public wxPanel
 		wxCheckBox* HousePreviewCheckBox;
 		wxCheckBox* PlayControlsCheckBox;
 		wxChoice* Choice_TimelineZooming;
+		wxChoice* CrosshairSizeChoice;
 		wxChoice* EffectAssistChoice;
 		wxChoice* ModelHandleSizeChoice;
 		wxChoice* ToolIconSizeChoice;
@@ -45,16 +46,17 @@ class ViewSettingsPanel: public wxPanel
 	protected:
 
 		//(*Identifiers(ViewSettingsPanel)
-		static const long ID_CHOICE3;
-		static const long ID_CHOICE4;
-		static const long ID_CHOICE5;
-		static const long ID_CHECKBOX1;
-		static const long ID_CHECKBOX2;
-		static const long ID_CHECKBOX5;
-		static const long ID_CHECKBOX3;
-		static const long ID_CHOICE_TIMELINEZOOMING;
-		static const long ID_CHECKBOX4;
-		static const long ID_CHECKBOX_ZoomMethod;
+		static const wxWindowID ID_CHOICE3;
+		static const wxWindowID ID_CHOICE4;
+		static const wxWindowID ID_CHOICE5;
+		static const wxWindowID ID_CHECKBOX1;
+		static const wxWindowID ID_CHECKBOX2;
+		static const wxWindowID ID_CHECKBOX5;
+		static const wxWindowID ID_CHECKBOX3;
+		static const wxWindowID ID_CHOICE_TIMELINEZOOMING;
+		static const wxWindowID ID_CHECKBOX4;
+		static const wxWindowID ID_CHECKBOX_ZoomMethod;
+		static const wxWindowID ID_CHOICE_CROSSHAIRSIZE;
 		//*)
 
 	private:
@@ -73,6 +75,7 @@ class ViewSettingsPanel: public wxPanel
 		void OnPresetPreviewCheckBoxClick(wxCommandEvent& event);
 		void OnCheckBox_ZoomMethodClick(wxCommandEvent& event);
 		void OnCheckBox_DisableKeyAccelerationClick(wxCommandEvent& event);
+		void OnCrosshairSizeChoiceSelect(wxCommandEvent& event);
 		//*)
 
 		DECLARE_EVENT_TABLE()

--- a/xLights/wxsmith/ViewSettingsPanel.wxs
+++ b/xLights/wxsmith/ViewSettingsPanel.wxs
@@ -27,7 +27,7 @@
 				</object>
 				<col>1</col>
 				<row>0</row>
-				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
 				<border>5</border>
 				<option>1</option>
 			</object>
@@ -126,7 +126,7 @@
 				</object>
 				<col>0</col>
 				<row>5</row>
-				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
 				<border>5</border>
 				<option>1</option>
 			</object>
@@ -175,6 +175,35 @@
 				</object>
 				<col>0</col>
 				<row>8</row>
+				<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxStaticText" name="wxID_ANY" variable="StaticText2" member="no">
+					<label>Group Center Crosshair Size</label>
+				</object>
+				<col>0</col>
+				<row>10</row>
+				<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxChoice" name="ID_CHOICE_CROSSHAIRSIZE" variable="CrosshairSizeChoice" member="yes">
+					<content>
+						<item>Large</item>
+						<item>Normal</item>
+						<item>Small</item>
+						<item>Tiny</item>
+						<item>None</item>
+					</content>
+					<selection>1</selection>
+					<tooltip>Control the size of the crosshair for group centering</tooltip>
+					<handler function="OnCrosshairSizeChoiceSelect" entry="EVT_CHOICE" />
+				</object>
+				<col>1</col>
+				<row>10</row>
 				<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
 				<border>5</border>
 				<option>1</option>

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -1494,6 +1494,7 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     mAltBackupDir = "";
     mIconSize = 16;
     _modelHandleSize = 1;
+    _crosshairSize = 1;
 
     _acParm1Intensity = 100;
     _acParm1RampUp = 0;
@@ -1751,6 +1752,9 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
 
     config->Read("xLightsModelHandleSize", &_modelHandleSize, 1);
     logger_base.debug("Model Handle Size: %d.", _modelHandleSize);
+
+    config->Read("xLightsCrosshairSize", &_crosshairSize, 1);
+    logger_base.debug("Group View Crosshair Size: %d.", _crosshairSize);
 
     config->Read("xLightsBackupOnSave", &mBackupOnSave, false);
     logger_base.debug("Backup on save: %s.", toStr(mBackupOnSave));
@@ -2167,6 +2171,7 @@ xLightsFrame::~xLightsFrame()
     config->Write("xLightsAltBackupDir", mAltBackupDir);
     config->Write("xFadePort", _xFadePort);
     config->Write("xLightsModelHandleSize", _modelHandleSize);
+    config->Write("xLightsCrosshairSize", _crosshairSize);
     config->Write("xLightsPlayVolume", playVolume);
     config->Write("xLightsVideoExportCodec", _videoExportCodec);
     config->Write("xLightsVideoExportBitrate", _videoExportBitrate);
@@ -9965,6 +9970,11 @@ void xLightsFrame::OnMenuItem_UserManualSelected(wxCommandEvent& event)
 void xLightsFrame::SetModelHandleSize(int i)
 {
     _modelHandleSize = i;
+    layoutPanel->Refresh();
+}
+
+void xLightsFrame::SetCrosshairSize(int i) {
+    _crosshairSize = i;
     layoutPanel->Refresh();
 }
 

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -1318,9 +1318,11 @@ public:
     int EffectAssistMode() const { return mEffectAssistMode;}
     void SetEffectAssistMode(int i);
 
-    int GetModelHandleScale() const { return _modelHandleSize; }
-    int ModelHandleSize() const { return _modelHandleSize;}
+    int GetModelHandleSize() const { return _modelHandleSize; }
     void SetModelHandleSize(int i);
+
+    int GetCrosshairSize() const { return _crosshairSize; }
+    void SetCrosshairSize(int i);
 
     const wxArrayString &RandomEffectsToUse() const { return _randomEffectsToUse;}
     void SetRandomEffectsToUse(const wxArrayString &e);
@@ -1630,6 +1632,7 @@ private:
     int abortedRenderJobs = 0;
     bool mSaveFseqOnSave;
     int _modelHandleSize = 1;
+    int _crosshairSize = 1;
 
     class RenderTree {
     public:


### PR DESCRIPTION
Ability to hide or increase/decrease size of the red cross for group centering.  #4885
Refactored and resubmitted.
