### PR TITLE
Count blanks/zeros as a pixel

### DIFF
--- a/xLights/SubModelsDialog.cpp
+++ b/xLights/SubModelsDialog.cpp
@@ -504,9 +504,6 @@ int SubModelsDialog::CountNodesInRange(const wxString& range) {
     wxStringTokenizer tokenizer(range, ",");
     while (tokenizer.HasMoreTokens()) {
         wxString nodeRange = tokenizer.GetNextToken();
-        if (nodeRange.IsEmpty())
-            continue;
-
         if (nodeRange.Contains("-")) {
             int dashPosition = nodeRange.Index('-');
             int start = wxAtoi(nodeRange.Left(dashPosition));
@@ -515,10 +512,10 @@ int SubModelsDialog::CountNodesInRange(const wxString& range) {
                 count += std::abs(end - start) + 1;
             }
         } else {
-            if (wxAtoi(nodeRange) > 0)
-                count++;
+            count++;
         }
     }
+    if (EndsWith(range, ",")) count++;
     return count;
 }
 
@@ -1076,7 +1073,7 @@ void SubModelsDialog::OnNodesGridCellRightClick(wxGridEvent& event)
     mnu.Append(SUBMODEL_DIALOG_EXPAND_STRANDS_ALL, "Expand All Strands");
     mnu.Append(SUBMODEL_DIALOG_COMPRESS_STRANDS_ALL, "Compress All Strands");
     mnu.Append(SUBMODEL_DIALOG_BLANKS_AS_ZERO, "Convert Blanks To Zeros");
-    mnu.Append(SUBMODEL_DIALOG_BLANKS_AS_EMPTY, "Convert Zeros To Empty");
+    mnu.Append(SUBMODEL_DIALOG_BLANKS_AS_EMPTY, "Convert Zeros To Blanks");
     mnu.Append(SUBMODEL_DIALOG_REMOVE_BLANKS_ZEROS, "Remove Blanks/Zeros");
 
     mnu.Connect(wxEVT_MENU, (wxObjectEventFunction)&SubModelsDialog::OnNodesGridPopup, nullptr, this);

--- a/xLights/UtilFunctions.cpp
+++ b/xLights/UtilFunctions.cpp
@@ -1389,7 +1389,7 @@ wxString CompressNodes(const wxString& nodes) {
                 }
             }
             // Add empty and separator
-            res += i + ",";
+            res += i + "0,";
             start = last = -1;
             dir = 0;
             continue;


### PR DESCRIPTION
When using placeholders, count them as a node. Ensure last one is also counted, due to wxStringTokenizer.
Standardize Zeros and Blanks
Make Compress use 0s by default - can always rightclick and remove - makes it easier to read - although count if not accounting for them.

![image](https://github.com/user-attachments/assets/e1abeec5-5fca-495d-9b19-c7171f0df92b)
