### PR TITLE
Render poly as flat if it is nearly horizontal #3625

### DIFF
--- a/xLights/models/PolyLineModel.cpp
+++ b/xLights/models/PolyLineModel.cpp
@@ -490,11 +490,10 @@ void PolyLineModel::InitModel()
             x1p = (pPos[i].x - minX) / deltax;
             x2p = (pPos[i + 1].x - minX) / deltax;
         }
-        if (deltay == 0.0f) {
+        if (std::abs(deltay) < 0.1f) {
             y1p = 0.0f;
             y2p = 0.0f;
-        }
-        else {
+        } else {
             y1p = (pPos[i].y - minY) / deltay;
             y2p = (pPos[i + 1].y - minY) / deltay;
         }


### PR DESCRIPTION
Floating precision meant it was never 0.0f and hence always skewed 45 degrees. It could likely still be a lot less strict but at least now if shows flat if the y values show the same value. #3625 