### PR TITLE
Fix polyline starting string values not kept. #5955

### DIFF
--- a/xLights/ui/modelproperties/adapters/PolyLinePropertyAdapter.cpp
+++ b/xLights/ui/modelproperties/adapters/PolyLinePropertyAdapter.cpp
@@ -69,15 +69,19 @@ void PolyLinePropertyAdapter::AddTypeProperties(wxPropertyGridInterface* grid, O
 
         if (_polyLine.HasIndivStartNodes()) {
             int c = _polyLine.GetNumStrings();
+            int nodeCount = (int)_polyLine.GetNodeCount();
             for (int x = 0; x < c; x++) {
                 int v = _polyLine.GetIndivStartNode(x);
                 if (v < 1) v = 1;
-                if (v > _polyLine.NodesPerString()) v = _polyLine.NodesPerString();
+                if (v > nodeCount) v = nodeCount;
                 if (x == 0) {
                     psn->SetValue(v);
                 } else {
                     nm = Model::StartChanAttrName(x);
-                    grid->AppendIn(p, new wxUIntProperty(nm, nm, v));
+                    wxPGProperty* pChild = grid->AppendIn(p, new wxUIntProperty(nm, nm, v));
+                    pChild->SetAttribute("Min", 1);
+                    pChild->SetAttribute("Max", nodeCount);
+                    pChild->SetEditor("SpinCtrl");
                 }
             }
         } else {
@@ -246,7 +250,7 @@ int PolyLinePropertyAdapter::OnPropertyGridChange(wxPropertyGridInterface* grid,
         int string = wxAtoi(s) - 1;
         int value = event.GetValue().GetInteger();
         if (value < 1) value = 1;
-        if (value > _polyLine.NodesPerString()) value = _polyLine.NodesPerString();
+        if (value > (int)_polyLine.GetNodeCount()) value = (int)_polyLine.GetNodeCount();
         _polyLine.SetIndivStartNode(string, value);
         _polyLine.IncrementChangeCount();
         _polyLine.AddASAPWork(OutputModelManager::WORK_RELOAD_MODEL_CHANGE |


### PR DESCRIPTION
PolyLine: Fix start nodes for String 3+ being clamped to wrong maximum

  When a PolyLine model has 3 or more strings, the start node values for String 2 and beyond were being clamped to NodesPerString() (total nodes ÷ string count) instead of the total node count. For example, on
   a 50-node/3-string model, NodesPerString() = 16, so String 3's default start node of 34 would be silently clamped to 16 — making it appear that entered values were reverting to defaults.