### PR TITLE
Prefix with Mac path separator to exclude on Batch Render files.

### DIFF
--- a/xLights/BatchRenderDialog.cpp
+++ b/xLights/BatchRenderDialog.cpp
@@ -195,7 +195,7 @@ void BatchRenderDialog::GetSeqList(const wxString& folder)
     wxArrayString files;
     GetAllFilesInDir(folder, files, "*.x*", wxDIR_FILES | wxDIR_DIRS);
     for (size_t i = 0; i < files.size(); /* no increment here */) {
-        if (files[i].StartsWith("Backup/") || files[i].StartsWith("Backup\\") || files[i].Contains("\\Backup\\") || files[i].Contains("/Backup/") || files[i].Contains("\\._")) {
+        if (files[i].StartsWith("Backup/") || files[i].StartsWith("Backup\\") || files[i].Contains("\\Backup\\") || files[i].Contains("/Backup/") || files[i].Contains("\\._") || files[i].Contains("/._")) {
             files.RemoveAt(i);
         } else {
             ++i; // Only increment if no removal


### PR DESCRIPTION
I need to add it again with the MAC path separator. Need both for when the usb drive is moved back to Windows.