### PR TITLE
Handle json exception when unicode char is used #5745

### DIFF
--- a/xLights/automation/LuaRunner.cpp
+++ b/xLights/automation/LuaRunner.cpp
@@ -220,7 +220,7 @@ sol::object LuaRunner::RunCommand(std::string const& cmd, std::map<std::string, 
 }
 
 std::string LuaRunner::JSONtoString(nlohmann::json const& json) const {
-    return json.dump(3);
+    return json.dump(3, ' ', false, nlohmann::json::error_handler_t::replace);
 }
 
 std::string LuaRunner::CommandtoString(std::string const& cmd, std::map<std::string, std::string> const& parms) const
@@ -250,7 +250,7 @@ std::string LuaRunner::TableToJSON(sol::object const& item) const
 {
     nlohmann::json json;
     ObjectToJSON(item, json);
-    return json.dump(3);
+    return json.dump(3, ' ', false, nlohmann::json::error_handler_t::replace);
 }
 
 void LuaRunner::ObjectToJSON(sol::object const& items, nlohmann::json& json) const

--- a/xLights/controllers/ESPixelStick.cpp
+++ b/xLights/controllers/ESPixelStick.cpp
@@ -1003,7 +1003,7 @@ bool ESPixelStick::SetOutputsV3(ModelManager* allmodels, OutputManager* outputMa
                 }
             }
 
-            std::string message = newJson.dump(3);
+            std::string message = newJson.dump(3, ' ', false, nlohmann::json::error_handler_t::replace);
             message = "S2" + message;
 
             if (_wsClient.Send(message)) {

--- a/xLights/controllers/WLED.cpp
+++ b/xLights/controllers/WLED.cpp
@@ -240,7 +240,7 @@ static size_t writeFunction(void* ptr, size_t size, size_t nmemb, std::string* d
 }
 
 bool WLED::PostJSON(nlohmann::json const& jsonVal) {
-    std::string str = jsonVal.dump(3);
+    std::string str = jsonVal.dump(3, ' ', false, nlohmann::json::error_handler_t::replace);
     const std::string url = GetCfgURL();
 
     static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));


### PR DESCRIPTION
Found user having unicode in names caused the json dump to throw an exception/crash. Added similar code in other similar calls. #5745