### PR TITLE
Minor tweak in node layout html #5444

### DIFF
--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -5217,7 +5217,7 @@ std::string Model::ChannelLayoutHtml(OutputManager* outputManager)
         for (int x = 0; x < BufferWi; ++x) {
             int n = chmap[y * BufferWi + x];
             if (n == 0) {
-                html += "<td></td>";
+                html += "<td>&nbsp&nbsp&nbsp</td>";
             } else {
                 int s = Nodes[n - 1]->StringNum + 1;
                 wxString bgcolor = (s % 2 == 1) ? "#ADD8E6" : "#90EE90";


### PR DESCRIPTION
Use the same spacing that is used in custom model so that the grid is better displayed. #5444 
It is still remains a bit of a compromise to make it fit nicely on your browser/screen.
Shrunk down for github here.
<img width="1162" height="572" alt="image" src="https://github.com/user-attachments/assets/7ab11bf9-1222-4e58-b3a3-ca0b921362ce" />
