### PR TITLE
Disable bkgrnd image and eff indicators during batch render #5155

### DIFF
--- a/xLights/BatchRenderDialog.cpp
+++ b/xLights/BatchRenderDialog.cpp
@@ -380,6 +380,18 @@ void BatchRenderDialog::ValidateWindow()
 void BatchRenderDialog::OnButton_OkClick(wxCommandEvent& event)
 {
     SaveSettings();
+    xLightsFrame* frame = static_cast<xLightsFrame*>(GetParent());
+    wxConfigBase* config = wxConfigBase::Get();
+    if (config != nullptr) {
+        config->Write("BatchRendererGridIconBackgrounds", frame->GridIconBackgrounds());
+        config->Write("BatchRendererGroupEffectBackgrounds", frame->ShowGroupEffectIndicator());
+    }
+    if(frame->GridIconBackgrounds()) {
+        frame->SetGridIconBackgrounds(false);
+    }
+    if(frame->ShowGroupEffectIndicator()) {
+        frame->SetShowGroupEffectIndicator(false);
+    }
     EndDialog(wxID_OK);
 }
 

--- a/xLights/TabSequence.cpp
+++ b/xLights/TabSequence.cpp
@@ -1143,6 +1143,19 @@ void xLightsFrame::OpenAndCheckSequence(const wxArrayString& origFilenames, bool
         logger_base.debug("Batch render cancelled.");
         EnableSequenceControls(true);
         printf("Batch render cancelled.\n");
+
+        wxConfigBase* config = wxConfigBase::Get();
+        if (config != nullptr) {
+            auto selectGridIcon = config->ReadBool("BatchRendererGridIconBackgrounds", false);
+            if (selectGridIcon) {
+                SetGridIconBackgrounds(selectGridIcon);
+            }
+            auto selectGroupEffect = config->ReadBool("BatchRendererGroupEffectBackgrounds", false);
+            if (selectGroupEffect) {
+                SetShowGroupEffectIndicator(selectGroupEffect);
+            }
+        }
+
         if (exitOnDone) {
             Destroy();
         }
@@ -1196,6 +1209,19 @@ void xLightsFrame::OpenRenderAndSaveSequences(const wxArrayString &origFilenames
         logger_base.debug("Batch render done.");
         printf("Done All Files\n");
         wxBell();
+
+        wxConfigBase* config = wxConfigBase::Get();
+        if (config != nullptr) {
+            auto selectGridIcon = config->ReadBool("BatchRendererGridIconBackgrounds", false);
+            if (selectGridIcon) {
+                SetGridIconBackgrounds(selectGridIcon);
+            }
+            auto selectGroupEffect = config->ReadBool("BatchRendererGroupEffectBackgrounds", false);
+            if (selectGroupEffect) {
+                SetShowGroupEffectIndicator(selectGroupEffect);
+            }
+        }
+
         if (exitOnDone) {
             Destroy();
         } else {
@@ -1210,6 +1236,19 @@ void xLightsFrame::OpenRenderAndSaveSequences(const wxArrayString &origFilenames
         logger_base.debug("Batch render cancelled.");
         EnableSequenceControls(true);
         printf("Batch render cancelled.\n");
+
+        wxConfigBase* config = wxConfigBase::Get();
+        if (config != nullptr) {
+            auto selectGridIcon = config->ReadBool("BatchRendererGridIconBackgrounds", false);
+            if (selectGridIcon) {
+                SetGridIconBackgrounds(selectGridIcon);
+            }
+            auto selectGroupEffect = config->ReadBool("BatchRendererGroupEffectBackgrounds", false);
+            if (selectGroupEffect) {
+                SetShowGroupEffectIndicator(selectGroupEffect);
+            }
+        }
+
         if (exitOnDone) {
             Destroy();
         }


### PR DESCRIPTION
To improve performance during a batch render, temporarily disable the background gif images displayed on the effects along with the group effect indicators. #5155 