### PR TITLE
Limit the splitter on submodel dialog from collapsing and hiding #4879

### DIFF
--- a/xLights/wxsmith/SubModelsDialog.wxs
+++ b/xLights/wxsmith/SubModelsDialog.wxs
@@ -137,6 +137,7 @@
 					</object>
 					<object class="sizeritem">
 						<object class="wxSplitterWindow" name="ID_SPLITTERWINDOW1" variable="SplitterWindow1" member="yes">
+							<minsize>100</minsize>
 							<orientation>vertical</orientation>
 							<style>wxSP_3D|wxSP_LIVE_UPDATE</style>
 							<handler function="OnSplitterSashPosChanging" entry="EVT_SPLITTER_SASH_POS_CHANGING" />
@@ -231,6 +232,7 @@
 																		<rowlabels>
 																			<item>Strand   1</item>
 																		</rowlabels>
+																		<maxsize>400,-1</maxsize>
 																		<style>wxVSCROLL</style>
 																		<handler function="OnNodesGridCellRightClick" entry="EVT_CMD_GRID_CELL_RIGHT_CLICK" />
 																		<handler function="OnNodesGridCellLeftDClick" entry="EVT_CMD_GRID_CELL_LEFT_DCLICK" />


### PR DESCRIPTION
The node values were hidden when you dialog was too small. Also impacted by non 100% windows resolutions. #4879 