### PR TITLE
Hinkspix was getting the wrong start channel assigned when it was following another controller

### DIFF
--- a/xLights/controllers/ControllerUploadData.cpp
+++ b/xLights/controllers/ControllerUploadData.cpp
@@ -1318,6 +1318,11 @@ void UDController::ClearPorts() {
 }
 
 void UDController::Rescan(bool eliminateOverlaps) {
+    // Ensure transient output/controller channel caches are current before
+    // evaluating controller/model channel ranges.
+    if (_outputManager != nullptr) {
+        _outputManager->SomethingChanged();
+    }
     ClearPorts();
 
     for (const auto& it : *_modelManager) {

--- a/xLights/models/ModelManager.cpp
+++ b/xLights/models/ModelManager.cpp
@@ -1034,7 +1034,7 @@ bool ModelManager::ReworkStartChannel() const
                 auto oldC = it->GetChannels();
                 // Set channel size won't always change the number of channels for some protocols
                 it->SetChannelSize(std::max((int32_t)1, (int32_t)ch - 1), allSortedModels);
-                if (it->GetChannels() != oldC || (eth != nullptr && eth->IsUniversePerString())) {
+                if (it->GetChannels() != oldC || (eth != nullptr && (eth->IsUniversePerString() || eth->SupportsUniversePerString()))) {
                     outputManager->SomethingChanged();
 
                     if (it->GetChannels() != oldC || (eth != nullptr && eth->IsUniversePerString() && xlights->IsSequencerInitialize())) { 


### PR DESCRIPTION
When a HinksPix PRO V1/V2 controller (which supports UniversePerString) had its outputs rebuilt by SetChannelSize(), the transient start channels were reset to -1 but SomethingChanged() was never called to recalculate them.
This caused subsequent controllers to get wrong start channels (e.g. 1 or 2 instead of the next available channel).  #6003 