### PR TITLE
Fix for SingleStrand values being copied over #5964

### DIFF
--- a/xLights/ui/effectpanels/EffectPanelManager.cpp
+++ b/xLights/ui/effectpanels/EffectPanelManager.cpp
@@ -133,7 +133,7 @@ void EffectPanelManager::RegisterPanels() {
     Register<ShapePanel>(E::eff_SHAPE, "Shape");
     Register<ShimmerPanel>(E::eff_SHIMMER, "Shimmer");
     Register<ShockwavePanel>(E::eff_SHOCKWAVE, "Shockwave");
-    Register<SingleStrandPanel>(E::eff_SINGLESTRAND, "Single Strand");
+    Register<SingleStrandPanel>(E::eff_SINGLESTRAND, "SingleStrand");
     Register<SketchPanel>(E::eff_SKETCH, "Sketch");
     Register<SnowflakesPanel>(E::eff_SNOWFLAKES, "Snowflakes");
     Register<SnowstormPanel>(E::eff_SNOWSTORM, "Snowstorm");


### PR DESCRIPTION
SingleStrandEffect::Name() returns "SingleStrand" (no space), but EffectPanelManager registered its panel as 
"Single Strand" (with space). 
Every other multi-word effect ("Moving Head", "VU Meter") uses the same string in both Name() and the panel registration — SingleStrand is the sole exception.