### PR TITLE
Add support for Bong69 8-Port LED Distro controllers (v1, v2, & v3) for WLED

### DIFF
--- a/controllers/wled.xcontroller
+++ b/controllers/wled.xcontroller
@@ -185,4 +185,30 @@
             <Port4>4</Port4>
         </Variant>
     </Controller>
+    <Controller Name="Bong69">
+        <Variant Name="8-Port Distro (PCB v1)" Base="WLED:ESP32WLEDSettings">
+            <MaxPixelPort>8</MaxPixelPort>
+            <MaxSerialPort>0</MaxSerialPort>
+            <Port1>15</Port1>
+            <Port2>14</Port2>
+            <Port3>12</Port3>
+            <Port4>4</Port4>
+            <Port5>2</Port5>
+            <Port6>17</Port6>
+            <Port7>5</Port7>
+            <Port8>33</Port8>
+        </Variant>
+        <Variant Name="8-Port Distro (PCB v2/v3)" Base="WLED:ESP32WLEDSettings">
+            <MaxPixelPort>8</MaxPixelPort>
+            <MaxSerialPort>0</MaxSerialPort>
+            <Port1>1</Port1>
+            <Port2>2</Port2>
+            <Port3>3</Port3>
+            <Port4>4</Port4>
+            <Port5>5</Port5>
+            <Port6>12</Port6>
+            <Port7>14</Port7>
+            <Port8>15</Port8>
+        </Variant>
+    </Controller>
 </Vendor>


### PR DESCRIPTION
This PR adds support for Bong69 8-Port Distro controllers (v1, v2, and v3) under WLED.

Details
- Introduced support logic for PCB v1, v2 & v3 of the Bong69 8-Port LED Distro boards
- The pinout definitions were derived from the board documentation available on the product page:
    🔗 https://www.tindie.com/products/bong69/8-port-led-distro/