### PR TITLE
Add basic regex to Layout Group Filter #5400

### DIFF
--- a/xLights/ModelGroupPanel.cpp
+++ b/xLights/ModelGroupPanel.cpp
@@ -18,6 +18,7 @@
 #include <wx/artprov.h>
 #include <wx/xml/xml.h>
 #include <wx/time.h>
+#include <regex>
 
 #include "ModelGroupPanel.h"
 #include "models/ModelManager.h"
@@ -85,38 +86,38 @@ public:
 };
 
 //(*IdInit(ModelGroupPanel)
-const long ModelGroupPanel::ID_STATICTEXT5 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT6 = wxNewId();
-const long ModelGroupPanel::ID_CHOICE1 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT12 = wxNewId();
-const long ModelGroupPanel::ID_CHOICE2 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT4 = wxNewId();
-const long ModelGroupPanel::ID_SPINCTRL1 = wxNewId();
-const long ModelGroupPanel::ID_CHOICE_PREVIEWS = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT7 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT10 = wxNewId();
-const long ModelGroupPanel::ID_SPINCTRL2 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT11 = wxNewId();
-const long ModelGroupPanel::ID_SPINCTRL3 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT8 = wxNewId();
-const long ModelGroupPanel::ID_COLOURPICKERCTRL_MG_TAGCOLOUR = wxNewId();
-const long ModelGroupPanel::ID_BUTTON2 = wxNewId();
-const long ModelGroupPanel::ID_CHECKBOX1 = wxNewId();
-const long ModelGroupPanel::ID_CHECKBOX3 = wxNewId();
-const long ModelGroupPanel::ID_CHECKBOX2 = wxNewId();
-const long ModelGroupPanel::ID_CHECKBOX4 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT3 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT2 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT9 = wxNewId();
-const long ModelGroupPanel::ID_TEXTCTRL1 = wxNewId();
-const long ModelGroupPanel::ID_BUTTON1 = wxNewId();
-const long ModelGroupPanel::ID_LISTCTRL1 = wxNewId();
-const long ModelGroupPanel::ID_BITMAPBUTTON4 = wxNewId();
-const long ModelGroupPanel::ID_BITMAPBUTTON3 = wxNewId();
-const long ModelGroupPanel::ID_BITMAPBUTTON1 = wxNewId();
-const long ModelGroupPanel::ID_BITMAPBUTTON2 = wxNewId();
-const long ModelGroupPanel::ID_STATICTEXT1 = wxNewId();
-const long ModelGroupPanel::ID_LISTCTRL2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT5 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT6 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHOICE1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT12 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHOICE2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT4 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_SPINCTRL1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHOICE_PREVIEWS = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT7 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT10 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_SPINCTRL2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT11 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_SPINCTRL3 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT8 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_COLOURPICKERCTRL_MG_TAGCOLOUR = wxNewId();
+const wxWindowID ModelGroupPanel::ID_BUTTON2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHECKBOX1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHECKBOX3 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHECKBOX2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_CHECKBOX4 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT3 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT9 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_TEXTCTRL1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_BUTTON1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_LISTCTRL1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_BITMAPBUTTON4 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_BITMAPBUTTON3 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_BITMAPBUTTON1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_BITMAPBUTTON2 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_STATICTEXT1 = wxNewId();
+const wxWindowID ModelGroupPanel::ID_LISTCTRL2 = wxNewId();
 //*)
 
 const long ModelGroupPanel::ID_MNU_CLEARALL = wxNewId();
@@ -242,6 +243,7 @@ ModelGroupPanel::ModelGroupPanel(wxWindow* parent, ModelManager &Models, LayoutP
 	StaticText9 = new wxStaticText(this, ID_STATICTEXT9, _("Filter:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT9"));
 	FlexGridSizer2->Add(StaticText9, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 1);
 	TextCtrl_Filter = new wxTextCtrl(this, ID_TEXTCTRL1, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_TEXTCTRL1"));
+	TextCtrl_Filter->SetToolTip(_("Allows for basic regex values ^\?.*$"));
 	FlexGridSizer2->Add(TextCtrl_Filter, 1, wxALL|wxEXPAND, 1);
 	ButtonClearFilter = new wxButton(this, ID_BUTTON1, _("x"), wxDefaultPosition, wxSize(20,-1), 0, wxDefaultValidator, _T("ID_BUTTON1"));
 	FlexGridSizer2->Add(ButtonClearFilter, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
@@ -270,35 +272,33 @@ ModelGroupPanel::ModelGroupPanel(wxWindow* parent, ModelManager &Models, LayoutP
 	FlexGridSizer3->Add(FlexGridSizer12, 1, wxALL|wxEXPAND, 0);
 	Panel_Sizer->Add(FlexGridSizer3, 0, wxEXPAND, 0);
 	SetSizer(Panel_Sizer);
-	Panel_Sizer->Fit(this);
-	Panel_Sizer->SetSizeHints(this);
 
-	Connect(ID_CHOICE1,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnChoiceModelLayoutTypeSelect);
-	Connect(ID_CHOICE2,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnChoice_DefaultCameraSelect);
-	Connect(ID_SPINCTRL1,wxEVT_COMMAND_SPINCTRL_UPDATED,(wxObjectEventFunction)&ModelGroupPanel::OnSizeSpinCtrlChange);
-	Connect(ID_CHOICE_PREVIEWS,wxEVT_COMMAND_CHOICE_SELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnChoicePreviewsSelect);
-	Connect(ID_SPINCTRL2,wxEVT_COMMAND_SPINCTRL_UPDATED,(wxObjectEventFunction)&ModelGroupPanel::OnSpinCtrl_XCentreOffsetChange);
-	Connect(ID_SPINCTRL3,wxEVT_COMMAND_SPINCTRL_UPDATED,(wxObjectEventFunction)&ModelGroupPanel::OnSpinCtrl_YCentreOffsetChange);
-	Connect(ID_COLOURPICKERCTRL_MG_TAGCOLOUR,wxEVT_COMMAND_COLOURPICKER_CHANGED,(wxObjectEventFunction)&ModelGroupPanel::OnColourPickerCtrl_ModelGroupTagColourColourChanged);
-	Connect(ID_BUTTON2,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnButtonAliasesClick);
-	Connect(ID_CHECKBOX1,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowSubmodelsClick);
-	Connect(ID_CHECKBOX3,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowInactiveModelsClick);
-	Connect(ID_CHECKBOX2,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowModelGroupsClick);
-	Connect(ID_CHECKBOX4,wxEVT_COMMAND_CHECKBOX_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowOnlyModelsInCurrentViewClick);
-	Connect(ID_TEXTCTRL1,wxEVT_COMMAND_TEXT_UPDATED,(wxObjectEventFunction)&ModelGroupPanel::OnTextCtrl_FilterText);
-	Connect(ID_BUTTON1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnButtonClearFilterClick);
-	Connect(ID_LISTCTRL1,wxEVT_COMMAND_LIST_BEGIN_DRAG,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupBeginDrag);
-	Connect(ID_LISTCTRL1,wxEVT_COMMAND_LIST_ITEM_SELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupItemSelect);
-	Connect(ID_LISTCTRL1,wxEVT_COMMAND_LIST_ITEM_DESELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupItemDeselect);
-	Connect(ID_LISTCTRL1,wxEVT_COMMAND_LIST_ITEM_ACTIVATED,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupItemActivated);
-	Connect(ID_BITMAPBUTTON4,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnButtonAddToModelGroupClick);
-	Connect(ID_BITMAPBUTTON3,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnButtonRemoveFromModelGroupClick);
-	Connect(ID_BITMAPBUTTON1,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnButtonUpClick);
-	Connect(ID_BITMAPBUTTON2,wxEVT_COMMAND_BUTTON_CLICKED,(wxObjectEventFunction)&ModelGroupPanel::OnButtonDownClick);
-	Connect(ID_LISTCTRL2,wxEVT_COMMAND_LIST_BEGIN_DRAG,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupBeginDrag);
-	Connect(ID_LISTCTRL2,wxEVT_COMMAND_LIST_ITEM_SELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemSelect);
-	Connect(ID_LISTCTRL2,wxEVT_COMMAND_LIST_ITEM_DESELECTED,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemDeselect);
-	Connect(ID_LISTCTRL2,wxEVT_COMMAND_LIST_ITEM_ACTIVATED,(wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemActivated);
+	Connect(ID_CHOICE1, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnChoiceModelLayoutTypeSelect);
+	Connect(ID_CHOICE2, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnChoice_DefaultCameraSelect);
+	Connect(ID_SPINCTRL1, wxEVT_COMMAND_SPINCTRL_UPDATED, (wxObjectEventFunction)&ModelGroupPanel::OnSizeSpinCtrlChange);
+	Connect(ID_CHOICE_PREVIEWS, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnChoicePreviewsSelect);
+	Connect(ID_SPINCTRL2, wxEVT_COMMAND_SPINCTRL_UPDATED, (wxObjectEventFunction)&ModelGroupPanel::OnSpinCtrl_XCentreOffsetChange);
+	Connect(ID_SPINCTRL3, wxEVT_COMMAND_SPINCTRL_UPDATED, (wxObjectEventFunction)&ModelGroupPanel::OnSpinCtrl_YCentreOffsetChange);
+	Connect(ID_COLOURPICKERCTRL_MG_TAGCOLOUR, wxEVT_COMMAND_COLOURPICKER_CHANGED, (wxObjectEventFunction)&ModelGroupPanel::OnColourPickerCtrl_ModelGroupTagColourColourChanged);
+	Connect(ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnButtonAliasesClick);
+	Connect(ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowSubmodelsClick);
+	Connect(ID_CHECKBOX3, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowInactiveModelsClick);
+	Connect(ID_CHECKBOX2, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowModelGroupsClick);
+	Connect(ID_CHECKBOX4, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnCheckBox_ShowOnlyModelsInCurrentViewClick);
+	Connect(ID_TEXTCTRL1, wxEVT_COMMAND_TEXT_UPDATED, (wxObjectEventFunction)&ModelGroupPanel::OnTextCtrl_FilterText);
+	Connect(ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnButtonClearFilterClick);
+	Connect(ID_LISTCTRL1, wxEVT_COMMAND_LIST_BEGIN_DRAG, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupBeginDrag);
+	Connect(ID_LISTCTRL1, wxEVT_COMMAND_LIST_ITEM_SELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupItemSelect);
+	Connect(ID_LISTCTRL1, wxEVT_COMMAND_LIST_ITEM_DESELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupItemDeselect);
+	Connect(ID_LISTCTRL1, wxEVT_COMMAND_LIST_ITEM_ACTIVATED, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxAddToModelGroupItemActivated);
+	Connect(ID_BITMAPBUTTON4, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnButtonAddToModelGroupClick);
+	Connect(ID_BITMAPBUTTON3, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnButtonRemoveFromModelGroupClick);
+	Connect(ID_BITMAPBUTTON1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnButtonUpClick);
+	Connect(ID_BITMAPBUTTON2, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&ModelGroupPanel::OnButtonDownClick);
+	Connect(ID_LISTCTRL2, wxEVT_COMMAND_LIST_BEGIN_DRAG, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupBeginDrag);
+	Connect(ID_LISTCTRL2, wxEVT_COMMAND_LIST_ITEM_SELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemSelect);
+	Connect(ID_LISTCTRL2, wxEVT_COMMAND_LIST_ITEM_DESELECTED, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemDeselect);
+	Connect(ID_LISTCTRL2, wxEVT_COMMAND_LIST_ITEM_ACTIVATED, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemActivated);
 	//*)
 
     Connect(ID_LISTCTRL2, wxEVT_CONTEXT_MENU, (wxObjectEventFunction)&ModelGroupPanel::OnListBoxModelsInGroupItemRClick);
@@ -378,6 +378,41 @@ bool canAddToGroup(ModelGroup *g, ModelManager &models, const std::string &model
     return true;
 }
 
+std::string ModelGroupPanel::WildcardToRegex(const std::string& wildcard) {
+    std::string pattern;
+    pattern.reserve(wildcard.size() + 4); // Account for potential .*
+    bool hasWildcards = wildcard.find_first_of("*?") != std::string::npos;
+    bool startsWithCaret = !wildcard.empty() && wildcard[0] == '^';
+    bool endsWithDollar = !wildcard.empty() && wildcard.back() == '$';
+
+    size_t start = startsWithCaret ? 1 : 0;
+    size_t end = endsWithDollar ? wildcard.size() - 1 : wildcard.size();
+    for (size_t i = start; i < end; ++i) {
+        char c = wildcard[i];
+        if (c == '*' || c == '?') {
+            pattern += (c == '*') ? ".*" : ".";
+        } else {
+            if (std::string(".^$+()[{\\|/").find(c) != std::string::npos) {
+                pattern += '\\';
+            }
+            pattern += c;
+        }
+    }
+
+    if (startsWithCaret) {
+        pattern = "^" + pattern;
+    } else {
+        pattern = ".*" + pattern;
+    }
+    if (endsWithDollar) {
+        pattern += "$";
+    } else {
+        pattern += ".*";
+    }
+
+    return pattern;
+}
+
 void ModelGroupPanel::UpdatePanel(const std::string& group)
 {
     // static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
@@ -455,13 +490,24 @@ void ModelGroupPanel::UpdatePanel(const std::string& group)
                         // logger_base.debug("Model not eligible to be added to group or already in group " + group + " : " + it.first);
                     }
                     else {
-                        if (filter == "" || Contains(::Lower(it.first), filter)) {
+                        std::string modelName = ::Lower(it.first);
+                        bool matches = filter == "";
+                        if (!matches) {
+                            try {
+                                std::string pattern = WildcardToRegex(filter.ToStdString());
+                                std::regex regexFilter(pattern, std::regex::icase);
+                                matches = std::regex_match(modelName, regexFilter);
+                            } catch (const std::regex_error& e) {
+                                matches = Contains(modelName, filter);
+                            }
+                        }
+                        if (matches) {
                             long item = ListBoxAddToModelGroup->InsertItem(ListBoxAddToModelGroup->GetItemCount(), it.first);
                             if (it.second->GetDisplayAs() == "ModelGroup") {
                                 ListBoxAddToModelGroup->SetItemTextColour(item,
-                                                                          IsDarkMode()
-                                                                              ? BLUE_ON_DARK
-                                                                              : *wxBLUE);
+                                    IsDarkMode()
+                                    ? BLUE_ON_DARK
+                                    : *wxBLUE);
                             }
                         }
                     }
@@ -470,7 +516,17 @@ void ModelGroupPanel::UpdatePanel(const std::string& group)
                             Model* sm = smit;
 
                             if (std::find(g->ModelNames().begin(), g->ModelNames().end(), sm->GetFullName()) == g->ModelNames().end()) {
-                                if (filter == "" || Contains(::Lower(sm->GetFullName()), filter)) {
+                                std::string subModelName = ::Lower(sm->GetFullName());
+                                bool matches = filter == "";
+                                if (!matches) {
+                                    try {
+                                        std::regex regexFilter(WildcardToRegex(filter.ToStdString()), std::regex::icase);
+                                        matches = std::regex_match(subModelName, regexFilter);
+                                    } catch (const std::regex_error&) {
+                                        matches = Contains(subModelName, filter);
+                                    }
+                                }
+                                if (matches) {
                                     long item = ListBoxAddToModelGroup->InsertItem(ListBoxAddToModelGroup->GetItemCount(), sm->GetFullName());
                                     ListBoxAddToModelGroup->SetItemTextColour(item, xlORANGE.asWxColor());
                                 }

--- a/xLights/ModelGroupPanel.h
+++ b/xLights/ModelGroupPanel.h
@@ -99,38 +99,38 @@ public:
 protected:
 
 	//(*Identifiers(ModelGroupPanel)
-	static const long ID_STATICTEXT5;
-	static const long ID_STATICTEXT6;
-	static const long ID_CHOICE1;
-	static const long ID_STATICTEXT12;
-	static const long ID_CHOICE2;
-	static const long ID_STATICTEXT4;
-	static const long ID_SPINCTRL1;
-	static const long ID_CHOICE_PREVIEWS;
-	static const long ID_STATICTEXT7;
-	static const long ID_STATICTEXT10;
-	static const long ID_SPINCTRL2;
-	static const long ID_STATICTEXT11;
-	static const long ID_SPINCTRL3;
-	static const long ID_STATICTEXT8;
-	static const long ID_COLOURPICKERCTRL_MG_TAGCOLOUR;
-	static const long ID_BUTTON2;
-	static const long ID_CHECKBOX1;
-	static const long ID_CHECKBOX3;
-	static const long ID_CHECKBOX2;
-	static const long ID_CHECKBOX4;
-	static const long ID_STATICTEXT3;
-	static const long ID_STATICTEXT2;
-	static const long ID_STATICTEXT9;
-	static const long ID_TEXTCTRL1;
-	static const long ID_BUTTON1;
-	static const long ID_LISTCTRL1;
-	static const long ID_BITMAPBUTTON4;
-	static const long ID_BITMAPBUTTON3;
-	static const long ID_BITMAPBUTTON1;
-	static const long ID_BITMAPBUTTON2;
-	static const long ID_STATICTEXT1;
-	static const long ID_LISTCTRL2;
+	static const wxWindowID ID_STATICTEXT5;
+	static const wxWindowID ID_STATICTEXT6;
+	static const wxWindowID ID_CHOICE1;
+	static const wxWindowID ID_STATICTEXT12;
+	static const wxWindowID ID_CHOICE2;
+	static const wxWindowID ID_STATICTEXT4;
+	static const wxWindowID ID_SPINCTRL1;
+	static const wxWindowID ID_CHOICE_PREVIEWS;
+	static const wxWindowID ID_STATICTEXT7;
+	static const wxWindowID ID_STATICTEXT10;
+	static const wxWindowID ID_SPINCTRL2;
+	static const wxWindowID ID_STATICTEXT11;
+	static const wxWindowID ID_SPINCTRL3;
+	static const wxWindowID ID_STATICTEXT8;
+	static const wxWindowID ID_COLOURPICKERCTRL_MG_TAGCOLOUR;
+	static const wxWindowID ID_BUTTON2;
+	static const wxWindowID ID_CHECKBOX1;
+	static const wxWindowID ID_CHECKBOX3;
+	static const wxWindowID ID_CHECKBOX2;
+	static const wxWindowID ID_CHECKBOX4;
+	static const wxWindowID ID_STATICTEXT3;
+	static const wxWindowID ID_STATICTEXT2;
+	static const wxWindowID ID_STATICTEXT9;
+	static const wxWindowID ID_TEXTCTRL1;
+	static const wxWindowID ID_BUTTON1;
+	static const wxWindowID ID_LISTCTRL1;
+	static const wxWindowID ID_BITMAPBUTTON4;
+	static const wxWindowID ID_BITMAPBUTTON3;
+	static const wxWindowID ID_BITMAPBUTTON1;
+	static const wxWindowID ID_BITMAPBUTTON2;
+	static const wxWindowID ID_STATICTEXT1;
+	static const wxWindowID ID_LISTCTRL2;
 	//*)
 
 	static const long ID_MNU_CLEARALL;
@@ -183,6 +183,7 @@ private:
 	int GetSelectedModelCount();
 	void OnPopup(wxCommandEvent& event);
 
+	std::string WildcardToRegex(const std::string& wildcard);
 	void SaveGroupChanges(bool updateCentre = false);
 	void AddSelectedModels(int index);
 	void RemoveSelectedModels();

--- a/xLights/wxsmith/ModelGroupPanel.wxs
+++ b/xLights/wxsmith/ModelGroupPanel.wxs
@@ -292,6 +292,7 @@
 											</object>
 											<object class="sizeritem">
 												<object class="wxTextCtrl" name="ID_TEXTCTRL1" variable="TextCtrl_Filter" member="yes">
+													<tooltip>Allows for basic regex values ^?.*$</tooltip>
 													<handler function="OnTextCtrl_FilterText" entry="EVT_TEXT" />
 												</object>
 												<flag>wxALL|wxEXPAND</flag>


### PR DESCRIPTION
Allow ^.?*$ to filter out the items when adding models to a group. #5400 
(also included some code::blocks updates)
![image](https://github.com/user-attachments/assets/90eed037-8b12-4dc7-b779-a4d53867ce1f)
