### PR TITLE
Fix Moving Head Adv beam Y offset having no effect when changed in Beam Properties.  #5947

### DIFF
--- a/xLights/models/DMX/DmxBeamAbility.h
+++ b/xLights/models/DMX/DmxBeamAbility.h
@@ -33,8 +33,8 @@ class DmxBeamAbility
         void SetBeamWidth( float width ) {
             beam_width = width; }
         void SetDefaultBeamWidth( float width ) { default_beam_width = width; }
-        void SetBeamYOffset(float offset) { default_beam_y_offset = offset; }
-        void SetDefaultBeamYOffset(float offset) { beam_y_offset = offset; }
+        void SetBeamYOffset(float offset) { beam_y_offset = offset; }
+        void SetDefaultBeamYOffset(float offset) { default_beam_y_offset = offset; }
         void SetBeamOrient(int orient) { beam_orient = orient; }
 
         void SetSupportsOrient(bool val) { supports_orient = val; }


### PR DESCRIPTION

The setter functions for the beam Y offset and its default value were accidentally swapped, causing user changes to be written to the wrong field and never reflected in the display or rendering.