### PR TITLE
#4723 Base Show Folder - Add Yes toAll / No to All for controllers

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,8 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.06  May ??, 2026
+    -enh (AGFazio)               Add 'Yes to All' / 'No to All' options when merging base show directory changes
+    -bug (AGFazio)               Fix submodels in a group showing at wrong indent level in sequencer element list
     -bug (derwin12)             Fix downloaded/imported models always getting start channel 1 (#6075)
     -bug (derwin12)             Fix unintended setting of ShadowModelFor (#5634)
     -bug (dkulp)                Fix macOS 11/12 launch crash "Symbol not found..." due to using

--- a/src-core/models/ModelManager.cpp
+++ b/src-core/models/ModelManager.cpp
@@ -1932,7 +1932,7 @@ bool ModelManager::MergeBaseXml(const std::string& baseShowDir, pugi::xml_node l
                                    changedModels, changedGroups);
 }
 
-bool ModelManager::MergeFromBase(const std::string& baseShowDir, bool prompt)
+bool ModelManager::MergeFromBase(const std::string& baseShowDir, bool prompt, bool& acceptAll, bool& rejectAll)
 {
     bool changed = false;
 
@@ -1951,8 +1951,8 @@ bool ModelManager::MergeFromBase(const std::string& baseShowDir, bool prompt)
             auto curr = GetModel(name);
             if (curr != nullptr && !curr->IsFromBase()) {
                 if (auto* ui = GetUICallbacks()) {
-                    if (ui->PromptYesNo(fmt::format("Model {} found that clashes with base show directory. Do you want to take the base show directory version?", name),
-                                        "Model clash")) {
+                    if (ui->PromptYesNoAll(fmt::format("Model {} found that clashes with base show directory. Do you want to take the base show directory version?", name),
+                                          "Model clash", acceptAll, rejectAll)) {
                         curr->SetFromBase(true);
                     }
                 }
@@ -1966,8 +1966,8 @@ bool ModelManager::MergeFromBase(const std::string& baseShowDir, bool prompt)
                 auto curr = GetModel(name);
                 if (curr != nullptr && !curr->IsFromBase()) {
                     if (auto* ui = GetUICallbacks()) {
-                        if (ui->PromptYesNo(fmt::format("Model Group {} found that clashes with base show directory. Do you want to take the base show directory version?", name),
-                                            "Model group clash")) {
+                        if (ui->PromptYesNoAll(fmt::format("Model Group {} found that clashes with base show directory. Do you want to take the base show directory version?", name),
+                                              "Model group clash", acceptAll, rejectAll)) {
                             curr->SetFromBase(true);
                         }
                     }

--- a/src-core/models/ModelManager.h
+++ b/src-core/models/ModelManager.h
@@ -95,7 +95,7 @@ class ModelManager : public ObjectManager
 
         int GetPreviewWidth() const { return previewWidth; }
         int GetPreviewHeight() const { return previewHeight; }
-        bool MergeFromBase(const std::string& baseShowDir, bool prompt);
+        bool MergeFromBase(const std::string& baseShowDir, bool prompt, bool& acceptAll, bool& rejectAll);
         static bool MergeBaseXml(const std::string& baseShowDir, pugi::xml_node localModelsNode, pugi::xml_node localGroupsNode);
         std::string GetLastGeneratedModelName() const { return lastGeneratedModelName; }
 

--- a/src-core/models/ViewObjectManager.cpp
+++ b/src-core/models/ViewObjectManager.cpp
@@ -294,7 +294,7 @@ bool ViewObjectManager::MergeBaseXml(const std::string& baseShowDir, pugi::xml_n
     return MergeBaseIntoCurrentObjectsXml(localViewObjectsNode, baseObjects, changedObjects);
 }
 
-bool ViewObjectManager::MergeFromBase(const std::string& baseShowDir, bool prompt)
+bool ViewObjectManager::MergeFromBase(const std::string& baseShowDir, bool prompt, bool& acceptAll, bool& rejectAll)
 {
     pugi::xml_document baseDoc;
     pugi::xml_node baseObjects;
@@ -310,8 +310,8 @@ bool ViewObjectManager::MergeFromBase(const std::string& baseShowDir, bool promp
             auto curr = GetObject(name);
             if (curr != nullptr && !curr->IsFromBase()) {
                 if (auto* ui = GetUICallbacks()) {
-                    if (ui->PromptYesNo(fmt::format("Object {} found that clashes with base show directory. Do you want to take the base show directory version?", name),
-                                        "Object clash")) {
+                    if (ui->PromptYesNoAll(fmt::format("Object {} found that clashes with base show directory. Do you want to take the base show directory version?", name),
+                                          "Object clash", acceptAll, rejectAll)) {
                         curr->SetFromBase(true);
                     }
                 }

--- a/src-core/models/ViewObjectManager.h
+++ b/src-core/models/ViewObjectManager.h
@@ -40,7 +40,7 @@ public:
     void AddViewObject(ViewObject *view_object);
     void Delete(const std::string &name);
     bool Rename(const std::string &oldName, const std::string &newName);
-    bool MergeFromBase(const std::string& baseShowDir, bool prompt);
+    bool MergeFromBase(const std::string& baseShowDir, bool prompt, bool& acceptAll, bool& rejectAll);
     static bool MergeBaseXml(const std::string& baseShowDir, pugi::xml_node localViewObjectsNode);
 
     void LoadViewObjects(pugi::xml_node objectNode);

--- a/src-core/outputs/OutputManager.cpp
+++ b/src-core/outputs/OutputManager.cpp
@@ -28,6 +28,7 @@
 #include "UtilFunctions.h"
 #include "utils/ExternalHooks.h"
 #include "utils/ip_utils.h"
+#include "render/UICallbacks.h"
 #include <cassert>
 #include <cstdlib>
 #include <spdlog/fmt/fmt.h>
@@ -337,7 +338,7 @@ bool OutputManager::Load(const std::string& showdir, bool syncEnabled) {
     return true;
 }
 
-bool OutputManager::MergeFromBase(bool prompt)
+bool OutputManager::MergeFromBase(bool prompt, bool& acceptAll, bool& rejectAll, UICallbacks* ui)
 {
     bool changed = false;
 
@@ -369,7 +370,12 @@ bool OutputManager::MergeFromBase(bool prompt)
 
                     bool force = false;
                     if (prompt && !it->IsFromBase()) {
-                        force = Confirm(fmt::format("Controller {} found that clashes with base show directory. Do you want to take the base show directory version?", it->GetName()), "Controller clash");
+                        if (ui) {
+                            force = ui->PromptYesNoAll(fmt::format("Controller {} found that clashes with base show directory. Do you want to take the base show directory version?", it->GetName()),
+                                                      "Controller clash", acceptAll, rejectAll);
+                        } else {
+                            force = Confirm(fmt::format("Controller {} found that clashes with base show directory. Do you want to take the base show directory version?", it->GetName()), "Controller clash");
+                        }
                     }
 
                     // we only update if controller originally came from base

--- a/src-core/outputs/OutputManager.h
+++ b/src-core/outputs/OutputManager.h
@@ -23,6 +23,7 @@ class Output;
 class Controller;
 class TestPreset;
 class Controller;
+class UICallbacks;
 class ControllerEthernet;
 
 #define NETWORKSFILE "xlights_networks.xml";
@@ -121,7 +122,7 @@ public:
             _dirty = true;
         }
     }
-    bool MergeFromBase(bool prompt);
+    bool MergeFromBase(bool prompt, bool& acceptAll, bool& rejectAll, UICallbacks* ui = nullptr);
     #pragma endregion 
 
     #pragma region Controller Management

--- a/src-core/outputs/OutputManager.h
+++ b/src-core/outputs/OutputManager.h
@@ -22,7 +22,6 @@
 class Output;
 class Controller;
 class TestPreset;
-class Controller;
 class UICallbacks;
 class ControllerEthernet;
 

--- a/src-core/render/UICallbacks.h
+++ b/src-core/render/UICallbacks.h
@@ -35,6 +35,21 @@ public:
     virtual bool PromptYesNo(const std::string& message,
                              const std::string& caption = "xLights") const = 0;
 
+    // Ask a yes/no question with Accept All / Reject All options for batch operations.
+    // Returns true to accept (take base version), false to reject.
+    // Sets acceptAll=true if "Yes to All" was selected; rejectAll=true if "No to All".
+    // If acceptAll is already true on entry, returns true without prompting.
+    // If rejectAll is already true on entry, returns false without prompting.
+    // The default implementation ignores the all-state and falls back to PromptYesNo.
+    virtual bool PromptYesNoAll(const std::string& message,
+                                const std::string& caption,
+                                bool& acceptAll,
+                                bool& rejectAll) const {
+        if (acceptAll) return true;
+        if (rejectAll) return false;
+        return PromptYesNo(message, caption);
+    }
+
     // ---- file / directory pickers ----
     // Returns the chosen path, or empty string if cancelled.
     virtual std::string PromptForDirectory(const std::string& message,

--- a/src-ui-wx/ui/app-shell/TabSetup.cpp
+++ b/src-ui-wx/ui/app-shell/TabSetup.cpp
@@ -472,7 +472,8 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
             PromptForDirectorySelection("Reselect Base Show Directory", dstr);
             _outputManager.SetBaseShowDir(dstr);
         }
-        if (_outputManager.MergeFromBase(false)) {
+        bool _acceptAll = false, _rejectAll = false;
+        if (_outputManager.MergeFromBase(false, _acceptAll, _rejectAll)) {
             _outputModelManager.AddASAPWork(OutputModelManager::WORK_UPDATE_NETWORK_LIST, "SetDir-controller");
             _outputModelManager.AddASAPWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "SetDir-controller");
             _outputModelManager.AddASAPWork(OutputModelManager::WORK_RESEND_CONTROLLER_CONFIG, "SetDir-controller");

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -2596,6 +2596,46 @@ bool xLightsFrame::PromptYesNo(const std::string& message,
     return wxMessageBox(message, caption, wxYES_NO | wxICON_QUESTION) == wxYES;
 }
 
+bool xLightsFrame::PromptYesNoAll(const std::string& message,
+                                   const std::string& caption,
+                                   bool& acceptAll,
+                                   bool& rejectAll) const {
+    if (acceptAll) return true;
+    if (rejectAll) return false;
+
+    wxDialog dlg(const_cast<xLightsFrame*>(this), wxID_ANY, caption,
+                 wxDefaultPosition, wxDefaultSize,
+                 wxDEFAULT_DIALOG_STYLE | wxCAPTION);
+
+    auto* outer = new wxBoxSizer(wxVERTICAL);
+    outer->Add(new wxStaticText(&dlg, wxID_ANY, message, wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE),
+               0, wxALL | wxEXPAND, 15);
+
+    auto* btnSizer = new wxStdDialogButtonSizer();
+    auto* btnYes    = new wxButton(&dlg, wxID_YES,  "Yes");
+    auto* btnYesAll = new wxButton(&dlg, wxID_ANY,  "Yes to All");
+    auto* btnNo     = new wxButton(&dlg, wxID_NO,   "No");
+    auto* btnNoAll  = new wxButton(&dlg, wxID_ANY,  "No to All");
+    btnSizer->Add(btnYes,    0, wxALL, 4);
+    btnSizer->Add(btnYesAll, 0, wxALL, 4);
+    btnSizer->Add(btnNo,     0, wxALL, 4);
+    btnSizer->Add(btnNoAll,  0, wxALL, 4);
+    btnSizer->Realize();
+    outer->Add(btnSizer, 0, wxALIGN_CENTER | wxBOTTOM, 10);
+
+    dlg.SetSizerAndFit(outer);
+    dlg.CenterOnParent();
+
+    int result = wxID_NO;
+    btnYes->Bind(wxEVT_BUTTON,    [&](wxCommandEvent&) { result = wxID_YES; dlg.EndModal(wxID_OK); });
+    btnYesAll->Bind(wxEVT_BUTTON, [&](wxCommandEvent&) { result = wxID_YES; acceptAll = true; dlg.EndModal(wxID_OK); });
+    btnNo->Bind(wxEVT_BUTTON,     [&](wxCommandEvent&) { result = wxID_NO;  dlg.EndModal(wxID_OK); });
+    btnNoAll->Bind(wxEVT_BUTTON,  [&](wxCommandEvent&) { result = wxID_NO;  rejectAll = true; dlg.EndModal(wxID_OK); });
+
+    dlg.ShowModal();
+    return result == wxID_YES;
+}
+
 std::string xLightsFrame::PromptForDirectory(const std::string& message,
                                              const std::string& defaultPath) const {
     wxDirDialog dlg(nullptr, message, defaultPath);
@@ -10661,8 +10701,14 @@ void xLightsFrame::UpdateFromBaseShowFolder(bool prompt)
         ObtainAccessToURL(_outputManager.GetBaseShowDir());
     }
 
+    // Shared accept-all / reject-all state threaded across all three merge passes so that
+    // "Yes to All" or "No to All" chosen during controller prompts also suppresses the
+    // subsequent model and object prompts (and vice-versa).
+    bool mergeAcceptAll = false;
+    bool mergeRejectAll = false;
+
     // bring in any controllers overwriting some of their properties ... but not all of them
-    if (_outputManager.MergeFromBase(prompt)) {
+    if (_outputManager.MergeFromBase(prompt, mergeAcceptAll, mergeRejectAll, this)) {
         _outputModelManager.AddASAPWork(OutputModelManager::WORK_UPDATE_NETWORK_LIST, "UpdateFromBaseShowFolder-controller");
         _outputModelManager.AddASAPWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "UpdateFromBaseShowFolder-controller");
         _outputModelManager.AddASAPWork(OutputModelManager::WORK_RESEND_CONTROLLER_CONFIG, "UpdateFromBaseShowFolder-controller");
@@ -10672,7 +10718,7 @@ void xLightsFrame::UpdateFromBaseShowFolder(bool prompt)
 
     // bring in any models ... overwriting any with the same name
     // bring in any model groups ... again overwriting any ... the models in the group should be a merge and deduplication
-    if (AllModels.MergeFromBase(_outputManager.GetBaseShowDir(), prompt)) {
+    if (AllModels.MergeFromBase(_outputManager.GetBaseShowDir(), prompt, mergeAcceptAll, mergeRejectAll)) {
         _outputModelManager.AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "UpdateFromBaseShowFolder-model");
         _outputModelManager.AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "UpdateFromBaseShowFolder-model");
         _outputModelManager.AddASAPWork(OutputModelManager::WORK_RELOAD_MODELLIST, "UpdateFromBaseShowFolder-model");
@@ -10682,7 +10728,7 @@ void xLightsFrame::UpdateFromBaseShowFolder(bool prompt)
         _outputModelManager.AddASAPWork(OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS, "UpdateFromBaseShowFolder-model");
     }
 
-    if (AllObjects.MergeFromBase(_outputManager.GetBaseShowDir(), prompt))
+    if (AllObjects.MergeFromBase(_outputManager.GetBaseShowDir(), prompt, mergeAcceptAll, mergeRejectAll))
     {
         _outputModelManager.AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "UpdateFromBaseShowFolder-object");
         _outputModelManager.AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "UpdateFromBaseShowFolder-object");

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -2605,11 +2605,12 @@ bool xLightsFrame::PromptYesNoAll(const std::string& message,
 
     wxDialog dlg(const_cast<xLightsFrame*>(this), wxID_ANY, caption,
                  wxDefaultPosition, wxDefaultSize,
-                 wxDEFAULT_DIALOG_STYLE | wxCAPTION);
+                 wxDEFAULT_DIALOG_STYLE | wxCAPTION | wxRESIZE_BORDER);
 
     auto* outer = new wxBoxSizer(wxVERTICAL);
-    outer->Add(new wxStaticText(&dlg, wxID_ANY, message, wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE),
-               0, wxALL | wxEXPAND, 15);
+    auto* messageText = new wxStaticText(&dlg, wxID_ANY, message, wxDefaultPosition, wxDefaultSize, wxST_NO_AUTORESIZE);
+    messageText->Wrap(500);
+    outer->Add(messageText, 0, wxALL | wxEXPAND, 15);
 
     auto* btnSizer = new wxStdDialogButtonSizer();
     auto* btnYes    = new wxButton(&dlg, wxID_YES,  "Yes");

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -1536,6 +1536,10 @@ public:
                      const std::string& caption = "xLights") const override;
     bool PromptYesNo(const std::string& message,
                      const std::string& caption = "xLights") const override;
+    bool PromptYesNoAll(const std::string& message,
+                        const std::string& caption,
+                        bool& acceptAll,
+                        bool& rejectAll) const override;
     std::string PromptForDirectory(const std::string& message,
                                    const std::string& defaultPath = "") const override;
     std::string PromptForFile(const std::string& message,


### PR DESCRIPTION
  When switching show directories with a Base Show Directory configured, xLights prompts Yes/No for every conflicting controller, model, model group, and view object — which can be dozens of dialogs for large setups.

Please test as I don't use Base Show folder options.