### PR TITLE
Add support organizational folder only

### DIFF
--- a/xLights/BitmapCache.cpp
+++ b/xLights/BitmapCache.cpp
@@ -610,6 +610,11 @@ wxBitmapBundle BitmapCache::GetPapgayoXIcon() {
 wxBitmapBundle BitmapCache::GetModelGroupIcon() {
     return CreateBitmapBundleFromXPMs(16, "ModelGroup", {model_16, model_64, model_64, model_64, model_64});
 }
+
+wxBitmapBundle BitmapCache::GetModelOrgGroupIcon() {
+    return CreateBitmapBundleFromXPMs(16, "xlART_PADLOCK_CLOSED", { padlock_close_14, padlock_close_28, padlock_close_28, padlock_close_28, padlock_close_28 });
+}
+
 wxBitmapBundle BitmapCache::GetFPPIcon() {
     return wxBitmapBundle::FromSVG(fpp_app_icon_svg, sizeof(fpp_app_icon_svg), wxSize(16, 16));
 }

--- a/xLights/BitmapCache.h
+++ b/xLights/BitmapCache.h
@@ -20,6 +20,7 @@ public:
     static wxBitmapBundle GetPapgayoIcon();
     static wxBitmapBundle GetPapgayoXIcon();
     static wxBitmapBundle GetModelGroupIcon();
+    static wxBitmapBundle GetModelOrgGroupIcon();
     
     static wxBitmapBundle GetLockIcon(bool locked);
     static const wxImage &GetCornerIcon(int position, int size);

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -1346,9 +1346,11 @@ int LayoutPanel::AddModelToTree(Model *model, wxTreeListItem* parent, bool expan
         wxASSERT(false);
     }
 
+    ModelGroup* mg = dynamic_cast<ModelGroup*>(model);
+    bool isOrgGroup = mg != nullptr ? mg->IsOrgGroup() : false; 
     wxTreeListItem item = TreeListViewModels->AppendItem(*parent, TreeModelName(model, fullName),
-                                                         LayoutUtils::GetModelTreeIcon(model->DisplayAs, LayoutUtils::GroupMode::Closed),
-                                                         LayoutUtils::GetModelTreeIcon(model->DisplayAs, LayoutUtils::GroupMode::Opened),
+                                                         LayoutUtils::GetModelTreeIcon(model->DisplayAs, LayoutUtils::GroupMode::Closed, isOrgGroup),
+                                                         LayoutUtils::GetModelTreeIcon(model->DisplayAs, LayoutUtils::GroupMode::Opened, isOrgGroup),
                                                          new ModelTreeData(model, nativeOrder, fullName));
 
     if (model->GetDisplayAs() != "ModelGroup") {

--- a/xLights/LayoutUtils.cpp
+++ b/xLights/LayoutUtils.cpp
@@ -30,6 +30,7 @@ namespace LayoutUtils
         idxs[Icon_File] = pushBack(imageList, wxArtProvider::GetBitmapBundle("wxART_NORMAL_FILE", wxART_LIST, sz));
         idxs[Icon_FolderClosed] = pushBack(imageList, wxArtProvider::GetBitmapBundle("xlART_GROUP_CLOSED", wxART_LIST, sz));
         idxs[Icon_FolderOpened] = pushBack(imageList, wxArtProvider::GetBitmapBundle("xlART_GROUP_OPEN", wxART_LIST, sz));
+        idxs[Icon_OrgGroup] = pushBack(imageList, wxArtProvider::GetBitmapBundle("wxART_HELP_FOLDER", wxART_LIST, sz));
         idxs[Icon_Group] = pushBack(imageList, BitmapCache::GetModelGroupIcon());
         idxs[Icon_Arches] = pushBack(imageList, wxArtProvider::GetBitmapBundle("xlART_ARCH_ICON", wxART_LIST));
         idxs[Icon_CandyCane] = pushBack(imageList, wxArtProvider::GetBitmapBundle("xlART_CANE_ICON", wxART_LIST));
@@ -56,9 +57,12 @@ namespace LayoutUtils
         CreateImageList(imageList, idxs);
     }
 
-    int GetModelTreeIcon(std::string const& type, GroupMode mode)
+    int GetModelTreeIcon(std::string const& type, GroupMode mode, bool orgGroup)
     {
         if (type == "ModelGroup") {
+            if (orgGroup == true) {
+                return Icon_OrgGroup;
+            }
             if (mode == GroupMode::Opened) {
                 return Icon_FolderOpened;
             }

--- a/xLights/LayoutUtils.h
+++ b/xLights/LayoutUtils.h
@@ -22,6 +22,7 @@ namespace LayoutUtils
         Icon_File,
         Icon_FolderClosed,
         Icon_FolderOpened,
+        Icon_OrgGroup,
         Icon_Group,
         Icon_Arches,
         Icon_CandyCane,
@@ -53,6 +54,6 @@ namespace LayoutUtils
 
     void CreateImageList(wxVector<wxBitmapBundle> & imageList);
     void CreateImageList(wxVector<wxBitmapBundle> & imageList, std::map<int, int> &remap);
-    int GetModelTreeIcon(std::string const& type, GroupMode mode);
+    int GetModelTreeIcon(std::string const& type, GroupMode mode, bool orgGroup = false);
 
 };

--- a/xLights/ModelGroupPanel.cpp
+++ b/xLights/ModelGroupPanel.cpp
@@ -85,38 +85,39 @@ public:
 };
 
 //(*IdInit(ModelGroupPanel)
-const long ModelGroupPanel::ID_STATICTEXT5 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT6 = wxNewId();
-const long ModelGroupPanel::ID_CHOICE1 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT12 = wxNewId();
-const long ModelGroupPanel::ID_CHOICE2 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT4 = wxNewId();
-const long ModelGroupPanel::ID_SPINCTRL1 = wxNewId();
-const long ModelGroupPanel::ID_CHOICE_PREVIEWS = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT7 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT10 = wxNewId();
-const long ModelGroupPanel::ID_SPINCTRL2 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT11 = wxNewId();
-const long ModelGroupPanel::ID_SPINCTRL3 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT8 = wxNewId();
-const long ModelGroupPanel::ID_COLOURPICKERCTRL_MG_TAGCOLOUR = wxNewId();
-const long ModelGroupPanel::ID_BUTTON2 = wxNewId();
-const long ModelGroupPanel::ID_CHECKBOX1 = wxNewId();
-const long ModelGroupPanel::ID_CHECKBOX3 = wxNewId();
-const long ModelGroupPanel::ID_CHECKBOX2 = wxNewId();
-const long ModelGroupPanel::ID_CHECKBOX4 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT3 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT2 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT9 = wxNewId();
-const long ModelGroupPanel::ID_TEXTCTRL1 = wxNewId();
-const long ModelGroupPanel::ID_BUTTON1 = wxNewId();
-const long ModelGroupPanel::ID_LISTCTRL1 = wxNewId();
-const long ModelGroupPanel::ID_BITMAPBUTTON4 = wxNewId();
-const long ModelGroupPanel::ID_BITMAPBUTTON3 = wxNewId();
-const long ModelGroupPanel::ID_BITMAPBUTTON1 = wxNewId();
-const long ModelGroupPanel::ID_BITMAPBUTTON2 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT1 = wxNewId();
-const long ModelGroupPanel::ID_LISTCTRL2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT5 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT6 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHOICE1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT12 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHOICE2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT4 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_SPINCTRL1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHOICE_PREVIEWS = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT7 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT10 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_SPINCTRL2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT11 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_SPINCTRL3 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT8 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_COLOURPICKERCTRL_MG_TAGCOLOUR = wxNewId();
+const wxWindowID ModelGroupPanel::ID_BUTTON2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHECKBOX5 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHECKBOX1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHECKBOX3 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHECKBOX2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHECKBOX4 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT3 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT9 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_TEXTCTRL1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_BUTTON1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_LISTCTRL1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_BITMAPBUTTON4 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_BITMAPBUTTON3 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_BITMAPBUTTON1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_BITMAPBUTTON2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_LISTCTRL2 = wxNewId();
 //*)
 
 const long ModelGroupPanel::ID_MNU_CLEARALL = wxNewId();
@@ -195,12 +196,12 @@ ModelGroupPanel::ModelGroupPanel(wxWindow* parent, ModelManager &Models, LayoutP
 	FlexGridSizer4 = new wxFlexGridSizer(0, 4, 0, 0);
 	StaticText10 = new wxStaticText(this, ID_STATICTEXT10, _("X"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT10"));
 	FlexGridSizer4->Add(StaticText10, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	SpinCtrl_XCentreOffset = new wxSpinCtrl(this, ID_SPINCTRL2, _T("0"), wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER, -5000, 5000, 0, _T("ID_SPINCTRL2"));
+	SpinCtrl_XCentreOffset = new wxSpinCtrl(this, ID_SPINCTRL2, _T("0"), wxDefaultPosition, wxDefaultSize, 0, -5000, 5000, 0, _T("ID_SPINCTRL2"));
 	SpinCtrl_XCentreOffset->SetValue(_T("0"));
 	FlexGridSizer4->Add(SpinCtrl_XCentreOffset, 1, wxALL|wxEXPAND, 2);
 	StaticText11 = new wxStaticText(this, ID_STATICTEXT11, _("Y"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT11"));
 	FlexGridSizer4->Add(StaticText11, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
-	SpinCtrl_YCentreOffset = new wxSpinCtrl(this, ID_SPINCTRL3, _T("0"), wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER, -5000, 5000, 0, _T("ID_SPINCTRL3"));
+	SpinCtrl_YCentreOffset = new wxSpinCtrl(this, ID_SPINCTRL3, _T("0"), wxDefaultPosition, wxDefaultSize, 0, -5000, 5000, 0, _T("ID_SPINCTRL3"));
 	SpinCtrl_YCentreOffset->SetValue(_T("0"));
 	FlexGridSizer4->Add(SpinCtrl_YCentreOffset, 1, wxALL|wxEXPAND, 2);
 	FlexGridSizer6->Add(FlexGridSizer4, 1, wxALL|wxEXPAND, 5);
@@ -211,6 +212,10 @@ ModelGroupPanel::ModelGroupPanel(wxWindow* parent, ModelManager &Models, LayoutP
 	FlexGridSizer5->Add(ColourPickerCtrl_ModelGroupTagColour, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
 	ButtonAliases = new wxButton(this, ID_BUTTON2, _("Aliases"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON2"));
 	FlexGridSizer5->Add(ButtonAliases, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	Checkbox_OrgGroup = new wxCheckBox(this, ID_CHECKBOX5, _("Group Folder"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX5"));
+	Checkbox_OrgGroup->SetValue(false);
+	Checkbox_OrgGroup->SetToolTip(_("Group of groups/folders to clean-up and reduce the number of items in the model/group list, especially for those with large number of submodel groups."));
+	FlexGridSizer5->Add(Checkbox_OrgGroup, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	FlexGridSizer6->Add(FlexGridSizer5, 1, wxALL|wxEXPAND, 5);
 	CheckBox_ShowSubmodels = new wxCheckBox(this, ID_CHECKBOX1, _("Show SubModels to Add"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX1"));
 	CheckBox_ShowSubmodels->SetValue(true);
@@ -270,35 +275,34 @@ ModelGroupPanel::ModelGroupPanel(wxWindow* parent, ModelManager &Models, LayoutP
 	FlexGridSizer3->Add(FlexGridSizer12, 1, wxALL|wxEXPAND, 0);
 	Panel_Sizer->Add(FlexGridSizer3, 0, wxEXPAND, 0);
 	SetSizer(Panel_Sizer);
-	Panel_Sizer->Fit(this);
-	Panel_Sizer->SetSizeHints(this);
 
-	Connect(ID_CHOICE1,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnChoiceModelLayoutTypeSelect);
-	Connect(ID_CHOICE2,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnChoice_DefaultCameraSelect);
-	Connect(ID_SPINCTRL1,wxEVT_COMMAND_SPINCTRL_UPDATED,(wxObjectEventFunction)&ModelGroupPanel::OnSizeSpinCtrlChange);
-	Connect(ID_CHOICE_PREVIEWS,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnChoicePreviewsSelect);
-	Connect(ID_SPINCTRL2,wxEVT_COMMAND_SPINCTRL_UPDATED,(wxObjectEventFunction)&ModelGroupPanel::OnSpinCtrl_XCentreOffsetChange);
-	Connect(ID_SPINCTRL3,wxEVT_COMMAND_SPINCTRL_UPDATED,(wxObjectEventFunction)&ModelGroupPanel::OnSpinCtrl_YCentreOffsetChange);
-	Connect(ID_COLOURPICKERCTRL_MG_TAGCOLOUR,wxEVT_COMMAND_COLOURPICKER_CHANGED,(wxObjectEventFunction)&ModelGroupPanel::OnColourPickerCtrl_ModelGroupTagColourColourChanged);
-	Connect(ID_BUTTON2,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnButtonAliasesClick);
-	Connect(ID_CHECKBOX1,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowSubmodelsClick);
-	Connect(ID_CHECKBOX3,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowInactiveModelsClick);
-	Connect(ID_CHECKBOX2,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowModelGroupsClick);
-	Connect(ID_CHECKBOX4,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowOnlyModelsInCurrentViewClick);
-	Connect(ID_TEXTCTRL1,wxEVT_COMMAND_TEXT_UPDATED,(wxObjectEventFunction)&ModelGroupPanel::OnTextCtrl_FilterText);
-	Connect(ID_BUTTON1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnButtonClearFilterClick);
-	Connect(ID_LISTCTRL1,wxEVT_COMMAND_LIST_BEGIN_DRAG,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupBeginDrag);
-	Connect(ID_LISTCTRL1,wxEVT_COMMAND_LIST_ITEM_SELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupItemSelect);
-	Connect(ID_LISTCTRL1,wxEVT_COMMAND_LIST_ITEM_DESELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupItemDeselect);
-	Connect(ID_LISTCTRL1,wxEVT_COMMAND_LIST_ITEM_ACTIVATED,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupItemActivated);
-	Connect(ID_BITMAPBUTTON4,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnButtonAddToModelGroupClick);
-	Connect(ID_BITMAPBUTTON3,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnButtonRemoveFromModelGroupClick);
-	Connect(ID_BITMAPBUTTON1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnButtonUpClick);
-	Connect(ID_BITMAPBUTTON2,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnButtonDownClick);
-	Connect(ID_LISTCTRL2,wxEVT_COMMAND_LIST_BEGIN_DRAG,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupBeginDrag);
-	Connect(ID_LISTCTRL2,wxEVT_COMMAND_LIST_ITEM_SELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemSelect);
-	Connect(ID_LISTCTRL2,wxEVT_COMMAND_LIST_ITEM_DESELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemDeselect);
-	Connect(ID_LISTCTRL2,wxEVT_COMMAND_LIST_ITEM_ACTIVATED,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemActivated);
+	Connect(ID_CHOICE1, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnChoiceModelLayoutTypeSelect);
+	Connect(ID_CHOICE2, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnChoice_DefaultCameraSelect);
+	Connect(ID_SPINCTRL1, wxEVT_COMMAND_SPINCTRL_UPDATED, (wxObjectEventFunction)&ModelGroupPanel::OnSizeSpinCtrlChange);
+	Connect(ID_CHOICE_PREVIEWS, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnChoicePreviewsSelect);
+	Connect(ID_SPINCTRL2, wxEVT_COMMAND_SPINCTRL_UPDATED, (wxObjectEventFunction)&ModelGroupPanel::OnSpinCtrl_XCentreOffsetChange);
+	Connect(ID_SPINCTRL3, wxEVT_COMMAND_SPINCTRL_UPDATED, (wxObjectEventFunction)&ModelGroupPanel::OnSpinCtrl_YCentreOffsetChange);
+	Connect(ID_COLOURPICKERCTRL_MG_TAGCOLOUR, wxEVT_COMMAND_COLOURPICKER_CHANGED, (wxObjectEventFunction)&ModelGroupPanel::OnColourPickerCtrl_ModelGroupTagColourColourChanged);
+	Connect(ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnButtonAliasesClick);
+	Connect(ID_CHECKBOX5, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnCheckbox_OrgGroupClick);
+	Connect(ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowSubmodelsClick);
+	Connect(ID_CHECKBOX3, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowInactiveModelsClick);
+	Connect(ID_CHECKBOX2, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowModelGroupsClick);
+	Connect(ID_CHECKBOX4, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowOnlyModelsInCurrentViewClick);
+	Connect(ID_TEXTCTRL1, wxEVT_COMMAND_TEXT_UPDATED, (wxObjectEventFunction)&ModelGroupPanel::OnTextCtrl_FilterText);
+	Connect(ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnButtonClearFilterClick);
+	Connect(ID_LISTCTRL1, wxEVT_COMMAND_LIST_BEGIN_DRAG, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupBeginDrag);
+	Connect(ID_LISTCTRL1, wxEVT_COMMAND_LIST_ITEM_SELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupItemSelect);
+	Connect(ID_LISTCTRL1, wxEVT_COMMAND_LIST_ITEM_DESELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupItemDeselect);
+	Connect(ID_LISTCTRL1, wxEVT_COMMAND_LIST_ITEM_ACTIVATED, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupItemActivated);
+	Connect(ID_BITMAPBUTTON4, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnButtonAddToModelGroupClick);
+	Connect(ID_BITMAPBUTTON3, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnButtonRemoveFromModelGroupClick);
+	Connect(ID_BITMAPBUTTON1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnButtonUpClick);
+	Connect(ID_BITMAPBUTTON2, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnButtonDownClick);
+	Connect(ID_LISTCTRL2, wxEVT_COMMAND_LIST_BEGIN_DRAG, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupBeginDrag);
+	Connect(ID_LISTCTRL2, wxEVT_COMMAND_LIST_ITEM_SELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemSelect);
+	Connect(ID_LISTCTRL2, wxEVT_COMMAND_LIST_ITEM_DESELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemDeselect);
+	Connect(ID_LISTCTRL2, wxEVT_COMMAND_LIST_ITEM_ACTIVATED, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemActivated);
 	//*)
 
     Connect(ID_LISTCTRL2, wxEVT_CONTEXT_MENU, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemRClick);
@@ -523,6 +527,7 @@ void ModelGroupPanel::UpdatePanel(const std::string& group)
         SpinCtrl_XCentreOffset->SetValue(wxAtoi(e->GetAttribute("XCentreOffset", "0")));
         SpinCtrl_YCentreOffset->SetValue(wxAtoi(e->GetAttribute("YCentreOffset", "0")));
         ColourPickerCtrl_ModelGroupTagColour->SetColour(e->GetAttribute("TagColour", "Black"));
+        Checkbox_OrgGroup->SetValue(e->GetAttribute("OrgGroup", "0") == "1");
     }
 
     ResizeColumns();
@@ -763,6 +768,8 @@ void ModelGroupPanel::SaveGroupChanges(bool centreUpdate)
         break;
     }
     e->AddAttribute("TagColour", ColourPickerCtrl_ModelGroupTagColour->GetColour().GetAsString());
+    e->DeleteAttribute("OrgGroup");
+    e->AddAttribute("OrgGroup", wxString::Format("%d",Checkbox_OrgGroup->IsChecked()));
     g->Reset();
     layoutPanel->ModelGroupUpdated(g);
 }
@@ -1441,4 +1448,9 @@ void ModelGroupPanel::OnSpinCtrlTextEnter(wxCommandEvent& evt)
 {
     wxWindow* win = dynamic_cast<wxWindow*>(evt.GetEventObject());
     win->Navigate();
+}
+
+void ModelGroupPanel::OnCheckbox_OrgGroupClick(wxCommandEvent& event)
+{
+    SaveGroupChanges();
 }

--- a/xLights/ModelGroupPanel.h
+++ b/xLights/ModelGroupPanel.h
@@ -71,6 +71,7 @@ public:
 	wxCheckBox* CheckBox_ShowModelGroups;
 	wxCheckBox* CheckBox_ShowOnlyModelsInCurrentView;
 	wxCheckBox* CheckBox_ShowSubmodels;
+	wxCheckBox* Checkbox_OrgGroup;
 	wxChoice* ChoiceModelLayoutType;
 	wxChoice* ChoicePreviews;
 	wxChoice* Choice_DefaultCamera;
@@ -99,38 +100,39 @@ public:
 protected:
 
 	//(*Identifiers(ModelGroupPanel)
-	static const long ID_STATICTEXT5;
-	static const long ID_STATICTEXT6;
-	static const long ID_CHOICE1;
-	static const long ID_STATICTEXT12;
-	static const long ID_CHOICE2;
-	static const long ID_STATICTEXT4;
-	static const long ID_SPINCTRL1;
-	static const long ID_CHOICE_PREVIEWS;
-	static const long ID_STATICTEXT7;
-	static const long ID_STATICTEXT10;
-	static const long ID_SPINCTRL2;
-	static const long ID_STATICTEXT11;
-	static const long ID_SPINCTRL3;
-	static const long ID_STATICTEXT8;
-	static const long ID_COLOURPICKERCTRL_MG_TAGCOLOUR;
-	static const long ID_BUTTON2;
-	static const long ID_CHECKBOX1;
-	static const long ID_CHECKBOX3;
-	static const long ID_CHECKBOX2;
-	static const long ID_CHECKBOX4;
-	static const long ID_STATICTEXT3;
-	static const long ID_STATICTEXT2;
-	static const long ID_STATICTEXT9;
-	static const long ID_TEXTCTRL1;
-	static const long ID_BUTTON1;
-	static const long ID_LISTCTRL1;
-	static const long ID_BITMAPBUTTON4;
-	static const long ID_BITMAPBUTTON3;
-	static const long ID_BITMAPBUTTON1;
-	static const long ID_BITMAPBUTTON2;
-	static const long ID_STATICTEXT1;
-	static const long ID_LISTCTRL2;
+	static const wxWindowID ID_STATICTEXT5;
+	static const wxWindowID ID_STATICTEXT6;
+	static const wxWindowID ID_CHOICE1;
+	static const wxWindowID ID_STATICTEXT12;
+	static const wxWindowID ID_CHOICE2;
+	static const wxWindowID ID_STATICTEXT4;
+	static const wxWindowID ID_SPINCTRL1;
+	static const wxWindowID ID_CHOICE_PREVIEWS;
+	static const wxWindowID ID_STATICTEXT7;
+	static const wxWindowID ID_STATICTEXT10;
+	static const wxWindowID ID_SPINCTRL2;
+	static const wxWindowID ID_STATICTEXT11;
+	static const wxWindowID ID_SPINCTRL3;
+	static const wxWindowID ID_STATICTEXT8;
+	static const wxWindowID ID_COLOURPICKERCTRL_MG_TAGCOLOUR;
+	static const wxWindowID ID_BUTTON2;
+	static const wxWindowID ID_CHECKBOX5;
+	static const wxWindowID ID_CHECKBOX1;
+	static const wxWindowID ID_CHECKBOX3;
+	static const wxWindowID ID_CHECKBOX2;
+	static const wxWindowID ID_CHECKBOX4;
+	static const wxWindowID ID_STATICTEXT3;
+	static const wxWindowID ID_STATICTEXT2;
+	static const wxWindowID ID_STATICTEXT9;
+	static const wxWindowID ID_TEXTCTRL1;
+	static const wxWindowID ID_BUTTON1;
+	static const wxWindowID ID_LISTCTRL1;
+	static const wxWindowID ID_BITMAPBUTTON4;
+	static const wxWindowID ID_BITMAPBUTTON3;
+	static const wxWindowID ID_BITMAPBUTTON1;
+	static const wxWindowID ID_BITMAPBUTTON2;
+	static const wxWindowID ID_STATICTEXT1;
+	static const wxWindowID ID_LISTCTRL2;
 	//*)
 
 	static const long ID_MNU_CLEARALL;
@@ -173,6 +175,7 @@ private:
 	void OnColourPickerCtrl_ModelGroupTagColourColourChanged(wxColourPickerEvent& event);
 	void OnChoice_DefaultCameraSelect(wxCommandEvent& event);
 	void OnButtonAliasesClick(wxCommandEvent& event);
+	void OnCheckbox_OrgGroupClick(wxCommandEvent& event);
 	//*)
 
 	DECLARE_EVENT_TABLE()

--- a/xLights/models/ModelGroup.cpp
+++ b/xLights/models/ModelGroup.cpp
@@ -543,6 +543,7 @@ bool ModelGroup::Reset(bool zeroBased) {
     this->zeroBased = zeroBased;
     selected = false;
     name = ModelXml->GetAttribute("name").Trim(true).Trim(false).ToStdString();
+    orgGroup = wxAtoi(ModelXml->GetAttribute("OrgGroup", "false"));
 
     DisplayAs = "ModelGroup";
     StringType = "RGB Nodes";

--- a/xLights/models/ModelGroup.h
+++ b/xLights/models/ModelGroup.h
@@ -42,6 +42,7 @@ class ModelGroup : public ModelWithScreenLocation<BoxedScreenLocation>
         void SetXCentreOffset( float cx );
         void SetYCentreOffset( float cy );
         std::string GetDefaultCamera() const;
+        bool IsOrgGroup() const { return orgGroup;}
 
         bool IsSelected() const { return selected;}
         const std::vector<std::string> &ModelNames() const { return modelNames;}
@@ -102,5 +103,6 @@ class ModelGroup : public ModelWithScreenLocation<BoxedScreenLocation>
         bool centreDefined = false;
         float centrex;
         float centrey;
+        bool orgGroup = false;
 };
 

--- a/xLights/sequencer/EffectsGrid.cpp
+++ b/xLights/sequencer/EffectsGrid.cpp
@@ -1175,7 +1175,7 @@ bool EffectsGrid::DragOver(int x, int y) {
     Model* m = mSequenceElements->GetXLightsFrame()->AllModels[ri->element->GetModelName()];
     ModelGroup* mg = dynamic_cast<ModelGroup*>(m);
 
-    if (row < mSequenceElements->GetVisibleRowInformationSize() && (mg != nullptr && !mg->IsOrgGroup())) {
+    if (row < mSequenceElements->GetVisibleRowInformationSize() && (mg == nullptr || !mg->IsOrgGroup())) {
         int effectIndex;
         HitLocation selectionType;
         int time = mTimeline->GetRawTimeMSfromPosition(x);

--- a/xLights/sequencer/RowHeading.h
+++ b/xLights/sequencer/RowHeading.h
@@ -74,6 +74,7 @@ private:
     wxBitmapBundle fppCommand_icon;
     wxBitmapBundle fppEffect_icon;
     wxBitmapBundle model_group_icon;
+    wxBitmapBundle model_orggroup_icon;
     
     int mSelectedRow = -1;
     SequenceElements* mSequenceElements = nullptr;

--- a/xLights/wxsmith/ModelGroupPanel.wxs
+++ b/xLights/wxsmith/ModelGroupPanel.wxs
@@ -200,6 +200,16 @@
 										<border>5</border>
 										<option>1</option>
 									</object>
+									<object class="sizeritem">
+										<object class="wxCheckBox" name="ID_CHECKBOX5" variable="Checkbox_OrgGroup" member="yes">
+											<label>Group Folder</label>
+											<tooltip>Group of groups/folders to clean-up and reduce the number of items in the model/group list, especially for those with large number of submodel groups.</tooltip>
+											<handler function="OnCheckbox_OrgGroupClick" entry="EVT_CHECKBOX" />
+										</object>
+										<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
 								</object>
 								<flag>wxALL|wxEXPAND</flag>
 								<border>5</border>

--- a/xLights/xLightsImportChannelMapDialog.cpp
+++ b/xLights/xLightsImportChannelMapDialog.cpp
@@ -851,7 +851,8 @@ bool xLightsImportChannelMapDialog::InitImport(std::string checkboxText) {
             Element* e = mSequenceElements->GetElement(i);
 
             Model *m = xlights->GetModel(e->GetName());
-            if (m != nullptr) {
+            ModelGroup* mg = dynamic_cast<ModelGroup*>(m);
+            if ((mg == nullptr || !mg->IsOrgGroup())) {
                 AddModel(m, ms);
             }
         }


### PR DESCRIPTION
This allows users to group multiple folders under one better organize the layout tab. It will not allow effects to be placed on it, copied over it or moved to it.  Import Effects will also skip displayting this group, however embeded groups will still display as normal.

![image](https://github.com/user-attachments/assets/7e04dc51-72dd-460d-84ac-2641f32eb591)

![image](https://github.com/user-attachments/assets/3c0c3c4f-4b34-47e8-82da-cf350830f95b)
