### PR TITLE
Influence the length of a blink #5361

### DIFF
--- a/xLights/effects/FacesEffect.cpp
+++ b/xLights/effects/FacesEffect.cpp
@@ -116,6 +116,10 @@ wxString FacesEffect::GetEffectString() {
     ret << p->Choice_Faces_EyeBlinkFrequency->GetStringSelection().ToStdString();
     ret << ",";
 
+    ret << "E_CHOICE_Faces_EyeBlinkDuration=";
+    ret << p->Choice_Faces_EyeBlinkDuration->GetStringSelection().ToStdString();
+    ret << ",";
+
     ret << "E_CHOICE_Faces_FaceDefinition=";
     ret << p->Face_FaceDefinitonChoice->GetStringSelection().ToStdString();
     ret << ",";
@@ -251,6 +255,18 @@ int FacesEffect::GetMaxEyeDelay( std::string& eyeBlinkFreqString ) const {
         maxEyeDelay = 2000;
     
     return maxEyeDelay;
+}
+
+int FacesEffect::GetEyeBlinkDuration(std::string& eyeBlinkDurationString) const {
+    int EyeBlinkDuration = 100; // Normal
+    if (eyeBlinkDurationString == "Slower")
+        EyeBlinkDuration = 50;
+    else if (eyeBlinkDurationString == "Long")
+        EyeBlinkDuration = 200;
+    else if (eyeBlinkDurationString == "Longer")
+        EyeBlinkDuration = 400;
+
+    return EyeBlinkDuration;
 }
 
 void FacesEffect::SetPanelStatus(Model* cls) {
@@ -473,6 +489,7 @@ void FacesEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderB
                                SettingsMap["CHOICE_Faces_Phoneme"],
                                SettingsMap.Get("CHOICE_Faces_Eyes", "Auto"),
                                SettingsMap.Get("CHOICE_Faces_EyeBlinkFrequency", "Normal"),
+                               SettingsMap.Get("CHOICE_Faces_EyeBlinkDuration", "Normal"),
                                SettingsMap.GetBool("CHECKBOX_Faces_Outline"),
                                alpha, SettingsMap.GetBool("CHECKBOX_Faces_SuppressShimmer", false));
     } else {
@@ -483,6 +500,7 @@ void FacesEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderB
                     SettingsMap["CHOICE_Faces_TimingTrack"],
                     SettingsMap["CHOICE_Faces_Eyes"],
                     SettingsMap["CHOICE_Faces_EyeBlinkFrequency"],
+                    SettingsMap["CHOICE_Faces_EyeBlinkDuration"],
                     SettingsMap.GetBool("CHECKBOX_Faces_Outline"),
                     SettingsMap.GetBool("CHECKBOX_Faces_TransparentBlack", false),
                     SettingsMap.GetInt("TEXTCTRL_Faces_TransparentBlack", 0),
@@ -496,7 +514,7 @@ void FacesEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderB
     //}
 }
 
-void FacesEffect::RenderFaces(RenderBuffer& buffer, const std::string& Phoneme, const std::string& eyes, const std::string& eyeBlinkFreq, bool outline, uint8_t alpha, bool suppressShimmer) {
+void FacesEffect::RenderFaces(RenderBuffer& buffer, const std::string& Phoneme, const std::string& eyes, const std::string& eyeBlinkFreq, const std::string& eyeBlinkDuration, bool outline, uint8_t alpha, bool suppressShimmer) {
     if (alpha == 0)
         return; // 0 alpha means there is nothing to do
 
@@ -528,7 +546,7 @@ void FacesEffect::RenderFaces(RenderBuffer& buffer, const std::string& Phoneme, 
     int Wt = buffer.BufferWi;
 
     // this draws eyes as well
-    drawoutline(buffer, PhonemeInt, outline, eyes, eyeBlinkFreq, buffer.BufferHt, buffer.BufferWi);
+    drawoutline(buffer, PhonemeInt, outline, eyes, eyeBlinkFreq, eyeBlinkDuration, buffer.BufferHt, buffer.BufferWi);
     mouth(buffer, PhonemeInt, Ht, Wt, shimmer); // draw a mouth syllable
 }
 
@@ -693,9 +711,10 @@ void FacesEffect::facesCircle(RenderBuffer& buffer, int Phoneme, int xc, int yc,
     }
 }
 
-void FacesEffect::drawoutline(RenderBuffer& buffer, int Phoneme, bool outline, const std::string& eyes, const std::string& eyeBlinkFreqIn, int BufferHt, int BufferWi) {
+void FacesEffect::drawoutline(RenderBuffer& buffer, int Phoneme, bool outline, const std::string& eyes, const std::string& eyeBlinkFreqIn, const std::string& eyeBlinkDurationIn, int BufferHt, int BufferWi) {
     std::string eye = eyes;
     std::string eyeBlinkFreq = eyeBlinkFreqIn;
+    std::string eyeBlinkDuration = eyeBlinkDurationIn;
 
     FacesRenderCache* cache = (FacesRenderCache*)buffer.infoCache[id];
     if (cache == nullptr) {
@@ -834,7 +853,7 @@ static bool parse_model(const wxString& want_model)
 // Outline_x_y = list of persistent/sticky elements (stays on after frame ends)
 // Eyes_x_y = list of random elements (intended for eye blinks, etc)
 
-void FacesEffect::RenderCoroFacesFromPGO(RenderBuffer& buffer, const std::string& Phoneme, const std::string& eyes, const std::string& eyeBlinkFreq, bool face_outline, uint8_t alpha, bool suppressShimmer)
+void FacesEffect::RenderCoroFacesFromPGO(RenderBuffer& buffer, const std::string& Phoneme, const std::string& eyes, const std::string& eyeBlinkFreq, const std::string& eyeBlinkDuration, bool face_outline, uint8_t alpha, bool suppressShimmer)
 {
     if (alpha == 0) return;
 
@@ -850,7 +869,7 @@ void FacesEffect::RenderCoroFacesFromPGO(RenderBuffer& buffer, const std::string
 
     if (auto_phonemes.find((const char*)Phoneme.c_str()) != auto_phonemes.end())
     {
-        RenderFaces(buffer, auto_phonemes[(const char*)Phoneme.c_str()], eyes, eyeBlinkFreq, face_outline, alpha, suppressShimmer);
+        RenderFaces(buffer, auto_phonemes[(const char*)Phoneme.c_str()], eyes, eyeBlinkFreq, eyeBlinkDuration, face_outline, alpha, suppressShimmer);
         return;
     }
 
@@ -924,13 +943,14 @@ static const std::string &findKey(const std::map<std::string, std::string> &m, c
 void FacesEffect::RenderFaces(RenderBuffer& buffer,
                               SequenceElements* elements, const std::string& faceDef,
                               const std::string& Phoneme, const std::string& trackName,
-                              const std::string& eyesIn, const std::string& eyeBlinkFreqIn, bool face_outline, bool transparentBlack, int transparentBlackLevel, uint8_t alpha, const std::string& outlineState, bool suppressShimmer)
-{
+                              const std::string& eyesIn, const std::string& eyeBlinkFreqIn, const std::string& eyeBlinkDurationIn,
+                              bool face_outline, bool transparentBlack, int transparentBlackLevel, uint8_t alpha, const std::string& outlineState, bool suppressShimmer) {
     if (alpha == 0)
         return; // if alpha is zero dont bother.
 
     std::string eyes = eyesIn;
     std::string eyeBlinkFreq = eyeBlinkFreqIn;
+    std::string eyeBlinkDuration = eyeBlinkDurationIn;
 
     FacesRenderCache* cache = (FacesRenderCache*)buffer.infoCache[id];
     if (cache == nullptr) {
@@ -1118,8 +1138,9 @@ void FacesEffect::RenderFaces(RenderBuffer& buffer,
                         } else {
                             //calculate the blink time taking into account user selection
                             int maxEyeDelay = GetMaxEyeDelay(eyeBlinkFreq);
+                            int EyeBlinkDuration = GetEyeBlinkDuration(eyeBlinkDuration);
                             cache->nextBlinkTime += intRand(maxEyeDelay-1000, maxEyeDelay);
-                            cache->blinkEndTime = buffer.curPeriod * buffer.frameTimeInMs + 101; // 100ms blink
+                            cache->blinkEndTime = buffer.curPeriod * buffer.frameTimeInMs + EyeBlinkDuration + 1; // 100ms blink
                             eyes = "Closed";
                         }
                     } else if ((buffer.curPeriod * buffer.frameTimeInMs) < cache->blinkEndTime) {
@@ -1135,8 +1156,9 @@ void FacesEffect::RenderFaces(RenderBuffer& buffer,
                 if ((buffer.curPeriod * buffer.frameTimeInMs) >= cache->nextBlinkTime) {
                     //calculate the blink time, taking into account user selection
                     int maxEyeDelay = GetMaxEyeDelay(eyeBlinkFreq);
+                    int EyeBlinkDuration = GetEyeBlinkDuration(eyeBlinkDuration);
                     cache->nextBlinkTime += intRand(maxEyeDelay-1000, maxEyeDelay);
-                    cache->blinkEndTime = buffer.curPeriod * buffer.frameTimeInMs + 101; // 100ms blink
+                    cache->blinkEndTime = buffer.curPeriod * buffer.frameTimeInMs + EyeBlinkDuration + 1; // 100ms blink
                     eyes = "Closed";
                 } else if ((buffer.curPeriod * buffer.frameTimeInMs) < cache->blinkEndTime) {
                     eyes = "Closed";
@@ -1334,7 +1356,7 @@ void FacesEffect::RenderFaces(RenderBuffer& buffer,
     }
 
     if (type == 2) {
-        RenderFaces(buffer, phoneme, eyes, eyeBlinkFreq, face_outline, alpha, suppressShimmer);
+        RenderFaces(buffer, phoneme, eyes, eyeBlinkFreq, eyeBlinkDuration, face_outline, alpha, suppressShimmer);
         return;
     }
     if (type == 3) {

--- a/xLights/effects/FacesEffect.h
+++ b/xLights/effects/FacesEffect.h
@@ -44,16 +44,17 @@ private:
     const std::map<std::string, int> eyeBlinkMap;
     void mouth(RenderBuffer& buffer, int Phoneme, int BufferHt, int BufferWt, bool shimmer);
     void drawline1(RenderBuffer& buffer, int Phoneme, int x1, int x2, int y1, int y2, int colorIdx);
-    void drawoutline(RenderBuffer& buffer, int Phoneme, bool outline, const std::string& eyes, const std::string& eyeBlinkFreq, int BufferHt, int BufferWi);
+    void drawoutline(RenderBuffer& buffer, int Phoneme, bool outline, const std::string& eyes, const std::string& eyeBlinkFreq, const std::string& eyeBlinkDuration, int BufferHt, int BufferWi);
     void facesCircle(RenderBuffer& buffer, int Phoneme, int xc, int yc, double radius, int start_degrees, int end_degrees, int colorIdx);
     void drawline3(RenderBuffer& buffer, int Phoneme, int x1, int x2, int y6, int y7, int colorIdx);
 
-    void RenderFaces(RenderBuffer& buffer, const std::string& Phoneme, const std::string& eyes, const std::string& eyeBlinkFreq, bool face_outline, uint8_t alpha, bool suppressShimmer);
-    void RenderCoroFacesFromPGO(RenderBuffer& buffer, const std::string& Phoneme, const std::string& eyes, const std::string& eyeBlinkFreq, bool face_outline, uint8_t alpha, bool suppressShimmer);
+    void RenderFaces(RenderBuffer& buffer, const std::string& Phoneme, const std::string& eyes, const std::string& eyeBlinkFreq, const std::string& eyeBlinkDuration, bool face_outline, uint8_t alpha, bool suppressShimmer);
+    void RenderCoroFacesFromPGO(RenderBuffer& buffer, const std::string& Phoneme, const std::string& eyes, const std::string& eyeBlinkFreq, const std::string& eyeBlinkDuration, bool face_outline, uint8_t alpha, bool suppressShimmer);
     void RenderFaces(RenderBuffer& buffer, SequenceElements* elements, const std::string& faceDefintion,
-                     const std::string& Phoneme, const std::string& track, const std::string& eyes, const std::string& eyeBlinkFreq, bool face_outline, bool transparentBlack, int transparentBlackLevel, uint8_t alpha, const std::string& outlineState, bool suppressShimmer);
+                     const std::string& Phoneme, const std::string& track, const std::string& eyes, const std::string& eyeBlinkFreq, const std::string& eyeBlinkDuration, bool face_outline, bool transparentBlack, int transparentBlackLevel, uint8_t alpha, const std::string& outlineState, bool suppressShimmer);
     std::string MakeKey(int bufferWi, int bufferHt, std::string dirstr, std::string picture, std::string stf);
     uint8_t CalculateAlpha(SequenceElements* elements, int leadFrames, bool fade, const std::string& timingTrack, RenderBuffer& buffer);
     bool ShimmerState(RenderBuffer& buffer) const;
     int GetMaxEyeDelay( std::string& eyeBlinkFreq ) const;
+    int GetEyeBlinkDuration(std::string& eyeBlinkDuration) const;
 };

--- a/xLights/effects/FacesPanel.cpp
+++ b/xLights/effects/FacesPanel.cpp
@@ -25,27 +25,30 @@
 //*)
 
 //(*IdInit(FacesPanel)
-const long FacesPanel::IDD_RADIOBUTTON_Faces_Phoneme = wxNewId();
-const long FacesPanel::ID_CHOICE_Faces_Phoneme = wxNewId();
-const long FacesPanel::IDD_RADIOBUTTON_Faces_TimingTrack = wxNewId();
-const long FacesPanel::ID_CHOICE_Faces_TimingTrack = wxNewId();
-const long FacesPanel::ID_STATICTEXT15 = wxNewId();
-const long FacesPanel::ID_CHOICE_Faces_FaceDefinition = wxNewId();
-const long FacesPanel::ID_STATICTEXT_Faces_Eyes = wxNewId();
-const long FacesPanel::ID_CHOICE_Faces_Eyes = wxNewId();
-const long FacesPanel::ID_STATICTEXT_EYEBLINKFREQUENCY = wxNewId();
-const long FacesPanel::ID_CHOICE_Faces_EyeBlinkFrequency = wxNewId();
-const long FacesPanel::ID_CHECKBOX_Faces_Outline = wxNewId();
-const long FacesPanel::ID_CHECKBOX_Faces_SuppressShimmer = wxNewId();
-const long FacesPanel::ID_STATICTEXT1 = wxNewId();
-const long FacesPanel::ID_CHOICE_Faces_UseState = wxNewId();
-const long FacesPanel::ID_CHECKBOX_Faces_SuppressWhenNotSinging = wxNewId();
-const long FacesPanel::ID_STATICTEXT_Faces_Lead_Frames = wxNewId();
-const long FacesPanel::ID_SPINCTRL_Faces_LeadFrames = wxNewId();
-const long FacesPanel::ID_CHECKBOX_Faces_Fade = wxNewId();
-const long FacesPanel::ID_CHECKBOX_Faces_TransparentBlack = wxNewId();
-const long FacesPanel::IDD_SLIDER_Faces_TransparentBlack = wxNewId();
-const long FacesPanel::ID_TEXTCTRL_Faces_TransparentBlack = wxNewId();
+const wxWindowID FacesPanel::IDD_RADIOBUTTON_Faces_Phoneme = wxNewId();
+const wxWindowID FacesPanel::ID_CHOICE_Faces_Phoneme = wxNewId();
+const wxWindowID FacesPanel::IDD_RADIOBUTTON_Faces_TimingTrack = wxNewId();
+const wxWindowID FacesPanel::ID_CHOICE_Faces_TimingTrack = wxNewId();
+const wxWindowID FacesPanel::ID_STATICTEXT15 = wxNewId();
+const wxWindowID FacesPanel::ID_CHOICE_Faces_FaceDefinition = wxNewId();
+const wxWindowID FacesPanel::ID_STATICTEXT_Faces_Eyes = wxNewId();
+const wxWindowID FacesPanel::ID_CHOICE_Faces_Eyes = wxNewId();
+const wxWindowID FacesPanel::ID_STATICTEXT_EYEBLINKFREQUENCY = wxNewId();
+const wxWindowID FacesPanel::ID_STATICTEXT3 = wxNewId();
+const wxWindowID FacesPanel::ID_CHOICE_Faces_EyeBlinkFrequency = wxNewId();
+const wxWindowID FacesPanel::ID_STATICTEXT2 = wxNewId();
+const wxWindowID FacesPanel::ID_CHOICE_Faces_EyeBlinkDuration = wxNewId();
+const wxWindowID FacesPanel::ID_CHECKBOX_Faces_Outline = wxNewId();
+const wxWindowID FacesPanel::ID_CHECKBOX_Faces_SuppressShimmer = wxNewId();
+const wxWindowID FacesPanel::ID_STATICTEXT1 = wxNewId();
+const wxWindowID FacesPanel::ID_CHOICE_Faces_UseState = wxNewId();
+const wxWindowID FacesPanel::ID_CHECKBOX_Faces_SuppressWhenNotSinging = wxNewId();
+const wxWindowID FacesPanel::ID_STATICTEXT_Faces_Lead_Frames = wxNewId();
+const wxWindowID FacesPanel::ID_SPINCTRL_Faces_LeadFrames = wxNewId();
+const wxWindowID FacesPanel::ID_CHECKBOX_Faces_Fade = wxNewId();
+const wxWindowID FacesPanel::ID_CHECKBOX_Faces_TransparentBlack = wxNewId();
+const wxWindowID FacesPanel::IDD_SLIDER_Faces_TransparentBlack = wxNewId();
+const wxWindowID FacesPanel::ID_TEXTCTRL_Faces_TransparentBlack = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(FacesPanel,wxPanel)
@@ -57,6 +60,7 @@ FacesPanel::FacesPanel(wxWindow* parent) : xlEffectPanel(parent)
 {
 	//(*Initialize(FacesPanel)
 	wxFlexGridSizer* FlexGridSizer1;
+	wxFlexGridSizer* FlexGridSizer2;
 	wxFlexGridSizer* FlexGridSizer47;
 	wxFlexGridSizer* FlexGridSizer7;
 	wxFlexGridSizer* FlexGridSizer97;
@@ -105,17 +109,31 @@ FacesPanel::FacesPanel(wxWindow* parent) : xlEffectPanel(parent)
 	Choice_Faces_Eyes->Append(_("Closed"));
 	Choice_Faces_Eyes->SetSelection( Choice_Faces_Eyes->Append(_("Auto")) );
 	Choice_Faces_Eyes->Append(_("(off)"));
+	Choice_Faces_Eyes->SetToolTip(_("When Auto, blink occurs during rest or (off)."));
 	FlexGridSizer98->Add(Choice_Faces_Eyes, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
-	StaticText_Faces_EyeBlinkFrequency = new wxStaticText(this, ID_STATICTEXT_EYEBLINKFREQUENCY, _("Eye Blink Frequency"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_EYEBLINKFREQUENCY"));
+	StaticText_Faces_EyeBlinkFrequency = new wxStaticText(this, ID_STATICTEXT_EYEBLINKFREQUENCY, _("Eye Blink"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_EYEBLINKFREQUENCY"));
 	FlexGridSizer98->Add(StaticText_Faces_EyeBlinkFrequency, 1, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer2 = new wxFlexGridSizer(0, 4, 0, 0);
+	StaticText4 = new wxStaticText(this, ID_STATICTEXT3, _("Frequency"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT3"));
+	FlexGridSizer2->Add(StaticText4, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	Choice_Faces_EyeBlinkFrequency = new BulkEditChoice(this, ID_CHOICE_Faces_EyeBlinkFrequency, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_Faces_EyeBlinkFrequency"));
 	Choice_Faces_EyeBlinkFrequency->Append(_("Slowest"));
 	Choice_Faces_EyeBlinkFrequency->Append(_("Slow"));
 	Choice_Faces_EyeBlinkFrequency->SetSelection( Choice_Faces_EyeBlinkFrequency->Append(_("Normal")) );
 	Choice_Faces_EyeBlinkFrequency->Append(_("Fast"));
 	Choice_Faces_EyeBlinkFrequency->Append(_("Fastest"));
-	FlexGridSizer98->Add(Choice_Faces_EyeBlinkFrequency, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
-	FlexGridSizer98->Add(-1,-1,1, wxALL|wxALIGN_CENTER_VERTICAL, 5);
+	Choice_Faces_EyeBlinkFrequency->SetToolTip(_("How often the blink happens."));
+	FlexGridSizer2->Add(Choice_Faces_EyeBlinkFrequency, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	StaticText3 = new wxStaticText(this, ID_STATICTEXT2, _("Duration"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT2"));
+	FlexGridSizer2->Add(StaticText3, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	Choice_Faces_EyeBlinkDuration = new BulkEditChoice(this, ID_CHOICE_Faces_EyeBlinkDuration, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_Faces_EyeBlinkDuration"));
+	Choice_Faces_EyeBlinkDuration->Append(_("Short"));
+	Choice_Faces_EyeBlinkDuration->SetSelection( Choice_Faces_EyeBlinkDuration->Append(_("Normal")) );
+	Choice_Faces_EyeBlinkDuration->Append(_("Long"));
+	Choice_Faces_EyeBlinkDuration->Append(_("Longer"));
+	FlexGridSizer2->Add(Choice_Faces_EyeBlinkDuration, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer98->Add(FlexGridSizer2, 1, wxALL|wxEXPAND, 5);
+	FlexGridSizer98->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	CheckBox_Faces_Outline = new BulkEditCheckBox(this, ID_CHECKBOX_Faces_Outline, _("Show outline"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_Faces_Outline"));
 	CheckBox_Faces_Outline->SetValue(false);
 	FlexGridSizer98->Add(CheckBox_Faces_Outline, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
@@ -124,7 +142,7 @@ FacesPanel::FacesPanel(wxWindow* parent) : xlEffectPanel(parent)
 	CheckBox_SuppressShimmer->SetValue(false);
 	FlexGridSizer98->Add(CheckBox_SuppressShimmer, 1, wxALL|wxEXPAND, 5);
 	StaticText2 = new wxStaticText(this, ID_STATICTEXT1, _("Use State as outline"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT1"));
-	FlexGridSizer98->Add(StaticText2, 1, wxALL|wxEXPAND, 5);
+	FlexGridSizer98->Add(StaticText2, 1, wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL, 5);
 	Choice1 = new BulkEditStateChoice(this, ID_CHOICE_Faces_UseState, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_Faces_UseState"));
 	FlexGridSizer98->Add(Choice1, 1, wxALL|wxEXPAND, 5);
 	FlexGridSizer98->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
@@ -151,20 +169,19 @@ FacesPanel::FacesPanel(wxWindow* parent) : xlEffectPanel(parent)
 	FlexGridSizer7->Add(CheckBox_TransparentBlack, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	Slider_Faces_TransparentBlack = new BulkEditSlider(this, IDD_SLIDER_Faces_TransparentBlack, 0, 0, 300, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("IDD_SLIDER_Faces_TransparentBlack"));
 	FlexGridSizer7->Add(Slider_Faces_TransparentBlack, 1, wxALL|wxEXPAND, 5);
-	TextCtrl_Faces_TransparentBlack = new BulkEditTextCtrl(this, ID_TEXTCTRL_Faces_TransparentBlack, _("0"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(40,-1)), wxTE_RIGHT, wxDefaultValidator, _T("ID_TEXTCTRL_Faces_TransparentBlack"));
+	TextCtrl_Faces_TransparentBlack = new BulkEditTextCtrl(this, ID_TEXTCTRL_Faces_TransparentBlack, _T("0"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(40,-1)), wxTE_RIGHT, wxDefaultValidator, _T("ID_TEXTCTRL_Faces_TransparentBlack"));
 	FlexGridSizer7->Add(TextCtrl_Faces_TransparentBlack, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	FlexGridSizer47->Add(FlexGridSizer7, 1, wxALL|wxEXPAND, 5);
 	SetSizer(FlexGridSizer47);
-	FlexGridSizer47->Fit(this);
-	FlexGridSizer47->SetSizeHints(this);
 
-	Connect(IDD_RADIOBUTTON_Faces_Phoneme,wxEVT_COMMAND_RADIOBUTTON_SELECTED,(wxObjectEventFunction)&FacesPanel::OnMouthMovementTypeSelected);
-	Connect(IDD_RADIOBUTTON_Faces_TimingTrack,wxEVT_COMMAND_RADIOBUTTON_SELECTED,(wxObjectEventFunction)&FacesPanel::OnMouthMovementTypeSelected);
-	Connect(ID_CHOICE_Faces_Eyes,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&FacesPanel::OnChoice_Faces_EyesSelect);
-	Connect(ID_CHOICE_Faces_EyeBlinkFrequency,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&FacesPanel::OnChoice_Faces_EyeBlinkFrequencySelect);
-	Connect(ID_CHECKBOX_Faces_Outline,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&FacesPanel::OnCheckBox_Faces_OutlineClick);
-	Connect(ID_CHECKBOX_Faces_SuppressWhenNotSinging,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&FacesPanel::OnCheckBox_SuppressWhenNotSingingClick);
-	Connect(ID_CHECKBOX_Faces_Fade,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&FacesPanel::OnCheckBox_FadeClick);
+	Connect(IDD_RADIOBUTTON_Faces_Phoneme, wxEVT_COMMAND_RADIOBUTTON_SELECTED, (wxObjectEventFunction)&FacesPanel::OnMouthMovementTypeSelected);
+	Connect(IDD_RADIOBUTTON_Faces_TimingTrack, wxEVT_COMMAND_RADIOBUTTON_SELECTED, (wxObjectEventFunction)&FacesPanel::OnMouthMovementTypeSelected);
+	Connect(ID_CHOICE_Faces_Eyes, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&FacesPanel::OnChoice_Faces_EyesSelect);
+	Connect(ID_CHOICE_Faces_EyeBlinkFrequency, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&FacesPanel::OnChoice_Faces_EyeBlinkFrequencySelect);
+	Connect(ID_CHOICE_Faces_EyeBlinkDuration, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&FacesPanel::OnChoice_Faces_EyeBlinkFrequencySelect);
+	Connect(ID_CHECKBOX_Faces_Outline, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&FacesPanel::OnCheckBox_Faces_OutlineClick);
+	Connect(ID_CHECKBOX_Faces_SuppressWhenNotSinging, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&FacesPanel::OnCheckBox_SuppressWhenNotSingingClick);
+	Connect(ID_CHECKBOX_Faces_Fade, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&FacesPanel::OnCheckBox_FadeClick);
 	//*)
 
     Connect(wxID_ANY, EVT_VC_CHANGED, (wxObjectEventFunction)&FacesPanel::OnVCChanged, 0, this);

--- a/xLights/effects/FacesPanel.h
+++ b/xLights/effects/FacesPanel.h
@@ -41,6 +41,7 @@ class FacesPanel: public xlEffectPanel
 		BulkEditCheckBox* CheckBox_SuppressShimmer;
 		BulkEditCheckBox* CheckBox_SuppressWhenNotSinging;
 		BulkEditCheckBox* CheckBox_TransparentBlack;
+		BulkEditChoice* Choice_Faces_EyeBlinkDuration;
 		BulkEditChoice* Choice_Faces_EyeBlinkFrequency;
 		BulkEditChoice* Choice_Faces_Eyes;
 		BulkEditChoice* Choice_Faces_Phoneme;
@@ -55,6 +56,8 @@ class FacesPanel: public xlEffectPanel
 		wxStaticText* StaticText14;
 		wxStaticText* StaticText1;
 		wxStaticText* StaticText2;
+		wxStaticText* StaticText3;
+		wxStaticText* StaticText4;
 		wxStaticText* StaticText71;
 		wxStaticText* StaticText_Faces_EyeBlinkFrequency;
 		//*)
@@ -62,27 +65,30 @@ class FacesPanel: public xlEffectPanel
 	protected:
 
 		//(*Identifiers(FacesPanel)
-		static const long IDD_RADIOBUTTON_Faces_Phoneme;
-		static const long ID_CHOICE_Faces_Phoneme;
-		static const long IDD_RADIOBUTTON_Faces_TimingTrack;
-		static const long ID_CHOICE_Faces_TimingTrack;
-		static const long ID_STATICTEXT15;
-		static const long ID_CHOICE_Faces_FaceDefinition;
-		static const long ID_STATICTEXT_Faces_Eyes;
-		static const long ID_CHOICE_Faces_Eyes;
-		static const long ID_STATICTEXT_EYEBLINKFREQUENCY;
-		static const long ID_CHOICE_Faces_EyeBlinkFrequency;
-		static const long ID_CHECKBOX_Faces_Outline;
-		static const long ID_CHECKBOX_Faces_SuppressShimmer;
-		static const long ID_STATICTEXT1;
-		static const long ID_CHOICE_Faces_UseState;
-		static const long ID_CHECKBOX_Faces_SuppressWhenNotSinging;
-		static const long ID_STATICTEXT_Faces_Lead_Frames;
-		static const long ID_SPINCTRL_Faces_LeadFrames;
-		static const long ID_CHECKBOX_Faces_Fade;
-		static const long ID_CHECKBOX_Faces_TransparentBlack;
-		static const long IDD_SLIDER_Faces_TransparentBlack;
-		static const long ID_TEXTCTRL_Faces_TransparentBlack;
+		static const wxWindowID IDD_RADIOBUTTON_Faces_Phoneme;
+		static const wxWindowID ID_CHOICE_Faces_Phoneme;
+		static const wxWindowID IDD_RADIOBUTTON_Faces_TimingTrack;
+		static const wxWindowID ID_CHOICE_Faces_TimingTrack;
+		static const wxWindowID ID_STATICTEXT15;
+		static const wxWindowID ID_CHOICE_Faces_FaceDefinition;
+		static const wxWindowID ID_STATICTEXT_Faces_Eyes;
+		static const wxWindowID ID_CHOICE_Faces_Eyes;
+		static const wxWindowID ID_STATICTEXT_EYEBLINKFREQUENCY;
+		static const wxWindowID ID_STATICTEXT3;
+		static const wxWindowID ID_CHOICE_Faces_EyeBlinkFrequency;
+		static const wxWindowID ID_STATICTEXT2;
+		static const wxWindowID ID_CHOICE_Faces_EyeBlinkDuration;
+		static const wxWindowID ID_CHECKBOX_Faces_Outline;
+		static const wxWindowID ID_CHECKBOX_Faces_SuppressShimmer;
+		static const wxWindowID ID_STATICTEXT1;
+		static const wxWindowID ID_CHOICE_Faces_UseState;
+		static const wxWindowID ID_CHECKBOX_Faces_SuppressWhenNotSinging;
+		static const wxWindowID ID_STATICTEXT_Faces_Lead_Frames;
+		static const wxWindowID ID_SPINCTRL_Faces_LeadFrames;
+		static const wxWindowID ID_CHECKBOX_Faces_Fade;
+		static const wxWindowID ID_CHECKBOX_Faces_TransparentBlack;
+		static const wxWindowID IDD_SLIDER_Faces_TransparentBlack;
+		static const wxWindowID ID_TEXTCTRL_Faces_TransparentBlack;
 		//*)
 
 	public:

--- a/xLights/wxsmith/FacesPanel.wxs
+++ b/xLights/wxsmith/FacesPanel.wxs
@@ -106,6 +106,7 @@
 								<item>(off)</item>
 							</content>
 							<selection>2</selection>
+							<tooltip>When Auto, blink occurs during rest or (off).</tooltip>
 							<handler function="OnChoice_Faces_EyesSelect" entry="EVT_CHOICE" />
 						</object>
 						<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
@@ -114,30 +115,70 @@
 					</object>
 					<object class="sizeritem">
 						<object class="wxStaticText" name="ID_STATICTEXT_EYEBLINKFREQUENCY" variable="StaticText_Faces_EyeBlinkFrequency" member="yes">
-							<label>Eye Blink Frequency</label>
+							<label>Eye Blink</label>
 						</object>
 						<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
 						<border>5</border>
 						<option>1</option>
 					</object>
 					<object class="sizeritem">
-						<object class="wxChoice" name="ID_CHOICE_Faces_EyeBlinkFrequency" subclass="BulkEditChoice" variable="Choice_Faces_EyeBlinkFrequency" member="yes">
-							<content>
-								<item>Slowest</item>
-								<item>Slow</item>
-								<item>Normal</item>
-								<item>Fast</item>
-								<item>Fastest</item>
-							</content>
-							<selection>2</selection>
-							<handler function="OnChoice_Faces_EyeBlinkFrequencySelect" entry="EVT_CHOICE" />
+						<object class="wxFlexGridSizer" variable="FlexGridSizer2" member="no">
+							<cols>4</cols>
+							<object class="sizeritem">
+								<object class="wxStaticText" name="ID_STATICTEXT3" variable="StaticText4" member="yes">
+									<label>Frequency</label>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxChoice" name="ID_CHOICE_Faces_EyeBlinkFrequency" subclass="BulkEditChoice" variable="Choice_Faces_EyeBlinkFrequency" member="yes">
+									<content>
+										<item>Slowest</item>
+										<item>Slow</item>
+										<item>Normal</item>
+										<item>Fast</item>
+										<item>Fastest</item>
+									</content>
+									<selection>2</selection>
+									<tooltip>How often the blink happens.</tooltip>
+									<handler function="OnChoice_Faces_EyeBlinkFrequencySelect" entry="EVT_CHOICE" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxStaticText" name="ID_STATICTEXT2" variable="StaticText3" member="yes">
+									<label>Duration</label>
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxChoice" name="ID_CHOICE_Faces_EyeBlinkDuration" subclass="BulkEditChoice" variable="Choice_Faces_EyeBlinkDuration" member="yes">
+									<content>
+										<item>Short</item>
+										<item>Normal</item>
+										<item>Long</item>
+										<item>Longer</item>
+									</content>
+									<selection>1</selection>
+									<handler function="OnChoice_Faces_EyeBlinkFrequencySelect" entry="EVT_CHOICE" />
+								</object>
+								<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
 						</object>
-						<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+						<flag>wxALL|wxEXPAND</flag>
 						<border>5</border>
 						<option>1</option>
 					</object>
 					<object class="spacer">
-						<flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 						<border>5</border>
 						<option>1</option>
 					</object>
@@ -167,7 +208,7 @@
 						<object class="wxStaticText" name="ID_STATICTEXT1" variable="StaticText2" member="yes">
 							<label>Use State as outline</label>
 						</object>
-						<flag>wxALL|wxEXPAND</flag>
+						<flag>wxALL|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
 						<border>5</border>
 						<option>1</option>
 					</object>


### PR DESCRIPTION
Add a new option to control the length of a blink. The current hard coded value is very quick and not noticeable for many props. This allows the user to make it a more distinct eye closed/open effect. Noticing that the time of a blink in real life is closer to 200ms and not the hard coded 100ms that is currently in place. #5361 
Note that the current frequency option only controls how often a blink occurs.

![image](https://github.com/user-attachments/assets/f41bd551-61cf-4595-9ba6-075a1bd8b185)
