### PR TITLE
Increase string count and correct node calc #4799

### DIFF
--- a/xLights/ControllerModelDialog.cpp
+++ b/xLights/ControllerModelDialog.cpp
@@ -1650,7 +1650,7 @@ public:
             GetModel()->ClearControllerBrightness();
             return true;
         } else if (id == ControllerModelDialog::CONTROLLER_MODEL_STRINGS) {
-            wxNumberEntryDialog dlg(parent, "Set String Count", "String Count", "Model String Count", GetModel()->GetNumPhysicalStrings(), 1, 48);
+            wxNumberEntryDialog dlg(parent, "Set String Count", "String Count", "Model String Count", GetModel()->GetNumPhysicalStrings(), 1, 100);
             if (dlg.ShowModal() == wxID_OK) {
                 std::string mess;
                 if (!GetModel()->ChangeStringCount(dlg.GetValue(), mess)) {

--- a/xLights/models/CustomModel.cpp
+++ b/xLights/models/CustomModel.cpp
@@ -113,7 +113,7 @@ void CustomModel::AddTypeProperties(wxPropertyGridInterface* grid, OutputManager
 
     p = grid->Append(new wxUIntProperty("# Strings", "CustomModelStrings", _strings));
     p->SetAttribute("Min", 1);
-    p->SetAttribute("Max", 48);
+    p->SetAttribute("Max", 100);
     p->SetEditor("SpinCtrl");
     p->SetHelpString("This is typically the number of connections from the prop to your controller.");
 
@@ -1768,6 +1768,7 @@ bool CustomModel::ChangeStringCount(long count, std::string& message)
     ModelXml->AddAttribute("CustomStrings", wxString::Format("%d", count));
 
     if (count != 1) {    
+        _strings = count;
         wxString nm = StartNodeAttrName(0);
         bool hasIndiv = ModelXml->HasAttribute(nm);
 


### PR DESCRIPTION
With more smart receivers one can use more than 48 ports. Also if updating the string count in the visualizer, use that value to determine the nodes per string if required. #4799 