### PR TITLE
Skip multi string shadow models in check sequence #5381

### DIFF
--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -5769,6 +5769,11 @@ std::string xLightsFrame::CheckSequence(bool displayInEditor, bool writeToFile)
     // Check for overlapping channels in models
     for (auto it = std::begin(AllModels); it != std::end(AllModels); ++it) {
         if (it->second->GetDisplayAs() != "ModelGroup") {
+            if(it->second->GetModelStartChannel().starts_with("@") && it->second->GetDisplayAs() == "Single Line" && it->second->GetNumStrings() > 1) {
+                logger_base.debug("Skipping Overlap Checking for %s [%s]", it->second->GetFullName().c_str(), it->second->GetModelStartChannel().c_str());
+                continue;
+            }
+
             auto m1start = it->second->GetFirstChannel() + 1;
             auto m1end = it->second->GetLastChannel() + 1;
 


### PR DESCRIPTION
MH shadow models flag as overlapping since they shadow multiple models. The current "shadow model for" doesn't handle this situation. This PR excludes them - should it be a preference or just exclude, like this, since it would always overlap intentionally. #5381 