### PR TITLE
Add FPP support for xLights Only state

### DIFF
--- a/controllers/fpp.xcontroller
+++ b/controllers/fpp.xcontroller
@@ -44,6 +44,7 @@
         <SupportsDefaultBrightness/>
         <SupportsDefaultGamma/>
         <PreferredInputProtocol>DDP</PreferredInputProtocol>
+		<PreferredState>xLights Only</PreferredState>
         <ConfigDriver>FPP</ConfigDriver>
 		<FPS40Pixels>800</FPS40Pixels>
 		<FPS40Pixels_SR>720</FPS40Pixels_SR>

--- a/xLights/controllers/ControllerCaps.cpp
+++ b/xLights/controllers/ControllerCaps.cpp
@@ -722,6 +722,10 @@ std::string ControllerCaps::GetPreferredInputProtocol() const
     return GetXmlNodeContent(_config, "PreferredInputProtocol", "");
 }
 
+std::string ControllerCaps::GetPreferredState() const {
+    return GetXmlNodeContent(_config, "PreferredState", "");
+}
+
 std::string ControllerCaps::GetConfigDriver() const
 {
     return GetXmlNodeContent(_config, "ConfigDriver", "");

--- a/xLights/controllers/ControllerCaps.h
+++ b/xLights/controllers/ControllerCaps.h
@@ -133,6 +133,7 @@ public:
     std::string GetID() const;
 
     std::string GetPreferredInputProtocol() const;
+    std::string GetPreferredState() const;
 
     std::vector<std::string> GetInputProtocols() const;
     std::vector<std::string> GetPixelProtocols() const;

--- a/xLights/outputs/ControllerEthernet.cpp
+++ b/xLights/outputs/ControllerEthernet.cpp
@@ -723,6 +723,10 @@ void ControllerEthernet::VMVChanged(wxPropertyGrid *grid)
                     SetProtocol(prefer);
                 }
             }
+            auto const& state = c->GetPreferredState();
+            if (!state.empty()) {
+                SetActive(state);
+            }
         }
     }
 }


### PR DESCRIPTION
One of the bigest issues we see on Zoom, people not knowing how to set up FPP absed ctrl to xLights only.