### PR TITLE
Correct Wipe, Blend, From Mid Transitions #5213

### DIFF
--- a/xLights/effects/ispc/LayerBlendingFunctions.ispc
+++ b/xLights/effects/ispc/LayerBlendingFunctions.ispc
@@ -204,11 +204,11 @@ export void GetColorsISPCKernel(uniform const LayerBlendingData &data,
                             nc = cnt;
                         }
                     }
-                }
+              }
             }
         } else if (data.useMask && mask) {
-            int32 x = idx / data.bufferHi;
-            int32 y = idx - (x * data.bufferHi);
+            int32 x = idx % data.bufferWi;
+            int32 y = idx / data.bufferWi;
             int32 midx = x * data.bufferHi + y;
 
             if (mask[midx] > 0) {


### PR DESCRIPTION
Found a conversion typo from metal to ispc #5213 

![image](https://github.com/user-attachments/assets/d0315dc6-d68b-43b2-90ec-bd755f6bdb4b)

![image](https://github.com/user-attachments/assets/f3f9afff-9c44-40a3-8f49-2165721a302c)
