### PR TITLE
Fix MediaManager tooltip and Add DoubleClick #5981

### DIFF
--- a/xLights/ui/MediaPickerCtrl.cpp
+++ b/xLights/ui/MediaPickerCtrl.cpp
@@ -17,6 +17,8 @@
 #include <wx/sizer.h>
 #include <wx/filepicker.h>
 #include <wx/filename.h>
+#include <wx/artprov.h>
+#include <wx/bmpbuttn.h>
 #include <filesystem>
 
 MediaPickerCtrl::MediaPickerCtrl(wxWindow* parent, wxWindowID id,
@@ -43,10 +45,10 @@ MediaPickerCtrl::MediaPickerCtrl(wxWindow* parent, wxWindowID id,
                                  wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
     sizer->Add(_selectButton, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 2);
 
-    // Clear button
-    _clearButton = new wxButton(this, wxID_ANY, wxString::FromUTF8("\xC3\x97"),  // multiplication sign as X
-                                wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
-    _clearButton->SetMinSize(wxSize(24, -1));
+    // Clear button — bitmap X matching the PicturesPanel style
+    wxBitmap clearBmp = wxArtProvider::GetBitmap(wxART_DELETE, wxART_BUTTON);
+    _clearButton = new wxBitmapButton(this, wxID_ANY, clearBmp,
+                                      wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
     _clearButton->SetToolTip("Clear selection");
     sizer->Add(_clearButton, 0, wxALIGN_CENTER_VERTICAL);
 

--- a/xLights/ui/MediaPickerCtrl.h
+++ b/xLights/ui/MediaPickerCtrl.h
@@ -14,6 +14,7 @@
 #include <wx/statbmp.h>
 #include <wx/textctrl.h>
 #include <wx/button.h>
+#include <wx/bmpbuttn.h>
 #include <wx/filepicker.h>
 #include <optional>
 #include <string>
@@ -63,7 +64,7 @@ private:
     MediaType _mediaType;
     wxTextCtrl* _pathCtrl = nullptr;
     wxButton* _selectButton = nullptr;
-    wxButton* _clearButton = nullptr;
+    wxBitmapButton* _clearButton = nullptr;
     wxStaticBitmap* _preview = nullptr;
     wxFilePickerCtrl* _linkedPicker = nullptr;
 };

--- a/xLights/ui/media/ManageMediaPanel.cpp
+++ b/xLights/ui/media/ManageMediaPanel.cpp
@@ -999,7 +999,11 @@ void ManageMediaPanel::OnTreeMouseMotion(wxMouseEvent& event)
 
     wxDataViewItem item;
     wxDataViewColumn* col = nullptr;
-    _mediaTree->HitTest(event.GetPosition(), item, col);
+    // event.GetPosition() is in inner-window coordinates; HitTest expects
+    // _mediaTree client coordinates (which include the header row offset).
+    wxPoint pos = inner->ClientToScreen(event.GetPosition());
+    pos = _mediaTree->ScreenToClient(pos);
+    _mediaTree->HitTest(pos, item, col);
 
     if (item.IsOk() && !_model->IsGroup(item)) {
         std::string path = _model->GetFilePath(item);
@@ -2109,6 +2113,15 @@ SelectMediaDialog::SelectMediaDialog(wxWindow* parent, SequenceMedia* sequenceMe
 
     _okButton->Bind(wxEVT_BUTTON, &SelectMediaDialog::OnOK, this);
     _addFromDiskButton->Bind(wxEVT_BUTTON, &SelectMediaDialog::OnAddFromDisk, this);
+
+    // Double-click (or Enter) on a leaf item accepts the selection and closes
+    _panel->_mediaTree->Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED,
+        [this](wxDataViewEvent& evt) {
+            auto paths = _panel->GetSelectedPaths();
+            if (paths.size() == 1)
+                EndModal(wxID_OK);
+            evt.Skip();
+        });
 
     // Pre-select the specified media file if provided
     if (!selectPath.empty()) {


### PR DESCRIPTION
Tooltip was off by one line because of the column header. Added the double click to select the item as well.
Also make the clear button show correctly on Windows.