### PR TITLE
Use Numeric Smart Remote IDs for Hinkspix #4869

### DIFF
--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -1175,13 +1175,19 @@ void Model::GetControllerProtocols(wxArrayString& cp, int& idx)
     }
 }
 
-wxArrayString Model::GetSmartRemoteValues(int smartRemoteCount)
+wxArrayString Model::GetSmartRemoteValues(int smartRemoteCount) const
 {
     wxArrayString res;
-    // res.push_back("None");
+    auto caps = GetControllerCaps();
+    bool hinkspix = (caps && caps->GetVendor() == "HinksPix");
+
     for (int i = 0; i < smartRemoteCount; ++i) {
-        res.push_back(wxString((char)(65 + i)));
-    }
+        if (hinkspix) {
+            res.push_back(wxString::Format("%d", i));
+        } else { 
+            res.push_back(wxString(char(65 + i)));
+        } 
+    } 
     return res;
 }
 
@@ -3411,12 +3417,21 @@ void Model::ReplaceIPInStartChannels(const std::string& oldIP, const std::string
     }
 }
 
-std::string Model::DecodeSmartRemote(int sr)
+std::string Model::DecodeSmartRemote(int sr) const
 {
     if (sr == 0)
         return "None";
+
+    auto caps = GetControllerCaps();
+    bool hinkspix = (caps && caps->GetVendor() == "HinksPix");
+
+    if (hinkspix) {
+        return std::to_string(sr - 1);
+    }
+
     return std::string(1, ('A' + sr - 1));
 }
+
 
 wxXmlNode* Model::GetControllerConnection() const
 {

--- a/xLights/models/Model.h
+++ b/xLights/models/Model.h
@@ -364,7 +364,7 @@ public:
     [[nodiscard]] std::string GetControllerConnectionPortRangeString() const;
     [[nodiscard]] std::string GetControllerConnectionAttributeString() const;
     void ReplaceIPInStartChannels(const std::string& oldIP, const std::string& newIP);
-    static std::string DecodeSmartRemote(int sr);
+    std::string DecodeSmartRemote(int sr) const;
 
     void SetTagColour(wxColour colour);
     [[nodiscard]] wxColour GetTagColour();
@@ -451,7 +451,7 @@ public:
     
     virtual std::vector<PWMOutput> GetPWMOutputs() const;
 
-    static wxArrayString GetSmartRemoteValues(int smartRemoteCount);
+    wxArrayString GetSmartRemoteValues(int smartRemoteCount) const;
 
     [[nodiscard]] unsigned long GetChangeCount() const {
         return changeCount;


### PR DESCRIPTION
Layout would show A-B-C for Hinkspix smart remotes whereas Visualizer was using the proper 0-1-2 nomenclature.   #4869 