### PR TITLE
Fix PolyLine drop pattern node count and crash (#6010)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,8 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.05  April ??, 2026
+    -bug (derwin12)             Fix PolyLine with drop patterns
+    -bug (derwin12)             Fix crash selecting multi-string PolyLine
     -change (dkulp)             Remove SPXML dependency, replace with pugixml for format imports and
                                 lightweight XsqFileScanner for sequence file header peeking
     -change (dkulp)             Migrate output runtime sockets from wxDatagramSocket/wxIPV4address to SocketAbstraction UDPSocket

--- a/src-core/models/PolyLineModel.cpp
+++ b/src-core/models/PolyLineModel.cpp
@@ -504,9 +504,6 @@ void PolyLineModel::InitModel()
     if (_autoDistributeLights) {
         // distribute the lights evenly across the line segments
         DistributeLightsEvenly( pPos, _dropSizes, mheight, _maxH, numLights );
-        if (!_creatingNewPolyLine) {
-            _autoDistributeLights = false;
-        }
     } else {
         // distribute the lights as defined by the polysizes
         DistributeLightsAcrossIndivSegments( pPos, _dropSizes, mheight, _maxH );
@@ -535,6 +532,8 @@ void PolyLineModel::DistributeLightsEvenly(       std::vector<xlPolyPoint>& pPos
     unsigned int drop_index = 0;
     size_t idx = 0;
     size_t seg_count = 0;
+    int drop_pos_count = 0;
+    int last_drop_pos_count = 0;
     int coords_per_node = Nodes[0].get()->Coords.size();
     float coord_offset = using_icicles ? 1.0f / (float)coords_per_node : 0.0f;
     int lights_to_distribute = SingleNode ? numLights : numLights * coords_per_node;
@@ -572,8 +571,8 @@ void PolyLineModel::DistributeLightsEvenly(       std::vector<xlPolyPoint>& pPos
                 }
                 else {
                     sub_segment = 0;
-                    _polyLineSizes[segment] = seg_count - last_seg_count;
-                    last_seg_count = seg_count;
+                    _polyLineSizes[segment] = drop_pos_count - last_drop_pos_count;
+                    last_drop_pos_count = drop_pos_count;
                     segment++;
                     seg_start = seg_end;
                     segment_length = pPos[segment].has_curve ? pPos[segment].curve->GetSegLength(sub_segment) : pPos[segment].length;
@@ -647,8 +646,9 @@ void PolyLineModel::DistributeLightsEvenly(       std::vector<xlPolyPoint>& pPos
         if( c == 0 ) {
             xpos++;
         }
+        drop_pos_count++;
     }
-    _polyLineSizes[segment] = seg_count - last_seg_count;
+    _polyLineSizes[segment] = drop_pos_count - last_drop_pos_count;
 }
 
 void PolyLineModel::DistributeLightsAcrossIndivSegments(       std::vector<xlPolyPoint>& pPos,

--- a/src-ui-wx/ui/modelproperties/adapters/PolyLinePropertyAdapter.cpp
+++ b/src-ui-wx/ui/modelproperties/adapters/PolyLinePropertyAdapter.cpp
@@ -62,7 +62,8 @@ void PolyLinePropertyAdapter::AddTypeProperties(wxPropertyGridInterface* grid, O
         p = grid->Append(new wxStringProperty("Start Nodes", "ModelIndividualStartNodes", ""));
 
         std::string nm = Model::StartChanAttrName(0);
-        wxPGProperty* psn = grid->AppendIn(p, new wxUIntProperty(nm, nm, _polyLine.GetIndivStartNode(0)));
+        int firstNode = (_polyLine.GetIndivStartNodesCount() > 0) ? _polyLine.GetIndivStartNode(0) : 1;
+        wxPGProperty* psn = grid->AppendIn(p, new wxUIntProperty(nm, nm, firstNode));
         psn->SetAttribute("Min", 1);
         psn->SetAttribute("Max", (int)_polyLine.GetNodeCount());
         psn->SetEditor("SpinCtrl");
@@ -153,6 +154,7 @@ int PolyLinePropertyAdapter::OnPropertyGridChange(wxPropertyGridInterface* grid,
         std::string segment = event.GetPropertyName().ToStdString();
         int idx = ExtractTrailingInt(segment) - 1;
         _polyLine.SetRawSegmentSize(idx, event.GetPropertyValue().GetLong());
+        _polyLine.SetAutoDistribute(false);
         _polyLine.IncrementChangeCount();
         _polyLine.AddASAPWork(OutputModelManager::WORK_RELOAD_MODEL_CHANGE |
                     OutputModelManager::WORK_CALCULATE_START_CHANNELS |


### PR DESCRIPTION
Node count was not calculated correctly and values may have been lost in the .04 migration for node drop polylines. https://github.com/xLightsSequencer/xLights/issues/6010