### PR TITLE
Proposed Fix For Cascade Down Port not working for multi-string model #5913

### DIFF
--- a/xLights/models/Model.h
+++ b/xLights/models/Model.h
@@ -824,10 +824,10 @@ public:
     // Smart Remote Functions
     void GetPortSR(int string, int& outport, int& outsr) const { return _controllerConnection.GetPortSR(string, outport, outsr); }
     [[nodiscard]] char GetSmartRemoteLetter() const { return _controllerConnection.GetSmartRemoteLetter(); }
-    [[nodiscard]] char GetSmartRemoteLetterForString(int string = 1) const { return _controllerConnection.GetSmartRemoteLetterForString(); }
+    [[nodiscard]] char GetSmartRemoteLetterForString(int string = 1) const { return _controllerConnection.GetSmartRemoteLetterForString(string); }
     [[nodiscard]] int GetSortableSmartRemote() const { return _controllerConnection.GetSortableSmartRemote(); }
     [[nodiscard]] int GetSmartTs() const { return _controllerConnection.GetSmartTs(); }
-    [[nodiscard]] int GetSmartRemoteForString(int string = 1) const { return _controllerConnection.GetSmartRemoteForString(); }
+    [[nodiscard]] int GetSmartRemoteForString(int string = 1) const { return _controllerConnection.GetSmartRemoteForString(string); }
     void SetSmartRemote(int sr) { return _controllerConnection.SetSmartRemote(sr); }
     void SetSmartRemoteTs(int ts ) { _controllerConnection.SetSmartRemoteTs(ts); }
     void SetSRCascadeOnPort(bool cascade) { return _controllerConnection.SetSRCascadeOnPort(cascade); }


### PR DESCRIPTION
When using the Controller Visualizer, enabling "Cascade Down Port" and changing the "Cascaded Remotes" count had no visible effect — all strings of a multi-string model remained on the same Smart Remote regardless of cascade settings. #5913