### PR TITLE
Fix multi-string custom models loaded from older saves leave strings starting at node 0.

### DIFF
--- a/xLights/XmlSerializer/XmlDeserializingModelFactory.cpp
+++ b/xLights/XmlSerializer/XmlDeserializingModelFactory.cpp
@@ -576,11 +576,19 @@ Model* XmlDeserializingModelFactory::DeserializeCustom(pugi::xml_node node, xLig
 
     model->Setup();
 
-    if (model->HasIndivStartNodes() && !model->HasIndividualStartChannels() && model->GetNodeCount() > 0) {
+    // Any per-string start nodes that were not present in the XML remain 0.
+    // Now that Setup() has built the node list, ComputeStringStartNode() returns
+    // accurate values. Set them and re-run Setup() so stringStartChan is consistent.
+    if (num_strings > 1) {
+        bool anyUpdated = false;
         for (int i = 0; i < num_strings; i++) {
             if (model->GetIndivStartNode(i) == 0) {
-                model->SetIndivStartNode(i, model->ComputeStringStartNode(i));
+                model->SetNodeSize(i, model->ComputeStringStartNode(i));
+                anyUpdated = true;
             }
+        }
+        if (anyUpdated) {
+            model->Setup();
         }
     }
 

--- a/xLights/XmlSerializer/XmlDeserializingModelFactory.cpp
+++ b/xLights/XmlSerializer/XmlDeserializingModelFactory.cpp
@@ -575,6 +575,15 @@ Model* XmlDeserializingModelFactory::DeserializeCustom(pugi::xml_node node, xLig
     }
 
     model->Setup();
+
+    if (model->HasIndivStartNodes() && !model->HasIndividualStartChannels() && model->GetNodeCount() > 0) {
+        for (int i = 0; i < num_strings; i++) {
+            if (model->GetIndivStartNode(i) == 0) {
+                model->SetIndivStartNode(i, model->ComputeStringStartNode(i));
+            }
+        }
+    }
+
     return model;
 }
 


### PR DESCRIPTION
Older versions of xLights did not save individual string start node values to the XML file — they were always computed at runtime. When loading these older files in 2026.03, the missing attributes defaulted  to 0 internally. Although rendering worked correctly (the runtime calculation already handled 0 as a fallback), Check Sequence would incorrectly flag all strings as starting outside the valid node range. On re-save, these zero values were also written to the XML, persisting the problem.

The fix computes the correct evenly-distributed start nodes for any string that has a zero value after the model is loaded, restoring the behaviour that older versions provided automatically.