### PR TITLE
Fix several PolyLine model issues

### DIFF
--- a/xLights/XmlSerializer/BaseSerializingVisitor.cpp
+++ b/xLights/XmlSerializer/BaseSerializingVisitor.cpp
@@ -856,7 +856,7 @@ void BaseSerializingVisitor::Visit(const PolyLineModel& model) {
     AttrCollector attrs;
     CommonVisitSteps(model, attrs);
     attrs.Add(XmlNodeKeys::LightsPerNodeAttribute, std::to_string(model.GetLightsPerNode()));
-    attrs.Add(XmlNodeKeys::NodesPerStringAttribute, std::to_string(model.NodesPerString()));
+    attrs.Add(XmlNodeKeys::NodesPerStringAttribute, std::to_string(model.GetTotalLightCount()));
     AddPolyPointScreenLocationAttributes(model, attrs);
     attrs.Add(XmlNodeKeys::PolyStringsAttribute,    std::to_string(model.GetNumStrings()));
     attrs.Add(XmlNodeKeys::AlternateNodesAttribute, model.HasAlternateNodes() ? "true" : "false");

--- a/xLights/models/ModelManager.cpp
+++ b/xLights/models/ModelManager.cpp
@@ -1319,7 +1319,9 @@ Model* ModelManager::CreateDefaultModel(const std::string& type, const std::stri
         m->SetLightsPerNode(1);
         model = m;
     } else if (type == "Poly Line") {
-        model = new PolyLineModel(*this);
+        auto* m = new PolyLineModel(*this);
+        m->SetTotalLightCount(50);
+        model = m;
     } else if (type == "MultiPoint") {
         model = new MultiPointModel(*this);
     } else if (type == "Cube") {

--- a/xLights/models/PolyLineModel.cpp
+++ b/xLights/models/PolyLineModel.cpp
@@ -789,7 +789,7 @@ int PolyLineModel::GetNumPhysicalStrings() const
 int PolyLineModel::NodesPerString() const
 {
     if (_strings <= 1) {
-        return Model::NodesPerString();
+        return _totalLightCount;
     }
 
     // For multi-string PolyLine, we need to account for drop pattern

--- a/xLights/ui/modelproperties/adapters/PolyLinePropertyAdapter.cpp
+++ b/xLights/ui/modelproperties/adapters/PolyLinePropertyAdapter.cpp
@@ -129,6 +129,7 @@ int PolyLinePropertyAdapter::OnPropertyGridChange(wxPropertyGridInterface* grid,
         _polyLine.AddASAPWork(OutputModelManager::WORK_RELOAD_MODEL_CHANGE |
                     OutputModelManager::WORK_CALCULATE_START_CHANNELS |
                     OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS |
+                    OutputModelManager::WORK_RELOAD_MODELLIST |
                     OutputModelManager::WORK_RELOAD_PROPERTYGRID, "PolyLineModel::OnPropertyGridChange::PolyLineNodes");
         return 0;
     } else if ("PolyLineLights" == event.GetPropertyName()) {


### PR DESCRIPTION
PolyLine models now default to 50 nodes when first placed on the layout 
Changing the node count now correctly updates the end channel in the model list 
PolyLine models set to right-to-left direction (Blue Square) now calculate start/end channels correctly 
PolyLine models now correctly retain their node count after saving and reloading a show