### PR TITLE
Dont allow submodes/faces to be copied to Image types #5499

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -5329,7 +5329,7 @@ void LayoutPanel::ExportFacesStatesSubModels() {
     wxArrayString choices;
     
     for (const auto& model : modelPreview->GetModels()) {
-        if (model->Name() == selectedBaseObject->Name())
+        if (model->Name() == selectedBaseObject->Name() || model->GetDisplayAs() == "Image")
             continue;
         choices.Add(model->Name());
     }


### PR DESCRIPTION
Exclude any image type models from the list of models available to export into faces/submodels/states. #5499