### PR TITLE
Fix Upload Output for FPP

### DIFF
--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -2051,7 +2051,7 @@ static bool mergeSerialInto(nlohmann::json &otherDmxData, nlohmann::json &otherO
             if (!device.empty() && !origDevice.empty() && origDevice == device) {
                 //same device, see if type matches and update or disable
                 std::string origType = GetJSONStringValue(otherOrigRoot["channelOutputs"][y], "type");
-                if (type == origType) {
+                if (!type.empty() && !origType.empty() && origType == type) {
                     //device and type the same, update values
                     found = true;
                     changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "description", GetJSONStringValue(otherDmxData["channelOutputs"][x], "description"));

--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -2043,31 +2043,33 @@ static bool UpdateJSONValue(nlohmann::json& v, const std::string& key, const std
 static bool mergeSerialInto(nlohmann::json &otherDmxData, nlohmann::json &otherOrigRoot, bool addDefaults) {
     bool changed = false;
     for (int x = 0; x < otherDmxData["channelOutputs"].size(); x++) {
-        std::string device = otherDmxData["channelOutputs"][x]["device"].get<std::string>();
-        std::string type = otherDmxData["channelOutputs"][x]["type"].get<std::string>();
+        std::string device = GetJSONStringValue(otherDmxData["channelOutputs"][x], "device");
+        std::string type = GetJSONStringValue(otherDmxData["channelOutputs"][x], "type");
         bool found = false;
         for (int y = 0; y < otherOrigRoot["channelOutputs"].size(); y++) {
-            if (otherOrigRoot["channelOutputs"][y]["device"].get<std::string>() == device) {
+            std::string origDevice = GetJSONStringValue(otherOrigRoot["channelOutputs"][y], "device");
+            if (!device.empty() && !origDevice.empty() && origDevice == device) {
                 //same device, see if type matches and update or disable
-                if (type == otherOrigRoot["channelOutputs"][y]["type"].get<std::string>()) {
+                std::string origType = GetJSONStringValue(otherOrigRoot["channelOutputs"][y], "type");
+                if (type == origType) {
                     //device and type the same, update values
                     found = true;
-                    changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "description", otherDmxData["channelOutputs"][x]["description"].get<std::string>());
+                    changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "description", GetJSONStringValue(otherDmxData["channelOutputs"][x], "description"));
                     changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "enabled", 1);
-                    changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "startChannel", otherDmxData["channelOutputs"][x]["startChannel"].get<int>());
-                    changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "channelCount", otherDmxData["channelOutputs"][x]["channelCount"].get<int>());
+                    changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "startChannel", GetJSONIntValue(otherDmxData["channelOutputs"][x], "startChannel"));
+                    changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "channelCount", GetJSONIntValue(otherDmxData["channelOutputs"][x], "channelCount"));
 
                     if (!addDefaults) {
                         if (type == "Renard") {
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "renardspeed", otherDmxData["channelOutputs"][x]["renardspeed"].get<int>());
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "renardparm", otherDmxData["channelOutputs"][x]["renardparm"].get<std::string>());
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "renardspeed", GetJSONIntValue(otherDmxData["channelOutputs"][x], "renardspeed"));
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "renardparm", GetJSONStringValue(otherDmxData["channelOutputs"][x], "renardparm"));
                         } else if (type == "LOR") {
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "firstControllerId", otherDmxData["channelOutputs"][x]["firstControllerId"].get<int>());
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "speed", otherDmxData["channelOutputs"][x]["speed"].get<int>());
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "firstControllerId", GetJSONIntValue(otherDmxData["channelOutputs"][x], "firstControllerId"));
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "speed", GetJSONIntValue(otherDmxData["channelOutputs"][x], "speed"));
                         } else if (type == "GenricSerial") {
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "speed", otherDmxData["channelOutputs"][x]["speed"].get<int>());
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "header", otherDmxData["channelOutputs"][x]["header"].get<std::string>());
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "footer", otherDmxData["channelOutputs"][x]["footer"].get<std::string>());
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "speed", GetJSONIntValue(otherDmxData["channelOutputs"][x], "speed"));
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "header", GetJSONStringValue(otherDmxData["channelOutputs"][x], "header"));
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "footer", GetJSONStringValue(otherDmxData["channelOutputs"][x], "footer"));
                         }
                     }
                 } else {
@@ -2356,9 +2358,9 @@ bool FPP::UploadVirtualMatrixOutputs(ModelManager* allmodels,
         for (int x = 0; x < origJson["channelOutputs"].size(); x++) {
             if (origJson["channelOutputs"][x]["type"].get<std::string>() == "VirtualMatrix") {
                 wxString dev = origJson["channelOutputs"][x]["device"].get<std::string>();
-                int port = (char)dev[2] - '0';
+                    int port = (char)dev[2] - '0';
                 if (models[port].find(ToUTF8(origJson["channelOutputs"][x]["description"].get<std::string>())) == models[port].end()) {
-                    UpdateJSONValue(origJson["channelOutputs"][x], "enabled", 0);
+                        UpdateJSONValue(origJson["channelOutputs"][x], "enabled", 0);
                 }
             }
         }

--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -2358,9 +2358,9 @@ bool FPP::UploadVirtualMatrixOutputs(ModelManager* allmodels,
         for (int x = 0; x < origJson["channelOutputs"].size(); x++) {
             if (origJson["channelOutputs"][x]["type"].get<std::string>() == "VirtualMatrix") {
                 wxString dev = origJson["channelOutputs"][x]["device"].get<std::string>();
-                    int port = (char)dev[2] - '0';
+                int port = (char)dev[2] - '0';
                 if (models[port].find(ToUTF8(origJson["channelOutputs"][x]["description"].get<std::string>())) == models[port].end()) {
-                        UpdateJSONValue(origJson["channelOutputs"][x], "enabled", 0);
+                    UpdateJSONValue(origJson["channelOutputs"][x], "enabled", 0);
                 }
             }
         }

--- a/xLights/controllers/FPP.cpp
+++ b/xLights/controllers/FPP.cpp
@@ -2043,33 +2043,31 @@ static bool UpdateJSONValue(nlohmann::json& v, const std::string& key, const std
 static bool mergeSerialInto(nlohmann::json &otherDmxData, nlohmann::json &otherOrigRoot, bool addDefaults) {
     bool changed = false;
     for (int x = 0; x < otherDmxData["channelOutputs"].size(); x++) {
-        std::string device = GetJSONStringValue(otherDmxData["channelOutputs"][x], "device");
-        std::string type = GetJSONStringValue(otherDmxData["channelOutputs"][x], "type");
+        std::string device = otherDmxData["channelOutputs"][x]["device"].get<std::string>();
+        std::string type = otherDmxData["channelOutputs"][x]["type"].get<std::string>();
         bool found = false;
         for (int y = 0; y < otherOrigRoot["channelOutputs"].size(); y++) {
-            std::string origDevice = GetJSONStringValue(otherOrigRoot["channelOutputs"][y], "device");
-            if (!device.empty() && !origDevice.empty() && origDevice == device) {
+            if (otherOrigRoot["channelOutputs"][y]["device"].get<std::string>() == device) {
                 //same device, see if type matches and update or disable
-                std::string origType = GetJSONStringValue(otherOrigRoot["channelOutputs"][y], "type");
-                if (type == origType) {
+                if (type == otherOrigRoot["channelOutputs"][y]["type"].get<std::string>()) {
                     //device and type the same, update values
                     found = true;
-                    changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "description", GetJSONStringValue(otherDmxData["channelOutputs"][x], "description"));
+                    changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "description", otherDmxData["channelOutputs"][x]["description"].get<std::string>());
                     changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "enabled", 1);
-                    changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "startChannel", GetJSONIntValue(otherDmxData["channelOutputs"][x], "startChannel"));
-                    changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "channelCount", GetJSONIntValue(otherDmxData["channelOutputs"][x], "channelCount"));
+                    changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "startChannel", otherDmxData["channelOutputs"][x]["startChannel"].get<int>());
+                    changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "channelCount", otherDmxData["channelOutputs"][x]["channelCount"].get<int>());
 
                     if (!addDefaults) {
                         if (type == "Renard") {
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "renardspeed", GetJSONIntValue(otherDmxData["channelOutputs"][x], "renardspeed"));
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "renardparm", GetJSONStringValue(otherDmxData["channelOutputs"][x], "renardparm"));
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "renardspeed", otherDmxData["channelOutputs"][x]["renardspeed"].get<int>());
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "renardparm", otherDmxData["channelOutputs"][x]["renardparm"].get<std::string>());
                         } else if (type == "LOR") {
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "firstControllerId", GetJSONIntValue(otherDmxData["channelOutputs"][x], "firstControllerId"));
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "speed", GetJSONIntValue(otherDmxData["channelOutputs"][x], "speed"));
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "firstControllerId", otherDmxData["channelOutputs"][x]["firstControllerId"].get<int>());
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "speed", otherDmxData["channelOutputs"][x]["speed"].get<int>());
                         } else if (type == "GenricSerial") {
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "speed", GetJSONIntValue(otherDmxData["channelOutputs"][x], "speed"));
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "header", GetJSONStringValue(otherDmxData["channelOutputs"][x], "header"));
-                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "footer", GetJSONStringValue(otherDmxData["channelOutputs"][x], "footer"));
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "speed", otherDmxData["channelOutputs"][x]["speed"].get<int>());
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "header", otherDmxData["channelOutputs"][x]["header"].get<std::string>());
+                            changed |= UpdateJSONValue(otherOrigRoot["channelOutputs"][y], "footer", otherDmxData["channelOutputs"][x]["footer"].get<std::string>());
                         }
                     }
                 } else {
@@ -2356,16 +2354,11 @@ bool FPP::UploadVirtualMatrixOutputs(ModelManager* allmodels,
         //we need to disable the virtual matrices that are on the ports of the
         //models we uploaded or they will conflict and produce errors
         for (int x = 0; x < origJson["channelOutputs"].size(); x++) {
-            std::string outputType = GetJSONStringValue(origJson["channelOutputs"][x], "type");
-            if (outputType == "VirtualMatrix") {
-                std::string device = GetJSONStringValue(origJson["channelOutputs"][x], "device");
-                if (!device.empty() && device.length() >= 3) {
-                    wxString dev = device;
-                    int port = (char)dev[2] - '0';
-                    std::string description = GetJSONStringValue(origJson["channelOutputs"][x], "description");
-                    if (models[port].find(ToUTF8(description)) == models[port].end()) {
-                        UpdateJSONValue(origJson["channelOutputs"][x], "enabled", 0);
-                    }
+            if (origJson["channelOutputs"][x]["type"].get<std::string>() == "VirtualMatrix") {
+                wxString dev = origJson["channelOutputs"][x]["device"].get<std::string>();
+                int port = (char)dev[2] - '0';
+                if (models[port].find(ToUTF8(origJson["channelOutputs"][x]["description"].get<std::string>())) == models[port].end()) {
+                    UpdateJSONValue(origJson["channelOutputs"][x], "enabled", 0);
                 }
             }
         }


### PR DESCRIPTION
Fixes an issue https://github.com/xLightsSequencer/xLights/issues/5566#issuecomment-3375269394

I only fixed the non safe json access for my issue, Probably want to refactor all the calls to `.get` that replaced `.AsString` and the others.

# Fix JSON Access Safety Issues in FPP.cpp

## Problem Description

The `FPP.cpp` file contained unsafe JSON field access patterns that would cause crashes when processing JSON payloads with missing fields. This was particularly problematic for certain channel output types like `HTTPVirtualDisplay` that don't include a `device` field.

### Root Cause

During the migration from `wxJSONValue` to `nlohmann::json`, the safe `AsString()` method was replaced with the unsafe `.get<std::string>()` method:

**Before (wxJSONValue - safe):**
```cpp
wxString device = otherDmxData["channelOutputs"][x]["device"].AsString();
```

**After Migration (nlohmann::json - unsafe):**
```cpp
std::string device = otherDmxData["channelOutputs"][x]["device"].get<std::string>();
```

### The Issue

The `nlohmann::json::get<T>()` method throws an exception if the requested key doesn't exist, while `wxJSONValue::AsString()` handled missing keys gracefully by returning empty strings.

### Example Problematic Payload

```json
{
    "enabled": 0,
    "type": "HTTPVirtualDisplay",
    "startChannel": 1,
    "channelCount": 8388608,
    "width": 1280,
    "height": 1024,
    "pixelSize": 2
}
```

This payload lacks a `device` field, causing the application to crash when the code tried to access `["device"].get<std::string>()`.

## Solution

### Safe JSON Access Pattern

Replaced all unsafe direct JSON access with the existing safe utility functions for my issue:

**Correct Migration (nlohmann::json - safe):**
```cpp
std::string device = GetJSONStringValue(otherDmxData["channelOutputs"][x], "device");
```

### Utility Function Used

The codebase already contained a safe accessor function:

```cpp
static std::string GetJSONStringValue(const nlohmann::json& val, const std::string &key, const std::string &def = "") {
    if (val.contains(key) && val[key].is_string()) {
        return val[key].get<std::string>();
    }
    return def;
}
```

This function:
- Checks if the key exists using `contains()`
- Validates the value is a string using `is_string()`
- Returns the actual value or a default (empty string) if missing/invalid
