### PR TITLE
Updated for Fix models with start nodes of 0 and DMX channel defaults #5876

### DIFF
--- a/xLights/XmlSerializer/XmlDeserializingModelFactory.cpp
+++ b/xLights/XmlSerializer/XmlDeserializingModelFactory.cpp
@@ -136,7 +136,7 @@ void XmlDeserializingModelFactory::CommonDeserializeSteps(Model* model, wxXmlNod
 
 void XmlDeserializingModelFactory::DeserializeControllerConnection(Model* model, wxXmlNode* ccNode) {
     auto& cc = model->GetCtrlConn();
-    cc.SetDMXChannel(std::stoi(ccNode->GetAttribute(XmlNodeKeys::ChannelAttribute, "-1").ToStdString()));
+    cc.SetDMXChannel(std::stoi(ccNode->GetAttribute(XmlNodeKeys::ChannelAttribute, "1").ToStdString()));
     cc.SetProtocol(ccNode->GetAttribute(XmlNodeKeys::ProtocolAttribute, xlEMPTY_STRING).ToStdString());
     cc.SetSerialProtocolSpeed(std::stoi(ccNode->GetAttribute(XmlNodeKeys::ProtocolSpeedAttribute, std::to_string(CtrlDefs::DEFAULT_PROTOCOL_SPEED)).ToStdString()));
     cc.SetCtrlPort(std::stoi(ccNode->GetAttribute(XmlNodeKeys::PortAttribute, std::to_string(CtrlDefs::DEFAULT_PORT)).ToStdString()));
@@ -573,7 +573,7 @@ Model* XmlDeserializingModelFactory::DeserializeMultiPoint(wxXmlNode* node, xLig
     }
 
     // Individual Start Nodes
-    if (num_strings > 1) {
+    if (num_strings > 1 && node->HasAttribute(model->StartNodeAttrName(0))) {
         model->SetHasIndivStartNodes(true);
         model->SetIndivStartNodesCount(num_strings);
         for (auto i = 0; i < num_strings;  i++) {
@@ -615,7 +615,7 @@ Model* XmlDeserializingModelFactory::DeserializePolyLine(wxXmlNode* node, xLight
     }
 
     // Individual Start Nodes
-    if (num_strings > 1) {
+    if (num_strings > 1 && node->HasAttribute(model->StartNodeAttrName(0))) {
         model->SetHasIndivStartNodes(true);
         model->SetIndivStartNodesCount(num_strings);
         for (auto i = 0; i < num_strings;  i++) {

--- a/xLights/models/CustomModel.h
+++ b/xLights/models/CustomModel.h
@@ -78,7 +78,7 @@ class CustomModel : public ModelWithScreenLocation<BoxedScreenLocation>
         [[nodiscard]] std::vector<std::vector<std::vector<int>>> & GetData() { return _locations; }  // letting the XmlSerializer functions access this member data for speed
         [[nodiscard]] int GetCustomNodeStringNumber(int node) const;
 
-        [[nodiscard]] const std::string StartNodeAttrName(int idx) const
+        [[nodiscard]] const std::string StartNodeAttrName(int idx) const override
         {
             return std::string("NodeStart") + std::to_string(idx + 1);
         }

--- a/xLights/models/Model.h
+++ b/xLights/models/Model.h
@@ -341,7 +341,7 @@ public:
     [[nodiscard]] int GetIndivStartNodesCount() const { return _indivStartNodes.size(); }
     void AddIndivStartNode(int node) { _indivStartNodes.push_back(node); }
     void SetIndivStartNode(int index, int node) { _indivStartNodes[index] = node; }
-    const std::string StartNodeAttrName(int idx) const { return ""; }
+    virtual const std::string StartNodeAttrName(int idx) const { return ""; }
 
     bool IsNodeInBufferRange(size_t nodeNum, int x1, int y1, int x2, int y2);
 

--- a/xLights/models/MultiPointModel.h
+++ b/xLights/models/MultiPointModel.h
@@ -39,7 +39,7 @@ public:
     void SetNumStrings(int strings) { _strings = strings; }
     void SetModelHeight(float height) { _height = height; }
 
-    const std::string StartNodeAttrName(int idx) const
+    const std::string StartNodeAttrName(int idx) const override
     {
         return "MultiNode" + std::to_string(idx + 1); // a space between "String" and "%i" breaks the start channels listed in Indiv Start Chans
     }

--- a/xLights/models/PolyLineModel.h
+++ b/xLights/models/PolyLineModel.h
@@ -71,7 +71,7 @@ public:
     void SetAutoDistribute(bool val) { _autoDistributeLights = val; }
     void ClearPolyLineCreate() { _creatingNewPolyLine = false; }
 
-    const std::string StartNodeAttrName(int idx) const
+    const std::string StartNodeAttrName(int idx) const override
     {
         return "PolyNode" + std::to_string(idx + 1); // a space between "String" and "%i" breaks the start channels listed in Indiv Start Chans
     }


### PR DESCRIPTION
  1. PolyLine, MultiPoint, and Custom models with multiple strings were loading with all start nodes set to 0, causing
  all strings to start on the same channel instead of their correct positions.
  2. DMX models (floods, etc.) were showing a start channel of 0 instead of the correct channel when loaded from
  existing show files.  #5876