### PR TITLE
#5250 - refresh properties grid with search/found model

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -9113,6 +9113,7 @@ bool LayoutPanel::HandleLayoutKeyBinding(wxKeyEvent& event) {
                     TreeListViewModels->EnsureVisible(nextItem);
                     lastFoundItem = nextItem;
                     found = true;
+                    HandleSelectionChanged();
                     break;
                 }
             }


### PR DESCRIPTION
Force refresh to update the Properties Grid.