### PR TITLE
Fix FSEQ being dumped on channel mismatch #5797

### DIFF
--- a/xLights/SeqFileUtilities.cpp
+++ b/xLights/SeqFileUtilities.cpp
@@ -533,10 +533,10 @@ void xLightsFrame::OpenSequence(const wxString& passed_filename, ConvertLogDialo
         logger_base.debug("Sequence Num Channels: %d or %d", numChan, _seqData.NumChannels());
         logger_base.debug("Sequence Num Frames: %d", (int)(CurrentSeqXmlFile->GetSequenceDurationMS() / ms));
 
-        if ((numChan != _seqData.NumChannels()) ||
+        if ((roundTo4(numChan) != _seqData.NumChannels()) ||
             (CurrentSeqXmlFile->GetSequenceDurationMS() / ms) > (long)_seqData.NumFrames()) {
             if (_seqData.NumChannels() > 0) {
-                if (numChan != _seqData.NumChannels()) {
+                if (roundTo4(numChan) != _seqData.NumChannels()) {
                     logger_base.warn("Fseq file had %u channels but sequence has %u channels so dumping the fseq data.", _seqData.NumChannels(), numChan);
                 } else {
                     if ((CurrentSeqXmlFile->GetSequenceDurationMS() / ms) > (long)_seqData.NumFrames()) {


### PR DESCRIPTION
Introduced in https://github.com/xLightsSequencer/xLights/commit/416edc3bc1d86b4188481150e7ab31970297f20c not realizing that fseq rounds to 4 channels in the fseq header.