### PR TITLE
Include model base in model group

### DIFF
--- a/xLights/xLightsImportChannelMapDialog.cpp
+++ b/xLights/xLightsImportChannelMapDialog.cpp
@@ -1019,13 +1019,10 @@ void xLightsImportChannelMapDialog::AddModel(Model *m, int &ms) {
         if (grp != nullptr) {
             auto modelNames = grp->ModelNames();
             for (const auto& it : modelNames) {
-                Model* mdl = grp->GetModel(it);
-                if (mdl != nullptr) {
                     if (groupModels != "") {
                         groupModels += ",";
                     }
-                    groupModels += mdl->GetName();
-                }
+                    groupModels += it;
             }
         }
     }


### PR DESCRIPTION
Groups with subModels only had the submodel name included. Should have Model/SubModel

<targetModels>
  <model name='Verticals' type='ModelGroup' class='' groupModels='House Vertical,**Window Frame/**Verticals'/>
  <model name='House Vertical' type='Single Line' class='Line'/>
  <model name='Empty' type='ModelGroup' class=''/>
  <model name='Tree' type='Tree' class=''/>
  <model name='Matrix' type='Matrix' class=''/>
  <model name='Icicles' type='Icicles' class='Icicles'/>
  <model name='Circle' type='Circle' class='Line'/>
  <model name='DmxSkull' type='DmxSkull' class='DMX Special Purpose'/>
  <model name='Single Line' type='Single Line' class='Line'/>
  <model name='Arches' type='Arches' class='Line'/>
  <model name='Candy Canes' type='Candy Canes' class='Line'/>
  <model name='Spinner' type='Spinner' class=''/>
  <model name='Star' type='Star' class=''/>
  <model name='Window Frame' type='Window Frame' class='Line'/>
</targetModels>