### PR TITLE
Check for crash condition #5269

### DIFF
--- a/xLights/outputs/ControllerEthernet.cpp
+++ b/xLights/outputs/ControllerEthernet.cpp
@@ -840,8 +840,11 @@ bool ControllerEthernet::SetChannelSize(int32_t channels, std::list<Model*> mode
         it2->AllOff();
         it2->EndFrame(0);
     }
-    
+
     if (_type == OUTPUT_ZCPP || _type == OUTPUT_DDP || _type == OUTPUT_TWINKLY) {
+        if (_outputs.front() == nullptr) {
+            return false;
+        }
         _outputs.front()->SetChannels(channels);
         return true;
     }
@@ -892,7 +895,8 @@ bool ControllerEthernet::SetChannelSize(int32_t channels, std::list<Model*> mode
         //if required universes is greater than  num of outputs, add needed universes
         int diff = universes - _outputs.size();
         for (int i = 0; i < diff; i++) {
-            auto const lastUsedUniverse = _outputs.back()->GetUniverse();
+            auto lastUsedUniverse = 1;
+            if (_outputs.back() != nullptr) lastUsedUniverse = _outputs.back()->GetUniverse();
             if (_type == OUTPUT_E131) {
                 _outputs.push_back(new E131Output());
                 if (dynamic_cast<E131Output*>(_outputs.back()) != nullptr) {


### PR DESCRIPTION
Resubmission: Not clear how it occurs or if this is the exact crash but here is a couple of safe guards.

There is a check for empty _outputs at the start, I am thinking that the list is initialized but not correct and has pointers to nothing.

Scott, this is currently coded, is this what you were suggesting?
    if (_outputs.size() == 0) return false;