### PR TITLE
Bug with Scaling default option #5396

### DIFF
--- a/xLights/effects/FanEffect.cpp
+++ b/xLights/effects/FanEffect.cpp
@@ -124,7 +124,7 @@ void FanEffect::adjustSettings(const std::string& version, Effect* effect, bool 
     SettingsMap& settings = effect->GetSettings();
 
     if (IsVersionOlder("2025.04", version)) {
-        settings["CHECKBOX_Fan_Scale"] = "0";
+        settings["E_CHECKBOX_Fan_Scale"] = "0";
     }
 }
 

--- a/xLights/effects/ShockwaveEffect.cpp
+++ b/xLights/effects/ShockwaveEffect.cpp
@@ -93,7 +93,7 @@ void ShockwaveEffect::adjustSettings(const std::string& version, Effect* effect,
     SettingsMap& settings = effect->GetSettings();
 
     if (IsVersionOlder("2025.04", version)) {
-        settings["CHECKBOX_Shockwave_Scale"] = "0";
+        settings["E_CHECKBOX_Shockwave_Scale"] = "0";
     }
 }
 


### PR DESCRIPTION
When an old sequence was loaded, the new scale to buffer was incorrectly being set to true.