### PR TITLE
Import Effects add option to convert to 'Per Model' #2787

### DIFF
--- a/xLights/wxsmith/xLightsImportChannelMapDialog.wxs
+++ b/xLights/wxsmith/xLightsImportChannelMapDialog.wxs
@@ -4,7 +4,6 @@
 		<title>Map Channels</title>
 		<id_arg>0</id_arg>
 		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxMAXIMIZE_BOX|wxFULL_REPAINT_ON_RESIZE</style>
-		<handler function="OnInit" entry="EVT_INIT_DIALOG" />
 		<handler function="OnClose" entry="EVT_CLOSE" />
 		<object class="wxFlexGridSizer" variable="OldSizer" member="yes">
 			<cols>1</cols>
@@ -65,7 +64,7 @@
 							</object>
 							<object class="sizeritem">
 								<object class="wxFlexGridSizer" variable="FlexGridSizer11" member="yes">
-									<cols>2</cols>
+									<cols>3</cols>
 									<growablecols>0</growablecols>
 									<object class="sizeritem">
 										<object class="wxCheckBox" name="ID_CHECKBOX11" variable="CheckBox_EraseExistingEffects" member="yes">
@@ -81,6 +80,16 @@
 											<checked>1</checked>
 										</object>
 										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
+									<object class="sizeritem">
+										<object class="wxCheckBox" name="ID_CHECKBOX5" variable="CheckBox_ConvertRenderStyle" member="yes">
+											<label>Convert Render Style</label>
+											<tooltip>When mapping model to group, convert render styles to &apos;Per Model&apos; when applicable</tooltip>
+											<handler function="OnCheckBox_ConvertRenderStyleClick" entry="EVT_CHECKBOX" />
+										</object>
+										<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
 										<border>5</border>
 										<option>1</option>
 									</object>
@@ -147,7 +156,6 @@
 									<object class="sizeritem">
 										<object class="wxCheckListBox" name="ID_CHECKLISTBOX1" variable="TimingTrackListBox" member="yes">
 											<style>wxLB_MULTIPLE|wxVSCROLL</style>
-											<handler function="OnTimingTrackListBoxToggled" entry="EVT_CHECKLISTBOX" />
 										</object>
 										<flag>wxALL|wxEXPAND</flag>
 										<option>1</option>

--- a/xLights/xLightsImportChannelMapDialog.cpp
+++ b/xLights/xLightsImportChannelMapDialog.cpp
@@ -442,6 +442,7 @@ const wxWindowID xLightsImportChannelMapDialog::ID_SPINCTRL1 = wxNewId();
 const wxWindowID xLightsImportChannelMapDialog::ID_CHECKBOX1 = wxNewId();
 const wxWindowID xLightsImportChannelMapDialog::ID_CHECKBOX11 = wxNewId();
 const wxWindowID xLightsImportChannelMapDialog::ID_CHECKBOX4 = wxNewId();
+const wxWindowID xLightsImportChannelMapDialog::ID_CHECKBOX5 = wxNewId();
 const wxWindowID xLightsImportChannelMapDialog::ID_CHECKBOX2 = wxNewId();
 const wxWindowID xLightsImportChannelMapDialog::ID_STATICTEXT_BLEND_TYPE = wxNewId();
 const wxWindowID xLightsImportChannelMapDialog::ID_CHECKBOX3 = wxNewId();
@@ -526,7 +527,7 @@ xLightsImportChannelMapDialog::xLightsImportChannelMapDialog(wxWindow* parent, c
     CheckBox_MapCCRStrand->SetValue(false);
     FlexGridSizer1->Add(CheckBox_MapCCRStrand, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
     Sizer1->Add(FlexGridSizer1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 1);
-    FlexGridSizer11 = new wxFlexGridSizer(0, 2, 0, 0);
+    FlexGridSizer11 = new wxFlexGridSizer(0, 3, 0, 0);
     FlexGridSizer11->AddGrowableCol(0);
     CheckBox_EraseExistingEffects = new wxCheckBox(Panel1, ID_CHECKBOX11, _("Erase existing effects on imported models"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX11"));
     CheckBox_EraseExistingEffects->SetValue(false);
@@ -534,6 +535,10 @@ xLightsImportChannelMapDialog::xLightsImportChannelMapDialog(wxWindow* parent, c
     CheckBox_LockEffects = new wxCheckBox(Panel1, ID_CHECKBOX4, _("Lock effects on import"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX4"));
     CheckBox_LockEffects->SetValue(true);
     FlexGridSizer11->Add(CheckBox_LockEffects, 1, wxALL|wxEXPAND, 5);
+    CheckBox_ConvertRenderStyle = new wxCheckBox(Panel1, ID_CHECKBOX5, _("Convert Render Style"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX5"));
+    CheckBox_ConvertRenderStyle->SetValue(false);
+    CheckBox_ConvertRenderStyle->SetToolTip(_("When mapping model to group, convert render styles to \'Per Model\' when applicable"));
+    FlexGridSizer11->Add(CheckBox_ConvertRenderStyle, 1, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
     Sizer1->Add(FlexGridSizer11, 1, wxALL|wxEXPAND, 1);
     FlexGridSizer_Blend_Mode = new wxFlexGridSizer(0, 2, 0, 0);
     CheckBox_Import_Blend_Mode = new wxCheckBox(Panel1, ID_CHECKBOX2, _("Import Model Blend Mode"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX2"));
@@ -616,6 +621,7 @@ xLightsImportChannelMapDialog::xLightsImportChannelMapDialog(wxWindow* parent, c
     OldSizer->SetSizeHints(this);
 
     Connect(ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&xLightsImportChannelMapDialog::OnCheckBox_MapCCRStrandClick);
+    Connect(ID_CHECKBOX5, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&xLightsImportChannelMapDialog::OnCheckBox_ConvertRenderStyleClick);
     Connect(ID_CHECKBOX3, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&xLightsImportChannelMapDialog::OnCheckBoxImportMediaClick);
     Connect(ID_BUTTON_IMPORT_OPTIONS, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&xLightsImportChannelMapDialog::OnButtonImportOptionsClick);
     Connect(ID_TEXTCTRL2, wxEVT_COMMAND_TEXT_UPDATED, (wxObjectEventFunction)&xLightsImportChannelMapDialog::OnTextCtrl_FindToText);
@@ -663,6 +669,7 @@ xLightsImportChannelMapDialog::xLightsImportChannelMapDialog(wxWindow* parent, c
 
     wxConfigBase* config = wxConfigBase::Get();
     CheckBox_LockEffects->SetValue(config->ReadBool("ImportEffectsLocked", false));
+    CheckBox_ConvertRenderStyle->SetValue(config->ReadBool("ImportEffectsRenderStyle", false));
 
     EnsureWindowHeaderIsOnScreen(this);
 }
@@ -912,6 +919,15 @@ bool xLightsImportChannelMapDialog::IsLockEffects() const
     wxConfigBase* config = wxConfigBase::Get();
     bool b = CheckBox_LockEffects->IsChecked();
     config->Write("ImportEffectsLocked", b);
+    config->Flush();
+    return b;
+}
+
+bool xLightsImportChannelMapDialog::IsConvertRenderStyle() const
+{
+    wxConfigBase* config = wxConfigBase::Get();
+    bool b = CheckBox_ConvertRenderStyle->IsChecked();
+    config->Write("ImportEffectsRenderStyle", b);
     config->Flush();
     return b;
 }
@@ -2813,4 +2829,8 @@ void xLightsImportChannelMapDialog::OnClose(wxCloseEvent& event)
     } else {
         EndDialog(wxID_CANCEL);
     }
+}
+
+void xLightsImportChannelMapDialog::OnCheckBox_ConvertRenderStyleClick(wxCommandEvent& event)
+{
 }

--- a/xLights/xLightsImportChannelMapDialog.h
+++ b/xLights/xLightsImportChannelMapDialog.h
@@ -382,7 +382,8 @@ class xLightsImportChannelMapDialog: public wxDialog
         bool InitImport(std::string checkboxText = "");
         void SetModelBlending(bool enabled);
         [[nodiscard]] bool GetImportModelBlending() const;
-        [[nodiscard]] bool IsLockEffects() const;
+        [[nodiscard]] bool IsLockEffects() const; 
+        [[nodiscard]] bool IsConvertRenderStyle() const; 
         void SetXsqPkg(SequencePackage* xsqPkg);
         [[nodiscard]] std::vector<std::string> const GetChannelNames() const;
         [[nodiscard]] ImportChannel* GetImportChannel(std::string const& name) const;
@@ -399,6 +400,7 @@ class xLightsImportChannelMapDialog: public wxDialog
 		wxButton* Button_Ok;
 		wxButton* Button_UpdateAliases;
 		wxCheckBox* CheckBoxImportMedia;
+		wxCheckBox* CheckBox_ConvertRenderStyle;
 		wxCheckBox* CheckBox_EraseExistingEffects;
 		wxCheckBox* CheckBox_Import_Blend_Mode;
 		wxCheckBox* CheckBox_LockEffects;
@@ -444,6 +446,7 @@ protected:
 		static const wxWindowID ID_CHECKBOX1;
 		static const wxWindowID ID_CHECKBOX11;
 		static const wxWindowID ID_CHECKBOX4;
+		static const wxWindowID ID_CHECKBOX5;
 		static const wxWindowID ID_CHECKBOX2;
 		static const wxWindowID ID_STATICTEXT_BLEND_TYPE;
 		static const wxWindowID ID_CHECKBOX3;
@@ -488,7 +491,7 @@ protected:
 		void OnListCtrl_AvailableColumnClick(wxListEvent& event);
 		void OnCheckBox_MapCCRStrandClick(wxCommandEvent& event);
 		void OnButton_AutoMapClick(wxCommandEvent& event);
-        void OnButton_AutoMapSelClick(wxCommandEvent& event);
+		void OnButton_AutoMapSelClick(wxCommandEvent& event);
 		void OnListCtrl_AvailableItemActivated(wxListEvent& event);
 		void OnButtonImportOptionsClick(wxCommandEvent& event);
 		void OnCheckBoxImportMediaClick(wxCommandEvent& event);
@@ -497,6 +500,7 @@ protected:
 		void OnButton_UpdateAliasesClick(wxCommandEvent& event);
 		void OnClose(wxCloseEvent& event);
 		void OnInit(wxInitDialogEvent& event);
+		void OnCheckBox_ConvertRenderStyleClick(wxCommandEvent& event);
 		//*)
 
         void RightClickTimingTracks(wxContextMenuEvent& event);


### PR DESCRIPTION
Additional option on import mapping that when checked, if you map a single model to a group it will convert the render style to 'Per Model'. This is similar code that is available on the sequencer, model right click. It only convers Default, Single Line and Per Preview to 'Per Model'. #2787 