### PR TITLE
Back to the original linking errors.. but compiles

### DIFF
--- a/xLights/Xlights.vcxproj
+++ b/xLights/Xlights.vcxproj
@@ -171,7 +171,8 @@
       <GenerateMapFile>false</GenerateMapFile>
     </Link>
     <Manifest>
-      <EnableDpiAwareness>true</EnableDpiAwareness>
+      <AdditionalManifestFiles>xLightsApp.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+      <EnableDpiAwareness>false</EnableDpiAwareness>
     </Manifest>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)..\bin\*.dll" "$(TargetDir)"
@@ -215,7 +216,8 @@ xcopy /Y /I "$(ProjectDir)..\resources\*.*" "$(TargetDir)resources\"
       <GenerateMapFile>false</GenerateMapFile>
     </Link>
     <Manifest>
-      <EnableDpiAwareness>true</EnableDpiAwareness>
+      <AdditionalManifestFiles>xLightsApp.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+      <EnableDpiAwareness>false</EnableDpiAwareness>
     </Manifest>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)..\bin\*.dll" "$(TargetDir)"
@@ -248,7 +250,8 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
       <GenerateMapFile>false</GenerateMapFile>
     </Link>
     <Manifest>
-      <EnableDpiAwareness>true</EnableDpiAwareness>
+      <AdditionalManifestFiles>xLightsApp.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+      <EnableDpiAwareness>false</EnableDpiAwareness>
     </Manifest>
     <PostBuildEvent>
       <Command>copy "$(SolutionDir)..\bin\*.dll" "$(TargetDir)"
@@ -288,8 +291,9 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
       <GenerateMapFile>true</GenerateMapFile>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>xLightsApp.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
       <OutputManifestFile>$(IntDir)$(TargetName)$(TargetExt).embed.manifest</OutputManifestFile>
-      <EnableDpiAwareness>true</EnableDpiAwareness>
+      <EnableDpiAwareness>false</EnableDpiAwareness>
     </Manifest>
     <ManifestResourceCompile>
       <ResourceOutputFileName>$(IntDir)$(TargetName)$(TargetExt).embed.manifest.res</ResourceOutputFileName>
@@ -330,8 +334,9 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
       <GenerateMapFile>true</GenerateMapFile>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>xLightsApp.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
       <OutputManifestFile>$(IntDir)$(TargetName)$(TargetExt).embed.manifest</OutputManifestFile>
-      <EnableDpiAwareness>true</EnableDpiAwareness>
+      <EnableDpiAwareness>false</EnableDpiAwareness>
     </Manifest>
     <ManifestResourceCompile>
       <ResourceOutputFileName>$(IntDir)$(TargetName)$(TargetExt).embed.manifest.res</ResourceOutputFileName>
@@ -373,8 +378,9 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
       <GenerateMapFile>true</GenerateMapFile>
     </Link>
     <Manifest>
+      <AdditionalManifestFiles>xLightsApp.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
       <OutputManifestFile>$(IntDir)$(TargetName)$(TargetExt).embed.manifest</OutputManifestFile>
-      <EnableDpiAwareness>true</EnableDpiAwareness>
+      <EnableDpiAwareness>false</EnableDpiAwareness>
     </Manifest>
     <ManifestResourceCompile>
       <ResourceOutputFileName>$(IntDir)$(TargetName)$(TargetExt).embed.manifest.res</ResourceOutputFileName>

--- a/xLights/Xlights.vcxproj
+++ b/xLights/Xlights.vcxproj
@@ -171,7 +171,6 @@
       <GenerateMapFile>false</GenerateMapFile>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>xLightsApp64.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
       <EnableDpiAwareness>true</EnableDpiAwareness>
     </Manifest>
     <PostBuildEvent>
@@ -216,7 +215,6 @@ xcopy /Y /I "$(ProjectDir)..\resources\*.*" "$(TargetDir)resources\"
       <GenerateMapFile>false</GenerateMapFile>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>xLightsApp64.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
       <EnableDpiAwareness>true</EnableDpiAwareness>
     </Manifest>
     <PostBuildEvent>
@@ -250,7 +248,6 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
       <GenerateMapFile>false</GenerateMapFile>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>xLightsApp64.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
       <EnableDpiAwareness>true</EnableDpiAwareness>
     </Manifest>
     <PostBuildEvent>
@@ -291,7 +288,6 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
       <GenerateMapFile>true</GenerateMapFile>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>xLightsApp64.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
       <OutputManifestFile>$(IntDir)$(TargetName)$(TargetExt).embed.manifest</OutputManifestFile>
       <EnableDpiAwareness>true</EnableDpiAwareness>
     </Manifest>
@@ -334,7 +330,6 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
       <GenerateMapFile>true</GenerateMapFile>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>xLightsApp64.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
       <OutputManifestFile>$(IntDir)$(TargetName)$(TargetExt).embed.manifest</OutputManifestFile>
       <EnableDpiAwareness>true</EnableDpiAwareness>
     </Manifest>
@@ -378,7 +373,6 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
       <GenerateMapFile>true</GenerateMapFile>
     </Link>
     <Manifest>
-      <AdditionalManifestFiles>xLightsApp64.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
       <OutputManifestFile>$(IntDir)$(TargetName)$(TargetExt).embed.manifest</OutputManifestFile>
       <EnableDpiAwareness>true</EnableDpiAwareness>
     </Manifest>

--- a/xLights/effects/OpenGLShaders.cpp
+++ b/xLights/effects/OpenGLShaders.cpp
@@ -10,6 +10,9 @@
 
 #ifndef __WXMAC__
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #endif
 #include <GL/gl.h>

--- a/xLights/render/WindowsHardwareVideoReader.h
+++ b/xLights/render/WindowsHardwareVideoReader.h
@@ -19,6 +19,12 @@
 //#define D3D_DEBUG_INFO
 #endif
 
+// Must be defined before windows.h (via d3d11.h) to prevent winsock.h being
+// included, which conflicts with winsock2.h included by other translation units.
+#ifndef _WINSOCKAPI_
+#define _WINSOCKAPI_
+#endif
+
 #include <d3d11.h>
 #include <D2d1.h>
 #include <D2d1helper.h>

--- a/xLights/xLightsApp64.manifest
+++ b/xLights/xLightsApp64.manifest
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly
+    xmlns="urn:schemas-microsoft-com:asm.v1"
+    xmlns:asmv3="urn:schemas-microsoft-com:asm.v3"
+    manifestVersion="1.0">
+
+    <assemblyIdentity
+        version="2026.0.0.0"
+        processorArchitecture="amd64"
+        name="xLights"
+        type="win32"
+    />
+    <description>xLights</description>
+    <dependency>
+        <dependentAssembly>
+            <assemblyIdentity
+                type="win32"
+                name="Microsoft.Windows.Common-Controls"
+                version="6.0.0.0"
+                processorArchitecture="amd64"
+                publicKeyToken="6595b64144ccf1df"
+                language="*"
+            />
+        </dependentAssembly>
+    </dependency>
+
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 / Windows 11 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+        </application>
+    </compatibility>
+  <asmv3:application>
+    <asmv3:windowsSettings>
+       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, system</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>


### PR DESCRIPTION
Still linking errors with manifest duplications

```
1>MSVCRTD.lib(initializers.obj) : warning LNK4098: defaultlib 'msvcrt.lib' conflicts with use of other libs; use /NODEFAULTLIB:library
1>CVTRES : fatal error CVT1100: duplicate resource.  type:MANIFEST, name:1, language:0x0409
1>LINK : fatal error LNK1123: failure during conversion to COFF: file invalid or corrupt
1>Done building project "Xlights.vcxproj" -- FAILED.
```