### PR TITLE
Pack FSEQ into minimum number of Universes

### DIFF
--- a/controllers/hinkspix.xcontroller
+++ b/controllers/hinkspix.xcontroller
@@ -6,7 +6,6 @@
 			<SupportsPixelPortNullPixels/>
 			<SupportsPixelPortDirection/>
 			<SupportsPixelPortColourOrder/>
-			<SupportsUniversePerString/>
 			<DMXAfterPixels/>
 			<SupportsUpload/>
 			<SupportsRemotes/>
@@ -45,6 +44,7 @@
 			<SupportsPixelPortDirection/>
 			<SupportsPixelPortColourOrder/>
 			<SupportsUniversePerString/>
+			<SupportsModifyFseqFrame/>
 			<DMXAfterPixels/>
 			<SupportsRemotes/>
 			<SupportsSmartRemotes>16</SupportsSmartRemotes>
@@ -60,9 +60,6 @@
 			<DisableMonitoring/>
 			<PixelProtocols>
 				<Protocol>ws2811</Protocol>
-				<Protocol>ws2801</Protocol>
-				<Protocol>tls3001</Protocol>
-				<Protocol>apa102</Protocol>
 			</PixelProtocols>
 			<SerialProtocols>
 				<Protocol>dmx</Protocol>
@@ -92,6 +89,7 @@
 			<SupportsPixelPortDirection/>
 			<SupportsPixelPortColourOrder/>
 			<SupportsUniversePerString/>
+			<SupportsModifyFseqFrame/>
 			<DMXAfterPixels/>
 			<SupportsRemotes/>
 			<SupportsSmartRemotes>16</SupportsSmartRemotes>
@@ -107,9 +105,6 @@
 			<DisableMonitoring/>
 			<PixelProtocols>
 				<Protocol>ws2811</Protocol>
-				<Protocol>ws2801</Protocol>
-				<Protocol>tls3001</Protocol>
-				<Protocol>apa102</Protocol>
 			</PixelProtocols>
 			<SerialProtocols>
 				<Protocol>dmx</Protocol>

--- a/xLights/controllers/BaseController.h
+++ b/xLights/controllers/BaseController.h
@@ -15,6 +15,7 @@
 
 #include "ControllerUploadData.h"
 #include "../UtilClasses.h"
+#include "OutputModelManager.h"
 
 class ModelManager;
 class OutputManager;

--- a/xLights/controllers/ControllerCaps.cpp
+++ b/xLights/controllers/ControllerCaps.cpp
@@ -402,6 +402,10 @@ bool ControllerCaps::SupportsUniversePerString() const
     return DoesXmlNodeExist(_config, "SupportsUniversePerString");
 }
 
+bool ControllerCaps::SupportsModifyFseqFrame() const {
+    return DoesXmlNodeExist(_config, "SupportsModifyFseqFrame");
+}
+
 bool ControllerCaps::DMXAfterPixels() const
 {
     return DoesXmlNodeExist(_config, "DMXAfterPixels");

--- a/xLights/controllers/ControllerCaps.h
+++ b/xLights/controllers/ControllerCaps.h
@@ -75,6 +75,7 @@ public:
     bool SupportsAutoUpload() const;
     bool DDPStartsAtOne() const;
     bool SupportsUniversePerString() const;
+    bool SupportsModifyFseqFrame() const;
     bool SupportsMultipleSimultaneousOutputProtocols() const;
     bool SupportsMultipleSimultaneousInputProtocols() const;
     bool MergeConsecutiveVirtualStrings() const;

--- a/xLights/controllers/ControllerUploadData.cpp
+++ b/xLights/controllers/ControllerUploadData.cpp
@@ -847,7 +847,7 @@ int32_t UDControllerPort::Channels() const {
     if (_virtualStrings.size() == 0) {
         if (_models.size() == 0) return 0;
 
-        if (_separateUniverses) {
+        if (_separateUniverses_Allowed) {
             int c = 0;
             for (const auto& it : _models) {
                 c += it->Channels();
@@ -1845,6 +1845,7 @@ bool UDController::Check(const ControllerCaps* rules, std::string& res) {
             }
 
             if (rules->SupportsUniversePerString() && _controller->GetType() == CONTROLLER_ETHERNET) {
+                it.second->SetSeparateUniverses_Allowed(true);
                 it.second->SetSeparateUniverses(((ControllerEthernet*)_controller)->IsUniversePerString());
             }
 
@@ -2101,6 +2102,22 @@ bool UDController::Check(const ControllerCaps* rules, std::string& res) {
         res += wxString::Format("ERR: Attempt to upload LED Panel Matrix but this controller does not support LED Panel Matrices.\n");
         success = false;
     }
+
+
+    if (rules->SupportsUniversePerString()) {
+        std::string CO;
+
+        for (const auto& it : _pixelPorts) {
+            for (const auto& it2 : it.second->GetModels()) {
+                CO = it2->GetColourOrder("RGB");
+                if (strlen(CO.c_str()) > 3) {
+                    res += wxString::Format("ERR: Controller does NOT Support Color Order %s.\n", CO);
+                    success = false;
+                }
+            }
+        }
+    }
+
 
     return success;
 }

--- a/xLights/controllers/ControllerUploadData.h
+++ b/xLights/controllers/ControllerUploadData.h
@@ -202,6 +202,7 @@ class UDControllerPort
     std::list<UDVirtualString*> _virtualStrings;
     std::string _type;
     bool _separateUniverses = false;
+    bool _separateUniverses_Allowed = false;  
     OutputManager* _om = nullptr;
     bool _isSmartRemotePort = false;
     #pragma endregion
@@ -310,6 +311,7 @@ class UDControllerPort
     [[nodiscard]] std::string GetSmartRemoteType(int smartRemote) const;
 
     void SetSeparateUniverses(bool sep) { _separateUniverses = sep; }
+    void SetSeparateUniverses_Allowed(bool sep) {_separateUniverses_Allowed = sep; }    
 
     void Dump() const;
     bool Check(Controller* c, bool pixel, const ControllerCaps* rules, std::string& res) const;

--- a/xLights/controllers/HinksPix.h
+++ b/xLights/controllers/HinksPix.h
@@ -25,7 +25,7 @@ class HinksPix;
 class wxJSONValue;
 
 struct HinksPixOutput {
-    HinksPixOutput(int output_ ,int defaultBrightness_) :
+    HinksPixOutput(int output_, int defaultBrightness_) :
         output(output_),
         universe(1),
         startChannel(1),
@@ -205,12 +205,57 @@ public:
 #pragma region Constructors and Destructors
     HinksPix(const std::string& ip, const std::string& fppProxy);
     virtual ~HinksPix();
+
 #pragma endregion
 
 #pragma region Getters and Setters
 #ifndef DISCOVERYONLY
     bool SetOutputs(ModelManager* allmodels, OutputManager* outputManager, Controller* controller, wxWindow* parent) override;
+
 #endif
     virtual bool UsesHTTP() const override { return true; }
 #pragma endregion
 };
+
+#define H_Fseq_IP_Size 30
+#define H_Num_Port_Strings (80 * 10)    // 80 ports on V3 with 10 per port max
+
+struct Tag_FseqFrame_PortString {
+    int32_t Port;
+    int32_t Start_Channel;
+    int32_t Num_Channels;
+    int32_t Brightness;
+    int32_t StringColor;
+
+};
+
+struct Tag_StringColor {
+    const char* Color;
+    int Value;
+};
+
+
+struct Tag_FseqFrame_Controller {
+    struct Tag_FseqFrame_Controller* next;
+
+    char IP[H_Fseq_IP_Size];
+
+    int32_t Start_Channel;
+    int32_t End_Channel;
+    int32_t Num_Channels;
+
+    int32_t Num_Port_Strings;
+    int32_t Port_String_Index;
+
+    bool UniversePerString_Active;
+
+    struct Tag_StringColor StringColor[6];
+    struct Tag_FseqFrame_PortString Ports[H_Num_Port_Strings];
+
+    uint8_t* Buff; // holds controller Frame
+};
+
+
+
+void HinksPix_ModifyFseqFrame(UDController *cud, uint8_t* data, int datasize);
+int Convert_ColorOrder_to_INT(struct Tag_FseqFrame_Controller* FFC, const char* C);

--- a/xLights/controllers/HinksPixExportDialog.cpp
+++ b/xLights/controllers/HinksPixExportDialog.cpp
@@ -1004,8 +1004,6 @@ void HinksPixExportDialog::OnButton_ExportClick(wxCommandEvent& /*event*/) {
             wxDirDialog dlg(this, "Select SD Directory for " + hix->GetName(), drive, wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
             if (dlg.ShowModal() == wxID_OK) {
                 drive = dlg.GetPath();
-            } else {
-                continue;
             }
             if (!ObtainAccessToURL(drive)) {
                 errorMsg = wxString::Format("Could not obtain write access for '%s'", drive);

--- a/xLights/models/ModelManager.cpp
+++ b/xLights/models/ModelManager.cpp
@@ -941,13 +941,13 @@ bool ModelManager::ReworkStartChannel() const
 
         if (it->IsAutoSize()) {
             auto eth = dynamic_cast<const ControllerEthernet*>(it);
-            if (it->GetChannels() != std::max((int32_t)1, (int32_t)ch - 1) || (eth != nullptr && eth->IsUniversePerString())) {
+            if (it->GetChannels() != std::max((int32_t)1, (int32_t)ch - 1) || (eth != nullptr && eth->SupportsUniversePerString())) {
                 logger_zcpp.debug("    Resizing output to %d channels.", std::max((int32_t)1, (int32_t)ch - 1));
 
                 auto oldC = it->GetChannels();
                 // Set channel size won't always change the number of channels for some protocols
                 it->SetChannelSize(std::max((int32_t)1, (int32_t)ch - 1), allSortedModels);
-                if (it->GetChannels() != oldC || (eth != nullptr && eth->IsUniversePerString())) {
+                if (it->GetChannels() != oldC || (eth != nullptr && eth->SupportsUniversePerString())) {
                     outputManager->SomethingChanged();
 
                     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_NETWORK_CHANGE, "ReworkStartChannel");

--- a/xLights/outputs/ControllerEthernet.h
+++ b/xLights/outputs/ControllerEthernet.h
@@ -165,6 +165,7 @@ public:
 #pragma region UI
     #ifndef EXCLUDENETWORKUI
         bool SupportsUniversePerString() const;
+        bool SupportsModifyFseqFrame() const;
     
         virtual void UpdateProperties(wxPropertyGrid* propertyGrid, ModelManager* modelManager, std::list<wxPGProperty*>& expandProperties, OutputModelManager* outputModelManager) override;
         virtual void AddProperties(wxPropertyGrid* propertyGrid, ModelManager* modelManager, std::list<wxPGProperty*>& expandProperties) override;


### PR DESCRIPTION
HinksPix Long Range has required multiple small Universes to properly build a E131 table This change reformats the created FSEQ by packing and reording Universes to minimize E131 packets