### PR TITLE
 Moving prop in layout visualizer gets stuck in infinite recalculation loop #5892

### DIFF
--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -5926,11 +5926,14 @@ void Model::SetModelChain(const std::string& modelChain)
     if (!mc.empty() && mc != "Beginning" && !StartsWith(mc, ">")) {
         mc = ">" + mc;
     }
+    if (mc == "Beginning" || mc == ">") {
+        mc = "";
+    }
+
+    if (_modelChain == mc) return;
+    _modelChain = mc;
 
     logger_base.debug("Model '%s' chained to '%s'.", (const char*)GetName().c_str(), (const char*)mc.c_str());
-    if (!mc.empty() && mc != "Beginning" && mc != ">") {
-        _modelChain = mc;
-    }
     AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER |
                 OutputModelManager::WORK_RGBEFFECTS_CHANGE |
                 OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS |

--- a/xLights/models/ModelManager.cpp
+++ b/xLights/models/ModelManager.cpp
@@ -1007,7 +1007,7 @@ bool ModelManager::ReworkStartChannel() const
                 auto oldC = it->GetChannels();
                 // Set channel size won't always change the number of channels for some protocols
                 it->SetChannelSize(std::max((int32_t)1, (int32_t)ch - 1), allSortedModels);
-                if (it->GetChannels() != oldC || (eth != nullptr && eth->SupportsUniversePerString())) {
+                if (it->GetChannels() != oldC || (eth != nullptr && eth->IsUniversePerString())) {
                     outputManager->SomethingChanged();
 
                     if (it->GetChannels() != oldC || (eth != nullptr && eth->IsUniversePerString() && xlights->IsSequencerInitialize())) { 


### PR DESCRIPTION
When moving a prop/model in the layout visualizer, xLights could get stuck in an endless recalculation loop, making the application unresponsive.

Also fixes a bug where clearing a model's chain assignment (setting it back to "Beginning") was silently ignored, leaving the old chain value in place.