### PR TITLE
Skip spaces in custom model string

### DIFF
--- a/xLights/models/CustomModel.cpp
+++ b/xLights/models/CustomModel.cpp
@@ -678,6 +678,13 @@ int CustomModel::GetCustomMaxChannel(const std::string& customModel) const
     std::string token;
 
     while (std::getline(ss, token, ',')) {
+        size_t start = token.find_first_not_of(" \t\n\r");
+        if (start == std::string::npos) {
+            continue;
+        }
+        size_t end = token.find_last_not_of(" \t\n\r");
+        token = token.substr(start, end - start + 1);
+
         if (!token.empty()) {
             try {
                 maxval = std::max(std::stoi(token), maxval);


### PR DESCRIPTION
From the crash logs exceptions were thrown when custom model had spaces between the commas. I think that comes from the custom model generator used by this twinkly user.