### PR TITLE
Try to stop the model from hallucinating

### DIFF
--- a/xLights/xLightsImportChannelMapDialog.h
+++ b/xLights/xLightsImportChannelMapDialog.h
@@ -448,7 +448,7 @@ class xLightsImportChannelMapDialog: public wxDialog
     std::string BuildSourceModelPrompt(const std::list<ImportChannel*>& sourceModels, std::function<bool(const ImportChannel*)> filter);
     std::string BuildTargetModelPrompt(const std::list<xLightsImportModelNode*>& targetModels, std::function<bool(const xLightsImportModelNode*)> filter);
     std::string BuildAlreadyMappedPrompt(const std::list<xLightsImportModelNode*>& targetModels, std::function<bool(const xLightsImportModelNode*)> filter);
-    bool RunAIPrompt(wxProgressDialog* dlg, const std::string& prompt, const std::list<xLightsImportModelNode*>& targetModels);
+    bool RunAIPrompt(wxProgressDialog* dlg, const std::string& prompt, const std::list<ImportChannel*>& sourceModels, const std::list<xLightsImportModelNode*>& targetModels);
 
     bool _dirty;
     wxFileName _filename;


### PR DESCRIPTION
Sometimes the model returns the targetModels as sourceModels (go figure) and we allow that mapping to happen, which is not valid.
This now checks to make sure the source we're trying to map to, is actually a source.

![image](https://github.com/user-attachments/assets/bc822cff-cb8f-468c-94ec-80179731183a)

