### PR TITLE
Add Resolve Missing Media feature for bulk media path fixing

### DIFF
--- a/src-core/render/SequenceMedia.cpp
+++ b/src-core/render/SequenceMedia.cpp
@@ -1488,6 +1488,62 @@ std::vector<std::string> SequenceMedia::GetVideoFilePaths() const {
     return paths;
 }
 
+std::vector<std::string> SequenceMedia::GetShaderPaths() const {
+    std::scoped_lock lock(_cacheMutex);
+    std::vector<std::string> paths;
+    paths.reserve(_shaderCache.size());
+    for (const auto& p : _shaderCache) paths.push_back(p.first);
+    return paths;
+}
+
+std::vector<std::string> SequenceMedia::GetBinaryFilePaths() const {
+    std::scoped_lock lock(_cacheMutex);
+    std::vector<std::string> paths;
+    paths.reserve(_binaryCache.size());
+    for (const auto& p : _binaryCache) paths.push_back(p.first);
+    return paths;
+}
+
+std::vector<std::string> SequenceMedia::GetSVGPaths() const {
+    std::scoped_lock lock(_cacheMutex);
+    std::vector<std::string> paths;
+    paths.reserve(_svgCache.size());
+    for (const auto& p : _svgCache) paths.push_back(p.first);
+    return paths;
+}
+
+std::vector<std::string> SequenceMedia::GetTextFilePaths() const {
+    std::scoped_lock lock(_cacheMutex);
+    std::vector<std::string> paths;
+    paths.reserve(_textCache.size());
+    for (const auto& p : _textCache) paths.push_back(p.first);
+    return paths;
+}
+
+std::vector<std::string> SequenceMedia::GetAllBrokenMediaPaths() const {
+    std::scoped_lock lock(_cacheMutex);
+    std::vector<std::string> broken;
+    for (const auto& p : _imageCache) {
+        if (p.second && !p.second->IsOk()) broken.push_back(p.first);
+    }
+    for (const auto& p : _videoCache) {
+        if (p.second && !p.second->IsOk()) broken.push_back(p.first);
+    }
+    for (const auto& p : _shaderCache) {
+        if (p.second && !p.second->IsOk()) broken.push_back(p.first);
+    }
+    for (const auto& p : _binaryCache) {
+        if (p.second && !p.second->IsOk()) broken.push_back(p.first);
+    }
+    for (const auto& p : _svgCache) {
+        if (p.second && !p.second->IsOk()) broken.push_back(p.first);
+    }
+    for (const auto& p : _textCache) {
+        if (p.second && !p.second->IsOk()) broken.push_back(p.first);
+    }
+    return broken;
+}
+
 // =====================================================================
 // SequenceMedia — Generalized embed/extract
 // =====================================================================

--- a/src-core/render/SequenceMedia.h
+++ b/src-core/render/SequenceMedia.h
@@ -382,6 +382,11 @@ public:
 
     // === Query helpers ===
     std::vector<std::string> GetVideoFilePaths() const;
+    std::vector<std::string> GetShaderPaths() const;
+    std::vector<std::string> GetBinaryFilePaths() const;
+    std::vector<std::string> GetSVGPaths() const;
+    std::vector<std::string> GetTextFilePaths() const;
+    std::vector<std::string> GetAllBrokenMediaPaths() const;
 
     // === Lifecycle ===
     void Clear();

--- a/src-ui-wx/ui/import-export/SeqFileUtilities.cpp
+++ b/src-ui-wx/ui/import-export/SeqFileUtilities.cpp
@@ -23,6 +23,9 @@
 #include "render/DataLayer.h"
 #include "ui/effects/EffectAssist.h"
 #include "utils/ExternalHooks.h"
+#include "utils/FileUtils.h"
+#include "effects/RenderableEffect.h"
+#include "effects/EffectManager.h"
 #include "import_export/FileConverter.h"
 #include "render/FontManager.h"
 #include "ui/layout/HousePreviewPanel.h"
@@ -33,6 +36,7 @@
 #include "ui/diagnostics/SearchPanel.h"
 #include "ui/sequencer/SelectPanel.h"
 #include "ui/sequencer/SeqSettingsDialog.h"
+#include "ui/media/ManageMediaPanel.h"
 #include "ui/media/SequenceVideoPanel.h"
 #include "ui/import-export/SuperStarImportDialog.h"
 #include "UtilFunctions.h"
@@ -714,6 +718,9 @@ void xLightsFrame::OpenSequence(const wxString& passed_filename, ConvertLogDialo
 
         AddToMRU(filename);
         UpdateRecentFilesList(false);
+
+        // Missing media detection is handled by ValidateEffectAssets() which runs
+        // after sequence loading completes in tabSequencer.cpp
     }
 }
 

--- a/src-ui-wx/ui/media/ManageMediaPanel.cpp
+++ b/src-ui-wx/ui/media/ManageMediaPanel.cpp
@@ -28,6 +28,7 @@
 #include <wx/image.h>
 #include <wx/dirdlg.h>
 #include <wx/msgdlg.h>
+#include <wx/progdlg.h>
 #include <wx/textdlg.h>
 #include <wx/datetime.h>
 #include <wx/config.h>
@@ -35,6 +36,11 @@
 #include <algorithm>
 
 #include "utils/ExternalHooks.h"
+#include "utils/FileUtils.h"
+#include "effects/RenderableEffect.h"
+#include "effects/EffectManager.h"
+
+#include <set>
 
 static std::string MediaTypeName(MediaType t) {
     switch (t) {
@@ -1580,6 +1586,290 @@ void ManageMediaPanel::OnBulkFindImages()
                  "Bulk Find Images", wxICON_INFORMATION | wxOK, this);
 
     Populate();
+}
+
+int ManageMediaPanel::ResolveAllMissingMedia(wxWindow* parent, SequenceMedia* sequenceMedia,
+                                              SequenceElements* sequenceElements,
+                                              xLightsFrame* xlFrame,
+                                              const std::string& showDirectory)
+{
+    if (sequenceElements == nullptr || xlFrame == nullptr) return 0;
+
+    // Scan all effects across the entire sequence to find missing file references.
+    // We scan effect settings directly rather than relying on the SequenceMedia cache,
+    // because cache entries may not exist for files that were never rendered.
+    std::set<std::string> brokenPathSet;
+
+    auto scanLayerForBroken = [&](EffectLayer* layer) {
+        for (int k = 0; k < layer->GetEffectCount(); ++k) {
+            Effect* eff = layer->GetEffect(k);
+            RenderableEffect* reff = xlFrame->GetEffectManager().GetEffect(eff->GetEffectIndex());
+            if (reff == nullptr) continue;
+            auto fileRefs = reff->GetFileReferences(nullptr, eff->GetSettings());
+            for (const auto& filePath : fileRefs) {
+                if (filePath.empty()) continue;
+                std::string resolved = FileUtils::FixFile("", filePath);
+                if (resolved.empty() || !FileExists(resolved)) {
+                    brokenPathSet.insert(filePath);
+                }
+            }
+        }
+    };
+
+    for (int i = 0; i < (int)sequenceElements->GetElementCount(); ++i) {
+        Element* e = sequenceElements->GetElement(i);
+        if (e->GetType() != ElementType::ELEMENT_TYPE_MODEL) continue;
+        ModelElement* model = dynamic_cast<ModelElement*>(e);
+        if (!model) continue;
+
+        for (int j = 0; j < (int)model->GetEffectLayerCount(); ++j)
+            scanLayerForBroken(model->GetEffectLayer(j));
+
+        for (int j = 0; j < (int)model->GetSubModelAndStrandCount(); ++j) {
+            SubModelElement* sub = model->GetSubModel(j);
+            for (int l = 0; l < (int)sub->GetEffectLayerCount(); ++l)
+                scanLayerForBroken(sub->GetEffectLayer(l));
+            if (sub->GetType() == ElementType::ELEMENT_TYPE_STRAND) {
+                StrandElement* strand = dynamic_cast<StrandElement*>(sub);
+                if (strand) {
+                    for (int k = 0; k < strand->GetNodeLayerCount(); ++k)
+                        scanLayerForBroken(strand->GetNodeLayer(k));
+                }
+            }
+        }
+    }
+
+    std::vector<std::string> brokenPaths(brokenPathSet.begin(), brokenPathSet.end());
+
+    if (brokenPaths.empty()) {
+        wxMessageBox("All media files are resolved. No missing files found.",
+                     "Resolve Missing Media", wxICON_INFORMATION | wxOK, parent);
+        return 0;
+    }
+
+    // Build list of directories to search automatically (show dir + media dirs)
+    std::vector<std::string> autoDirs;
+    if (!showDirectory.empty()) autoDirs.push_back(showDirectory);
+    if (xlFrame) {
+        for (const auto& md : xlFrame->GetMediaFolders()) {
+            if (md != showDirectory)
+                autoDirs.push_back(md);
+        }
+    }
+
+    const std::string sep(1, wxFileName::GetPathSeparator());
+    int found = 0;
+    int notFound = 0;
+    wxArrayString resolvedDetails;
+    wxArrayString unresolvedDetails;
+
+    // Normalize a name for fuzzy comparison: lowercase, strip spaces/underscores/dashes/trailing digits
+    auto normalizeName = [](const wxString& name) -> wxString {
+        wxString result;
+        wxString lower = name.Lower();
+        for (size_t i = 0; i < lower.Len(); ++i) {
+            wxChar ch = lower[i];
+            if (ch != ' ' && ch != '_' && ch != '-')
+                result += ch;
+        }
+        // Strip trailing digits
+        while (!result.IsEmpty() && wxIsdigit(result.Last()))
+            result.RemoveLast();
+        return result;
+    };
+
+    // Helper: search a list of directories for a missing file (exact + fuzzy)
+    auto searchDirsForFile = [&](const std::string& oldPath,
+                                 const std::vector<std::string>& dirs) -> wxString {
+        wxFileName fnOld(oldPath);
+        wxString nameToFind = fnOld.GetFullName();
+        if (nameToFind.IsEmpty()) return wxString();
+
+        // Exact match across all search dirs
+        for (const auto& dir : dirs) {
+            wxArrayString results;
+            wxDir::GetAllFiles(dir, &results, nameToFind, wxDIR_FILES | wxDIR_DIRS);
+            if (!results.IsEmpty()) return results[0];
+        }
+
+        // Fuzzy match using normalized names
+        wxString baseName = fnOld.GetName();
+        if (baseName.IsEmpty()) return wxString();
+        wxString normalizedMissing = normalizeName(baseName);
+
+        wxArrayString candidates;
+        for (const auto& dir : dirs) {
+            wxArrayString allFiles;
+            wxDir::GetAllFiles(dir, &allFiles, wxEmptyString, wxDIR_FILES | wxDIR_DIRS);
+            for (const auto& f : allFiles) {
+                wxFileName fn(f);
+                wxString normalizedCandidate = normalizeName(fn.GetName());
+                if (normalizedCandidate == normalizedMissing) {
+                    candidates.Add(f);
+                }
+            }
+        }
+
+        // Use the first fuzzy match automatically; the summary dialog will show what was matched
+        return candidates.IsEmpty() ? wxString() : candidates[0];
+    };
+
+    // Helper: update all effect references for an old path to a new path
+    auto updateEffectRefs = [&](const std::string& oldPath, const std::string& newPath) {
+        auto scanLayer = [&](EffectLayer* layer) {
+            for (int k = 0; k < layer->GetEffectCount(); ++k) {
+                Effect* eff = layer->GetEffect(k);
+                const SettingsMap& settings = eff->GetSettings();
+                std::vector<std::string> keysToUpdate;
+                for (auto it = settings.begin(); it != settings.end(); ++it) {
+                    if (it->second == oldPath)
+                        keysToUpdate.push_back(it->first);
+                }
+                for (const auto& key : keysToUpdate)
+                    eff->SetSetting(key, newPath);
+            }
+        };
+
+        for (int i = 0; i < (int)sequenceElements->GetElementCount(); ++i) {
+            Element* e = sequenceElements->GetElement(i);
+            if (e->GetType() != ElementType::ELEMENT_TYPE_MODEL) continue;
+            ModelElement* model = dynamic_cast<ModelElement*>(e);
+            if (!model) continue;
+
+            for (int j = 0; j < (int)model->GetEffectLayerCount(); ++j)
+                scanLayer(model->GetEffectLayer(j));
+
+            for (int j = 0; j < (int)model->GetSubModelAndStrandCount(); ++j) {
+                SubModelElement* sub = model->GetSubModel(j);
+                for (int l = 0; l < (int)sub->GetEffectLayerCount(); ++l)
+                    scanLayer(sub->GetEffectLayer(l));
+                if (sub->GetType() == ElementType::ELEMENT_TYPE_STRAND) {
+                    StrandElement* strand = dynamic_cast<StrandElement*>(sub);
+                    if (strand) {
+                        for (int k = 0; k < strand->GetNodeLayerCount(); ++k)
+                            scanLayer(strand->GetNodeLayer(k));
+                    }
+                }
+            }
+        }
+    };
+
+    // Phase 1: Automatically search show/media directories
+    std::vector<std::string> stillMissing;
+    if (!autoDirs.empty()) {
+        wxProgressDialog prog("Resolving Media", "Searching show and media folders...",
+                              (int)brokenPaths.size(), parent,
+                              wxPD_APP_MODAL | wxPD_AUTO_HIDE);
+        int index = 0;
+        for (const auto& oldPath : brokenPaths) {
+            prog.Update(index++);
+            wxString foundFile = searchDirsForFile(oldPath, autoDirs);
+            if (!foundFile.IsEmpty()) {
+                std::string finalPath = foundFile.ToStdString();
+                std::string rel = xlFrame->MakeRelativePath(finalPath);
+                if (!rel.empty()) finalPath = rel;
+                if (finalPath != oldPath) {
+                    updateEffectRefs(oldPath, finalPath);
+                }
+                resolvedDetails.Add(wxFileName(oldPath).GetFullName() + " -> " + wxFileName(finalPath).GetFullName());
+                ++found;
+            } else {
+                stillMissing.push_back(oldPath);
+            }
+        }
+    } else {
+        stillMissing = brokenPaths;
+    }
+
+    // Phase 2: If files are still missing, ask user to pick an additional folder
+    if (!stillMissing.empty()) {
+        wxString msg = wxString::Format("Automatically resolved %d file(s).\n"
+                                        "%zu file(s) still missing.\n\n"
+                                        "Would you like to select another folder to search?",
+                                        found, stillMissing.size());
+        if (wxMessageBox(msg, "Resolve Missing Media", wxYES_NO | wxICON_QUESTION, parent) == wxYES) {
+            wxString defaultDir = showDirectory.empty() ? wxString() : wxString(showDirectory);
+            wxDirDialog dlg(parent, "Select folder containing missing media files", defaultDir,
+                            wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
+            if (dlg.ShowModal() == wxID_OK) {
+                std::string userDir = dlg.GetPath().ToStdString();
+                ObtainAccessToURL(userDir);
+                std::vector<std::string> userDirs = { userDir };
+
+                wxProgressDialog prog2("Resolving Media", "Searching selected folder...",
+                                       (int)stillMissing.size(), parent,
+                                       wxPD_APP_MODAL | wxPD_AUTO_HIDE | wxPD_CAN_ABORT);
+                int index = 0;
+                std::vector<std::string> finallyMissing;
+                for (const auto& oldPath : stillMissing) {
+                    if (!prog2.Update(index++, wxString::Format("Searching for %s...", wxFileName(oldPath).GetFullName()))) {
+                        break;
+                    }
+                    wxString foundFile = searchDirsForFile(oldPath, userDirs);
+                    if (!foundFile.IsEmpty()) {
+                        std::string finalPath = foundFile.ToStdString();
+                        std::string rel = xlFrame->MakeRelativePath(finalPath);
+                        if (!rel.empty()) finalPath = rel;
+                        if (finalPath != oldPath) {
+                            updateEffectRefs(oldPath, finalPath);
+                        }
+                        resolvedDetails.Add(wxFileName(oldPath).GetFullName() + " -> " + wxFileName(finalPath).GetFullName());
+                        ++found;
+                    } else {
+                        unresolvedDetails.Add(wxFileName(oldPath).GetFullName());
+                        ++notFound;
+                    }
+                }
+            }
+        } else {
+            for (const auto& p : stillMissing)
+                unresolvedDetails.Add(wxFileName(p).GetFullName());
+            notFound = (int)stillMissing.size();
+        }
+    }
+
+    if (found > 0 || notFound > 0) {
+        wxDialog dlg(parent, wxID_ANY, "Resolve Missing Media", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
+        auto* sizer = new wxBoxSizer(wxVERTICAL);
+
+        if (found > 0) {
+            auto* resolvedHeader = new wxStaticText(&dlg, wxID_ANY, wxString::Format("Resolved %d file(s):", found));
+            resolvedHeader->SetFont(resolvedHeader->GetFont().Bold());
+            sizer->Add(resolvedHeader, 0, wxALL, 10);
+
+            wxString resolvedText;
+            for (const auto& r : resolvedDetails)
+                resolvedText += r + "\n";
+            auto* resolvedList = new wxTextCtrl(&dlg, wxID_ANY, resolvedText, wxDefaultPosition, wxSize(500, std::min(100, (int)resolvedDetails.GetCount() * 20 + 10)),
+                                                wxTE_MULTILINE | wxTE_READONLY | wxTE_DONTWRAP);
+            sizer->Add(resolvedList, 1, wxLEFT | wxRIGHT | wxEXPAND, 10);
+        }
+
+        if (notFound > 0) {
+            auto* unresolvedHeader = new wxStaticText(&dlg, wxID_ANY, wxString::Format("Unresolved %d file(s):", notFound));
+            unresolvedHeader->SetFont(unresolvedHeader->GetFont().Bold());
+            sizer->Add(unresolvedHeader, 0, wxALL, 10);
+
+            wxString unresolvedText;
+            for (const auto& u : unresolvedDetails)
+                unresolvedText += u + "\n";
+            auto* unresolvedList = new wxTextCtrl(&dlg, wxID_ANY, unresolvedText, wxDefaultPosition, wxSize(500, std::min(100, (int)unresolvedDetails.GetCount() * 20 + 10)),
+                                                  wxTE_MULTILINE | wxTE_READONLY | wxTE_DONTWRAP);
+            sizer->Add(unresolvedList, 1, wxLEFT | wxRIGHT | wxEXPAND, 10);
+
+            auto* tipText = new wxStaticText(&dlg, wxID_ANY, "Use Tools/Check Sequence for more details.");
+            sizer->Add(tipText, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+        }
+
+        auto* btnSizer = dlg.CreateStdDialogButtonSizer(wxOK);
+        sizer->Add(btnSizer, 0, wxALL | wxEXPAND, 10);
+
+        dlg.SetSizerAndFit(sizer);
+        dlg.CentreOnParent();
+        dlg.ShowModal();
+    }
+
+    return found;
 }
 
 void ManageMediaPanel::OnAddButtonClick(wxCommandEvent& event)

--- a/src-ui-wx/ui/media/ManageMediaPanel.cpp
+++ b/src-ui-wx/ui/media/ManageMediaPanel.cpp
@@ -1657,7 +1657,6 @@ int ManageMediaPanel::ResolveAllMissingMedia(wxWindow* parent, SequenceMedia* se
         }
     }
 
-    const std::string sep(1, wxFileName::GetPathSeparator());
     int found = 0;
     int notFound = 0;
     wxArrayString resolvedDetails;
@@ -1678,40 +1677,60 @@ int ManageMediaPanel::ResolveAllMissingMedia(wxWindow* parent, SequenceMedia* se
         return result;
     };
 
-    // Helper: search a list of directories for a missing file (exact + fuzzy)
-    auto searchDirsForFile = [&](const std::string& oldPath,
-                                 const std::vector<std::string>& dirs) -> wxString {
+    // Build a file index for a set of directories (scanned once, used for all lookups)
+    struct FileIndex {
+        std::map<std::string, wxString> exactMap;        // lowercase filename -> full path
+        std::map<std::string, std::vector<wxString>> fuzzyMap;  // normalized base -> list of full paths
+    };
+
+    auto buildFileIndex = [&](const std::vector<std::string>& dirs) -> FileIndex {
+        FileIndex idx;
+        for (const auto& dir : dirs) {
+            wxArrayString allFiles;
+            wxDir::GetAllFiles(dir, &allFiles, wxEmptyString, wxDIR_FILES);
+            for (const auto& f : allFiles) {
+                wxFileName fn(f);
+                std::string exactKey = fn.GetFullName().Lower().ToStdString();
+                if (idx.exactMap.find(exactKey) == idx.exactMap.end()) {
+                    idx.exactMap[exactKey] = f;
+                }
+                std::string fuzzyKey = normalizeName(fn.GetName()).ToStdString();
+                if (!fuzzyKey.empty()) {
+                    idx.fuzzyMap[fuzzyKey].push_back(f);
+                }
+            }
+        }
+        return idx;
+    };
+
+    // Helper: search a file index for a missing file (exact + fuzzy)
+    auto searchIndexForFile = [&](const std::string& oldPath,
+                                  const FileIndex& idx) -> wxString {
         wxFileName fnOld(oldPath);
         wxString nameToFind = fnOld.GetFullName();
         if (nameToFind.IsEmpty()) return wxString();
 
-        // Exact match across all search dirs
-        for (const auto& dir : dirs) {
-            wxArrayString results;
-            wxDir::GetAllFiles(dir, &results, nameToFind, wxDIR_FILES | wxDIR_DIRS);
-            if (!results.IsEmpty()) return results[0];
-        }
+        // Exact filename match
+        std::string exactKey = nameToFind.Lower().ToStdString();
+        auto exactIt = idx.exactMap.find(exactKey);
+        if (exactIt != idx.exactMap.end()) return exactIt->second;
 
         // Fuzzy match using normalized names
         wxString baseName = fnOld.GetName();
+        wxString missingExt = fnOld.GetExt().Lower();
         if (baseName.IsEmpty()) return wxString();
-        wxString normalizedMissing = normalizeName(baseName);
+        std::string fuzzyKey = normalizeName(baseName).ToStdString();
 
-        wxArrayString candidates;
-        for (const auto& dir : dirs) {
-            wxArrayString allFiles;
-            wxDir::GetAllFiles(dir, &allFiles, wxEmptyString, wxDIR_FILES | wxDIR_DIRS);
-            for (const auto& f : allFiles) {
-                wxFileName fn(f);
-                wxString normalizedCandidate = normalizeName(fn.GetName());
-                if (normalizedCandidate == normalizedMissing) {
-                    candidates.Add(f);
-                }
+        auto fuzzyIt = idx.fuzzyMap.find(fuzzyKey);
+        if (fuzzyIt == idx.fuzzyMap.end() || fuzzyIt->second.empty()) return wxString();
+
+        // Prefer a candidate with the same extension as the missing file
+        for (const auto& candidate : fuzzyIt->second) {
+            if (wxFileName(candidate).GetExt().Lower() == missingExt) {
+                return candidate;
             }
         }
-
-        // Use the first fuzzy match automatically; the summary dialog will show what was matched
-        return candidates.IsEmpty() ? wxString() : candidates[0];
+        return fuzzyIt->second[0];
     };
 
     // Helper: update all effect references for an old path to a new path
@@ -1757,13 +1776,14 @@ int ManageMediaPanel::ResolveAllMissingMedia(wxWindow* parent, SequenceMedia* se
     // Phase 1: Automatically search show/media directories
     std::vector<std::string> stillMissing;
     if (!autoDirs.empty()) {
+        FileIndex autoIndex = buildFileIndex(autoDirs);
         wxProgressDialog prog("Resolving Media", "Searching show and media folders...",
                               (int)brokenPaths.size(), parent,
                               wxPD_APP_MODAL | wxPD_AUTO_HIDE);
         int index = 0;
         for (const auto& oldPath : brokenPaths) {
             prog.Update(index++);
-            wxString foundFile = searchDirsForFile(oldPath, autoDirs);
+            wxString foundFile = searchIndexForFile(oldPath, autoIndex);
             if (!foundFile.IsEmpty()) {
                 std::string finalPath = foundFile.ToStdString();
                 std::string rel = xlFrame->MakeRelativePath(finalPath);
@@ -1795,17 +1815,24 @@ int ManageMediaPanel::ResolveAllMissingMedia(wxWindow* parent, SequenceMedia* se
                 std::string userDir = dlg.GetPath().ToStdString();
                 ObtainAccessToURL(userDir);
                 std::vector<std::string> userDirs = { userDir };
+                FileIndex userIndex = buildFileIndex(userDirs);
 
                 wxProgressDialog prog2("Resolving Media", "Searching selected folder...",
                                        (int)stillMissing.size(), parent,
                                        wxPD_APP_MODAL | wxPD_AUTO_HIDE | wxPD_CAN_ABORT);
                 int index = 0;
-                std::vector<std::string> finallyMissing;
+                bool aborted = false;
                 for (const auto& oldPath : stillMissing) {
                     if (!prog2.Update(index++, wxString::Format("Searching for %s...", wxFileName(oldPath).GetFullName()))) {
+                        // User aborted — track remaining as unresolved
+                        for (size_t r = index - 1; r < stillMissing.size(); ++r) {
+                            unresolvedDetails.Add(wxFileName(stillMissing[r]).GetFullName());
+                            ++notFound;
+                        }
+                        aborted = true;
                         break;
                     }
-                    wxString foundFile = searchDirsForFile(oldPath, userDirs);
+                    wxString foundFile = searchIndexForFile(oldPath, userIndex);
                     if (!foundFile.IsEmpty()) {
                         std::string finalPath = foundFile.ToStdString();
                         std::string rel = xlFrame->MakeRelativePath(finalPath);

--- a/src-ui-wx/ui/media/ManageMediaPanel.h
+++ b/src-ui-wx/ui/media/ManageMediaPanel.h
@@ -106,6 +106,13 @@ public:
     void ExpandGroups();
     void RequestExpandGroups();
 
+    // Resolve all missing media (images, videos, shaders, binary) by searching a user-selected directory.
+    // Returns the number of files resolved. Can be called from outside the panel (e.g., Tools menu).
+    static int ResolveAllMissingMedia(wxWindow* parent, SequenceMedia* sequenceMedia,
+                                      SequenceElements* sequenceElements,
+                                      xLightsFrame* xlFrame,
+                                      const std::string& showDirectory);
+
 private:
     void OnIdle(wxIdleEvent& event);
     void OnTreeItemSelected(wxDataViewEvent& event);

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -6781,7 +6781,7 @@ void xLightsFrame::ValidateEffectAssets()
         dlg.CentreOnParent();
 
         if (dlg.ShowModal() == wxID_YES) {
-            int resolved = ManageMediaPanel::ResolveAllMissingMedia(this,
+            ManageMediaPanel::ResolveAllMissingMedia(this,
                                                       &_sequenceElements.GetSequenceMedia(),
                                                       &_sequenceElements,
                                                       this, CurrentDir.ToStdString());

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -80,6 +80,7 @@
 #include "ui/layout/HousePreviewPanel.h"
 #include "ui/setup/IPEntryDialog.h"
 #include "ui/media/JukeboxPanel.h"
+#include "ui/media/ManageMediaPanel.h"
 #include "ui/app-shell/KeyBindingEditDialog.h"
 #include "ui/layout/LayoutGroup.h"
 #include "ui/layout/LayoutPanel.h"
@@ -277,6 +278,7 @@ const wxWindowID xLightsFrame::ID_MNU_COLOURREPLACE = wxNewId();
 const wxWindowID xLightsFrame::ID_MENUITEM13 = wxNewId();
 const wxWindowID xLightsFrame::ID_MNU_CHECKSEQ = wxNewId();
 const wxWindowID xLightsFrame::ID_MNU_CLEANUPFILE = wxNewId();
+const wxWindowID xLightsFrame::ID_MNU_RESOLVE_MISSING_MEDIA = wxNewId();
 const wxWindowID xLightsFrame::ID_MNU_PACKAGESEQUENCE = wxNewId();
 const wxWindowID xLightsFrame::ID_MNU_DOWNLOADSEQUENCES = wxNewId();
 const wxWindowID xLightsFrame::ID_MENU_BATCH_RENDER = wxNewId();
@@ -1080,6 +1082,8 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     Menu1->Append(MenuItemCheckSequence);
     MenuItem_CleanupFileLocations = new wxMenuItem(Menu1, ID_MNU_CLEANUPFILE, _("Cleanup File Locations"), _("Moves all files into or under the show folder."), wxITEM_NORMAL);
     Menu1->Append(MenuItem_CleanupFileLocations);
+    MenuItem_ResolveMissingMedia = new wxMenuItem(Menu1, ID_MNU_RESOLVE_MISSING_MEDIA, _("Resolve Missing Media..."), _("Find and fix all broken media file references in the sequence."), wxITEM_NORMAL);
+    Menu1->Append(MenuItem_ResolveMissingMedia);
     MenuItem_PackageSequence = new wxMenuItem(Menu1, ID_MNU_PACKAGESEQUENCE, _("Package &Sequence"), wxEmptyString, wxITEM_NORMAL);
     Menu1->Append(MenuItem_PackageSequence);
     MenuItem_DownloadSequences = new wxMenuItem(Menu1, ID_MNU_DOWNLOADSEQUENCES, _("Download Sequences/Lyrics"), wxEmptyString, wxITEM_NORMAL);
@@ -1370,6 +1374,7 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     Connect(ID_MENUITEM13, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnActionTestMenuItemSelected);
     Connect(ID_MNU_CHECKSEQ, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItemCheckSequenceSelected);
     Connect(ID_MNU_CLEANUPFILE, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItem_CleanupFileLocationsSelected);
+    Connect(ID_MNU_RESOLVE_MISSING_MEDIA, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItem_ResolveMissingMediaSelected);
     Connect(ID_MNU_PACKAGESEQUENCE, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItem_PackageSequenceSelected);
     Connect(ID_MNU_DOWNLOADSEQUENCES, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItem_DownloadSequencesSelected);
     Connect(ID_MENU_BATCH_RENDER, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItemBatchRenderSelected);
@@ -6745,7 +6750,80 @@ void xLightsFrame::ValidateEffectAssets()
     }
 
     if (missing != "" && (_promptBatchRenderIssues || (!_renderMode && !_checkSequenceMode))) {
-        wxMessageBox("Sequence references files which cannot be found:\nShow Folder: " + showDirectory + "\n" + missing + "\n Use Tools/Check Sequence for more details.", "Missing assets");
+        wxDialog dlg(this, wxID_ANY, "Missing assets", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
+        auto* sizer = new wxBoxSizer(wxVERTICAL);
+
+        auto* headerText = new wxStaticText(&dlg, wxID_ANY, "Sequence references files which cannot be found:");
+        headerText->SetFont(headerText->GetFont().Bold());
+        sizer->Add(headerText, 0, wxALL, 10);
+
+        auto* showText = new wxStaticText(&dlg, wxID_ANY, "Show Folder: " + showDirectory);
+        sizer->Add(showText, 0, wxLEFT | wxRIGHT, 10);
+
+        auto* fileList = new wxTextCtrl(&dlg, wxID_ANY, missing, wxDefaultPosition, wxSize(500, 100),
+                                        wxTE_MULTILINE | wxTE_READONLY | wxTE_DONTWRAP);
+        sizer->Add(fileList, 1, wxALL | wxEXPAND, 10);
+
+        auto* promptText = new wxStaticText(&dlg, wxID_ANY, "Would you like to resolve them now?");
+        sizer->Add(promptText, 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+
+        auto* btnYes = new wxButton(&dlg, wxID_YES, "Yes");
+        auto* btnNo = new wxButton(&dlg, wxID_NO, "No");
+        btnYes->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&) { dlg.EndModal(wxID_YES); });
+        btnNo->Bind(wxEVT_BUTTON, [&dlg](wxCommandEvent&) { dlg.EndModal(wxID_NO); });
+        auto* btnSizer = new wxBoxSizer(wxHORIZONTAL);
+        btnSizer->AddStretchSpacer();
+        btnSizer->Add(btnNo, 0, wxRIGHT, 5);
+        btnSizer->Add(btnYes, 0, 0, 0);
+        sizer->Add(btnSizer, 0, wxALL | wxEXPAND, 10);
+
+        dlg.SetSizerAndFit(sizer);
+        dlg.CentreOnParent();
+
+        if (dlg.ShowModal() == wxID_YES) {
+            int resolved = ManageMediaPanel::ResolveAllMissingMedia(this,
+                                                      &_sequenceElements.GetSequenceMedia(),
+                                                      &_sequenceElements,
+                                                      this, CurrentDir.ToStdString());
+            // If there are still unresolved files, remind user about Check Sequence
+            std::string stillMissing;
+            for (const auto& it : _sequenceElements.GetAllReferencedFiles()) {
+                auto f = FileUtils::FixFile("", it);
+                if (!FileExists(f, false)) {
+                    stillMissing += it + "\n";
+                }
+            }
+            if (!stillMissing.empty()) {
+                wxDialog dlg2(this, wxID_ANY, "Missing assets", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
+                auto* s2 = new wxBoxSizer(wxVERTICAL);
+                auto* h2 = new wxStaticText(&dlg2, wxID_ANY, "Some files are still missing:");
+                h2->SetFont(h2->GetFont().Bold());
+                s2->Add(h2, 0, wxALL, 10);
+                auto* fl2 = new wxTextCtrl(&dlg2, wxID_ANY, stillMissing, wxDefaultPosition, wxSize(500, 100),
+                                           wxTE_MULTILINE | wxTE_READONLY | wxTE_DONTWRAP);
+                s2->Add(fl2, 1, wxLEFT | wxRIGHT | wxEXPAND, 10);
+                s2->Add(new wxStaticText(&dlg2, wxID_ANY, "Use Tools/Check Sequence for more details."), 0, wxALL, 10);
+                s2->Add(dlg2.CreateStdDialogButtonSizer(wxOK), 0, wxALL | wxEXPAND, 10);
+                dlg2.SetSizerAndFit(s2);
+                dlg2.CentreOnParent();
+                dlg2.ShowModal();
+            }
+        } else {
+            wxDialog dlg2(this, wxID_ANY, "Missing assets", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
+            auto* s2 = new wxBoxSizer(wxVERTICAL);
+            auto* h2 = new wxStaticText(&dlg2, wxID_ANY, "Sequence references files which cannot be found:");
+            h2->SetFont(h2->GetFont().Bold());
+            s2->Add(h2, 0, wxALL, 10);
+            s2->Add(new wxStaticText(&dlg2, wxID_ANY, "Show Folder: " + showDirectory), 0, wxLEFT | wxRIGHT, 10);
+            auto* fl2 = new wxTextCtrl(&dlg2, wxID_ANY, missing, wxDefaultPosition, wxSize(500, 100),
+                                       wxTE_MULTILINE | wxTE_READONLY | wxTE_DONTWRAP);
+            s2->Add(fl2, 1, wxALL | wxEXPAND, 10);
+            s2->Add(new wxStaticText(&dlg2, wxID_ANY, "Use Tools/Check Sequence for more details."), 0, wxLEFT | wxRIGHT | wxBOTTOM, 10);
+            s2->Add(dlg2.CreateStdDialogButtonSizer(wxOK), 0, wxALL | wxEXPAND, 10);
+            dlg2.SetSizerAndFit(s2);
+            dlg2.CentreOnParent();
+            dlg2.ShowModal();
+        }
     }
 }
 
@@ -8105,6 +8183,19 @@ void xLightsFrame::OnMenuItem_CleanupFileLocationsSelected(wxCommandEvent& event
         wxMessageBox("You must have a sequence opened in order to run Cleanup File Locations.", "Missing Sequence", wxOK);
     }
     spdlog::debug("Cleaning up file locations ... DONE.");
+}
+
+void xLightsFrame::OnMenuItem_ResolveMissingMediaSelected(wxCommandEvent& event)
+{
+    if (CurrentSeqXmlFile == nullptr) {
+        wxMessageBox("You must have a sequence open to resolve missing media.", "No Sequence", wxOK);
+        return;
+    }
+
+    ManageMediaPanel::ResolveAllMissingMedia(this,
+                                              &_sequenceElements.GetSequenceMedia(),
+                                              &_sequenceElements,
+                                              this, CurrentDir.ToStdString());
 }
 
 

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -631,6 +631,7 @@ public:
     void OnChar(wxKeyEvent& event);
     void OnMenuItem_ZoomSelected(wxCommandEvent& event);
     void OnMenuItem_CleanupFileLocationsSelected(wxCommandEvent& event);
+    void OnMenuItem_ResolveMissingMediaSelected(wxCommandEvent& event);
     void OnMenuItem_Generate2DPathSelected(wxCommandEvent& event);
     void OnMenuItem_GenerateAIImage(wxCommandEvent& event);
     void OnMenuItem_PrepareAudioSelected(wxCommandEvent& event);
@@ -803,6 +804,7 @@ public:
     static const wxWindowID ID_MENUITEM13;
     static const wxWindowID ID_MNU_CHECKSEQ;
     static const wxWindowID ID_MNU_CLEANUPFILE;
+    static const wxWindowID ID_MNU_RESOLVE_MISSING_MEDIA;
     static const wxWindowID ID_MNU_PACKAGESEQUENCE;
     static const wxWindowID ID_MNU_DOWNLOADSEQUENCES;
     static const wxWindowID ID_MENU_BATCH_RENDER;
@@ -1003,6 +1005,7 @@ public:
     wxMenuItem* MenuItemViewSavePerspective;
     wxMenuItem* MenuItem_ACLIghts;
     wxMenuItem* MenuItem_CleanupFileLocations;
+    wxMenuItem* MenuItem_ResolveMissingMedia;
     wxMenuItem* MenuItem_ColorReplace;
     wxMenuItem* MenuItem_CrashXLights;
     wxMenuItem* MenuItem_Donate;


### PR DESCRIPTION
## Summary
- Adds **Tools > Resolve Missing Media** menu item to find and fix all broken media file references in a sequence
- **Auto-prompts on sequence open** when missing media is detected, replacing the old info-only "Missing assets" dialog with an actionable resolve flow
- Covers **all media types**: images, video, shaders, glediator/binary files
- **Two-phase search**: automatically searches show/media directories first, then optionally lets the user pick an additional folder
- **Fuzzy name matching**: finds files even when renamed — ignores spaces, underscores, dashes, and trailing digits (e.g. `Matrix Full1.avi` matches `MatrixFull.avi`)
- Shows a **detailed summary dialog** listing resolved files (old name -> new name) and unresolved files with scrollable text areas

## Changes
- **SequenceMedia.h/.cpp** — Added path getters for all media cache types and `GetAllBrokenMediaPaths()`
- **ManageMediaPanel.h/.cpp** — Added static `ResolveAllMissingMedia()` method with search, fuzzy matching, and effect reference update logic
- **xLightsMain.h/.cpp** — Added Tools menu item, handler, and upgraded `ValidateEffectAssets()` to offer resolve instead of just reporting
- **SeqFileUtilities.cpp** — Deferred missing media detection to `ValidateEffectAssets()` to avoid duplicate prompts

## Test plan
- [ ] Open a sequence with missing media files — prompted to resolve
- [ ] Click Yes — auto-searches show/media dirs, finds exact and fuzzy matches
- [ ] If still missing, prompted to pick a folder — searches recursively
- [ ] Summary shows resolved (old -> new) and unresolved files
- [ ] Click No — shows original missing files list with "Use Tools/Check Sequence" hint
- [ ] Tools > Resolve Missing Media works manually on an open sequence
- [ ] No sequence open — menu item shows appropriate message
- [ ] Sequence with no missing media — shows "All media files are resolved"

🤖 Generated with [Claude Code](https://claude.com/claude-code)