### PR TITLE
Enable the tab key on the layout property grid #5519

### DIFF
--- a/xLights/KeyBindingEditDialog.cpp
+++ b/xLights/KeyBindingEditDialog.cpp
@@ -141,7 +141,7 @@ KeyBindingEditDialog::KeyBindingEditDialog(xLightsFrame* parent, KeyBindingMap* 
 		wxPG_SPLITTER_AUTO_CENTER | // Automatically center splitter until user manually adjusts it
 		// Default style
 		wxPG_DEFAULT_STYLE);
-	_propertyGrid->SetExtraStyle(wxPG_EX_HELP_AS_TOOLTIPS);
+	_propertyGrid->SetExtraStyle(wxWS_EX_PROCESS_IDLE | wxPG_EX_HELP_AS_TOOLTIPS);
     _propertyGrid->Connect(wxEVT_KILL_FOCUS,(wxObjectEventFunction)&xlPropertyGrid::OnKillFocus, 0, _propertyGrid);
 	FlexGridSizer3->Add(_propertyGrid, 1, wxALL | wxEXPAND, 5);
 	_propertyGrid->Connect(wxEVT_PG_CHANGED, (wxObjectEventFunction)&KeyBindingEditDialog::OnControllerPropertyGridChange, 0, this);

--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -453,7 +453,7 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
                                         wxPG_SPLITTER_AUTO_CENTER | // Automatically center splitter until user manually adjusts it
                                         // Default style
                                         wxPG_DEFAULT_STYLE);
-    propertyEditor->SetExtraStyle(wxPG_EX_HELP_AS_TOOLTIPS);
+    propertyEditor->SetExtraStyle(wxWS_EX_PROCESS_IDLE | wxPG_EX_HELP_AS_TOOLTIPS);
     propertyEditor->Connect(wxEVT_KILL_FOCUS,(wxObjectEventFunction)&xlPropertyGrid::OnKillFocus, 0, propertyEditor);
     LayoutUtils::CreateImageList(m_imageList);
 


### PR DESCRIPTION
This property was removed - putting it back fixes the issue. #5519 