### PR TITLE
Increase group max grid size #4991

### DIFF
--- a/xLights/ModelGroupPanel.cpp
+++ b/xLights/ModelGroupPanel.cpp
@@ -183,7 +183,7 @@ ModelGroupPanel::ModelGroupPanel(wxWindow* parent, ModelManager &Models, LayoutP
 	FlexGridSizer6->Add(Choice_DefaultCamera, 1, wxALL|wxEXPAND, 5);
 	GridSizeLabel = new wxStaticText(this, ID_STATICTEXT4, _("Max Grid Size:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT4"));
 	FlexGridSizer6->Add(GridSizeLabel, 1, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
-	SizeSpinCtrl = new wxSpinCtrl(this, ID_SPINCTRL1, _T("400"), wxDefaultPosition, wxDefaultSize, 0, 10, 2000, 400, _T("ID_SPINCTRL1"));
+	SizeSpinCtrl = new wxSpinCtrl(this, ID_SPINCTRL1, _T("400"), wxDefaultPosition, wxDefaultSize, 0, 10, 4000, 400, _T("ID_SPINCTRL1"));
 	SizeSpinCtrl->SetValue(_T("400"));
 	FlexGridSizer6->Add(SizeSpinCtrl, 1, wxALL|wxEXPAND, 2);
 	StaticText6 = new wxStaticText(this, wxID_ANY, _("Preview:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));

--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -4213,6 +4213,10 @@ void Model::InitRenderBufferNodes(const std::string& tp, const std::string& came
             int maxDimension = ((ModelGroup*)this)->GetGridSize();
             if (maxDimension != 0 && (maxX - minX > maxDimension || maxY - minY > maxDimension)) {
                 // we need to resize all the points by this amount
+                logger_base.warn("Model Group (%s), Actual Grid Size of %.0f exceeded the Max Grid Size of %d.",
+                    (const char*)GetFullName().c_str(), 
+                    ((maxX - minX) > (maxY - minY) ? (maxX - minX) : (maxY - minY)), 
+                    maxDimension);
                 factor = std::max(((float)(maxX - minX)) / (float)maxDimension, ((float)(maxY - minY)) / (float)maxDimension);
                 // But if it is already smaller we dont want to make it bigger
                 if (factor < 1.0) {

--- a/xLights/wxsmith/ModelGroupPanel.wxs
+++ b/xLights/wxsmith/ModelGroupPanel.wxs
@@ -93,7 +93,7 @@
 								<object class="wxSpinCtrl" name="ID_SPINCTRL1" variable="SizeSpinCtrl" member="yes">
 									<value>400</value>
 									<min>10</min>
-									<max>2000</max>
+									<max>4000</max>
 									<handler function="OnSizeSpinCtrlChange" entry="EVT_SPINCTRL" />
 								</object>
 								<flag>wxALL|wxEXPAND</flag>


### PR DESCRIPTION
Max grid size is used for groups with a per preview effect. Increased the max value allowed and added a log line if you exceeded the set value. #4991. 