### PR TITLE
Catch crash with duplicate effect #5633

### DIFF
--- a/xLights/effects/DuplicateEffect.cpp
+++ b/xLights/effects/DuplicateEffect.cpp
@@ -109,6 +109,13 @@ void DuplicateEffect::SetPanelStatus(Model* cls)
     // remove all the models
     dp->Choice_Model->Clear();
 
+    if (cls == nullptr)
+        return;
+
+    const ModelManager& mgr = cls->GetModelManager();
+    xLightsFrame* xlights = mgr.GetXLightsFrame();
+    if (xlights == nullptr) return;
+
     // get the sequence elements
     auto& se = cls->GetModelManager().GetXLightsFrame()->GetSequenceElements();
 


### PR DESCRIPTION
the duplicate effect was built to be used on the model. It is causing crash when used on strands and nodes.