### PR TITLE
Exclude the mac metadata files from the batch render picklist #5501

### DIFF
--- a/xLights/BatchRenderDialog.cpp
+++ b/xLights/BatchRenderDialog.cpp
@@ -195,7 +195,7 @@ void BatchRenderDialog::GetSeqList(const wxString& folder)
     wxArrayString files;
     GetAllFilesInDir(folder, files, "*.x*", wxDIR_DEFAULT);
     for (size_t i = 0; i < files.size(); /* no increment here */) {
-        if (files[i].StartsWith("Backup/") || files[i].StartsWith("Backup\\") || files[i].Contains("\\Backup\\") || files[i].Contains("/Backup/")) {
+        if (files[i].StartsWith("Backup/") || files[i].StartsWith("Backup\\") || files[i].Contains("\\Backup\\") || files[i].Contains("/Backup/") || files[i].StartsWith("._")) {
             files.RemoveAt(i);
         } else {
             ++i; // Only increment if no removal


### PR DESCRIPTION
Found that MacOS creates meta files if you are not using Apple FS - so exclude those on the batch render pic list. #5501