### PR TITLE
Submodel duplicate nodes check - split between same line and cross lines

### DIFF
--- a/xLights/models/SubModel.cpp
+++ b/xLights/models/SubModel.cpp
@@ -27,21 +27,48 @@ const std::vector<std::string> SubModel::BUFFER_STYLES{ DEFAULT, KEEP_XY, STACKE
 // Check for duplicate nodes in a submodel
 void SubModel::CheckDuplicates(const std::vector<int>& nodeIndexes)
 {
-    _duplicateNodes = "";
+    _sameLineDuplicates = "";
+    _crossLineDuplicates = "";
+    std::set<int> lineNodes;
+    std::set<int> seenNodes;
+    std::set<int> sameLineDups;     // Track same-line duplicates
+    std::vector<int> sameDupNodes;  // For sorting
+    std::vector<int> crossDupNodes; // For sorting
 
-    auto it = begin(nodeIndexes);
-
-    while (it != end(nodeIndexes)) {
-        auto it2 = it;
-        ++it2;
-        while (it2 != end(nodeIndexes)) {
-            if (*it == *it2) {
-                if (_duplicateNodes != "") _duplicateNodes += ", ";
-                _duplicateNodes += wxString::Format("%d", *it + 1);
-            }
-            ++it2;
+    for (int node : nodeIndexes) {
+        if (node == -1) {
+            lineNodes.clear();
+            continue;
         }
-        ++it;
+
+        if (!lineNodes.insert(node).second) {
+            sameLineDups.insert(node);
+            sameDupNodes.push_back(node);
+        }
+
+        if (!seenNodes.insert(node).second && sameLineDups.find(node) == sameLineDups.end()) {
+            crossDupNodes.push_back(node);
+        }
+    }
+
+    // Sort the vectors
+    std::sort(sameDupNodes.begin(), sameDupNodes.end());
+    std::sort(crossDupNodes.begin(), crossDupNodes.end());
+
+    // Remove duplicates from the sorted vectors
+    sameDupNodes.erase(std::unique(sameDupNodes.begin(), sameDupNodes.end()), sameDupNodes.end());
+    crossDupNodes.erase(std::unique(crossDupNodes.begin(), crossDupNodes.end()), crossDupNodes.end());
+
+    for (int node : sameDupNodes) {
+        if (_sameLineDuplicates != "")
+            _sameLineDuplicates += ", ";
+        _sameLineDuplicates += wxString::Format("%d", node + 1);
+    }
+
+    for (int node : crossDupNodes) {
+        if (_crossLineDuplicates != "")
+            _crossLineDuplicates += ", ";
+        _crossLineDuplicates += wxString::Format("%d", node + 1);
     }
 }
 
@@ -113,6 +140,7 @@ SubModel::SubModel(Model* p, wxXmlNode* n) :
                         }
                     }
                 }
+                nodeIndexes.push_back(-1);
                 line++;
             }
 
@@ -252,6 +280,7 @@ SubModel::SubModel(Model* p, wxXmlNode* n) :
                         row++;
                     }
                 }
+                nodeIndexes.push_back(-1);
                 line++;
             }
             CheckDuplicates(nodeIndexes);

--- a/xLights/models/SubModel.h
+++ b/xLights/models/SubModel.h
@@ -58,7 +58,12 @@ public:
     virtual void InitRenderBufferNodes(const std::string &type, const std::string &camera, const std::string &transform,
         std::vector<NodeBaseClassPtr> &Nodes, int &BufferWi, int &BufferHi, int stagger, bool deep = false) const override;
 
-    std::string GetDuplicateNodes() const { return _duplicateNodes; }
+    std::string GetSameLineDuplicates() const {
+        return _sameLineDuplicates;
+    }
+    std::string GetCrossLineDuplicates() const {
+        return _crossLineDuplicates;
+    }
 
     [[nodiscard]] FaceStateData const& GetFaceInfo() const override { return parent->faceInfo; };
     [[nodiscard]] FaceStateNodes const& GetFaceInfoNodes() const override { return parent->faceInfoNodes; };
@@ -72,7 +77,8 @@ private:
     const std::string _type;
     const std::string _bufferStyle;
     std::string _propertyGridDisplay;
-    std::string _duplicateNodes;
+    std::string _sameLineDuplicates;
+    std::string _crossLineDuplicates;
     
     static std::vector<std::string> SUBMODEL_BUFFER_STYLES;
 };

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -6134,9 +6134,20 @@ std::string xLightsFrame::CheckSequence(bool displayInEditor, bool writeToFile)
             for (int i = 0; i < it.second->GetNumSubModels(); ++i) {
                 SubModel* sm = dynamic_cast<SubModel*>(it.second->GetSubModel(i));
                 if (sm != nullptr) {
-                    std::string dups = sm->GetDuplicateNodes();
-                    if (dups != "") {
-                        wxString msg = wxString::Format("    WARN: SubModel '%s' contains duplicate nodes: %s. This may not render as expected.", (const char*)sm->GetFullName().c_str(), (const char*)dups.c_str());
+                    std::string sameDups = sm->GetSameLineDuplicates();
+                    std::string crossDups = sm->GetCrossLineDuplicates();
+
+                    if (sameDups != "") {
+                        wxString msg = wxString::Format("    WARN: SubModel '%s' contains same line duplicate nodes: %s.",
+                                                        (const char*)sm->GetFullName().c_str(),
+                                                        (const char*)sameDups.c_str());
+                        LogAndTrack(report, "models", CheckSequenceReport::ReportIssue::WARNING, msg.ToStdString(), "submodelsdups", errcount, warncount);
+                    }
+
+                    if (crossDups != "") {
+                        wxString msg = wxString::Format("    WARN: SubModel '%s' contains cross line duplicate nodes: %s.",
+                                                        (const char*)sm->GetFullName().c_str(),
+                                                        (const char*)crossDups.c_str());
                         LogAndTrack(report, "models", CheckSequenceReport::ReportIssue::WARNING, msg.ToStdString(), "submodelsdups", errcount, warncount);
                     }
                 }


### PR DESCRIPTION
Splitting the duplicate submodels warning message into 2 categories:
1. Same line duplicates - When a node appears multiple times within a single line (e.g., "1,3,5,7,9,5" - node 5 is duplicated)
2. Cross line duplicates - When a node appears across multiple lines (e.g., line 1: "1,3,5", line 2: "7,5,9" - node 5 appears in both lines)

The distinction is important because cross-line duplicates are often intentional (like overlapping petals), while same-line duplicates typically indicate issues that need fixing.

Additional improvement: Node numbers are now sorted.

Here is the new messages rendered (nodes sorted)
![image](https://github.com/user-attachments/assets/16ff73ff-9264-46d2-960e-6b4f8c7d8a85)


**Before it was listing all the duplicates (nodes not sorted)**
![image](https://github.com/user-attachments/assets/c05a76a8-e770-4a64-9756-22f1e8ed8141)
