### PR TITLE
Dont prompt to use backups during a batch render (#5872)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,7 +12,6 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.05  April ??, 2026
-    -bug (derwin12)             Suppress autosave backup prompt during batch render
     -bug (derwin12)             Make Random Effects Random Again
     -bug (derwin12)             Cube Model ignored Direction
     -enh (AGFazio)              Add face definition matrix previews

--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,7 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.05  April ??, 2026
+    -bug (derwin12)             Suppress autosave backup prompt during batch render
     -bug (derwin12)             Make Random Effects Random Again
     -bug (derwin12)             Cube Model ignored Direction
     -enh (AGFazio)              Add face definition matrix previews

--- a/src-ui-wx/ui/app-shell/TabSequence.cpp
+++ b/src-ui-wx/ui/app-shell/TabSequence.cpp
@@ -161,7 +161,7 @@ void xLightsFrame::LoadEffectsFile()
         xx.SetExt("xbkp");
         wxString asfile = xx.GetLongPath();
 
-        if (((!_renderMode && !_checkSequenceMode) || _promptBatchRenderIssues) && FileExists(asfile)) {
+        if (!_renderMode && !_checkSequenceMode && FileExists(asfile)) {
             // the autosave file exists
             wxDateTime xmltime = fn.GetModificationTime();
             wxFileName asfn(asfile);
@@ -274,7 +274,7 @@ void xLightsFrame::LoadEffectsFile()
         // Check for autosave backup of presets file
         wxFileName presetsBkp(presetsFile);
         presetsBkp.SetFullName(_(XLIGHTS_PRESETS_FILE_BACKUP));
-        if (((!_renderMode && !_checkSequenceMode) || _promptBatchRenderIssues) && FileExists(presetsBkp.GetFullPath())) {
+        if (!_renderMode && !_checkSequenceMode && FileExists(presetsBkp.GetFullPath())) {
             if (FileExists(presetsFile.GetFullPath())) {
                 wxDateTime jsonTime = presetsFile.GetModificationTime();
                 wxDateTime bkpTime = presetsBkp.GetModificationTime();

--- a/src-ui-wx/ui/import-export/SeqFileUtilities.cpp
+++ b/src-ui-wx/ui/import-export/SeqFileUtilities.cpp
@@ -274,7 +274,7 @@ void xLightsFrame::OpenSequence(const wxString& passed_filename, ConvertLogDialo
 
         if (rp.IsEmpty()) {
             // check if there is a autosave backup file which is newer than the file we have been asked to open
-            if (((!_renderMode && !_checkSequenceMode) || _promptBatchRenderIssues) && wxFileName(filename).GetExt().Lower() != "xbkp" && wxFileName(filename).GetExt().Lower() != "fseq") {
+            if (!_renderMode && !_checkSequenceMode && wxFileName(filename).GetExt().Lower() != "xbkp" && wxFileName(filename).GetExt().Lower() != "fseq") {
                 wxFileName fn(filename);
                 wxFileName xx = fn;
                 xx.SetExt("xbkp");


### PR DESCRIPTION
Remove the prompt for newer backups that will stop your batch render. Keep the ability to stop/ignore render issues via the preference.