### PR TITLE
Wave effect bug #5321

### DIFF
--- a/xLights/effects/WaveEffect.cpp
+++ b/xLights/effects/WaveEffect.cpp
@@ -68,14 +68,6 @@ void WaveEffect::adjustSettings(const std::string& version, Effect* effect, bool
 #define WAVETYPE_DECAYSINE  3
 #define WAVETYPE_IVYFRACTAL  4
 
-//#define WANT_DEBUG_IMPL
-//#define WANT_DEBUG  -99 //unbuffered in case app crashes
-//#include "djdebug.cpp"
-#ifndef debug_function //dummy defs if debug cpp not included above
-#define debug(level, ...)
-#define debug_more(level, ...)
-#define debug_function(level)
-#endif
 
 
 class WaveRenderCache : public EffectRenderCache {
@@ -179,7 +171,6 @@ void WaveEffect::Render(Effect *effect, const SettingsMap &SettingsMap, RenderBu
     } else if (WaveType == WAVETYPE_IVYFRACTAL) { //generate branches at start of effect
         if (buffer.needToInit || (WaveBuffer0.size() != NumberWaves * buffer.BufferWi)) {
             r = 0;
-            debug(10, "regen wave path, state %0.1f", state);
             int delay = 0;
             int delta = 0; //next branch length, angle
             WaveBuffer0.resize(NumberWaves * buffer.BufferWi);
@@ -197,7 +188,7 @@ void WaveEffect::Render(Effect *effect, const SettingsMap &SettingsMap, RenderBu
             buffer.needToInit = false;
         }
     }
-    double degree_per_x = NumberWaves / buffer.BufferWi;
+    double degree_per_x = static_cast<double>(NumberWaves) / buffer.BufferWi;
     hsv.saturation = 1.0;
     hsv.value = 1.0;
     hsv.hue = 1.0;

--- a/xLights/effects/assist/AssistPanel.cpp
+++ b/xLights/effects/assist/AssistPanel.cpp
@@ -117,6 +117,7 @@ void AssistPanel::RefreshEffect() {
         wxSize sz = GetSize();
         mGridCanvas->SetNumColumns(bw);
         mGridCanvas->SetNumRows(bh);
+        mGridCanvas->SetToolTip(wxString::Format("Render Buffer - %dC x %dR", bw, bh));
         mGridCanvas->SetEffect(mEffect);
         mGridCanvas->AdjustSize(sz);
         mGridCanvas->Refresh();

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -4299,7 +4299,11 @@ void xLightsFrame::OnTimer_AutoSaveTrigger(wxTimerEvent& event)
                 logged = true;
             }
         } else {
-            logger_base.debug("AutoSave skipped because sequence is playing or suspended.");
+            static bool logged = false;
+            if (!logged) {
+                logger_base.debug("AutoSave skipped because sequence is playing or suspended.");
+                logged = true;
+            }
         }
         if (mAutoSaveInterval > 0) {
             AutoSaveTimer.StartOnce(1000); // try again in a short period of time as we did not actually save this time


### PR DESCRIPTION
For larger buffers, a low # of waves it rounded to 0 meaning it didn't move. Also removed some old debug code, added a tooltip for the effect assist and removed duplicate logging of the autosave skipped message.
Note there is no need to add a scale to buffer as it already does that with the existing code. It draws the wave the same no matter what the buffer size (after the bug fix).