### PR TITLE
Fix: Import from zip does not bring in images #5863

### DIFF
--- a/xLights/SequencePackage.cpp
+++ b/xLights/SequencePackage.cpp
@@ -367,6 +367,8 @@ std::string SequencePackage::FixAndImportMedia(Effect* mappedEffect, EffectLayer
                 auto img = sm.GetImage(v);
                 if (img->IsEmbedded() && !tm.HasImage(v)) {
                     tm.AddEmbeddedImage(v, img->GetEmbeddedData());
+                } else if (!img->IsEmbedded()) {
+                    settingEffectFile = "E_TEXTCTRL_Pictures_Filename";
                 }
             } else {
                 settingEffectFile = "E_TEXTCTRL_Pictures_Filename";
@@ -414,12 +416,18 @@ std::string SequencePackage::FixAndImportMedia(Effect* mappedEffect, EffectLayer
 
         // import the asset if we have it, otherwise track it as missing
         wxFileName fileToCopy = _media[picFilePath.GetFullName()];
-
+        
         if (fileToCopy.IsOk() && FileExists(fileToCopy)) {
             wxFileName copiedAsset = CopyMediaToTarget(targetMediaFolder, fileToCopy);
             settings.erase(settingEffectFile);
             wxString newSetting = copiedAsset.GetFullPath().ToStdString();
             settings[settingEffectFile] = newSetting;
+            if (effName == "Pictures") {
+                auto &tm = target->GetParentElement()->GetSequenceElements()->GetSequenceMedia();
+                if (!tm.HasImage(newSetting.ToStdString())) {
+                    tm.GetImage(newSetting.ToStdString());
+                }
+            }
         } else {
             if (picFilePath != "")
                 _missingMedia.push_back(picFilePath.GetFullName().ToStdString());

--- a/xLights/xLightsImportChannelMapDialog.cpp
+++ b/xLights/xLightsImportChannelMapDialog.cpp
@@ -964,6 +964,7 @@ xLightsImportChannelMapDialog::~xLightsImportChannelMapDialog()
 bool xLightsImportChannelMapDialog::InitImport(std::string checkboxText) {
     if (_xsqPkg != nullptr && _xsqPkg->IsPkg()) {
         SetImportMediaTooltip();
+        _xsqPkg->GetImportOptions()->SetImportActive(CheckBoxImportMedia->IsChecked());
     } else {
         Sizer1->Hide(FlexGridSizerImportMedia, true);
     }
@@ -1557,6 +1558,7 @@ void xLightsImportChannelMapDialog::LoadJSONMapping(wxString const& filename, bo
         }
         if (data.contains("importmedia")) {
             CheckBoxImportMedia->SetValue(data.at("importmedia").get<bool>());
+            _xsqPkg->GetImportOptions()->SetImportActive(CheckBoxImportMedia->IsChecked());
         }
     }
 


### PR DESCRIPTION
When importing a sequence from a zip package, Pictures effect images were not being copied to the show folder and were not appearing in the sequence or image panel. Additionally, after a successful import, the first image clicked would not show a preview. #5863