### PR TITLE
5895 visualizer not updating model properties

### DIFF
--- a/xLights/ControllerModelDialog.cpp
+++ b/xLights/ControllerModelDialog.cpp
@@ -1606,18 +1606,21 @@ public:
         } else if (id == ControllerModelDialog::CONTROLLER_BRIGHTNESS) {
             wxNumberEntryDialog dlg(parent, "Enter the Model Brightness", "Brightness", "Model Brightness", GetModel()->GetControllerBrightness(), 0, 100);
             if (dlg.ShowModal() == wxID_OK) {
+                GetModel()->SetControllerProperty(CtrlProps::BRIGHTNESS_ACTIVE);
                 GetModel()->SetControllerBrightness(dlg.GetValue());
             }
             return true;
         } else if (id == ControllerModelDialog::CONTROLLER_STARTNULLS) {
             wxNumberEntryDialog dlg(parent, "Enter the Model Start Nulls", "Start Nulls", "Start Nulls", GetModel()->GetControllerStartNulls(), 0, 100);
             if (dlg.ShowModal() == wxID_OK) {
+                GetModel()->SetControllerProperty(CtrlProps::START_NULLS_ACTIVE);
                 GetModel()->SetControllerStartNulls(dlg.GetValue());
             }
             return true;
         } else if (id == ControllerModelDialog::CONTROLLER_ENDNULLS) {
             wxNumberEntryDialog dlg(parent, "Enter the End Nulls", "End Nulls", "Model End Nulls", GetModel()->GetControllerEndNulls(), 0, 100);
             if (dlg.ShowModal() == wxID_OK) {
+                GetModel()->SetControllerProperty(CtrlProps::END_NULLS_ACTIVE);
                 GetModel()->SetControllerEndNulls(dlg.GetValue());
             }
             return true;
@@ -1629,12 +1632,14 @@ public:
                 dlg.SetSelection(selection);
             }
             if (dlg.ShowModal() == wxID_OK) {
+                GetModel()->SetControllerProperty(CtrlProps::COLOR_ORDER_ACTIVE);
                 GetModel()->SetControllerColorOrder(choices[dlg.GetSelection()]);
             }
             return true;
         } else if (id == ControllerModelDialog::CONTROLLER_GROUPCOUNT) {
             wxNumberEntryDialog dlg(parent, "Enter the Group Count", "Group Count", "Model Group Count", GetModel()->GetControllerGroupCount(), 1, 500);
             if (dlg.ShowModal() == wxID_OK) {
+                GetModel()->SetControllerProperty(CtrlProps::GROUP_COUNT_ACTIVE);
                 GetModel()->SetControllerGroupCount(dlg.GetValue());
             }
             return true;
@@ -1643,6 +1648,7 @@ public:
             if (dialog.ShowModal() == wxID_OK) {
                 auto d_gamma = wxAtof(dialog.GetValue());
                 if (d_gamma > 0.1 && d_gamma < 100.0) {
+                    GetModel()->SetControllerProperty(CtrlProps::GAMMA_ACTIVE);
                     GetModel()->SetControllerGamma(d_gamma);
                 }
             }

--- a/xLights/models/PolyLineModel.cpp
+++ b/xLights/models/PolyLineModel.cpp
@@ -931,6 +931,7 @@ int PolyLineModel::OnPropertyGridChange(wxPropertyGridInterface* grid, wxPropert
         AddASAPWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "PolyLineModel::OnPropertyGridChange::ModelIndividualSegments2");
         AddASAPWork(OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS, "PolyLineModel::OnPropertyGridChange::ModelIndividualSegments2");
         AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "PolyLineModel::OnPropertyGridChange::ModelIndividualSegments2");
+        AddASAPWork(OutputModelManager::WORK_RELOAD_MODELLIST, "PolyLineModel::OnPropertyGridChange::ModelIndividualSegments2");
         return 0;
     }
     else if (event.GetPropertyName().StartsWith("PolyCornerProperties.")) {


### PR DESCRIPTION
My master got a bit messed up but this looks like what I was trying to commit.

When you right click on the model in the visualizer and change brightness, gamma etc. , the changes were not reflected on the model or the layout panel. Not clear why the serializing would have broken this function. Perhaps you can comment on that..
https://github.com/xLightsSequencer/xLights/issues/5895