### PR TITLE
Set the default playlist random value #5514

### DIFF
--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -1304,6 +1304,9 @@ bool FPP::UploadPlaylist(const std::string &name) {
     }
     origJson.Remove(wxString("playlistInfo"));
     origJson["name"] = name;
+    if (!origJson.HasMember("random")) {
+        origJson["random"] = 0;
+    }
 
     PostJSONToURL("/api/playlist/" + URLEncode(name), origJson);
     return false;


### PR DESCRIPTION
When a new playlist is used, the random value is not set and shows "invalid" on the fpp page. #5514