### PR TITLE
Handle effect movement #5403

### DIFF
--- a/xLights/sequencer/EffectsGrid.cpp
+++ b/xLights/sequencer/EffectsGrid.cpp
@@ -1787,6 +1787,7 @@ void EffectsGrid::mouseDown(wxMouseEvent& event) {
     int selectedTimeMS = mTimeline->GetAbsoluteTimeMSfromPosition(event.GetX());
     mStartResizeTimeMS = selectedTimeMS;
     int row = GetRow(event.GetY());
+    mSelectedRow = GetRow(event.GetY()) + mSequenceElements->GetFirstVisibleModelRow();
     if (row >= mSequenceElements->GetVisibleRowInformationSize() || row < 0)
         return;
     mSequenceElements->get_undo_mgr().CreateUndoStep();
@@ -3755,7 +3756,6 @@ void EffectsGrid::Resize(int position, bool offset, bool control) {
 }
 
 void EffectsGrid::ScrollBy(int by) {
-    mSelectedRow -= by;
 }
 
 void EffectsGrid::MoveSelectedEffectUp(bool shift) {
@@ -3780,44 +3780,9 @@ void EffectsGrid::MoveSelectedEffectUp(bool shift) {
         }
         SetRCToolTip();
         UpdateSelectedEffects();
-        MakeRowVisible(mRangeEndRow - mSequenceElements->GetNumberOfTimingRows());
+        MakeRowVisible(mRangeEndRow - mSequenceElements->GetNumberOfTimingRows() - 1);
         Draw();
-    } else if (!MultipleEffectsSelected() && mSelectedEffect != nullptr && !mSelectedEffect->IsLocked() && mSelectedRow > 0) {
-        logger_base.debug("EffectsGrid::MoveSelectedEffectUp moving single effect.");
-        int row = mSelectedRow - 1;
-        xlights->AbortRender();
-        EffectLayer* el = mSelectedEffect->GetParentEffectLayer();
-        while (row + mSequenceElements->GetFirstVisibleModelRow() >= mSequenceElements->GetNumberOfTimingRows()) {
-            EffectLayer* new_el = mSequenceElements->GetEffectLayer(mSequenceElements->GetFirstVisibleModelRow() + row);
-            if (new_el != nullptr) {
-                if (new_el->GetRangeIsClearMS(mSelectedEffect->GetStartTimeMS(), mSelectedEffect->GetEndTimeMS())) {
-                    mSequenceElements->get_undo_mgr().CreateUndoStep();
-                    Effect* ef = new_el->AddEffect(0,
-                                                   mSelectedEffect->GetEffectName(),
-                                                   mSelectedEffect->GetSettingsAsString(),
-                                                   mSelectedEffect->GetPaletteAsString(),
-                                                   mSelectedEffect->GetStartTimeMS(),
-                                                   mSelectedEffect->GetEndTimeMS(),
-                                                   EFFECT_SELECTED,
-                                                   false);
-                    if (ef != nullptr) {
-                        mSelectedRow = row;
-                        mSelectedEffect = ef;
-                        el->DeleteSelectedEffects(mSequenceElements->get_undo_mgr());
-                        mSequenceElements->get_undo_mgr().CaptureAddedEffect(new_el->GetParentElement()->GetModelName(), new_el->GetIndex(), ef->GetID());
-                        RaiseSelectedEffectChanged(ef, false, true);
-                        sendRenderDirtyEvent();
-                        MakeRowVisible(mSelectedRow + mSequenceElements->GetFirstVisibleModelRow() - mSequenceElements->GetNumberOfTimingRows());
-                    } else {
-                        logger_base.warn("Problem adding effect when moving effect up %s", (const char*)mSelectedEffect->GetEffectName().c_str());
-                    }
-                    Draw();
-                    return;
-                }
-            }
-            row--;
-        }
-    } else if (MultipleEffectsSelected()) {
+    } else {
         logger_base.debug("EffectsGrid::MoveSelectedEffectUp moving multiple effects.");
 
         // check if its clear for all effects
@@ -3912,42 +3877,7 @@ void EffectsGrid::MoveSelectedEffectDown(bool shift) {
         UpdateSelectedEffects();
         MakeRowVisible(mRangeEndRow - mSequenceElements->GetNumberOfTimingRows() + 1);
         Draw();
-    } else if (!MultipleEffectsSelected() && mSelectedEffect != nullptr && !mSelectedEffect->IsLocked() && mSelectedRow >= 0) {
-        logger_base.debug("EffectsGrid::MoveSelectedEffectDown moving single effect.");
-        int row = mSelectedRow + 1;
-        xlights->AbortRender();
-        EffectLayer* el = mSelectedEffect->GetParentEffectLayer();
-        while (row < mSequenceElements->GetRowInformationSize()) {
-            EffectLayer* new_el = mSequenceElements->GetEffectLayer(mSequenceElements->GetFirstVisibleModelRow() + row);
-            if (new_el != nullptr) {
-                if (new_el->GetRangeIsClearMS(mSelectedEffect->GetStartTimeMS(), mSelectedEffect->GetEndTimeMS())) {
-                    mSequenceElements->get_undo_mgr().CreateUndoStep();
-                    Effect* ef = new_el->AddEffect(0,
-                                                   mSelectedEffect->GetEffectName(),
-                                                   mSelectedEffect->GetSettingsAsString(),
-                                                   mSelectedEffect->GetPaletteAsString(),
-                                                   mSelectedEffect->GetStartTimeMS(),
-                                                   mSelectedEffect->GetEndTimeMS(),
-                                                   EFFECT_SELECTED,
-                                                   false);
-                    if (ef != nullptr) {
-                        mSelectedRow = row;
-                        mSelectedEffect = ef;
-                        el->DeleteSelectedEffects(mSequenceElements->get_undo_mgr());
-                        mSequenceElements->get_undo_mgr().CaptureAddedEffect(new_el->GetParentElement()->GetModelName(), new_el->GetIndex(), ef->GetID());
-                        RaiseSelectedEffectChanged(ef, false, true);
-                        sendRenderDirtyEvent();
-                        MakeRowVisible(mSelectedRow + mSequenceElements->GetFirstVisibleModelRow() - mSequenceElements->GetNumberOfTimingRows() + 1);
-                    } else {
-                        logger_base.warn("Error adding effect when moving effects down %s", (const char*)mSelectedEffect->GetEffectName().c_str());
-                    }
-                    Draw();
-                    return;
-                }
-            }
-            ++row;
-        }
-    } else if (MultipleEffectsSelected()) {
+    } else {
         logger_base.debug("EffectsGrid::MoveSelectedEffectDown moving multiple effects.");
 
         // check if its clear for all effects
@@ -6233,7 +6163,7 @@ void EffectsGrid::SetFirstEffectSelected() {
             for (int i = 0; i < num_effects && !found; ++i) {
                 Effect* eff = el->GetEffect(i);
                 if (eff->GetSelected()) {
-                    mSelectedRow = row- mSequenceElements->GetFirstVisibleModelRow();
+                    mSelectedRow = row - mSequenceElements->GetFirstVisibleModelRow();
                     mSelectedEffect = eff;
                     RaiseSelectedEffectChanged(eff, false);
                     RaisePlayModelEffect(element, eff, false);


### PR DESCRIPTION
The code used for handle a single effect movement would did not account for expanding strands, timing marks, nodes etc. The range selection is cleaner and works correctly even with one effect selected. No apparent performance issue found. #5403