### PR TITLE
Restore the default metronome timing track options #5847

### DIFF
--- a/xLights/sequencer/RowHeading.cpp
+++ b/xLights/sequencer/RowHeading.cpp
@@ -955,6 +955,9 @@ void RowHeading::OnLayerPopup(wxCommandEvent& event)
                                 }
                             }
                         }
+                    } else {
+                        xml_file->AddFixedTimingSection(selected_timing, mSequenceElements->GetXLightsFrame());
+                        timing_added = true;
                     }
                 } else {
                     DisplayError(wxString::Format("Fixed Timing section %s already exists!", selected_timing).ToStdString());


### PR DESCRIPTION
The else portion was inadvertently removed. Restores the default timing track creations from the right click menu. 
You can still create them via the metronome option in the mean time. #5847 