### PR TITLE
Fix opening .xsqz sequence packages via double-click #5943

### DIFF
--- a/xLights/SequencePackage.cpp
+++ b/xLights/SequencePackage.cpp
@@ -212,6 +212,7 @@ void SequencePackage::Extract()
                     spdlog::error("Could not create sequence file at '{}'", (const char*)fnOutput.GetFullName().c_str());
                 } else {
                     zis.Read(fos);
+                    fos.Close();
                     wxString ext = fnOutput.GetExt();
 
                     if (ext == "xsq") {
@@ -242,7 +243,6 @@ void SequencePackage::Extract()
                         _media[fnOutput.GetFullName()] = fnOutput;
                     }
                 }
-                fos.Close();
             }
         }
 

--- a/xLights/xLightsApp.cpp
+++ b/xLights/xLightsApp.cpp
@@ -679,8 +679,20 @@ bool xLightsApp::OnInit()
             // temporarily set the show folder
             showDir = xsqPkg.GetTempShowFolder();
 
-            // save the folder and we will remove it when we shutdown
-            cleanupDir = showDir;
+            spdlog::info("xsqz IsPkg={} IsValid={} tempShowFolder='{}' tempDir='{}' xsqFile='{}'",
+                xsqPkg.IsPkg(), xsqPkg.IsValid(),
+                showDir.ToStdString(),
+                xsqPkg.GetTempDir(),
+                xsqFile.GetFullPath().ToStdString());
+
+            // if the package includes xlights_rgbeffects.xml, point the frame constructor
+            // at the extracted show folder so it loads it directly (avoids a second SetDir)
+            if (!showDir.IsEmpty()) {
+                xLightsApp::showDir = showDir;
+            }
+
+            // save the temp dir root so it gets cleaned up on shutdown
+            cleanupDir = xsqPkg.GetTempDir();
 
         } else {
             spdlog::debug("Zip file did not contain sequence.");
@@ -711,6 +723,8 @@ bool xLightsApp::OnInit()
     }
 
     if (readOnlyZipFile != "") {
+        spdlog::info("xsqz: CurrentDir='{}' after construction", topFrame->CurrentDir.ToStdString());
+
         // tell xlights not to allow saving ... at least as much as possible
         topFrame->SetReadOnlyMode(true);
 

--- a/xLights/xLightsMain.cpp
+++ b/xLights/xLightsMain.cpp
@@ -3726,6 +3726,9 @@ void xLightsFrame::UpdateEffectAssistWindow(Effect* effect, RenderableEffect* re
 
 void xLightsFrame::CheckUnsavedChanges()
 {
+    if (readOnlyMode) {
+        return;
+    }
     if (UnsavedRgbEffectsChanges) {
         // This is not necessary but it shows the user that the save button is red which I am hoping makes it clearer
         // to the user what this prompt is for

--- a/xLights/xLightsTimer.cpp
+++ b/xLights/xLightsTimer.cpp
@@ -435,7 +435,7 @@ wxThread::ExitCode xlTimerThread::Entry()
             fudgefactor = _fudgefactor;
             if (!_stop && !suspend)
             {
-                spdlog::debug("THREAD {}: Timer %s fired {}.", wxThread::GetCurrentId(), (const char*)_name.c_str(), _timer->GetFired());
+                spdlog::debug("THREAD {}: Timer {} fired {}.", wxThread::GetCurrentId(), (const char*)_name.c_str(), _timer->GetFired());
                 _timer->Notify();
             }
             if (oneshot)


### PR DESCRIPTION
When double-clicking an .xsqz file to open it in xLights, the app was failing to switch to the show folder contained in the package. This caused a "Sequence Element Mismatch" dialog because the models from the wrong show folder were being used. Additionally, on exit the app would prompt to save changes that were not meaningful since the package is read-only.

This fix ensures xLights correctly loads the show configuration bundled inside the package, and suppresses any save prompts while viewing a read-only sequence package.