### PR TITLE
Moving a model to a different port in the layout visualizer no longer … gets stuck in an infinite recalculation loop.

### DIFF
--- a/xLights/models/Model.cpp
+++ b/xLights/models/Model.cpp
@@ -4175,11 +4175,14 @@ void Model::SetModelChain(const std::string& modelChain)
     if (!mc.empty() && mc != "Beginning" && !StartsWith(mc, ">")) {
         mc = ">" + mc;
     }
+    if (mc == "Beginning" || mc == ">") {
+        mc = "";
+    }
+
+    if (_modelChain == mc) return;
+    _modelChain = mc;
 
     logger_base.debug("Model '%s' chained to '%s'.", (const char*)GetName().c_str(), (const char*)mc.c_str());
-    if (!mc.empty() && mc != "Beginning" && mc != ">") {
-        _modelChain = mc;
-    }
     AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER |
                 OutputModelManager::WORK_RGBEFFECTS_CHANGE |
                 OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS |

--- a/xLights/models/ModelManager.cpp
+++ b/xLights/models/ModelManager.cpp
@@ -1007,7 +1007,7 @@ bool ModelManager::ReworkStartChannel() const
                 auto oldC = it->GetChannels();
                 // Set channel size won't always change the number of channels for some protocols
                 it->SetChannelSize(std::max((int32_t)1, (int32_t)ch - 1), allSortedModels);
-                if (it->GetChannels() != oldC || (eth != nullptr && eth->SupportsUniversePerString())) {
+                if (it->GetChannels() != oldC || (eth != nullptr && eth->IsUniversePerString())) {
                     outputManager->SomethingChanged();
 
                     if (it->GetChannels() != oldC || (eth != nullptr && eth->IsUniversePerString() && xlights->IsSequencerInitialize())) { 


### PR DESCRIPTION
When dragging a prop between ports, the chain assignment was repeatedly triggering recalculation even when the value had not actually changed. The fix prevents redundant work from being queued when the model chain is unchanged, and also prevents unnecessary network change notifications from firing when auto-sizing outputs on protocols that support but are not using universe-per-string mode.  #5892 