### PR TITLE
Allow filter to have multiple items #5667

### DIFF
--- a/xLights/sequencer/Effect.cpp
+++ b/xLights/sequencer/Effect.cpp
@@ -412,6 +412,10 @@ bool Effect::FilteredIn(const std::string& filterText, bool isFilterTextRegex) c
                 return true;
             token = strtok(nullptr, tokens.c_str());
         }
+
+        const std::string search = ";" + filterText + ";";
+        const std::string needle = ";" + name + ";";
+        return search.find(needle) != std::string::npos;
     }
 
     return false;


### PR DESCRIPTION
I didnt want to break existing code, so I added this extra lines to find the label when it matches the filter items separated by a ;. The original code tokenized the labels - not clear to me why we would need that so I didn't change that code.
This function is buried in a few places. If a beat track is 1-2-3-4 you can filter on say 2;3.
Not clear how it handles a track with a label of "Wish you a merry Christmas" - it looks like it would be true on "Wish" for example.
So leaving that as is. Regex is not changed functionality.