### PR TITLE
Fix effect movement when selected by drag selection box

### DIFF
--- a/xLights/sequencer/EffectsGrid.cpp
+++ b/xLights/sequencer/EffectsGrid.cpp
@@ -6017,7 +6017,7 @@ void EffectsGrid::SetFirstEffectSelected() {
             for (int i = 0; i < num_effects && !found; ++i) {
                 Effect* eff = el->GetEffect(i);
                 if (eff->GetSelected()) {
-                    mSelectedRow = row;
+                    mSelectedRow = row- mSequenceElements->GetFirstVisibleModelRow();
                     mSelectedEffect = eff;
                     RaiseSelectedEffectChanged(eff, false);
                     RaisePlayModelEffect(element, eff, false);


### PR DESCRIPTION
There is a bug where if you select an effect by dragging a selection box and moved with arrow keys, it would move it to an incorrect position.  It is because mSelectedRow was set to absolute row index and not the visual row index.  
