### PR TITLE
Fix crash when dragging curve control points on a polyline segment (#5173)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,7 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.05  April ??, 2026
+    -bug (derwin12)             Fix crash when adding/defining a curve on the last polyline segment
     -bug (derwin12)             Make Random Effects Random Again
     -bug (derwin12)             Cube Model ignored Direction
     -enh (AGFazio)              Add face definition matrix previews

--- a/src-core/models/PolyLineModel.cpp
+++ b/src-core/models/PolyLineModel.cpp
@@ -710,9 +710,11 @@ void PolyLineModel::DistributeLightsAcrossSegment( const int                    
         bool up = dropSizes[drop_index] < 0;
         unsigned int drops_this_node = std::abs(dropSizes[drop_index]);
         while (current_pos > seg_end) {
+            float next_length = isCurve ? pPos[segment].curve->GetSegLength(sub_segment + 1) : 1.0f;
+            if (next_length <= 0.0f) break;  // no more sub-segments; stay on current one
             sub_segment++;
             seg_start = seg_end;
-            segment_length = isCurve ? pPos[segment].curve->GetSegLength(sub_segment) : 1.0f;
+            segment_length = next_length;
             seg_end = seg_start + segment_length;
         }
         glm::vec3 v;

--- a/src-core/models/PolyPointScreenLocation.cpp
+++ b/src-core/models/PolyPointScreenLocation.cpp
@@ -77,6 +77,7 @@ void PolyPointScreenLocation::SetCurve(int seg_num, bool create)
 {
 
     if (_locked) return;
+    if (seg_num < 0 || seg_num >= (int)mPos.size() - 1) return;
 
     if (create) {
         mPos[seg_num].has_curve = true;
@@ -1558,6 +1559,7 @@ void PolyPointScreenLocation::InsertHandle(int after_handle, float zoom, int sca
     std::unique_lock<std::mutex> locker(_mutex);
 
     int pos = after_handle;
+    if (pos < 0 || pos >= (int)mPos.size() - 1) return;
     float x1_pos = mPos[pos].x;
     float x2_pos = mPos[pos+1].x;
     float y1_pos = mPos[pos].y;

--- a/src-core/models/Shapes.cpp
+++ b/src-core/models/Shapes.cpp
@@ -489,7 +489,7 @@ float BezierCurve3D::GetSegLength(int segment) {
     if (!matrix_valid) {
         UpdateMatrices();
     }
-    if (segment < num_points - 1) {
+    if (segment >= 0 && segment < num_points - 1) {
         return points[segment].length;
     }
     else {

--- a/src-ui-wx/ui/modelproperties/adapters/PolyLinePropertyAdapter.cpp
+++ b/src-ui-wx/ui/modelproperties/adapters/PolyLinePropertyAdapter.cpp
@@ -301,6 +301,10 @@ int PolyLinePropertyAdapter::OnPropertyGridSelection(wxPropertyGridInterface* gr
         str = str.SubString(str.Find(".") + 1, str.length());
         str = str.SubString(6, str.length());
         int segment = wxAtoi(str) - 1;
+        // Corners are 1-indexed points; the last corner has no outgoing segment,
+        // so clamp to the last valid segment index.
+        int maxSeg = _polyLine.GetNumSegments() - 1;
+        if (segment > maxSeg) segment = maxSeg;
         return segment;
     }
     return -1;


### PR DESCRIPTION
Long standing bug where you create a curve on the last segment. When you go to make the curve, it would crash.