### PR TITLE
Fix the submodel crash on delete #5879

### DIFF
--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -2857,23 +2857,29 @@ std::string Model::DecodeSmartRemote(int sr) const
 
 void Model::RemoveSubModel(const std::string& name)
 {
-    for (auto a = subModels.begin(); a != subModels.end(); ++a) {
-        Model* m = *a;
+    for (auto it = subModels.begin(); it != subModels.end(); ) {
+        Model* m = *it;
         if (m->GetName() == name) {
-            delete m;
-            subModels.erase(a);
             sortedSubModels.erase(name);
+            delete m;
+            it = subModels.erase(it);
+            return;
+        } else {
+            ++it;
         }
     }
 }
 
 void Model::RemoveAllSubModels()
 {
-    for (auto a = subModels.begin(); a != subModels.end(); ++a) {
-        Model* m = *a;
+    for (auto it = subModels.begin(); it != subModels.end(); ) {
+        Model* m = *it;
+
+        sortedSubModels.erase(m->GetName());
+
         delete m;
-        subModels.erase(a);
-        sortedSubModels.erase(name);
+
+        it = subModels.erase(it);
     }
 }
 


### PR DESCRIPTION
Order of the deletion was incorrect (cant use iterator when you delete from the list). The delete also was using an unassigned "name" value. Claude thought the variable name needed clean up too :-) #5879 