### PR TITLE
Save and restore xschedule splitter positions #5103

### DIFF
--- a/xSchedule/xScheduleMain.cpp
+++ b/xSchedule/xScheduleMain.cpp
@@ -762,6 +762,8 @@ xScheduleFrame::xScheduleFrame(wxWindow* parent, const std::string& showdir, con
 
     SetPosition(wxPoint(x, y));
     SetSize(w, h);
+    SplitterWindow1->SetSashPosition(config->ReadLong("xsSashPositionV", 500));
+    SplitterWindow2->SetSashPosition(config->ReadLong("xsSashPositionH", 150));
     EnsureWindowHeaderIsOnScreen(this);
 
     logger_base.debug("xSchedule UI %d,%d %dx%d.", x, y, w, h);
@@ -1089,6 +1091,8 @@ xScheduleFrame::~xScheduleFrame()
         config->Write(_("xsWindowPosY"), y);
         config->Write(_("xsWindowPosW"), w);
         config->Write(_("xsWindowPosH"), h);
+        config->Write("xsSashPositionV", SplitterWindow1->GetSashPosition());
+        config->Write("xsSashPositionH", SplitterWindow2->GetSashPosition());
         config->Flush();
     }
 
@@ -3771,4 +3775,6 @@ void xScheduleFrame::OnMenuItem_ResetWindowLocationsSelected(wxCommandEvent& eve
     config->DeleteEntry(_("xsWindowPosY"));
     config->DeleteEntry(_("xsWindowPosW"));
     config->DeleteEntry(_("xsWindowPosH"));
+    config->DeleteEntry("xsSashPositionH");
+    config->DeleteEntry("xsSashPositionV");
 }


### PR DESCRIPTION
Along with the window position of the main xschedule pane, save and restore the splitter positions that control the separation of the playlist, controllers and schedule. #5103