### PR TITLE
Add ZIP upload to ESPixelStick

### DIFF
--- a/xLights/Discovery.h
+++ b/xLights/Discovery.h
@@ -101,7 +101,8 @@ public:
     std::string proxy;
     std::string username;
     std::string password;
-    
+    bool canZipUpload = false;
+
     wxJSONValue extraData;
 };
 

--- a/xLights/controllers/FPP.h
+++ b/xLights/controllers/FPP.h
@@ -70,6 +70,7 @@ class FPP : public BaseController
     std::string controllerModel;
     std::string controllerVariant;
     bool upload;
+    bool canZipUpload = false;
 
     wxWindow *parent = nullptr;
     void setProgress(FPPUploadProgressDialog*d, wxGauge *g) { progressDialog = d; progress = g; }


### PR DESCRIPTION
If the version supports ZipUploads (new parm from Marting) we'll zip and upload the sequence. 10x reduction and over 30x speed upload speed,. No more getting stuck and killed by the 5min curl timeout