### PR TITLE
Add Status display for all controllers

### DIFF
--- a/xLights/TabSetup.cpp
+++ b/xLights/TabSetup.cpp
@@ -17,6 +17,7 @@
 #include <wx/artprov.h>
 #include <wx/propgrid/propgrid.h>
 #include <wx/propgrid/advprops.h>
+#include <wx/thread.h>
 
 #include "xLightsMain.h"
 #include "LayoutPanel.h"
@@ -60,6 +61,25 @@
 #include "../xFade/wxLED.h"
 
 #include <log4cpp/Category.hh>
+
+// Thread class to ping a single controller
+class ControllerPingThread : public wxThread {
+public:
+    ControllerPingThread(Controller* controller) :
+        wxThread(wxTHREAD_DETACHED), _controller(controller) {
+    }
+
+protected:
+    virtual ExitCode Entry() override {
+        if (_controller && _controller->IsActive()) {
+            _controller->Ping();
+        }
+        return (ExitCode)0;
+    }
+
+private:
+    Controller* _controller;
+};
 
 const long xLightsFrame::ID_List_Controllers = wxNewId();
 const long xLightsFrame::ID_NETWORK_ADDETHERNET = wxNewId();
@@ -1576,6 +1596,46 @@ void xLightsFrame::OnButtonAddControllerNullClick(wxCommandEvent& event) {
 }
 #pragma endregion
 
+wxBitmap xLightsFrame::CreateLedBitmap(bool online) {
+    wxBitmap bitmap(8, 8);
+    wxMemoryDC dc(bitmap);
+    dc.SetBrush(online ? *wxGREEN_BRUSH : *wxRED_BRUSH);
+    dc.SetPen(*wxTRANSPARENT_PEN);
+    dc.DrawCircle(4, 4, 4);
+    dc.SelectObject(wxNullBitmap);
+    return bitmap;
+}
+
+void xLightsFrame::OnPingTimer(wxTimerEvent& event) {
+    if (Notebook1->GetSelection() != SETUPTAB || _pingInProgress) {
+        return;
+    }
+    _pingInProgress = true;
+    for (int row = 0; row < List_Controllers->GetItemCount(); ++row) {
+        auto controller = dynamic_cast<Controller*>(_outputManager.GetController(List_Controllers->GetItemText(row, 0).ToStdString()));
+        if (controller != nullptr && controller->IsActive()) {
+            ControllerPingThread* thread = new ControllerPingThread(controller);
+            thread->Run();
+        }
+    }
+    _pingInProgress = false;
+    StatusRefreshTimer(event);
+}
+
+void xLightsFrame::StatusRefreshTimer(wxTimerEvent& event) {
+    if (Notebook1->GetSelection() == SETUPTAB) {
+        List_Controllers->Freeze();
+        for (int row = 0; row < List_Controllers->GetItemCount(); ++row) {
+            auto controller = dynamic_cast<Controller*>(_outputManager.GetController(List_Controllers->GetItemText(row, 0).ToStdString()));
+            if (controller != nullptr && controller->IsActive()) {
+                int imageIndex = (controller->GetLastPingState() == Output::PINGSTATE::PING_OK || controller->GetLastPingState() == Output::PINGSTATE::PING_WEBOK) ? 0 : 1;
+                List_Controllers->SetItem(row, 12, "", imageIndex);
+            }
+        }
+        List_Controllers->Thaw();
+    }
+}
+
 void xLightsFrame::InitialiseControllersTab(bool rebuildPropGrid) {
     inInitialize = true;
     // create the checked tree control
@@ -1592,7 +1652,13 @@ void xLightsFrame::InitialiseControllersTab(bool rebuildPropGrid) {
         Connect(ID_List_Controllers, wxEVT_LIST_BEGIN_DRAG, (wxObjectEventFunction)&xLightsFrame::OnListItemBeginDragControllers);
         Connect(ID_List_Controllers, wxEVT_LIST_ITEM_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnListItemSelectedControllers);
 
-        List_Controllers->AppendColumn("Name");
+        // Create image list with actual LED bitmaps
+        wxImageList* imageList = new wxImageList(8, 8, true, 2);
+        imageList->Add(CreateLedBitmap(true));
+        imageList->Add(CreateLedBitmap(false));
+        List_Controllers->AssignImageList(imageList, wxIMAGE_LIST_SMALL);
+
+        List_Controllers->AppendColumn("   Name");
         List_Controllers->AppendColumn("Protocol");
         List_Controllers->AppendColumn("Address");
         List_Controllers->AppendColumn("Universes/Id");
@@ -1604,11 +1670,12 @@ void xLightsFrame::InitialiseControllersTab(bool rebuildPropGrid) {
         List_Controllers->AppendColumn("Auto Layout");
         List_Controllers->AppendColumn("Auto Size");
         List_Controllers->AppendColumn("Description");
+        List_Controllers->AppendColumn("Status", wxLIST_FORMAT_LEFT, _controllerPingInterval >0 ? 45 : 0);
 
         wxConfigBase* config = wxConfigBase::Get();
         if (config != nullptr) {
             wxString co;
-            config->Read("ControllerTabColumnOrder", &co, "0,1,2,3,4,5,6,7,8,9,10,11");
+            config->Read("ControllerTabColumnOrder", &co, "0,1,2,3,4,5,6,7,8,9,10,11,12");
             wxArrayString tokens = wxSplit(co, ',');
             wxArrayInt controllerTabColumns;
             for (const auto& token : tokens) {
@@ -1617,6 +1684,7 @@ void xLightsFrame::InitialiseControllersTab(bool rebuildPropGrid) {
                     controllerTabColumns.Add(static_cast<int>(value));
                 }
             }
+            if (controllerTabColumns.size() != 13) controllerTabColumns.Add(13);
             List_Controllers->SetColumnsOrder(controllerTabColumns);
         }
 
@@ -1659,7 +1727,7 @@ void xLightsFrame::InitialiseControllersTab(bool rebuildPropGrid) {
 
     // Reload the list
     for (const auto& it : _outputManager.GetControllers()) {
-        int row = List_Controllers->InsertItem(List_Controllers->GetItemCount(), it->GetName());
+        int row = List_Controllers->InsertItem(List_Controllers->GetItemCount(), it->GetName(), -1);
         if (std::find(begin(selections), end(selections), it->GetName()) != selections.end()) {
             List_Controllers->SetItemState(row, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
         }
@@ -1685,6 +1753,10 @@ void xLightsFrame::InitialiseControllersTab(bool rebuildPropGrid) {
         else if (!it->IsActive()) {
             List_Controllers->SetItemTextColour(row, *wxLIGHT_GREY);
         }
+        if (it->IsActive() && _controllerPingInterval > 0) {
+            int imageIndex = (it->GetLastPingState() == Output::PINGSTATE::PING_OK || it->GetLastPingState() == Output::PINGSTATE::PING_WEBOK) ? 0 : 1;
+            List_Controllers->SetItem(row, 12, "", imageIndex);
+        }
     }
 
     auto sz = 0;
@@ -1694,7 +1766,7 @@ void xLightsFrame::InitialiseControllersTab(bool rebuildPropGrid) {
         sz += List_Controllers->GetColumnWidth(i);
     }
 
-    int lc = List_Controllers->GetColumnCount() - 1;
+    int lc = List_Controllers->GetColumnCount() - 2;
     List_Controllers->SetColumnWidth(lc, wxLIST_AUTOSIZE_USEHEADER);
     if (List_Controllers->GetColumnWidth(lc) < 100) List_Controllers->SetColumnWidth(lc, 100);
 

--- a/xLights/preferences/OtherSettingsPanel.cpp
+++ b/xLights/preferences/OtherSettingsPanel.cpp
@@ -56,6 +56,8 @@ const wxWindowID OtherSettingsPanel::ID_STATICTEXT6 = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_CHOICE_ALIASPROMPT = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_TEXTCTRL1 = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_CHECKBOX9 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_STATICTEXT7 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CTRLPINGINTERVAL = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(OtherSettingsPanel,wxPanel)
@@ -74,6 +76,7 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     wxFlexGridSizer* FlexGridSizer5;
     wxFlexGridSizer* FlexGridSizer6;
     wxFlexGridSizer* FlexGridSizer7;
+    wxFlexGridSizer* FlexGridSizer8;
     wxGridBagSizer* GridBagSizer1;
     wxGridBagSizer* GridBagSizer2;
     wxStaticBoxSizer* StaticBoxSizer1;
@@ -171,7 +174,7 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     FlexGridSizer5->Add(Choice_LinkControllerUpload, 1, wxALL|wxEXPAND, 5);
     GridBagSizer1->Add(FlexGridSizer5, wxGBPosition(7, 0), wxDefaultSpan, wxALL|wxEXPAND, 0);
     FlexGridSizer7 = new wxFlexGridSizer(0, 2, 0, 0);
-    StaticText7 = new wxStaticText(this, ID_STATICTEXT6, _("Model renaming alias behavior"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT6"));
+    StaticText7 = new wxStaticText(this, ID_STATICTEXT6, _("Model renaming alias behavior:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT6"));
     FlexGridSizer7->Add(StaticText7, 1, wxALL|wxEXPAND, 5);
     Choice_AliasPromptBehavior = new wxChoice(this, ID_CHOICE_ALIASPROMPT, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_ALIASPROMPT"));
     Choice_AliasPromptBehavior->SetSelection( Choice_AliasPromptBehavior->Append(_("Always Prompt")) );
@@ -189,6 +192,14 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     GPURenderCheckbox->SetValue(true);
     GPURenderCheckbox->SetToolTip(_("Some effects can be rendered on the GPU if this is enabled."));
     GridBagSizer1->Add(GPURenderCheckbox, wxGBPosition(2, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    FlexGridSizer8 = new wxFlexGridSizer(0, 2, 0, 0);
+    FlexGridSizer8->AddGrowableCol(1);
+    StaticText8 = new wxStaticText(this, ID_STATICTEXT7, _("Controller ping interval in seconds (0=Off):"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT7"));
+    FlexGridSizer8->Add(StaticText8, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    CtrlPingInterval = new wxSpinCtrlDouble(this, ID_CTRLPINGINTERVAL, _T("0"), wxDefaultPosition, wxDefaultSize, 0, 0, 300, 0, 10, _T("ID_CTRLPINGINTERVAL"));
+    CtrlPingInterval->SetValue(_T("0"));
+    FlexGridSizer8->Add(CtrlPingInterval, 1, wxALL|wxEXPAND, 5);
+    GridBagSizer1->Add(FlexGridSizer8, wxGBPosition(10, 0), wxDefaultSpan, wxALL, 0);
     SetSizer(GridBagSizer1);
 
     Connect(ID_CHOICE1, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
@@ -209,6 +220,7 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     Connect(ID_TEXTCTRL1, wxEVT_COMMAND_TEXT_UPDATED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
     Connect(ID_TEXTCTRL1, wxEVT_COMMAND_TEXT_ENTER, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
     Connect(ID_CHECKBOX9, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CTRLPINGINTERVAL, wxEVT_SPINCTRLDOUBLE, (wxObjectEventFunction)&OtherSettingsPanel::OnSpinCtrlDoubleBitrateChange);
     Connect(wxEVT_PAINT, (wxObjectEventFunction)&OtherSettingsPanel::OnPaint);
     //*)
 
@@ -253,6 +265,7 @@ bool OtherSettingsPanel::TransferDataFromWindow() {
     frame->SetRenameModelAliasPromptBehavior(Choice_AliasPromptBehavior->GetStringSelection());
 	frame->SetPromptBatchRenderIssues(CheckBox_BatchRenderPromptIssues->GetValue());
 	frame->SetIgnoreVendorModelRecommendations(CheckBox_IgnoreVendorModelRecommendations->GetValue());
+    frame->SetControllerPingInterval(CtrlPingInterval->GetValue());
 	frame->SetPurgeDownloadCacheOnStart(CheckBox_PurgeDownloadCache->GetValue());
     frame->SetVideoExportCodec(ChoiceCodec->GetStringSelection());
     frame->SetVideoExportBitrate(SpinCtrlDoubleBitrate->GetValue());
@@ -277,6 +290,7 @@ bool OtherSettingsPanel::TransferDataToWindow() {
     Choice_AliasPromptBehavior->SetStringSelection(frame->GetRenameModelAliasPromptBehavior());
 	CheckBox_BatchRenderPromptIssues->SetValue(frame->GetPromptBatchRenderIssues());
 	CheckBox_IgnoreVendorModelRecommendations->SetValue(frame->GetIgnoreVendorModelRecommendations());
+    CtrlPingInterval->SetValue(frame->GetControllerPingInterval());
 	CheckBox_PurgeDownloadCache->SetValue(frame->GetPurgeDownloadCacheOnStart());
     ChoiceCodec->SetStringSelection(frame->GetVideoExportCodec());
     SpinCtrlDoubleBitrate->SetValue(frame->GetVideoExportBitrate());

--- a/xLights/preferences/OtherSettingsPanel.h
+++ b/xLights/preferences/OtherSettingsPanel.h
@@ -48,6 +48,7 @@ class OtherSettingsPanel: public wxPanel
 		wxChoice* Choice_LinkSave;
 		wxChoice* Choice_MinTipLevel;
 		wxChoice* HardwareVideoRenderChoice;
+		wxSpinCtrlDouble* CtrlPingInterval;
 		wxSpinCtrlDouble* SpinCtrlDoubleBitrate;
 		wxStaticText* StaticText2;
 		wxStaticText* StaticText3;
@@ -55,6 +56,7 @@ class OtherSettingsPanel: public wxPanel
 		wxStaticText* StaticText5;
 		wxStaticText* StaticText6;
 		wxStaticText* StaticText7;
+		wxStaticText* StaticText8;
 		wxTextCtrl* eMailTextControl;
 		//*)
 
@@ -87,6 +89,8 @@ class OtherSettingsPanel: public wxPanel
 		static const wxWindowID ID_CHOICE_ALIASPROMPT;
 		static const wxWindowID ID_TEXTCTRL1;
 		static const wxWindowID ID_CHECKBOX9;
+		static const wxWindowID ID_STATICTEXT7;
+		static const wxWindowID ID_CTRLPINGINTERVAL;
 		//*)
 
 	private:

--- a/xLights/wxsmith/OtherSettingsPanel.wxs
+++ b/xLights/wxsmith/OtherSettingsPanel.wxs
@@ -304,7 +304,7 @@
 					<cols>2</cols>
 					<object class="sizeritem">
 						<object class="wxStaticText" name="ID_STATICTEXT6" variable="StaticText7" member="yes">
-							<label>Model reanaming alias behavior:</label>
+							<label>Model renaming alias behavior:</label>
 						</object>
 						<flag>wxALL|wxEXPAND</flag>
 						<border>5</border>
@@ -370,6 +370,35 @@
 				<row>2</row>
 				<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
 				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxFlexGridSizer" variable="FlexGridSizer8" member="no">
+					<cols>2</cols>
+					<growablecols>1</growablecols>
+					<object class="sizeritem">
+						<object class="wxStaticText" name="ID_STATICTEXT7" variable="StaticText8" member="yes">
+							<label>Controller ping interval in seconds (0=Off):</label>
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxSpinCtrlDouble" name="ID_CTRLPINGINTERVAL" variable="CtrlPingInterval" member="yes">
+							<value>0</value>
+							<max>300.000000</max>
+							<increment>10.000000</increment>
+							<handler function="OnSpinCtrlDoubleBitrateChange" entry="EVT_SPINCTRLDOUBLE" />
+						</object>
+						<flag>wxALL|wxEXPAND</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<col>0</col>
+				<row>10</row>
+				<flag>wxALL</flag>
 				<option>1</option>
 			</object>
 		</object>

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -659,6 +659,9 @@ private :
 	void SetEffectAssistWindowState(bool show);
     void UpdateEffectAssistWindow(Effect* effect, RenderableEffect* ren_effect);
     void AddDebugFilesToReport(wxDebugReport &report);
+    wxTimer* _pingTimer;
+    wxTimer* _statusRefreshTimer;
+    bool _pingInProgress = false;
 
 public:
 
@@ -1122,6 +1125,7 @@ public:
     bool _autoSavePerspecive = true;
     bool _ignoreVendorModelRecommendations = false;
     bool _purgeDownloadCacheOnStart = false;
+    int _controllerPingInterval = 0;
     int _fseqVersion;
     int _timelineZooming;
     bool _wasMaximised = false;
@@ -1262,6 +1266,8 @@ public:
 
     bool GetIgnoreVendorModelRecommendations() const { return _ignoreVendorModelRecommendations; }
     void SetIgnoreVendorModelRecommendations(bool b) { _ignoreVendorModelRecommendations = b; }
+    int GetControllerPingInterval() const { return _controllerPingInterval; }
+    void SetControllerPingInterval(int secs) { _controllerPingInterval = secs; }
     void PurgeDownloadCache();
 
     bool GetPurgeDownloadCacheOnStart() const { return _purgeDownloadCacheOnStart; }
@@ -1384,6 +1390,9 @@ public:
     void SelectController(const std::string& controllerName);
     void UnselectAllControllers();
     void InitialiseControllersTab(bool rebuildPropGrid = true);
+    void OnPingTimer(wxTimerEvent& event);
+    void StatusRefreshTimer(wxTimerEvent& event);
+    wxBitmap CreateLedBitmap(bool online);
     void SetControllersProperties(bool rebuildPropGrid = true);
     void DeleteSelectedControllers();
     void UnlinkSelectedControllers();


### PR DESCRIPTION
Option in Preferences/Other to set an interval ping timer to refresh controller ping status. This is the same status used by the PingLed (still there for now) When disables, it doesn't show.

Added as the last column, but now you can rearrange and save columns so you can put it where you want.
![image](https://github.com/user-attachments/assets/46ebb4fb-653b-4204-8787-f6285cec9fbc)
