### PR TITLE
Catch Crashing Emoji Effect #4062

### DIFF
--- a/xLights/effects/ShapeEffect.cpp
+++ b/xLights/effects/ShapeEffect.cpp
@@ -25,6 +25,7 @@
 #include "nanosvg/src/nanosvg.h"
 
 #include <regex>
+#include <log4cpp/Category.hh>
 
 #include "../../include/shape-16.xpm"
 #include "../../include/shape-24.xpm"
@@ -666,6 +667,11 @@ void ShapeEffect::Render(Effect *effect, const SettingsMap &SettingsMap, RenderB
     }
 
     if (Object_To_Draw == RENDER_SHAPE_EMOJI || Object_To_Draw == RENDER_SHAPE_SVG) {
+        if (buffer.BufferWi <= 0 || buffer.BufferHt <= 0 || buffer.BufferWi > 15000) {
+            static log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+            logger_base.error("Shape Effect (Emoji): Invalid buffer size: width=%d, height=%d", buffer.BufferWi, buffer.BufferHt);
+            return;
+        }
         auto context = buffer.GetTextDrawingContext();
         context->Clear();
     }


### PR DESCRIPTION
What was originally thought to be a wxwidget issue, the original sequence had an emoji effect on a whole house set to Single Line. The resulting buffer was too big to create the context and would crash. I have set the buffer limit to something reasonable so it doesn't crash. Changing the group's Single Line render style to Max Grid or using Per Preview would have avoided this crashing condition as well. #4062 