### PR TITLE
Make the controller status section collapsable #3617

### DIFF
--- a/bin/xScheduleWeb/js/sidebar.js
+++ b/bin/xScheduleWeb/js/sidebar.js
@@ -16,17 +16,28 @@ function populateSideBar() {
         `;
         $('#sideBar1').html(sidebar1);
 
-        var sidebar2 = `
-        <div class="list-group">
-        <div class="list-group-item active main-color-bg"><span class="glyphicon glyphicon glyphicon-sort" aria-hidden="true"></span> Controller Status </div>
+    var sidebar2 = `
+    <div class="list-group">
+      <div class="list-group-item active main-color-bg" data-toggle="collapse" data-target="#controllerStatusCollapse" style="cursor: pointer;">
+        <span class="glyphicon glyphicon-sort" aria-hidden="true"></span> Controller Status
+        <span class="glyphicon glyphicon-chevron-down pull-right" aria-hidden="true"></span>
+      </div>
+      <div id="controllerStatusCollapse" class="collapse in">
         <table class="table table-sm table-dark">
-        <tbody id="controllerStatusTable">
-        </tbody>
+          <tbody id="controllerStatusTable">
+          </tbody>
         </table>
-        </div>
-        `;
-        $('#sideBar2').html(sidebar2);
+      </div>
+    </div>
+   `;
+    $('#sideBar2').html(sidebar2);
 
+    $('#controllerStatusCollapse').on('show.bs.collapse', function () {
+        $(this).prev().find('.glyphicon.pull-right').removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up');
+    });
+    $('#controllerStatusCollapse').on('hide.bs.collapse', function () {
+        $(this).prev().find('.glyphicon.pull-right').removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down');
+    });
 
   }
 


### PR DESCRIPTION
Rather than mess with order, this change simply makes the controller section collapsable. When using a narrow device you can reduce the area for that section. #3617 

<img width="431" height="540" alt="image" src="https://github.com/user-attachments/assets/4fab541b-c942-4d90-bfd2-c29a01ae5193" />
