### PR TITLE
Fix submodel aliases reading and writing #5962

### DIFF
--- a/xLights/SubModelsDialog.cpp
+++ b/xLights/SubModelsDialog.cpp
@@ -639,7 +639,7 @@ void SubModelsDialog::SaveSubModelInfoIntoThisModel(Model *m)
     std::vector<std::pair<wxString, wxString>> submodelAliases;
     const std::vector<Model*>& subs = m->GetSubModels();
     for (auto& sub : subs) {
-        const std::list<std::string> & aliases = m->GetAliases();
+        const std::list<std::string> & aliases = sub->GetAliases();
         for (auto& alias : aliases) {
             submodelAliases.push_back(std::make_pair(sub->GetName(), alias));
         }

--- a/xLights/XmlSerializer/XmlDeserializingModelFactory.cpp
+++ b/xLights/XmlSerializer/XmlDeserializingModelFactory.cpp
@@ -407,6 +407,15 @@ void XmlDeserializingModelFactory::DeserializeSubModel(Model* model, pugi::xml_n
         // Subbuffer type
         sm->AddSubbuffer(smData->subBuffer);
     }
+
+    // Load aliases for this submodel (handles both "Aliases" and legacy "aliases")
+    for (pugi::xml_node child = node.first_child(); child; child = child.next_sibling()) {
+        std::string_view childName = child.name();
+        if (childName == XmlNodeKeys::AliasesAttribute || childName == "aliases") {
+            DeserializeAliases(sm, child);
+            break;
+        }
+    }
 }
 
 void XmlDeserializingModelFactory::DeserializeAliases(Model* model, pugi::xml_node node)


### PR DESCRIPTION
Was not able to save and reload aliases created on submodels.
**Unconfirmed but submodel aliases may have shown model aliases and actual aliases would have been lost.**

Restore rgbeffects if possible...