### PR TITLE
Dont perform backup if opening an xsqz file. #5482

### DIFF
--- a/xLights/TabSetup.cpp
+++ b/xLights/TabSetup.cpp
@@ -445,7 +445,7 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
     _outputModelManager.AddImmediateWork(OutputModelManager::WORK_RESEND_CONTROLLER_CONFIG, "SetDir");
     logger_base.debug("Start channels done.");
 
-    if (mBackupOnLaunch && !_renderMode) {
+    if (mBackupOnLaunch && !_renderMode && !CurrentDir.StartsWith(wxFileName::GetTempDir())) {
         logger_base.debug("Backing up show directory before we do anything this session in this folder : %s.", (const char *)CurrentDir.c_str());
         DoBackup(false, true);
         logger_base.debug("Backup completed.");


### PR DESCRIPTION
When opening an .xsqz sequence package, xLights extracts the contents to a temporary folder and briefly sets it as the show directory. This was incorrectly triggering a backup of the temporary folder, which is unnecessary and potentially slow. The backup is now skipped when the show directory is located under the system temp directory. #5482 