### PR TITLE
DDP Falcon V4/V5 being discovered as E131 causing crash #5269

### DIFF
--- a/xLights/outputs/DDPOutput.cpp
+++ b/xLights/outputs/DDPOutput.cpp
@@ -363,7 +363,7 @@ void DDPOutput::PrepareDiscovery(Discovery &discovery) {
                 dd = discovery.AddController(controller);
             }
             ControllerEthernet* controller = dd->controller;
-
+            controller->SetProtocol(OUTPUT_DDP);
             if (controller == nullptr){
                 logger_base.warn("Unsupported DDP controller");
             }


### PR DESCRIPTION
Seems low risk - if you hit discover and Falcon controller is DDP, it was returning as E131 then crashing as the channels per universe were not really meant to be E131 but DDP. For Falcon V4 & V5. #5269. As they are just adding it, no harm forcing it to DDP anyways as a sort of best practices. 