### PR TITLE
Fix fadeout for prepare audio

### DIFF
--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -9930,7 +9930,7 @@ void xLightsFrame::OnMenuItem_PrepareAudioSelected(wxCommandEvent& event)
                             } else {
                                 // exponent out
                                 // 1 - log 10 (x/fadeoutsamples +.1)
-                                double f = 1.0 - pow(10.0, ((double)(inputSamples - i) / fadeinsamples - 1.0) - 0.1) * 1.1;
+                                double f = exp(-it.fadeout * (double)(i - fadeoutstart) / fadeoutsamples); // Exponential fade-out
                                 if (f < 0)
                                     f = 0.0;
                                 if (f > 1)


### PR DESCRIPTION
Fadeout wasn't really fading out (use still using fadeinsamples).
Before (top) and after (bottom)
![image](https://github.com/user-attachments/assets/28c48954-f4e0-4381-8c67-0da436a293b9)


Sample xaudio:
<xaudio>
    <targetfile>TestOutFix.mp3</targetfile>
    <items>
       <item>
          <targettime>0.0</targettime>
          <length>10.0</length>
          <sourcetime>30.0</sourcetime>
	  <fadeinsecs>1.5</fadeinsecs>
	  <fadeoutsecs>1.5</fadeoutsecs>
          <gain>1.0</gain>
          <file>Test.mp3</file>
       </item>
    </items>
 </xaudio>