### PR TITLE
Reset Channels when Layout Changes

### DIFF
--- a/xLights/SeqFileUtilities.cpp
+++ b/xLights/SeqFileUtilities.cpp
@@ -533,10 +533,10 @@ void xLightsFrame::OpenSequence(const wxString& passed_filename, ConvertLogDialo
         logger_base.debug("Sequence Num Channels: %d or %d", numChan, _seqData.NumChannels());
         logger_base.debug("Sequence Num Frames: %d", (int)(CurrentSeqXmlFile->GetSequenceDurationMS() / ms));
 
-        if ((numChan > _seqData.NumChannels()) ||
+        if ((numChan != _seqData.NumChannels()) ||
             (CurrentSeqXmlFile->GetSequenceDurationMS() / ms) > (long)_seqData.NumFrames()) {
             if (_seqData.NumChannels() > 0) {
-                if (numChan > _seqData.NumChannels()) {
+                if (numChan != _seqData.NumChannels()) {
                     logger_base.warn("Fseq file had %u channels but sequence has %u channels so dumping the fseq data.", _seqData.NumChannels(), numChan);
                 } else {
                     if ((CurrentSeqXmlFile->GetSequenceDurationMS() / ms) > (long)_seqData.NumFrames()) {

--- a/xLights/sequencer/tabSequencer.cpp
+++ b/xLights/sequencer/tabSequencer.cpp
@@ -250,6 +250,7 @@ void xLightsFrame::InitSequencer()
     if (CurrentSeqXmlFile != nullptr && CurrentSeqXmlFile->GetSequenceLoaded()) {
         if (_seqData.NumChannels() != roundTo4(GetMaxNumChannels())) {
             logger_base.info("Number of channels has changed ... reallocating sequence data memory.");
+            logger_base.info("Channels prior %d and channels current %d", _seqData.NumChannels(), roundTo4(GetMaxNumChannels()));
 
             AbortRender();
 


### PR DESCRIPTION
Previously only increases in channels would force a fseq flush. With this change any increase or decrease will cause this reset.
The resulting fseq file now contains an accurate channel count and subsequent data.
(Can wait till the new year if there is any risk to this change)