### PR TITLE
Update WLED/Bong69 to reflect support for new PCB v4.

### DIFF
--- a/controllers/wled.xcontroller
+++ b/controllers/wled.xcontroller
@@ -198,7 +198,7 @@
             <Port7>5</Port7>
             <Port8>33</Port8>
         </Variant>
-        <Variant Name="8-Port Distro (PCB v2/v3)" Base="WLED:ESP32WLEDSettings">
+        <Variant Name="8-Port Distro (PCB v2/v3/v4)" Base="WLED:ESP32WLEDSettings">
             <MaxPixelPort>8</MaxPixelPort>
             <MaxSerialPort>0</MaxSerialPort>
             <Port1>1</Port1>


### PR DESCRIPTION
This PR updates the device identification string to reflect support for the new WLED Bong69 PCB v4 board, which is backward compatible with PCB v2 and PCB v3.  

The PR updates the displayed board name / identifier only.