### PR TITLE
Compiles but crashes on IPUTILS call..

### DIFF
--- a/xLights/utils/ip_utils.cpp
+++ b/xLights/utils/ip_utils.cpp
@@ -16,7 +16,7 @@
 #include <regex>
 #include <thread>
 
-#ifndef __WXMSW__
+#ifndef _WIN32
 #include <netdb.h>
 #include <arpa/inet.h>
 #else


### PR DESCRIPTION
Crashes on Iputils and then the logger?
    bool should_log(level::level_enum msg_level) const {
        return msg_level >= level_.load(std::memory_order_relaxed);
    }