### PR TITLE
Enable the OK button on ExportModel groups (#5856)

### DIFF
--- a/src-ui-wx/ui/shared/dialogs/CheckboxSelectDialog.cpp
+++ b/src-ui-wx/ui/shared/dialogs/CheckboxSelectDialog.cpp
@@ -166,6 +166,7 @@ void CheckboxSelectDialog::SelectAllLayers(bool select)
     {
         CheckListBox_Items->Check(i, select);
     }
+    ValidateWindow();
 }
 
 void CheckboxSelectDialog::SelectHighLightedLayers(bool select)
@@ -177,4 +178,5 @@ void CheckboxSelectDialog::SelectHighLightedLayers(bool select)
             CheckListBox_Items->Check(i, select);
         }
 	}
+    ValidateWindow();
 }


### PR DESCRIPTION
If you did a select all or select highlight, it wouldnt enable the OK button. #5856 