### PR TITLE
Remove temporary files from .xsqz extract #4933

### DIFF
--- a/xLights/xLightsApp.cpp
+++ b/xLights/xLightsApp.cpp
@@ -375,10 +375,6 @@ int main(int argc, char **argv)
     int rc =  wxEntry(argc, argv);
     logger_base.info("Main: wxWidgets exited with rc=" + wxString::Format("%d", rc));
 
-    if (cleanupFolder != "") {
-        wxDir::Remove(cleanupFolder, wxPATH_RMDIR_RECURSIVE);
-    }
-
     return rc;
 }
 
@@ -708,6 +704,7 @@ bool xLightsApp::OnInit()
 
             // save the folder and we will remove it when we shutdown
             cleanupFolder = showDir;
+            cleanupDir = showDir;
 
         } else {
             logger_base.debug("Zip file did not contain sequence.");        
@@ -795,4 +792,5 @@ bool xLightsApp::ProcessIdle() {
 //global flags from command line:
 wxString xLightsApp::mediaDir;
 wxString xLightsApp::showDir;
+wxString xLightsApp::cleanupDir;
 wxArrayString xLightsApp::sequenceFiles;

--- a/xLights/xLightsApp.h
+++ b/xLights/xLightsApp.h
@@ -35,6 +35,7 @@ public:
     static xLightsFrame* GetFrame() { return __frame; }
     static wxString showDir;
     static wxString mediaDir;
+    static wxString cleanupDir;
     static wxArrayString sequenceFiles;
     static xLightsFrame* __frame;
 

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -2883,6 +2883,11 @@ void xLightsFrame::OnClose(wxCloseEvent& event)
 
     logger_base.debug("Heartbeat exit.");
 
+    if (xLightsApp::cleanupDir != "") {
+        logger_base.info("Cleaning up temp folder %s", (const char*)xLightsApp::cleanupDir.c_str());
+        wxDir::Remove(xLightsApp::cleanupDir, wxPATH_RMDIR_RECURSIVE);
+    }
+
     Destroy();
     logger_base.info("xLights Closed.");
 


### PR DESCRIPTION
On windows the cleanup code was not being run. Moved it to the caller routine. Note that this leaves behind the empty tempdir and only removes the show folder (was coded that way originally). #4933 
I didnt want to touch the code that hits the Mac side of things - so some cleanup could take place to make this more better :-)

```
2025-08-11 13:28:18,779 42188 log_base [DEBUG] Heartbeat exit.
2025-08-11 13:28:18,779 42188 log_base [INFO] Cleaning up temp folder C:\Users\daryl\AppData\Local\Temp\Mr Grinch Titan - curtis scott_1754933267576\Youre a Mean One Mr
2025-08-11 13:28:19,266 42188 log_base [INFO] xLights Closed.
```

