### PR TITLE
Make RGB image in layout visible #5713

### DIFF
--- a/xLights/models/ImageModel.cpp
+++ b/xLights/models/ImageModel.cpp
@@ -379,7 +379,7 @@ void ImageModel::DisplayModelOnWindow(ModelPreview* preview, xlGraphicsContext *
     int w, h;
     preview->GetVirtualCanvasSize(w, h);
 
-    bool drawColor = (StringType.rfind("Single Color",0) != 0 && StringType != "Node Single Color");
+    bool drawColor = preview->GetName() != "Layout" && StringType.rfind("Single Color",0) != 0 && StringType != "Node Single Color";
 
     xlTexture *texture = _images[preview->GetName().ToStdString()];
     xlTexture* textureColorOverlay = _images[preview->GetName().ToStdString() + "_color_overlay"];


### PR DESCRIPTION
If one uses the new feature to make an image react to RGB, the image would not show up in the layout. It was stripped of color to be ready to show the RGB effect. This change negates that for the Layout preview. #5713 