### PR TITLE
Handle IPV6 proxy addresses #3415

### DIFF
--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -272,13 +272,13 @@ bool FPP::GetURLAsString(const std::string& url, std::string& val, bool recordEr
     static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
     static log4cpp::Category& logger_curl = log4cpp::Category::getInstance(std::string("log_curl"));
 
-    std::string fullUrl = ipAddress + url;
+    std::string fullUrl = (ip_utils::IsIPv6(ipAddress) ? "[" + ipAddress + "]" : ipAddress) + url;
     std::string ipAddForGet = ipAddress;
     if (fppType == FPP_TYPE::ESPIXELSTICK) {
         fullUrl = ipAddress + "/fpp?path=" + url;
     }
     if (!_fppProxy.empty()) {
-        fullUrl = "http://" + _fppProxy + "/proxy/" + fullUrl;
+        fullUrl = "http://" +  (ip_utils::IsIPv6(_fppProxy) ? "[" + _fppProxy + "]" : _fppProxy) + "/proxy/" + fullUrl;
         ipAddForGet = _fppProxy;
     } else {
         fullUrl = "http://" + fullUrl;
@@ -335,7 +335,7 @@ int FPP::TransferToURL(const std::string& url, const std::vector<uint8_t>& val, 
         fullUrl = ipAddress + "/fpp?path=" +  url;
     }
     if (!_fppProxy.empty()) {
-        fullUrl = "http://" + _fppProxy + "/proxy/" + fullUrl;
+        fullUrl = "http://" +  ip_utils::IsIPv6(_fppProxy) ? "[" + _fppProxy + "]" : _fppProxy + "/proxy/" + fullUrl;
         ipAddForGet = _fppProxy;
     } else {
         fullUrl = "http://" + fullUrl;

--- a/xLights/outputs/ControllerEthernet.cpp
+++ b/xLights/outputs/ControllerEthernet.cpp
@@ -448,8 +448,11 @@ void ControllerEthernet::SetFPPProxy(const std::string& proxy) {
 
 std::string ControllerEthernet::GetFPPProxy() const {
 
-    if (_fppProxy != "" && _fppProxy != _ip) {
-        return _fppProxy;
+    if (_fppProxy != "") {
+        std::string _resolvedfppProxy = ip_utils::ResolveIP(_fppProxy);
+        if (_resolvedfppProxy != _ip) {
+            return _resolvedfppProxy;
+        }
     }
 
     // a controller should not proxy itself

--- a/xLights/outputs/IPOutput.cpp
+++ b/xLights/outputs/IPOutput.cpp
@@ -117,7 +117,7 @@ Output::PINGSTATE IPOutput::Ping(const std::string& ip, const std::string& proxy
 #endif
         std::string url = "http://";
         if (proxy != "") {
-            url += proxy + "/proxy/";
+            url += (ip_utils::IsIPv6(proxy) ? "[" + proxy + "]" : proxy) + "/proxy/";
         }
         url += ip + "/";
         if (Curl::HTTPSGet(url, "", "", 2) != "") {

--- a/xLights/utils/ip_utils.cpp
+++ b/xLights/utils/ip_utils.cpp
@@ -81,6 +81,11 @@ namespace ip_utils
         return hostAddr.Matches(ips);
     }
 
+    bool IsIPv6(const std::string& ip) {
+        wxIPV6address ipv6Addr;
+        return ipv6Addr.Hostname(ip)  && ip.find(':') != std::string::npos;
+    }
+
     std::string CleanupIP(const std::string& ip)
     {
         bool hasChar = false;

--- a/xLights/utils/ip_utils.h
+++ b/xLights/utils/ip_utils.h
@@ -19,6 +19,7 @@ namespace ip_utils
 
 	bool IsIPValidOrHostname(const std::string &ip, bool iponly = false);
     bool IsValidHostname(const std::string& ip);
+	bool IsIPv6(const std::string& ip);
 	std::string CleanupIP(const std::string& ip);
 	std::string ResolveIP(const std::string& ip);
 


### PR DESCRIPTION
For some reason my pi hostname returns IPV6 address, This messes up the use of a hostname as the proxy and broke uploads. 
This code checks if an IPV6 and wraps with [] as required for IPV6. #3415 