### PR TITLE
Correct the default face placement #4245

### DIFF
--- a/xLights/ModelFaceDialog.cpp
+++ b/xLights/ModelFaceDialog.cpp
@@ -360,6 +360,7 @@ ModelFaceDialog::ModelFaceDialog(wxWindow* parent, OutputManager* outputManager,
 	//*)
 
     model = nullptr;
+    MatrixImagePlacementChoice->SetStringSelection("Scaled");
 
     modelPreview = new ModelPreview(ModelPreviewPanelLocation);
     modelPreview->SetMinSize(wxSize(150, 150));


### PR DESCRIPTION
An unselect image placement is treated as Scale to fit, contrary to what is show on the dialog. If you actually select "Center" it is an unscaled centering of the image. 
This change makes "Scaled" the option that is shown to the user if nothing has been selected.

Any downside to changing this like this? It seems to address the problem and doesn't impact current layouts. #4245 

This default is actually Scaled unless you select off then on and choose it directly.
![image](https://github.com/user-attachments/assets/5dd67e03-0363-4622-b0e4-7902bbb8e852)
