### PR TITLE
Provide a better cube visualization for dumb rgb #4652

### DIFF
--- a/xLights/models/CubeModel.cpp
+++ b/xLights/models/CubeModel.cpp
@@ -966,6 +966,19 @@ void CubeModel::InitModel()
         }
     }
 
+    if (Nodes.size() == 1 && width * height * depth > 1)
+    {
+        Nodes[0]->Coords.resize(width * height * depth);
+        for (int n = 0; n < width * height * depth; n++)
+        {
+            Nodes[0]->Coords[n].bufX = 0;
+            Nodes[0]->Coords[n].bufY = 0;
+            Nodes[0]->Coords[n].screenX = std::get<0>(locations[n]) - width / 2.0f;
+            Nodes[0]->Coords[n].screenY = std::get<1>(locations[n]) - height / 2.0f;
+            Nodes[0]->Coords[n].screenZ = depth - std::get<2>(locations[n]) - 1 - depth / 2.0f;
+        }
+    }
+
     if (Contains(CUBE_STYLES_VALUES[GetStyleIndex()], "Left/Right")) {
         _strandLength = width * height;
         _strands = depth;
@@ -1146,6 +1159,11 @@ int CubeModel::MapToNodeIndex(int strand, int node) const
 
 std::string CubeModel::ChannelLayoutHtml(OutputManager* outputManager)
 {
+    if (SingleNode || SingleChannel || Nodes.size() == 1)
+    {
+        return Model::ChannelLayoutHtml(outputManager);
+    }
+
     size_t NodeCount = GetNodeCount();
 
     std::vector<int> chmap;

--- a/xLights/models/CubeModel.cpp
+++ b/xLights/models/CubeModel.cpp
@@ -973,9 +973,9 @@ void CubeModel::InitModel()
         {
             Nodes[0]->Coords[n].bufX = 0;
             Nodes[0]->Coords[n].bufY = 0;
-            Nodes[0]->Coords[n].screenX = std::get<0>(locations[n]) - width / 2.0f;
-            Nodes[0]->Coords[n].screenY = std::get<1>(locations[n]) - height / 2.0f;
-            Nodes[0]->Coords[n].screenZ = depth - std::get<2>(locations[n]) - 1 - depth / 2.0f;
+            Nodes[0]->Coords[n].screenX = std::get<0>(locations[n]) - width / 2;
+            Nodes[0]->Coords[n].screenY = std::get<1>(locations[n]) - height / 2;
+            Nodes[0]->Coords[n].screenZ = depth - std::get<2>(locations[n]) - 1 - depth / 2;
         }
     }
 


### PR DESCRIPTION
When using dumb rgb, the cube would simply show 1 "pixel". With this change it places all the nodes in the cube for a more accurate look. #4652 