### PR TITLE
Proposed fix for single channel candy cane #5903

### DIFF
--- a/xLights/models/CandyCaneModel.cpp
+++ b/xLights/models/CandyCaneModel.cpp
@@ -260,6 +260,13 @@ void CandyCaneModel::InitModel() {
     int NumCanes = parm1;
     int SegmentsPerCane = parm2;
 
+    // When a SingleNode model is saved, parm2 is stored as 1 and parm3 holds lights per cane.
+    // On reload, restore parm2 from parm3 so SetNodeCount gets the correct count.
+    if (SingleNode && parm2 <= 1 && parm3 > 1) {
+        SegmentsPerCane = parm3;
+        parm2 = parm3;
+    }
+
     SetNodeCount(NumCanes, SegmentsPerCane, rgbOrder);
     if (SingleNode) {
         SegmentsPerCane = 1;


### PR DESCRIPTION
Single color candy canes reverted to 1 light per cane after saving and reloading a show. 
This fix ensures the lights per cane setting is correctly preserved across saves and reloads. #5903 