### PR TITLE
Fix infinite loop when saving Controllers with No Controller DMX submodels (#6015)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,7 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.05  April ??, 2026
+    -bug (derwin12)             Fix infinite loop saving Controllers tab when No Controller DMX models with submodels are present
     -bug (derwin12)             Fix PolyLine with drop patterns
     -bug (derwin12)             Fix crash selecting multi-string PolyLine
     -change (dkulp)             Remove SPXML dependency, replace with pugixml for format imports and

--- a/src-core/models/ModelManager.cpp
+++ b/src-core/models/ModelManager.cpp
@@ -1060,17 +1060,28 @@ bool ModelManager::ReworkStartChannel() const
     // first we need to work out the last used channel by all controllers and models other than those on No Controller
     uint32_t lastChannel = 0;
     for (const auto& it : _outputManager->GetControllers()) {
-        lastChannel = std::max(lastChannel, (uint32_t)it->GetEndChannel());
+        auto ec = (uint32_t)it->GetEndChannel();
+        if (ec > lastChannel) {
+            lastChannel = ec;
+        }
     }
 
     std::list<std::string> modelsToSet;
     {
         std::lock_guard<std::recursive_mutex> lock(_modelMutex);
         for (auto itm : models) {
+            // SubModels share channel space with their parent — skip them here;
+            // the parent (or its controller) already accounts for their channels.
+            if (dynamic_cast<SubModel*>(itm.second) != nullptr) continue;
             std::list<std::string> visited;
-            if (ModelHasNoDependencyOnNoController(itm.second, visited) || itm.second->GetControllerName() == NO_CONTROLLER) {
-                if (itm.second->GetControllerName() != NO_CONTROLLER) {
-                    lastChannel = std::max(lastChannel, itm.second->GetLastChannel() + 1);
+            auto ctrlName = itm.second->GetControllerName();
+            bool isNoController = (ctrlName == NO_CONTROLLER || ctrlName.empty());
+            if (ModelHasNoDependencyOnNoController(itm.second, visited) || isNoController) {
+                if (!isNoController) {
+                    auto lc = (uint32_t)itm.second->GetLastChannel() + 1;
+                    if (lc > lastChannel) {
+                        lastChannel = lc;
+                    }
                 } else {
                     modelsToSet.push_back(itm.first);
                 }
@@ -1109,7 +1120,8 @@ bool ModelManager::ModelHasNoDependencyOnNoController(Model* m, std::list<std::s
         std::string dependson = BeforeFirst(sc.substr(1), ':');
         Model* mm = GetModel(dependson);
         if (mm != nullptr) {
-            if (mm->GetControllerName() == NO_CONTROLLER)
+            auto mmCtrl = mm->GetControllerName();
+            if (mmCtrl == NO_CONTROLLER || mmCtrl.empty())
                 return false;
             return ModelHasNoDependencyOnNoController(mm, visited);
         }


### PR DESCRIPTION
ModelHasNoDependencyOnNoController — empty controller name treated as "No Controller" No-Controller packing loop — empty controller name routes to modelsToSet, not lastChannel