### PR TITLE
Fix bug where large video was incorrectly rendered #5310

### DIFF
--- a/xLights/effects/ispc/VideoFunctions.ispc
+++ b/xLights/effects/ispc/VideoFunctions.ispc
@@ -36,7 +36,6 @@ export void VideoEffectProcess(const uniform VideoData &data,
 
     uniform int ch = data.ch;
 
-
     foreach (index = startIdx...endIdx) {
         float fidx = index;
         float y = (floor)(fidx / data.buffer_width);
@@ -47,9 +46,6 @@ export void VideoEffectProcess(const uniform VideoData &data,
         }
 
         int newIndex = x + data.startx + ((y + data.starty) * data.buffer_width);
-        if (newIndex < 0 || newIndex >= (data.buffer_width * data.buffer_height)) {
-            continue;
-        }
 
         int row = (int)(data.image_height - 1 - y - data.yoffset);
         if (row < 0 || row >= data.image_height) {

--- a/xLights/models/CubeModel.cpp
+++ b/xLights/models/CubeModel.cpp
@@ -411,8 +411,8 @@ std::vector<std::tuple<int, int, int>> CubeModel::BuildCube() const
     if (abs(yr) == 1) std::swap(width, depth);
     if (abs(xr) == 1) std::swap(height, depth);
 
-    logger_base.debug("%s %s StrandStyle: %s StrandPerLayer: %d", (const char*)ModelXml->GetAttribute("Start", "").c_str(), (const char*)ModelXml->GetAttribute("Style", "").c_str(), (const char*)ModelXml->GetAttribute("StrandPerLine", "").c_str(), IsStrandPerLayer());
-    logger_base.debug("%dx%dx%d -> (%d,%d,%d,%d) -> %dx%dx%d", parm1, parm2, parm3, xr, yr, zr, xf, width, height, depth);
+    //logger_base.debug("%s %s StrandStyle: %s StrandPerLayer: %d", (const char*)ModelXml->GetAttribute("Start", "").c_str(), (const char*)ModelXml->GetAttribute("Style", "").c_str(), (const char*)ModelXml->GetAttribute("StrandPerLine", "").c_str(), IsStrandPerLayer());
+    //logger_base.debug("%dx%dx%d -> (%d,%d,%d,%d) -> %dx%dx%d", parm1, parm2, parm3, xr, yr, zr, xf, width, height, depth);
 
     for(int i = 0; i < width*height*depth; i++)
     {


### PR DESCRIPTION
If the video was larger than the model it was truncated. Introduced in the commit last night. #5310 
Also removed some old chatty log lines.