### PR TITLE
Update manifest.json to fix icons paths

### DIFF
--- a/bin/xScheduleWeb/img/favcon/manifest.json
+++ b/bin/xScheduleWeb/img/favcon/manifest.json
@@ -1,40 +1,42 @@
 {
- "name": "App",
+ "name": "xLights Scheduler",
+ "short_name": "xLights Schr",
+ "display": "browser",
  "icons": [
   {
-   "src": "\/android-icon-36x36.png",
+   "src": "android-icon-36x36.png",
    "sizes": "36x36",
-   "type": "image\/png",
+   "type": "image/png",
    "density": "0.75"
   },
   {
-   "src": "\/android-icon-48x48.png",
+   "src": "android-icon-48x48.png",
    "sizes": "48x48",
-   "type": "image\/png",
+   "type": "image/png",
    "density": "1.0"
   },
   {
-   "src": "\/android-icon-72x72.png",
+   "src": "android-icon-72x72.png",
    "sizes": "72x72",
-   "type": "image\/png",
+   "type": "image/png",
    "density": "1.5"
   },
   {
-   "src": "\/android-icon-96x96.png",
+   "src": "android-icon-96x96.png",
    "sizes": "96x96",
-   "type": "image\/png",
+   "type": "image/png",
    "density": "2.0"
   },
   {
-   "src": "\/android-icon-144x144.png",
+   "src": "android-icon-144x144.png",
    "sizes": "144x144",
-   "type": "image\/png",
+   "type": "image/png",
    "density": "3.0"
   },
   {
-   "src": "\/android-icon-192x192.png",
+   "src": "android-icon-192x192.png",
    "sizes": "192x192",
-   "type": "image\/png",
+   "type": "image/png",
    "density": "4.0"
   }
  ]


### PR DESCRIPTION
Fixed xScheduler icon paths in the manifest.json to resolve issue on Android Firefox. Since the images are in the same folder as the manifest.json we don't need any path info. Also changed the "name" and added the "short_name" and "display" values since those are usually required in the manifest.json.

This fixes an issue on Android when using Firefox as the browser where the xScheduler icon was not used when you added the site to your "Home Screen".

![xScheduler Home Icons](https://github.com/user-attachments/assets/c383bf69-4f3d-439a-9a15-73601b74ce84)
