### PR TITLE
5324 submodel window size

### DIFF
--- a/xLights/SubModelsDialog.cpp
+++ b/xLights/SubModelsDialog.cpp
@@ -448,6 +448,15 @@ void SubModelsDialog::OnInit(wxInitDialogEvent& event)
         NodesGrid->SetColSize(1, secondColWidth);
     }
 
+    const wxSize clientSize = GetClientSize();
+    const int buttonAreaHeight = FromDIP(50);
+    const int margin = FromDIP(20);
+    const int maxPanel3Height = clientSize.GetHeight() - buttonAreaHeight - margin;
+    Panel3->SetMaxSize(wxSize(-1, maxPanel3Height));
+    if (Panel3->GetSizer()) {
+        Panel3->GetSizer()->SetSizeHints(Panel3);
+    }
+
     EnsureWindowHeaderIsOnScreen(this);
     Layout();
 }
@@ -4504,6 +4513,7 @@ void SubModelsDialog::OnCheckBox_OutputToLightsClick(wxCommandEvent& event)
 }
 
 void SubModelsDialog::OnSplitterSashPosChanging(wxSplitterEvent& event) {
+    log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
     if (NodesGrid && NodesGrid->GetNumberCols() > 0) {
         const int newPos = event.GetSashPosition() - FromDIP(310);
         if (newPos > 200) {
@@ -4512,6 +4522,7 @@ void SubModelsDialog::OnSplitterSashPosChanging(wxSplitterEvent& event) {
             NodesGrid->SetColSize(0, ToDIP(310));
         }
         const int sashPos = FromDIP(event.GetSashPosition());
+        logger_base.debug("Sash pos = %d", sashPos);
         if (sashPos < 510) {
             event.SetSashPosition(FromDIP(510));
         } else {

--- a/xLights/SubModelsDialog.cpp
+++ b/xLights/SubModelsDialog.cpp
@@ -4513,7 +4513,6 @@ void SubModelsDialog::OnCheckBox_OutputToLightsClick(wxCommandEvent& event)
 }
 
 void SubModelsDialog::OnSplitterSashPosChanging(wxSplitterEvent& event) {
-    log4cpp::Category &logger_base = log4cpp::Category::getInstance(std::string("log_base"));
     if (NodesGrid && NodesGrid->GetNumberCols() > 0) {
         const int newPos = event.GetSashPosition() - FromDIP(310);
         if (newPos > 200) {
@@ -4522,7 +4521,6 @@ void SubModelsDialog::OnSplitterSashPosChanging(wxSplitterEvent& event) {
             NodesGrid->SetColSize(0, ToDIP(310));
         }
         const int sashPos = FromDIP(event.GetSashPosition());
-        logger_base.debug("Sash pos = %d", sashPos);
         if (sashPos < 510) {
             event.SetSashPosition(FromDIP(510));
         } else {


### PR DESCRIPTION
When the number of lines of the submodel is bigger than the screen size, the buttons would fall off the bottom of the screen. This change sets the max to the screen minus the buttons. The panel already had the scroll bar. #5324 