### PR TITLE
Fix 3D spiral gradient flip when Rotation value curve crosses zero (#4807)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,7 +13,8 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.06  May ??, 2026
     -bug (derwin12)             Improve Shape effect emoji rendering on Windows and Direction
-    -bug (AGFazio)                Fix Square and Smooth Circle model appearances not scaling with zoom in the layout view
+    -bug (derwin12)             Fix 3D Spiral gradient flip when Rotation value curve crosses zero
+    -bug (AGFazio)              Fix Square and Smooth Circle model appearances not scaling with zoom in the layout view
     -enh (dkulp)                Add "Lossless RGB Video, *.mov" model export format — uncompressed RGB24
                                     in a mov container, bit-exact and decoded natively by AVFoundation,
                                     replaces the deprecated uncompressed AVI export for pixel-perfect
@@ -63,11 +64,11 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                     using stale defaults of 0 for Start/End Radius/Width).
     -bug (dkulp)                Fix Pinwheel Rotation default mismatch between renderer and panel
     -bug (derwin12)             Fix crash after using Join in the SubModels dialog.
-
     -change (dkulp)             Effect default / min / max / divisor values are now read from the JSON metadata at
                                     startup instead of from #define constants in each effect. The JSON is the
                                     source of truth — adjusting a slider's default or range in resources/effectmetadata/
                                     now actually changes the effect's render behavior. ~45 effects migrated.
+
 2026.05  April 9, 2026
 =======
 2026.05  April ??, 2026

--- a/src-core/effects/SpiralsEffect.cpp
+++ b/src-core/effects/SpiralsEffect.cpp
@@ -175,8 +175,9 @@ void SpiralsEffect::Render(Effect *effect, const SettingsMap &SettingsMap, Rende
             int strand = (strand_base + thick) % buffer.BufferWi;
             for (int y = 0; y < buffer.BufferHt; y++) {
                 double xd = strand + SpiralState / 10.0 + y * Rotation / buffer.BufferHt;
-                int x = (int)fmod(xd, buffer.BufferWi);
-                if (x < 0) x += buffer.BufferWi;
+                double wrappedX = fmod(xd, buffer.BufferWi);
+                if (wrappedX < 0) wrappedX += buffer.BufferWi;
+                int x = (int)wrappedX;
 
                 if (isSpacial) {
                     buffer.palette.GetSpatialColor(ColorIdx, (float)thick / (float)SpiralThickness, (float)y / (float)buffer.BufferHt, color);

--- a/src-core/effects/SpiralsEffect.cpp
+++ b/src-core/effects/SpiralsEffect.cpp
@@ -134,7 +134,7 @@ void SpiralsEffect::Render(Effect *effect, const SettingsMap &SettingsMap, Rende
         sdata.colorCount     = (int)colorcnt;
         sdata.spiralState    = (float)SpiralState;
         sdata.rotation       = Rotation;
-        sdata.rotation_sign  = Rotation < 0 ? -1.0f : 1.0f;
+        sdata.rotation_sign  = Direction < 0 ? -1.0f : 1.0f;
         sdata.deltaStrands   = (float)deltaStrands;
         sdata.spiralThickness = (float)SpiralThickness;
         sdata.show3D         = Show3D ? 1 : 0;
@@ -174,7 +174,8 @@ void SpiralsEffect::Render(Effect *effect, const SettingsMap &SettingsMap, Rende
         std::function<void(int)> spiralF = [&](int thick) {
             int strand = (strand_base + thick) % buffer.BufferWi;
             for (int y = 0; y < buffer.BufferHt; y++) {
-                int x = (int)((strand + SpiralState / 10.0 + y * Rotation / buffer.BufferHt)) % buffer.BufferWi;
+                double xd = strand + SpiralState / 10.0 + y * Rotation / buffer.BufferHt;
+                int x = (int)fmod(xd, buffer.BufferWi);
                 if (x < 0) x += buffer.BufferWi;
 
                 if (isSpacial) {
@@ -187,7 +188,7 @@ void SpiralsEffect::Render(Effect *effect, const SettingsMap &SettingsMap, Rende
                 if (Show3D) {
                     double f = 1.0;
 
-                    if (Rotation < 0) {
+                    if (Direction < 0) {
                         f = double(thick + 1) / SpiralThickness;
                     } else {
                         f = double(SpiralThickness - thick) / SpiralThickness;
@@ -208,8 +209,8 @@ void SpiralsEffect::Render(Effect *effect, const SettingsMap &SettingsMap, Rende
             }
         };
         
-        if ((!isSpacial && !Blend) && SpiralThickness > 2) {
-            // if we aren't blending or dealing with spacial, we can use parallel
+        if ((!isSpacial && !Blend && !Show3D) && SpiralThickness > 2) {
+            // if we aren't blending, dealing with spacial or rendering 3D, we can use parallel
             parallel_for(0, SpiralThickness, [&spiralF](int i) { spiralF(i); }, 1);
         } else {
             for (int i = 0; i < SpiralThickness; i++) {


### PR DESCRIPTION
Fix 3D spiral gradient flip when Rotation value curve crosses zero by using Direction instead of Rotation for shading direction in both the ISPC and scalar render paths.