### PR TITLE
Don't export or report on Sketch backgound file missing

### DIFF
--- a/xLights/effects/SketchEffect.cpp
+++ b/xLights/effects/SketchEffect.cpp
@@ -198,9 +198,6 @@ std::list<std::string> SketchEffect::CheckEffectSettings(const SettingsMap& sett
 std::list<std::string> SketchEffect::GetFileReferences(Model* model, const SettingsMap& SettingsMap) const
 {
     std::list<std::string> res;
-    if (SettingsMap["E_FILEPICKER_SketchBackground"] != "") {
-        res.push_back(SettingsMap["E_FILEPICKER_SketchBackground"]);
-    }
     return res;
 }
 


### PR DESCRIPTION
Backgound file not needed once paths are created. (#4865)