### PR TITLE
Proposed fix for Missing Aliases on Groups #5888

### DIFF
--- a/xLights/XmlSerializer/BaseSerializingVisitor.cpp
+++ b/xLights/XmlSerializer/BaseSerializingVisitor.cpp
@@ -783,7 +783,9 @@ void BaseSerializingVisitor::Visit(const ModelGroup& model) {
     }
 
     SortAttributes(attrs);
-    WriteOpenTag("modelGroup", attrs, true);
+    WriteOpenTag("modelGroup", attrs, false);
+    WriteOtherElements(dynamic_cast<const Model*>(&model));
+    WriteCloseTag();
 }
 
 void BaseSerializingVisitor::Visit(const MultiPointModel& model) {

--- a/xLights/XmlSerializer/XmlDeserializingModelFactory.cpp
+++ b/xLights/XmlSerializer/XmlDeserializingModelFactory.cpp
@@ -820,10 +820,12 @@ Model* XmlDeserializingModelFactory::DeserializeModelGroup(wxXmlNode* node, xLig
         }
     }
     
+    DeserializeCommonModelChildElements(model, node, xlights, importing);
+
     // Note: We call RebuildBuffers() to finalize the model group
     // This handles node initialization and buffer setup
     model->RebuildBuffers();
-    
+
     return model;
 }
 


### PR DESCRIPTION
Added the ability to write and read these extra elements for Groups. Since groups cant have faces/states/etc the code call writeOtherElements are ignored leaving just the aliases to be written/read. #5888 