### PR TITLE
Discovery changes and enhancements

### DIFF
--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -3268,6 +3268,9 @@ static void ProcessFPPSystems(Discovery &discovery, const std::string &systemsSt
                 if (found->typeId == 0) {
                     found->typeId = inst.typeId;
                 }
+                if (found->uuid == "") {
+                    found->uuid = inst.uuid;
+                }
                 if (inst.ranges.size() > found->ranges.size()) {
                     //if the json has the ranges, use it as the json can have a more exact set of ranges
                     //the Ping packet is limited to either 40 (v2) or 120 (v3) characters so

--- a/xLights/utils/ip_utils.cpp
+++ b/xLights/utils/ip_utils.cpp
@@ -73,6 +73,14 @@ namespace ip_utils
         return false;
     }
 
+    bool IsValidHostname(const std::string& ip) {
+        static wxRegEx hostAddr(R"(^([a-zA-Z0-9\-]+)(\.?)([a-zA-Z0-9\-]{2,})$)");
+
+        wxString ips = wxString(ip).Trim(false).Trim(true);
+        
+        return hostAddr.Matches(ips);
+    }
+
     std::string CleanupIP(const std::string& ip)
     {
         bool hasChar = false;

--- a/xLights/utils/ip_utils.h
+++ b/xLights/utils/ip_utils.h
@@ -18,6 +18,7 @@ namespace ip_utils
 	bool IsIPValid(const std::string& ip);
 
 	bool IsIPValidOrHostname(const std::string &ip, bool iponly = false);
+    bool IsValidHostname(const std::string& ip);
 	std::string CleanupIP(const std::string& ip);
 	std::string ResolveIP(const std::string& ip);
 


### PR DESCRIPTION
1. Fixed warning issue with IPs being reversed
2. Detect and check if UUID has more than one interface that's actually pingable - remove the extra prompt if IP is from the ColorLight or show network
3. Alert if duplicate Hostname found - ie: default FPP name
4. If an FPP instance is detected make it xLight Only and to the best that we can set vendor to FPP (unless it used a cape and we have all the info)
5. When adding a controller, ping hostnames and if they resolve use that to add controller (if user later changes it to IP - there won't be a prompt on next discovery)