### PR TITLE
Use the persepective to save/restore the display editor sizing #5420

### DIFF
--- a/xLights/sequencer/tabSequencer.cpp
+++ b/xLights/sequencer/tabSequencer.cpp
@@ -3132,10 +3132,6 @@ void xLightsFrame::ShowDisplayElements(wxCommandEvent& event)
 {
     displayElementsPanel->Initialize();
     wxAuiPaneInfo & info = m_mgr->GetPane("DisplayElements");
-    info.BestSize(wxSize(750, 1050));
-    int w, h;
-    displayElementsPanel->GetSize(&w, &h);
-    info.FloatingSize(std::max(750, w), std::max(1050, h));
     info.Show();
     m_mgr->Update();
     UpdateViewMenu();
@@ -3185,10 +3181,6 @@ void xLightsFrame::ShowHideDisplayElementsWindow(wxCommandEvent& event)
     if (visible) {
         info.Hide();
     } else {
-        info.BestSize(wxSize(750, 1050));
-        int w, h;
-        displayElementsPanel->GetSize(&w, &h);
-        info.FloatingSize(std::max(750, w), std::max(1050, h));
         info.Show();
     }
     m_mgr->Update();


### PR DESCRIPTION
Don't force the panel to full height, etc. Just use the perspective that is in use. ie. Set the size of the panel, save the perspective and it will stick going forward. #5420 