### PR TITLE
Add clear all and clear selected on import effects #5408

### DIFF
--- a/xLights/xLightsImportChannelMapDialog.h
+++ b/xLights/xLightsImportChannelMapDialog.h
@@ -588,6 +588,8 @@ protected:
         static const long ID_MNU_EXPANDALL;
         static const long ID_MNU_SHOWALLMAPPED;
         static const long ID_MNU_AUTOMAPSELECTED;
+        static const wxWindowID ID_MNU_CLEARSELECTED;
+        static const wxWindowID ID_MNU_CLEARALL;
         static const long ID_MNU_AUTOMAPSELECTED_AVAIL;
         static const wxWindowID ID_MNU_ADD_EMPTY_GROUP;
 
@@ -624,6 +626,8 @@ protected:
         void RightClickModelsAvail(wxDataViewEvent& event);
         void CollapseAll();
         void ExpandAll();
+        void ClearAll();
+        void ClearSelected();
         void AddEmptyGroup();
         void ShowAllMapped();
         void OnPopupTimingTracks(wxCommandEvent& event);


### PR DESCRIPTION
With automap and such, there was no way to  quickly clear out bad maps/bad attempts. Adding a right click option to clear all or selected items. *If* the item is collapsed, it will remove items on the subs and strands as well. #5408 