### PR TITLE
Universe Per String triggers the Save Layout Bug #4184

### DIFF
--- a/xLights/TabSetup.cpp
+++ b/xLights/TabSetup.cpp
@@ -885,7 +885,7 @@ void xLightsFrame::NetworkChange() {
 void xLightsFrame::NetworkChannelsChange() {
 
     static log4cpp::Category& logger_work = log4cpp::Category::getInstance(std::string("log_work"));
-    logger_work.debug("        NetowrkChannelsChange.");
+    logger_work.debug("        NetworkChannelsChange.");
 
     _outputManager.SomethingChanged();
     _outputModelManager.AddASAPWork(OutputModelManager::WORK_RESEND_CONTROLLER_CONFIG, "NetworkChannelsChange");

--- a/xLights/models/ModelManager.cpp
+++ b/xLights/models/ModelManager.cpp
@@ -947,7 +947,7 @@ bool ModelManager::ReworkStartChannel() const
                 auto oldC = it->GetChannels();
                 // Set channel size won't always change the number of channels for some protocols
                 it->SetChannelSize(std::max((int32_t)1, (int32_t)ch - 1), allSortedModels);
-                if (it->GetChannels() != oldC || (eth != nullptr && eth->IsUniversePerString())) {
+                if (it->GetChannels() != oldC || (eth != nullptr && xlights->IsSequencerInitialize() && eth->IsUniversePerString() )) {
                     outputManager->SomethingChanged();
 
                     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_NETWORK_CHANGE, "ReworkStartChannel");

--- a/xLights/xLightsMain.h
+++ b/xLights/xLightsMain.h
@@ -1735,6 +1735,7 @@ public:
     bool IsACActive();
     void GetACSettings(ACTYPE& type, ACSTYLE& style, ACTOOL& tool, ACMODE& mode);
     int GetACIntensity();
+    bool IsSequencerInitialize() {return mSequencerInitialize;}
     void GetACRampValues(int& a, int& b);
     void UpdateACToolbar(bool forceState = true); // if force state is false then it will force disable the AC toolbar
     void SetACSettings(ACTOOL tool);


### PR DESCRIPTION
If Universe per string is enabled then don't trigger the save icon on initial load of xLights. Bypass the recalc on initial load. Use the mSequencerInitialize flag that indicates that the sequencer panel has been loaded to indicate if we are on the initial load or not.