### PR TITLE
Fix Color Wheel Count by clear the default colors before loading (#6019)

### DIFF
--- a/src-core/XmlSerializer/XmlDeserializingModelFactory.cpp
+++ b/src-core/XmlSerializer/XmlDeserializingModelFactory.cpp
@@ -1043,6 +1043,7 @@ void XmlDeserializingModelFactory::DeserializeColorWheelAttributes(DmxColorAbili
     ability->SetWheelChannel(node.attribute("DmxColorWheelChannel").as_int(0));
     ability->SetDimmerChannel(node.attribute("DmxDimmerChannel").as_int(0));
     ability->SetWheelDelay(node.attribute("DmxColorWheelDelay").as_int(0));
+    ability->ClearColors();
     for (int i = 0; i< DmxColorAbilityWheel::MAX_COLORS; ++i) {
         auto dmxkey = std::format("DmxColorWheelDMX{}", i);
         auto colorkey = std::format("DmxColorWheelColor{}", i);

--- a/src-core/models/DMX/DmxColorAbilityWheel.h
+++ b/src-core/models/DMX/DmxColorAbilityWheel.h
@@ -57,6 +57,7 @@ class DmxColorAbilityWheel : public DmxColorAbility
         void SetWheelDelay(uint32_t delay) { wheel_delay = delay; }
         void AddColor(const std::string& dmxcolor, uint8_t dmxVal);
         void AddWheelColor(xlColor col, uint8_t dmxVal) { colors.emplace_back(std::move(col), dmxVal); }
+        void ClearColors() { colors.clear(); }
         void PopColor() { if (!colors.empty()) colors.pop_back(); }
         void SetWheelColorDMX(size_t idx, uint8_t val) { colors[idx].dmxValue = val; }
         void SetWheelColor(size_t idx, xlColor col) { colors[idx].color = std::move(col); }


### PR DESCRIPTION
The 4 default count was being added to the value.