### PR TITLE
Use the orientation metadata tag for jpg images #5515

### DIFF
--- a/xLights/LayoutPanel.cpp
+++ b/xLights/LayoutPanel.cpp
@@ -2478,6 +2478,12 @@ void LayoutPanel::showBackgroundProperties()
         backgroundFile = previewBackgroundFile;
         if (backgroundFile != "" && FileExists(backgroundFile) && wxIsReadable(backgroundFile)) {
             background = new wxImage(backgroundFile);
+            if (background->IsOk()) {
+                int orientation = GetExifOrientation(backgroundFile);
+                if (orientation != 1) { // 1 means no rotation needed
+                    *background = ApplyOrientation(*background, orientation);
+                }
+            }
         }
     }
     wxPGProperty* prop = propertyEditor->Append(new xlImageProperty("Background Image",

--- a/xLights/ModelPreview.cpp
+++ b/xLights/ModelPreview.cpp
@@ -1233,6 +1233,11 @@ bool ModelPreview::StartDrawing(wxDouble pointSize, bool fromPaint)
                                   (const char *)GetName().c_str());
                 wxImage image(mBackgroundImage);
                 if (image.IsOk()) {
+                    int orientation = GetExifOrientation(mBackgroundImage);
+                    if (orientation != 1) {
+                        image = ApplyOrientation(image, orientation);
+                        logger_base.debug("    Applied EXIF orientation %d to background image.", orientation);
+                    }
                     backgroundSize.Set(image.GetWidth(), image.GetHeight());
                     background = currentContext->createTexture(image, mBackgroundImage, true);
                     logger_base.debug("    Loaded.");

--- a/xLights/UtilFunctions.cpp
+++ b/xLights/UtilFunctions.cpp
@@ -23,6 +23,7 @@
 #include <random>
 #include <thread>
 #include <time.h>
+#include <fstream>
 
 #include "ExternalHooks.h"
 #include "UtilFunctions.h"
@@ -275,6 +276,123 @@ static std::vector<std::string> __nonExistentFiles;
 void ClearNonExistentFiles() {
     std::unique_lock<std::recursive_mutex> lock(__fixFilesMutex);
     __nonExistentFiles.clear();
+}
+
+wxImage ApplyOrientation(const wxImage& img, int orient) {
+    wxImage res = img.Copy();
+    switch (orient) {
+    case 2: return res.Mirror(true);  // horizontal flip
+    case 3: return res.Rotate180();
+    case 4: return res.Mirror(false); // vertical flip
+    case 5: return res.Mirror(true).Rotate90(false); // horizontal flip + 90° CCW
+    case 6: return res.Rotate90(true);  // 90° CW
+    case 7: return res.Mirror(true).Rotate90(true);  // horizontal flip + 90° CW
+    case 8: return res.Rotate90(false); // 90° CCW
+    default: return res;
+    }
+}
+
+int GetExifOrientation(const wxString& filename) {
+    static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
+    std::ifstream file(filename.ToStdString(), std::ios::binary);
+    if (!file) {
+        logger_base.debug("Failed to open file: %s", (const char*)filename.c_str());
+        file.close();
+        return 1; // Default orientation
+    }
+
+    unsigned char byte1, byte2;
+    file.read(reinterpret_cast<char*>(&byte1), 1);
+    file.read(reinterpret_cast<char*>(&byte2), 1);
+    if (byte1 != 0xFF || byte2 != 0xD8) {
+        file.close();
+        return 1;
+    }
+
+    while (file) {
+        file.read(reinterpret_cast<char*>(&byte1), 1);
+        if (byte1 != 0xFF) break;
+        file.read(reinterpret_cast<char*>(&byte2), 1);
+        if (byte2 == 0xD9 || byte2 == 0xDA) break;
+
+        unsigned short len;
+        file.read(reinterpret_cast<char*>(&len), 2);
+        len = ((len >> 8) & 0xFF) | ((len << 8) & 0xFF00); // big-endian
+        if (len < 2) break;
+
+        if (byte2 == 0xE1) { // APP1 segment
+            std::vector<char> data(len - 2);
+            file.read(data.data(), len - 2);
+
+            if (data.size() < 14) continue; // too small to hold Exif header
+
+            if (memcmp(data.data(), "Exif\0\0", 6) != 0) {
+                continue;
+            }
+
+            size_t tiff_header = 6; // TIFF header starts right after Exif\0\0
+            bool littleEndian = (data[tiff_header] == 'I' && data[tiff_header + 1] == 'I');
+            unsigned short fortytwo = littleEndian ?
+                ((unsigned char)data[tiff_header + 3] << 8) | (unsigned char)data[tiff_header + 2] :
+                ((unsigned char)data[tiff_header + 2] << 8) | (unsigned char)data[tiff_header + 3];
+
+            if (fortytwo != 42) {
+                logger_base.debug("Invalid TIFF header identifier in %s", (const char*)filename.c_str());
+                return 1;
+            }
+
+            // Read offset to IFD0
+            unsigned int ifd_offset;
+            if (littleEndian) {
+                ifd_offset =  (unsigned char)data[tiff_header + 4]       |
+                    ((unsigned char)data[tiff_header + 5] << 8) |
+                    ((unsigned char)data[tiff_header + 6] << 16)|
+                    ((unsigned char)data[tiff_header + 7] << 24);
+            } else {
+                ifd_offset = ((unsigned char)data[tiff_header + 4] << 24)|
+                    ((unsigned char)data[tiff_header + 5] << 16)|
+                    ((unsigned char)data[tiff_header + 6] << 8) |
+                    (unsigned char)data[tiff_header + 7];
+            }
+
+            size_t pos = tiff_header + ifd_offset;
+            if (pos + 2 > data.size()) return 1;
+
+            unsigned short num_entries = littleEndian ?
+                ((unsigned char)data[pos + 1] << 8) | (unsigned char)data[pos] :
+                ((unsigned char)data[pos] << 8) | (unsigned char)data[pos + 1];
+            pos += 2;
+
+            for (unsigned short i = 0; i < num_entries; ++i) {
+                if (pos + 12 > data.size()) break;
+
+                unsigned short tag = littleEndian ?
+                    ((unsigned char)data[pos + 1] << 8) | (unsigned char)data[pos] :
+                    ((unsigned char)data[pos] << 8) | (unsigned char)data[pos + 1];
+
+                if (tag == 0x0112) { // Orientation
+                    unsigned short orient = littleEndian ?
+                        ((unsigned char)data[pos + 9] << 8) | (unsigned char)data[pos + 8] :
+                        ((unsigned char)data[pos + 8] << 8) | (unsigned char)data[pos + 9];
+                    return static_cast<int>(orient);
+                }
+                pos += 12;
+            }
+        } else {
+            file.seekg(len - 2, std::ios::cur);
+        }
+    }
+
+    // Fallback: wxImage may know the orientation
+    wxLogNull logNo;
+    wxImage img;
+    if (img.LoadFile(filename, wxBITMAP_TYPE_JPEG)) {
+        if (img.HasOption("Orientation")) {
+            int orient = img.GetOptionInt("Orientation");
+            return orient;
+        }
+    }
+    return 1; // default
 }
 
 std::string GetResourcesDirectory() {

--- a/xLights/UtilFunctions.h
+++ b/xLights/UtilFunctions.h
@@ -79,6 +79,9 @@ void ShiftNodes(std::map<std::string, std::string> & nodes, int shift, int min, 
 //reverse nodes, numbering 1->100, 100->1
 void ReverseNodes(std::map<std::string, std::string> & nodes, int max);
 
+wxImage ApplyOrientation(const wxImage& img, int orient);
+int GetExifOrientation(const wxString& filename);
+
 std::string GetResourcesDirectory();
 
 inline long roundTo4(long i) {

--- a/xLights/effects/PicturesEffect.cpp
+++ b/xLights/effects/PicturesEffect.cpp
@@ -240,7 +240,7 @@ typedef std::vector< std::pair<wxPoint, xlColor> > PixelVector;
 
 class PicturesRenderCache : public EffectRenderCache {
 public:
-    PicturesRenderCache() : imageCount(0), frame(0),  gifImage(nullptr), maxmovieframes(0) {};
+    PicturesRenderCache() : imageCount(0), frame(0),  gifImage(nullptr), maxmovieframes(0), orientation(1) {};
     virtual ~PicturesRenderCache()
     {
         if (gifImage != nullptr) {
@@ -255,6 +255,7 @@ public:
     int frame;
     int maxmovieframes;
     wxString PictureName;
+    int orientation;
     GIFImage* gifImage;
     std::vector<PixelVector> PixelsByFrame;
 };
@@ -610,6 +611,7 @@ void PicturesEffect::Render(RenderBuffer& buffer,
                 }
                 
                 cache->PictureName = NewPictureName;
+                cache->orientation = GetExifOrientation(NewPictureName);
 
                 if (cache->imageCount > 1) {
 #ifdef DEBUG_GIF
@@ -631,9 +633,11 @@ void PicturesEffect::Render(RenderBuffer& buffer,
                             logger_base.error("Error loading image file: %s.", (const char*)NewPictureName.c_str());
                             image.Create(5, 5, true);
                         }
+                        image = ApplyOrientation(image, cache->orientation);
                         rawimage = image;
                     } else {
                         image = gifImage->GetFrame(0);
+                        image = ApplyOrientation(image, cache->orientation);
                         rawimage = image;
                     }
                 } else {
@@ -641,6 +645,7 @@ void PicturesEffect::Render(RenderBuffer& buffer,
                         logger_base.error("Error loading image file: %s.", (const char*)NewPictureName.c_str());
                         image.Create(5, 5, true);
                     }
+                    image = ApplyOrientation(image, cache->orientation);
                     rawimage = image;
                 }
             }
@@ -655,10 +660,12 @@ void PicturesEffect::Render(RenderBuffer& buffer,
 
             if (loopGIF) {
                 image = gifImage->GetFrameForTime((buffer.curPeriod - buffer.curEffStartPer) * buffer.frameTimeInMs * frameRateAdj, true);
+                image = ApplyOrientation(image, cache->orientation);
             }
             else {
                 int ii = cache->imageCount * buffer.GetEffectTimeIntervalPosition(frameRateAdj) * 0.99;
                 image = gifImage->GetFrame(ii);
+                image = ApplyOrientation(image, cache->orientation);
             }
 
             rawimage = image;


### PR DESCRIPTION
Jpg files can have a rotation in the metadata, if found, honor that setting in picture effects and background images #5515 