### PR TITLE
Add optional RGB palette-based coloring to Candle effect

### DIFF
--- a/xLights/effects/CandleEffect.cpp
+++ b/xLights/effects/CandleEffect.cpp
@@ -110,6 +110,7 @@ void CandleEffect::SetDefaultParameters()
     SetSliderValue(fp->Slider_Candle_WindVariability, 5);
 
     SetCheckBoxValue(fp->CheckBox_PerNode, false);
+	SetCheckBoxValue(fp->CheckBox_UsePalette, false);
 }
 
 void CandleEffect::Update(wxByte& flameprime, wxByte& flame, wxByte& wind, size_t windVariability, size_t flameAgility, size_t windCalmness, size_t windBaseline)
@@ -160,6 +161,14 @@ void CandleEffect::Render(Effect* effect, const SettingsMap& SettingsMap, Render
     int windVariability = GetValueCurveInt("Candle_WindVariability", 5, SettingsMap, oset, CANDLE_WINDVARIABILITY_MIN, CANDLE_WINDVARIABILITY_MAX, buffer.GetStartTimeMS(), buffer.GetEndTimeMS());
     int windBaseline = GetValueCurveInt("Candle_WindBaseline", 30, SettingsMap, oset, CANDLE_WINDBASELINE_MIN, CANDLE_WINDBASELINE_MAX, buffer.GetStartTimeMS(), buffer.GetEndTimeMS());
     bool perNode = SettingsMap.GetBool("CHECKBOX_PerNode", false);
+	bool usePalette = SettingsMap.GetBool("CHECKBOX_UsePalette", false);
+	
+	const auto& pal = effect->GetPalette();
+    if (usePalette && pal.empty()) {
+        //If "Use Palette" selected, but no colors are selected skip processing and return black.
+        buffer.Fill(xlBLACK);
+        return;    
+    }
 
     CandleRenderCache* cache = GetCache(buffer, id);
     std::vector<CandleState>& states = cache->_states;
@@ -185,7 +194,7 @@ void CandleEffect::Render(Effect* effect, const SettingsMap& SettingsMap, Render
 
     if (perNode) {
         int maxW = cache->maxWid;
-        parallel_for(0, buffer.BufferHt, [&buffer, &states, maxW, windVariability, flameAgility, windCalmness, windBaseline, this](int y) {
+        parallel_for(0, buffer.BufferHt, [&buffer, &states, maxW, windVariability, flameAgility, windCalmness, windBaseline, usePalette, &pal, this](int y) {
             for (size_t x = 0; x < buffer.BufferWi; x++) {
                 size_t index = y * maxW + x;
                 if (index >= states.size()) {
@@ -202,8 +211,17 @@ void CandleEffect::Render(Effect* effect, const SettingsMap& SettingsMap, Render
                     if (state->flameg > state->flamer)
                         state->flameprimeg = state->flameprimer;
 
-                    //  Now play Candle
-                    xlColor c = xlColor(state->flameprimer, state->flameprimeg / 2, 0);
+                    xlColor c;
+                    if (usePalette) {
+                        xlColor c1 = pal[0];
+                        xlColor c2 = pal.size() > 1 ? pal[1] : xlBLACK;  //Choose black as other color if only one color selected.
+                        float t = float(state->flameprimer) / 255.0f;
+                        c.red = wxByte(c1.red * (1.0f - t) + c2.red * t);
+                        c.green = wxByte(c1.green * (1.0f - t) + c2.green * t);
+                        c.blue = wxByte(c1.blue * (1.0f - t) + c2.blue * t);
+                    } else {
+                        c = xlColor(state->flameprimer, state->flameprimeg / 2, 0);
+                    }
                     buffer.SetPixel(x, y, c);
                 }
             }
@@ -220,7 +238,17 @@ void CandleEffect::Render(Effect* effect, const SettingsMap& SettingsMap, Render
             state->flameprimeg = state->flameprimer;
 
         //  Now play Candle
-        xlColor c = xlColor(state->flameprimer, state->flameprimeg / 2, 0);
+        xlColor c;
+        if (usePalette) {
+            xlColor c1 = pal[0];
+            xlColor c2 = pal.size() > 1 ? pal[1] : xlBLACK;  //Choose black as other color if only one color selected.
+            float t = float(state->flameprimer) / 255.0f;
+            c.red = wxByte(c1.red * (1.0f - t) + c2.red * t);
+            c.green = wxByte(c1.green * (1.0f - t) + c2.green * t);
+            c.blue = wxByte(c1.blue * (1.0f - t) + c2.blue * t);
+        } else {
+            c = xlColor(state->flameprimer, state->flameprimeg / 2, 0);
+        }
         for (size_t y = 0; y < buffer.BufferHt; y++) {
             for (size_t x = 0; x < buffer.BufferWi; x++) {
                 buffer.SetPixel(x, y, c);

--- a/xLights/effects/CandlePanel.cpp
+++ b/xLights/effects/CandlePanel.cpp
@@ -27,27 +27,28 @@
 //*)
 
 //(*IdInit(CandlePanel)
-const long CandlePanel::ID_STATICTEXT_Candle_FlameAgility = wxNewId();
-const long CandlePanel::IDD_SLIDER_Candle_FlameAgility = wxNewId();
-const long CandlePanel::ID_VALUECURVE_Candle_FlameAgility = wxNewId();
-const long CandlePanel::ID_TEXTCTRL_Candle_FlameAgility = wxNewId();
-const long CandlePanel::ID_BITMAPBUTTON_SLIDER_Candle_FlameAgility = wxNewId();
-const long CandlePanel::ID_STATICTEXT_Candle_WindBaseline = wxNewId();
-const long CandlePanel::IDD_SLIDER_Candle_WindBaseline = wxNewId();
-const long CandlePanel::ID_VALUECURVE_Candle_WindBaseline = wxNewId();
-const long CandlePanel::ID_TEXTCTRL_Candle_WindBaseline = wxNewId();
-const long CandlePanel::ID_BITMAPBUTTON_SLIDER_Candle_WindBaseline = wxNewId();
-const long CandlePanel::ID_STATICTEXT_Candle_WindVariability = wxNewId();
-const long CandlePanel::IDD_SLIDER_Candle_WindVariability = wxNewId();
-const long CandlePanel::ID_VALUECURVE_Candle_WindVariability = wxNewId();
-const long CandlePanel::ID_TEXTCTRL_Candle_WindVariability = wxNewId();
-const long CandlePanel::ID_BITMAPBUTTON_SLIDER_Candle_WindVariability = wxNewId();
-const long CandlePanel::ID_STATICTEXT_Candle_WindCalmness = wxNewId();
-const long CandlePanel::IDD_SLIDER_Candle_WindCalmness = wxNewId();
-const long CandlePanel::ID_VALUECURVE_Candle_WindCalmness = wxNewId();
-const long CandlePanel::ID_TEXTCTRL_Candle_WindCalmness = wxNewId();
-const long CandlePanel::ID_BITMAPBUTTON_SLIDER_Candle_WindCalmness = wxNewId();
-const long CandlePanel::ID_CHECKBOX_PerNode = wxNewId();
+const wxWindowID CandlePanel::ID_STATICTEXT_Candle_FlameAgility = wxNewId();
+const wxWindowID CandlePanel::IDD_SLIDER_Candle_FlameAgility = wxNewId();
+const wxWindowID CandlePanel::ID_VALUECURVE_Candle_FlameAgility = wxNewId();
+const wxWindowID CandlePanel::ID_TEXTCTRL_Candle_FlameAgility = wxNewId();
+const wxWindowID CandlePanel::ID_BITMAPBUTTON_SLIDER_Candle_FlameAgility = wxNewId();
+const wxWindowID CandlePanel::ID_STATICTEXT_Candle_WindBaseline = wxNewId();
+const wxWindowID CandlePanel::IDD_SLIDER_Candle_WindBaseline = wxNewId();
+const wxWindowID CandlePanel::ID_VALUECURVE_Candle_WindBaseline = wxNewId();
+const wxWindowID CandlePanel::ID_TEXTCTRL_Candle_WindBaseline = wxNewId();
+const wxWindowID CandlePanel::ID_BITMAPBUTTON_SLIDER_Candle_WindBaseline = wxNewId();
+const wxWindowID CandlePanel::ID_STATICTEXT_Candle_WindVariability = wxNewId();
+const wxWindowID CandlePanel::IDD_SLIDER_Candle_WindVariability = wxNewId();
+const wxWindowID CandlePanel::ID_VALUECURVE_Candle_WindVariability = wxNewId();
+const wxWindowID CandlePanel::ID_TEXTCTRL_Candle_WindVariability = wxNewId();
+const wxWindowID CandlePanel::ID_BITMAPBUTTON_SLIDER_Candle_WindVariability = wxNewId();
+const wxWindowID CandlePanel::ID_STATICTEXT_Candle_WindCalmness = wxNewId();
+const wxWindowID CandlePanel::IDD_SLIDER_Candle_WindCalmness = wxNewId();
+const wxWindowID CandlePanel::ID_VALUECURVE_Candle_WindCalmness = wxNewId();
+const wxWindowID CandlePanel::ID_TEXTCTRL_Candle_WindCalmness = wxNewId();
+const wxWindowID CandlePanel::ID_BITMAPBUTTON_SLIDER_Candle_WindCalmness = wxNewId();
+const wxWindowID CandlePanel::ID_CHECKBOX_PerNode = wxNewId();
+const wxWindowID CandlePanel::ID_CHECKBOX_UsePalette = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(CandlePanel,wxPanel)
@@ -76,7 +77,7 @@ CandlePanel::CandlePanel(wxWindow* parent) : xlEffectPanel(parent)
 	BitmapButton_Candle_FlameAgilityVC = new BulkEditValueCurveButton(this, ID_VALUECURVE_Candle_FlameAgility, GetValueCurveNotSelectedBitmap(), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_VALUECURVE_Candle_FlameAgility"));
 	FlexGridSizer1->Add(BitmapButton_Candle_FlameAgilityVC, 1, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
 	FlexGridSizer38->Add(FlexGridSizer1, 1, wxALL|wxEXPAND, 0);
-	TextCtrl_Candle_FlameAgility = new BulkEditTextCtrl(this, ID_TEXTCTRL_Candle_FlameAgility, _("2"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(20,-1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_Candle_FlameAgility"));
+	TextCtrl_Candle_FlameAgility = new BulkEditTextCtrl(this, ID_TEXTCTRL_Candle_FlameAgility, _T("2"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(20,-1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_Candle_FlameAgility"));
 	TextCtrl_Candle_FlameAgility->SetMaxLength(2);
 	FlexGridSizer38->Add(TextCtrl_Candle_FlameAgility, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
 	BitmapButton_Candle_FlameAgility = new xlLockButton(this, ID_BITMAPBUTTON_SLIDER_Candle_FlameAgility, wxNullBitmap, wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_SLIDER_Candle_FlameAgility"));
@@ -91,7 +92,7 @@ CandlePanel::CandlePanel(wxWindow* parent) : xlEffectPanel(parent)
 	BitmapButton_Candle_WindBaselineVC = new BulkEditValueCurveButton(this, ID_VALUECURVE_Candle_WindBaseline, GetValueCurveNotSelectedBitmap(), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_VALUECURVE_Candle_WindBaseline"));
 	FlexGridSizer2->Add(BitmapButton_Candle_WindBaselineVC, 1, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
 	FlexGridSizer38->Add(FlexGridSizer2, 1, wxALL|wxEXPAND, 0);
-	TextCtrl_Candle_WindBaseline = new BulkEditTextCtrl(this, ID_TEXTCTRL_Candle_WindBaseline, _("30"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(20,-1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_Candle_WindBaseline"));
+	TextCtrl_Candle_WindBaseline = new BulkEditTextCtrl(this, ID_TEXTCTRL_Candle_WindBaseline, _T("30"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(20,-1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_Candle_WindBaseline"));
 	TextCtrl_Candle_WindBaseline->SetMaxLength(3);
 	FlexGridSizer38->Add(TextCtrl_Candle_WindBaseline, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
 	BitmapButton_Cande_WindBaseline = new xlLockButton(this, ID_BITMAPBUTTON_SLIDER_Candle_WindBaseline, wxNullBitmap, wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_SLIDER_Candle_WindBaseline"));
@@ -106,7 +107,7 @@ CandlePanel::CandlePanel(wxWindow* parent) : xlEffectPanel(parent)
 	BitmapButton_Candle_WindVariabilityVC = new BulkEditValueCurveButton(this, ID_VALUECURVE_Candle_WindVariability, GetValueCurveNotSelectedBitmap(), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_VALUECURVE_Candle_WindVariability"));
 	FlexGridSizer3->Add(BitmapButton_Candle_WindVariabilityVC, 1, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
 	FlexGridSizer38->Add(FlexGridSizer3, 1, wxALL|wxEXPAND, 0);
-	TextCtrl_Candle_WindVariability = new BulkEditTextCtrl(this, ID_TEXTCTRL_Candle_WindVariability, _("5"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(20,-1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_Candle_WindVariability"));
+	TextCtrl_Candle_WindVariability = new BulkEditTextCtrl(this, ID_TEXTCTRL_Candle_WindVariability, _T("5"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(20,-1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_Candle_WindVariability"));
 	TextCtrl_Candle_WindVariability->SetMaxLength(2);
 	FlexGridSizer38->Add(TextCtrl_Candle_WindVariability, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 2);
 	BitmapButton_Cande_WinfVariability = new xlLockButton(this, ID_BITMAPBUTTON_SLIDER_Candle_WindVariability, wxNullBitmap, wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_SLIDER_Candle_WindVariability"));
@@ -121,7 +122,7 @@ CandlePanel::CandlePanel(wxWindow* parent) : xlEffectPanel(parent)
 	BitmapButton_Candle_WindCalmnessVC = new BulkEditValueCurveButton(this, ID_VALUECURVE_Candle_WindCalmness, GetValueCurveNotSelectedBitmap(), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_VALUECURVE_Candle_WindCalmness"));
 	FlexGridSizer4->Add(BitmapButton_Candle_WindCalmnessVC, 1, wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
 	FlexGridSizer38->Add(FlexGridSizer4, 1, wxALL|wxEXPAND, 0);
-	TextCtrl_Candle_WindCalmness = new BulkEditTextCtrl(this, ID_TEXTCTRL_Candle_WindCalmness, _("2"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(20,-1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_Candle_WindCalmness"));
+	TextCtrl_Candle_WindCalmness = new BulkEditTextCtrl(this, ID_TEXTCTRL_Candle_WindCalmness, _T("2"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(20,-1)), 0, wxDefaultValidator, _T("ID_TEXTCTRL_Candle_WindCalmness"));
 	TextCtrl_Candle_WindCalmness->SetMaxLength(2);
 	FlexGridSizer38->Add(TextCtrl_Candle_WindCalmness, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	BitmapButton_Candle_WindCalmness = new xlLockButton(this, ID_BITMAPBUTTON_SLIDER_Candle_WindCalmness, wxNullBitmap, wxDefaultPosition, wxSize(14,14), wxBU_AUTODRAW|wxBORDER_NONE, wxDefaultValidator, _T("ID_BITMAPBUTTON_SLIDER_Candle_WindCalmness"));
@@ -133,16 +134,23 @@ CandlePanel::CandlePanel(wxWindow* parent) : xlEffectPanel(parent)
 	FlexGridSizer38->Add(CheckBox_PerNode, 1, wxALL|wxEXPAND, 5);
 	FlexGridSizer38->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	FlexGridSizer38->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer38->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	CheckBox_UsePalette = new BulkEditCheckBox(this, ID_CHECKBOX_UsePalette, _("Use Palette"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_UsePalette"));
+	CheckBox_UsePalette->SetValue(false);
+	FlexGridSizer38->Add(CheckBox_UsePalette, 1, wxALL, 5);
+	FlexGridSizer38->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer38->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	SetSizer(FlexGridSizer38);
+	FlexGridSizer38->SetSizeHints(this);
 
-	Connect(ID_VALUECURVE_Candle_FlameAgility,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CandlePanel::OnVCButtonClick);
-	Connect(ID_BITMAPBUTTON_SLIDER_Candle_FlameAgility,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CandlePanel::OnLockButtonClick);
-	Connect(ID_VALUECURVE_Candle_WindBaseline,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CandlePanel::OnVCButtonClick);
-	Connect(ID_BITMAPBUTTON_SLIDER_Candle_WindBaseline,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CandlePanel::OnLockButtonClick);
-	Connect(ID_VALUECURVE_Candle_WindVariability,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CandlePanel::OnVCButtonClick);
-	Connect(ID_BITMAPBUTTON_SLIDER_Candle_WindVariability,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CandlePanel::OnLockButtonClick);
-	Connect(ID_VALUECURVE_Candle_WindCalmness,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CandlePanel::OnVCButtonClick);
-	Connect(ID_BITMAPBUTTON_SLIDER_Candle_WindCalmness,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&CandlePanel::OnLockButtonClick);
+	Connect(ID_VALUECURVE_Candle_FlameAgility, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CandlePanel::OnVCButtonClick);
+	Connect(ID_BITMAPBUTTON_SLIDER_Candle_FlameAgility, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CandlePanel::OnLockButtonClick);
+	Connect(ID_VALUECURVE_Candle_WindBaseline, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CandlePanel::OnVCButtonClick);
+	Connect(ID_BITMAPBUTTON_SLIDER_Candle_WindBaseline, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CandlePanel::OnLockButtonClick);
+	Connect(ID_VALUECURVE_Candle_WindVariability, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CandlePanel::OnVCButtonClick);
+	Connect(ID_BITMAPBUTTON_SLIDER_Candle_WindVariability, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CandlePanel::OnLockButtonClick);
+	Connect(ID_VALUECURVE_Candle_WindCalmness, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CandlePanel::OnVCButtonClick);
+	Connect(ID_BITMAPBUTTON_SLIDER_Candle_WindCalmness, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CandlePanel::OnLockButtonClick);
 	//*)
 
     Connect(wxID_ANY, EVT_VC_CHANGED, (wxObjectEventFunction)&CandlePanel::OnVCChanged, 0, this);

--- a/xLights/effects/CandlePanel.h
+++ b/xLights/effects/CandlePanel.h
@@ -34,6 +34,7 @@ class CandlePanel: public xlEffectPanel
 
 		//(*Declarations(CandlePanel)
 		BulkEditCheckBox* CheckBox_PerNode;
+		BulkEditCheckBox* CheckBox_UsePalette;
 		BulkEditSlider* Slider_Candle_FlameAgility;
 		BulkEditSlider* Slider_Candle_WindBaseline;
 		BulkEditSlider* Slider_Candle_WindCalmness;
@@ -59,27 +60,28 @@ class CandlePanel: public xlEffectPanel
 	protected:
 
 		//(*Identifiers(CandlePanel)
-		static const long ID_STATICTEXT_Candle_FlameAgility;
-		static const long IDD_SLIDER_Candle_FlameAgility;
-		static const long ID_VALUECURVE_Candle_FlameAgility;
-		static const long ID_TEXTCTRL_Candle_FlameAgility;
-		static const long ID_BITMAPBUTTON_SLIDER_Candle_FlameAgility;
-		static const long ID_STATICTEXT_Candle_WindBaseline;
-		static const long IDD_SLIDER_Candle_WindBaseline;
-		static const long ID_VALUECURVE_Candle_WindBaseline;
-		static const long ID_TEXTCTRL_Candle_WindBaseline;
-		static const long ID_BITMAPBUTTON_SLIDER_Candle_WindBaseline;
-		static const long ID_STATICTEXT_Candle_WindVariability;
-		static const long IDD_SLIDER_Candle_WindVariability;
-		static const long ID_VALUECURVE_Candle_WindVariability;
-		static const long ID_TEXTCTRL_Candle_WindVariability;
-		static const long ID_BITMAPBUTTON_SLIDER_Candle_WindVariability;
-		static const long ID_STATICTEXT_Candle_WindCalmness;
-		static const long IDD_SLIDER_Candle_WindCalmness;
-		static const long ID_VALUECURVE_Candle_WindCalmness;
-		static const long ID_TEXTCTRL_Candle_WindCalmness;
-		static const long ID_BITMAPBUTTON_SLIDER_Candle_WindCalmness;
-		static const long ID_CHECKBOX_PerNode;
+		static const wxWindowID ID_STATICTEXT_Candle_FlameAgility;
+		static const wxWindowID IDD_SLIDER_Candle_FlameAgility;
+		static const wxWindowID ID_VALUECURVE_Candle_FlameAgility;
+		static const wxWindowID ID_TEXTCTRL_Candle_FlameAgility;
+		static const wxWindowID ID_BITMAPBUTTON_SLIDER_Candle_FlameAgility;
+		static const wxWindowID ID_STATICTEXT_Candle_WindBaseline;
+		static const wxWindowID IDD_SLIDER_Candle_WindBaseline;
+		static const wxWindowID ID_VALUECURVE_Candle_WindBaseline;
+		static const wxWindowID ID_TEXTCTRL_Candle_WindBaseline;
+		static const wxWindowID ID_BITMAPBUTTON_SLIDER_Candle_WindBaseline;
+		static const wxWindowID ID_STATICTEXT_Candle_WindVariability;
+		static const wxWindowID IDD_SLIDER_Candle_WindVariability;
+		static const wxWindowID ID_VALUECURVE_Candle_WindVariability;
+		static const wxWindowID ID_TEXTCTRL_Candle_WindVariability;
+		static const wxWindowID ID_BITMAPBUTTON_SLIDER_Candle_WindVariability;
+		static const wxWindowID ID_STATICTEXT_Candle_WindCalmness;
+		static const wxWindowID IDD_SLIDER_Candle_WindCalmness;
+		static const wxWindowID ID_VALUECURVE_Candle_WindCalmness;
+		static const wxWindowID ID_TEXTCTRL_Candle_WindCalmness;
+		static const wxWindowID ID_BITMAPBUTTON_SLIDER_Candle_WindCalmness;
+		static const wxWindowID ID_CHECKBOX_PerNode;
+		static const wxWindowID ID_CHECKBOX_UsePalette;
 		//*)
 
 	public:

--- a/xLights/wxsmith/CandlePanel.wxs
+++ b/xLights/wxsmith/CandlePanel.wxs
@@ -249,6 +249,29 @@
 				<border>5</border>
 				<option>1</option>
 			</object>
+			<object class="spacer">
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxCheckBox" name="ID_CHECKBOX_UsePalette" subclass="BulkEditCheckBox" variable="CheckBox_UsePalette" member="yes">
+					<label>Use Palette</label>
+				</object>
+				<flag>wxALL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="spacer">
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="spacer">
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
 		</object>
 	</object>
 </wxsmith>


### PR DESCRIPTION
This PR adds support for optionally using up to two palette colors in the Candle effect.

- RGB values are calculated dynamically based on flame intensity.
- If only one palette color is selected, black is used as the second color.
- The default Candle behavior remains unchanged unless 'Use Palette' is enabled.
- 'Use Palette' is disabled by default to ensure compatibility with existing sequences.

The original Candle effect uses hard-coded colors that cannot be changed. This update introduces greater creative flexibility by allowing users to customize the flame’s color behavior via the palette.

Example of the Candle effect using different color selections:
![Xlights_CBLaAjnUt7](https://github.com/user-attachments/assets/9bb432c5-f587-47b9-a202-bbb66678e1fb)





