### PR TITLE
Add warning to clear render cache if FPS is modified. #5737

### DIFF
--- a/xLights/SeqSettingsDialog.cpp
+++ b/xLights/SeqSettingsDialog.cpp
@@ -1806,12 +1806,6 @@ void SeqSettingsDialog::OnBitmapButton_ModifyTimingClick(wxCommandEvent& event)
         xLightsParent->CloseSequence();
         xLightsParent->OpenSequence( name, nullptr );
         xml_file = xLightsParent->CurrentSeqXmlFile;
-
-        if ( xLightsParent->_renderCache.IsEnabled() ) {
-            auto& se = xLightsParent->GetSequenceElements();
-            xLightsParent->_renderCache.Purge(&se , true);
-            wxMessageBox("Render Cache is enabled. To avoid render artifacts, render cache has been purged.");
-        }
     }
 }
 

--- a/xLights/SeqSettingsDialog.cpp
+++ b/xLights/SeqSettingsDialog.cpp
@@ -1806,6 +1806,10 @@ void SeqSettingsDialog::OnBitmapButton_ModifyTimingClick(wxCommandEvent& event)
         xLightsParent->CloseSequence();
         xLightsParent->OpenSequence( name, nullptr );
         xml_file = xLightsParent->CurrentSeqXmlFile;
+
+        if ( xLightsParent->_renderCache.IsEnabled() ) {
+            wxMessageBox("Render Cache is enabled. Be sure to do Tools->Purge Render Cache to avoid render artifacts.");
+        }
     }
 }
 

--- a/xLights/SeqSettingsDialog.cpp
+++ b/xLights/SeqSettingsDialog.cpp
@@ -1808,7 +1808,9 @@ void SeqSettingsDialog::OnBitmapButton_ModifyTimingClick(wxCommandEvent& event)
         xml_file = xLightsParent->CurrentSeqXmlFile;
 
         if ( xLightsParent->_renderCache.IsEnabled() ) {
-            wxMessageBox("Render Cache is enabled. Be sure to do Tools->Purge Render Cache to avoid render artifacts.");
+            auto& se = xLightsParent->GetSequenceElements();
+            xLightsParent->_renderCache.Purge(&se , true);
+            wxMessageBox("Render Cache is enabled. To avoid render artifacts, render cache has been purged.");
         }
     }
 }


### PR DESCRIPTION
if render cache is enabled the effects may not show the expected results without clearing the render cache. Add the warning to inform the user. #5737 