### PR TITLE
Fix state effect from revalidating on lasso #5783

### DIFF
--- a/xLights/effects/StateEffect.cpp
+++ b/xLights/effects/StateEffect.cpp
@@ -76,6 +76,7 @@ void StateEffect::SetPanelStatus(Model* cls) {
     if (fp == nullptr) {
         return;
     }
+    fp->_loadingSettings = true;
 
     auto lastTiming = fp->Choice_State_TimingTrack->GetStringSelection();
     auto lastState = fp->Choice_StateDefinitonChoice->GetStringSelection();
@@ -118,6 +119,7 @@ void StateEffect::SetPanelStatus(Model* cls) {
     }
 
     fp->SetEffect(this, cls);
+    fp->_loadingSettings = false;
 }
 
 std::list<std::string> StateEffect::GetStates(Model* cls, std::string model) {

--- a/xLights/effects/StatePanel.cpp
+++ b/xLights/effects/StatePanel.cpp
@@ -49,6 +49,7 @@ StatePanel::StatePanel(wxWindow* parent) : xlEffectPanel(parent)
 {
     _effect = nullptr;
     _model = nullptr;
+	_loadingSettings = false;
 
 	//(*Initialize(StatePanel)
 	wxFlexGridSizer* FlexGridSizer1;
@@ -192,12 +193,14 @@ void StatePanel::SetEffect(StateEffect* effect, Model* model)
     _effect = effect;
     _model = model;
 
-    UpdateStateList();
+    if (!_loadingSettings) {
+        UpdateStateList();
+    }
 }
 
 void StatePanel::OnMouthMovementTypeSelected(wxCommandEvent& event)
 {
-	ValidateWindow();
+    ValidateWindow();
 }
 
 void StatePanel::OnState_StateDefinitonChoiceSelect(wxCommandEvent& event)

--- a/xLights/effects/StatePanel.h
+++ b/xLights/effects/StatePanel.h
@@ -35,6 +35,7 @@ class StatePanel: public xlEffectPanel
 
 	public:
         void SetEffect(StateEffect* effect, Model* model);
+		bool _loadingSettings;
 
 		StatePanel(wxWindow* parent);
 		virtual ~StatePanel();
@@ -43,8 +44,8 @@ class StatePanel: public xlEffectPanel
 		//(*Declarations(StatePanel)
 		BulkEditChoice* Choice_State_Color;
 		BulkEditChoice* Choice_State_Mode;
-		BulkEditChoice* Choice_State_TimingTrack;
 		BulkEditChoice* Choice_State_State;
+		BulkEditChoice* Choice_State_TimingTrack;
 		BulkEditSlider* SLIDER_State_Fade_Time;
 		BulkEditStateChoice* Choice_StateDefinitonChoice;
 		BulkEditTextCtrl* TextCtrl_State_Fade_Time;

--- a/xLights/sequencer/tabSequencer.cpp
+++ b/xLights/sequencer/tabSequencer.cpp
@@ -56,6 +56,7 @@
 #include "../LayoutPanel.h"
 #include "../TraceLog.h"
 #include "../effects/EffectPanelUtils.h"
+#include "../effects/StatePanel.h"
 #include "../UtilFunctions.h"
 #include "../ExternalHooks.h"
 #include "../models/ModelGroup.h"
@@ -2645,6 +2646,14 @@ void xLightsFrame::SetEffectControls(const std::string &modelName, const std::st
                                      int startTimeMs, int endTimeMs, bool setDefaults) {
     static log4cpp::Category& logger_base = log4cpp::Category::getInstance(std::string("log_base"));
     if (CurrentSeqXmlFile == nullptr) return;
+
+    if (effectName == "State") {
+        StatePanel* fp = dynamic_cast<StatePanel*>(EffectsPanel1->GetSelectedPanel());
+        if (fp != nullptr) {
+            fp->_loadingSettings = true;
+        }
+    }
+
     //timingPanel->Freeze();
     //bufferPanel->Freeze();
     //colorPanel->Freeze();
@@ -2657,7 +2666,47 @@ void xLightsFrame::SetEffectControls(const std::string &modelName, const std::st
     }
 
     EffectsPanel1->SetEffectPanelStatus(model, effectName, startTimeMs, endTimeMs);
-    SetEffectControls(settings);
+
+    if (effectName == "State") {
+        std::vector<std::pair<std::string, std::string>> sortedSettings;
+        for (const auto& setting : settings) {
+            sortedSettings.push_back(setting);
+        }
+
+        // Sort with StateDefinition before State
+        std::stable_sort(sortedSettings.begin(), sortedSettings.end(),
+            [](const std::pair<std::string, std::string>& a,
+                const std::pair<std::string, std::string>& b) {
+                    bool a_is_def = (a.first == "E_CHOICE_State_StateDefinition");
+                    bool b_is_def = (b.first == "E_CHOICE_State_StateDefinition");
+                    bool a_is_state = (a.first == "E_CHOICE_State_State");
+                    bool b_is_state = (b.first == "E_CHOICE_State_State");
+
+                    if (a_is_def && b_is_state) {
+                        return true;
+                    }
+                    if (a_is_state && b_is_def) {
+                        return false;
+                    }
+
+                    return false;
+            });
+
+        SettingsMap orderedSettings;
+        for (const auto& setting : sortedSettings) {
+            orderedSettings[setting.first] = setting.second;
+        }
+
+        SetEffectControls(settings); // DWE DWE
+
+        StatePanel* fp = dynamic_cast<StatePanel*>(EffectsPanel1->GetSelectedPanel());
+        if (fp != nullptr) {
+            fp->_loadingSettings = false;
+        }
+    } else {
+        SetEffectControls(settings);
+    }
+
     SetEffectControls(palette);
     RenderableEffect *ef = GetEffectManager().GetEffect(effectName);
     if (ef != nullptr) {

--- a/xLights/sequencer/tabSequencer.cpp
+++ b/xLights/sequencer/tabSequencer.cpp
@@ -2697,7 +2697,7 @@ void xLightsFrame::SetEffectControls(const std::string &modelName, const std::st
             orderedSettings[setting.first] = setting.second;
         }
 
-        SetEffectControls(settings); // DWE DWE
+        SetEffectControls(orderedSettings);
 
         StatePanel* fp = dynamic_cast<StatePanel*>(EffectsPanel1->GetSelectedPanel());
         if (fp != nullptr) {

--- a/xLights/wxsmith/StatePanel.wxs
+++ b/xLights/wxsmith/StatePanel.wxs
@@ -151,6 +151,7 @@
 						<object class="wxSlider" name="ID_SLIDER_State_Fade_Time" subclass="BulkEditSlider" variable="SLIDER_State_Fade_Time" member="yes">
 							<max>1000</max>
 							<tickfreq>100</tickfreq>
+							<tick>1</tick>
 						</object>
 						<flag>wxALL|wxEXPAND</flag>
 						<border>5</border>


### PR DESCRIPTION
Do not validate the state when loading and also ensure the State Definition is validated before checking the State Value. #5783 
Devs - perhaps there is a better solution but this appears to work with minimal risk. Previously as you moved a lasso over the effect it tried to revalidate and hence could overwrite perfectly valid values because of the ordering/bug.