### PR TITLE
#5047 Make Effect Presets panel dockable

### DIFF
--- a/src-ui-wx/ui/app-shell/TabSetup.cpp
+++ b/src-ui-wx/ui/app-shell/TabSetup.cpp
@@ -233,8 +233,13 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
     // Check to see if any show directory files need to be saved
     CheckUnsavedChanges();
 
-    // Force re-initialization of Effect Presets panel when show directory changes
+    // Force re-initialization of Effect Presets panel when show directory changes.
+    // If the panel is already visible, reload it immediately; otherwise defer until next show.
     _effectPresetsInitialized = false;
+    if (EffectTreeDlg != nullptr && m_mgr->GetPane("EffectPresets").IsShown()) {
+        EffectTreeDlg->InitItems(_effectPresetManager);
+        _effectPresetsInitialized = true;
+    }
 
     // update most recently used array
     int idx = mruDirectories.Index(nd);

--- a/src-ui-wx/ui/app-shell/TabSetup.cpp
+++ b/src-ui-wx/ui/app-shell/TabSetup.cpp
@@ -233,11 +233,8 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
     // Check to see if any show directory files need to be saved
     CheckUnsavedChanges();
 
-    // Force update of Preset dialog
-    if (EffectTreeDlg != nullptr) {
-        delete EffectTreeDlg;
-    }
-    EffectTreeDlg = nullptr;
+    // Force re-initialization of Effect Presets panel when show directory changes
+    _effectPresetsInitialized = false;
 
     // update most recently used array
     int idx = mruDirectories.Index(nd);

--- a/src-ui-wx/ui/sequencer/EffectTreeDialog.cpp
+++ b/src-ui-wx/ui/sequencer/EffectTreeDialog.cpp
@@ -202,6 +202,7 @@ void EffectTreeDialog::InitItems(EffectPresetManager& manager)
         EffectsFileDirty();
     }
 
+    TreeCtrl1->DeleteChildren(treeRootID);
     TreeCtrl1->SetItemData(treeRootID, new MyTreeItemData(&_presetManager->GetRoot()));
 
     AddTreeElementsRecursive(_presetManager->GetRoot(), treeRootID);

--- a/src-ui-wx/ui/sequencer/EffectTreeDialog.cpp
+++ b/src-ui-wx/ui/sequencer/EffectTreeDialog.cpp
@@ -13,12 +13,12 @@
 #include <wx/string.h>
 //*)
 
-#include <wx/persist/toplevel.h>
 #include <wx/busyinfo.h>
 #include <wx/utils.h>
 #include <wx/artprov.h>
 
 #include "EffectTreeDialog.h"
+#include "xLightsApp.h"
 #include "ui/shared/utils/wxUtilities.h"
 #include "render/SequenceMedia.h"
 #include <fstream>
@@ -58,7 +58,7 @@ const wxWindowID EffectTreeDialog::ID_BUTTON_SEARCH = wxNewId();
 const wxWindowID EffectTreeDialog::ID_TIMER_GIF = wxNewId();
 //*)
 
-BEGIN_EVENT_TABLE(EffectTreeDialog,wxDialog)
+BEGIN_EVENT_TABLE(EffectTreeDialog,wxPanel)
 	//(*EventTable(EffectTreeDialog)
 	//*)
     EVT_COMMAND(wxID_ANY, EVT_EFFTREEDROP, EffectTreeDialog::OnDropEffect)
@@ -67,7 +67,7 @@ END_EVENT_TABLE()
 #define MIN_PREVIEW_SIZE 64
 #define MAX_PREVIEW_SIZE 256
 
-EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint& pos,const wxSize& size)
+EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint& pos,const wxSize& size,long style)
 {
 	//(*Initialize(EffectTreeDialog)
 	wxBoxSizer* BoxSizer2;
@@ -76,9 +76,8 @@ EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint&
 	wxFlexGridSizer* FlexGridSizer2;
 	wxFlexGridSizer* FlexGridSizer3;
 	wxGridSizer* BoxSizer1;
-	wxStdDialogButtonSizer* StdDialogButtonSizer1;
 
-	Create(parent, wxID_ANY, _("Effect Presets"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, _T("wxID_ANY"));
+	Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, style, _T("wxID_ANY"));
 	FlexGridSizer1 = new wxFlexGridSizer(0, 1, 0, 0);
 	FlexGridSizer1->AddGrowableCol(0);
 	FlexGridSizer1->AddGrowableRow(0);
@@ -136,13 +135,8 @@ EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint&
 	FlexGridSizer3->Add(BoxSizer2, 1, wxALL|wxEXPAND, 5);
 	FlexGridSizer2->Add(FlexGridSizer3, 1, wxALL|wxEXPAND, 5);
 	FlexGridSizer1->Add(FlexGridSizer2, 1, wxALL|wxEXPAND, 5);
-	StdDialogButtonSizer1 = new wxStdDialogButtonSizer();
-	StdDialogButtonSizer1->AddButton(new wxButton(this, wxID_OK, _("Close")));
-	StdDialogButtonSizer1->Realize();
-	FlexGridSizer1->Add(StdDialogButtonSizer1, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	SetSizer(FlexGridSizer1);
 	TimerGif.SetOwner(this, ID_TIMER_GIF);
-	FlexGridSizer1->SetSizeHints(this);
 
 	Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_BEGIN_DRAG, (wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1BeginDrag);
 	Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_ITEM_ACTIVATED, (wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1ItemActivated);
@@ -167,20 +161,12 @@ EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint&
 	//*)
 
     treeRootID = TreeCtrl1->AddRoot("Effect Presets");
-    xLightParent = (xLightsFrame*)parent;
+    xLightParent = xLightsApp::GetFrame();
 
     EffectTreeDialogTextDropTarget* effDropTarget = new EffectTreeDialogTextDropTarget(this, TreeCtrl1, "EffectPresetOrGroup");
     TreeCtrl1->SetDropTarget(effDropTarget);
 
-    // remember dialog size/location
-    if (!wxPersistentRegisterAndRestore(this, "xLights.EffectTreeDialog")) {
-        // defaults if this hasn't already been persisted
-        SetSize(700, 600);
-        CenterOnScreen();
-    }
-
-
-    // Get the optimal preview size based on current dialog size
+    // Get the optimal preview size based on current panel size
     int previewSize = GetOptimalPreviewSize();
 
     // Set size for bitmap widget and blank image to optimal size so the dialog
@@ -677,12 +663,6 @@ void EffectTreeDialog::OnTreeCtrl1ItemActivated(wxTreeEvent& event)
 void EffectTreeDialog::EffectsFileDirty()
 {
     xLightParent->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "EffectsFileDirty");
-}
-
-void EffectTreeDialog::OnButton_OKClick(wxCommandEvent& event)
-{
-    Show(false);
-    ValidateWindow();
 }
 
 void EffectTreeDialog::OnTreeCtrl1BeginDrag(wxTreeEvent& event)

--- a/src-ui-wx/ui/sequencer/EffectTreeDialog.h
+++ b/src-ui-wx/ui/sequencer/EffectTreeDialog.h
@@ -12,7 +12,7 @@
 
 //(*Headers(EffectTreeDialog)
 #include <wx/button.h>
-#include <wx/dialog.h>
+#include <wx/panel.h>
 #include <wx/sizer.h>
 #include <wx/statbmp.h>
 #include <wx/textctrl.h>
@@ -31,13 +31,13 @@
 
 class xLightsFrame;
 
-class EffectTreeDialog : public wxDialog
+class EffectTreeDialog : public wxPanel
 {
     void ValidateWindow();
 
 	public:
 
-		EffectTreeDialog(wxWindow* parent,wxWindowID id=wxID_ANY,const wxPoint& pos=wxDefaultPosition,const wxSize& size=wxDefaultSize);
+		EffectTreeDialog(wxWindow* parent,wxWindowID id=wxID_ANY,const wxPoint& pos=wxDefaultPosition,const wxSize& size=wxDefaultSize,long style=wxTAB_TRAVERSAL);
 		virtual ~EffectTreeDialog();
 
 		//(*Declarations(EffectTreeDialog)
@@ -99,7 +99,6 @@ class EffectTreeDialog : public wxDialog
 		void OnbtDeleteClick(wxCommandEvent& event);
 		void OnbtAddGroupClick(wxCommandEvent& event);
 		void OnTreeCtrl1ItemActivated(wxTreeEvent& event);
-		void OnButton_OKClick(wxCommandEvent& event);
 		void OnTreeCtrl1BeginDrag(wxTreeEvent& event);
 		void OnbtImportClick(wxCommandEvent& event);
 		void OnbtExportClick(wxCommandEvent& event);

--- a/src-ui-wx/ui/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/ui/sequencer/tabSequencer.cpp
@@ -55,6 +55,7 @@
 #include "MainSequencer.h"
 #include "ui/sequencer/PerspectivesPanel.h"
 #include "ui/sequencer/SelectPanel.h"
+#include "ui/sequencer/EffectTreeDialog.h"
 #include "ui/diagnostics/SearchPanel.h"
 #include "ui/layout/LayoutGroup.h"
 #include "ui/media/JukeboxPanel.h"
@@ -194,6 +195,11 @@ void xLightsFrame::CreateSequencer()
     m_mgr->AddPane(_coloursPanel, wxAuiPaneInfo().Name(wxT("ColourDropper")).Caption(wxT("Colours")).Top().Layer(0).Hide());
     m_mgr->AddPane(jukeboxPanel,wxAuiPaneInfo().Name(wxT("Jukebox")).Caption(wxT("Jukebox")).Top().Layer(0).Hide());
     m_mgr->AddPane(_findDataPanel, wxAuiPaneInfo().Name(wxT("FindData")).Caption(wxT("Find Data")).Top().Layer(0).Hide());
+
+    spdlog::debug("CreateSequencer: Adding Effect Presets Panel.");
+    EffectTreeDlg = new EffectTreeDialog(PanelSequencer);
+    m_mgr->AddPane(EffectTreeDlg, wxAuiPaneInfo().Name(wxT("EffectPresets")).Caption(wxT("Effect Presets"))
+        .Float().BestSize(700, 600).Hide());
     // The three shared panels use an internal wxScrolledWindow so they can
     // shrink below the natural content size. MinSize on the AUI pane lets
     // the user drag below the natural content height — the inner scroll
@@ -230,6 +236,7 @@ void xLightsFrame::ResetWindowsToDefaultPositions(wxCommandEvent& event)
     m_mgr->GetPane("Perspectives").Caption("Perspectives").Dock().Left().Layer(1).Hide();
     m_mgr->GetPane("Effect").Caption("Effect").Dock().Left().Layer(0).Show().Row(1);
     m_mgr->GetPane("SelectEffect").Caption("Select Effects").Dock().Left().Layer(1).Hide();
+    m_mgr->GetPane("EffectPresets").Caption("Effect Presets").Float().Hide();
 
     m_mgr->GetPane("EffectDropper").Caption("Effects").Dock().Top().Layer(0).Hide();
     m_mgr->GetPane("Color").Caption("Color").Top().Dock().Layer(0).Show();

--- a/src-ui-wx/wxsmith/EffectTreeDialog.wxs
+++ b/src-ui-wx/wxsmith/EffectTreeDialog.wxs
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <wxsmith>
-	<object class="wxDialog" name="EffectTreeDialog">
-		<title>Effect Presets</title>
-		<id_arg>0</id_arg>
-		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER</style>
+	<object class="wxPanel" name="EffectTreeDialog">
 		<object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
 			<cols>1</cols>
 			<growablecols>0</growablecols>
@@ -199,18 +196,6 @@
 					</object>
 				</object>
 				<flag>wxALL|wxEXPAND</flag>
-				<border>5</border>
-				<option>1</option>
-			</object>
-			<object class="sizeritem">
-				<object class="wxStdDialogButtonSizer" variable="StdDialogButtonSizer1" member="no">
-					<object class="button">
-						<object class="wxButton" name="wxID_OK">
-							<label>Close</label>
-						</object>
-					</object>
-				</object>
-				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
 				<border>5</border>
 				<option>1</option>
 			</object>

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -322,6 +322,7 @@ const wxWindowID xLightsFrame::ID_MENUITEM17 = wxNewId();
 const wxWindowID xLightsFrame::ID_MNU_VALUECURVES = wxNewId();
 const wxWindowID xLightsFrame::ID_MNU_COLOURDROPPER = wxNewId();
 const wxWindowID xLightsFrame::ID_MENUITEM_EFFECT_ASSIST_WINDOW = wxNewId();
+const wxWindowID xLightsFrame::ID_MENUITEM_EFFECT_PRESETS = wxNewId();
 const wxWindowID xLightsFrame::ID_MENUITEM_SELECT_EFFECT = wxNewId();
 const wxWindowID xLightsFrame::ID_MENUITEM_SEARCH_EFFECTS = wxNewId();
 const wxWindowID xLightsFrame::ID_MENUITEM_VIDEOPREVIEW = wxNewId();
@@ -1185,6 +1186,8 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     MenuItem18->Append(MenuItemColourDropper);
     MenuItemEffectAssist = new wxMenuItem(MenuItem18, ID_MENUITEM_EFFECT_ASSIST_WINDOW, _("Effect Assist"), wxEmptyString, wxITEM_CHECK);
     MenuItem18->Append(MenuItemEffectAssist);
+    MenuItemEffectPresets = new wxMenuItem(MenuItem18, ID_MENUITEM_EFFECT_PRESETS, _("Effect Presets"), wxEmptyString, wxITEM_CHECK);
+    MenuItem18->Append(MenuItemEffectPresets);
     MenuItemSelectEffect = new wxMenuItem(MenuItem18, ID_MENUITEM_SELECT_EFFECT, _("Select Effect"), wxEmptyString, wxITEM_CHECK);
     MenuItem18->Append(MenuItemSelectEffect);
     MenuItemSearchEffects = new wxMenuItem(MenuItem18, ID_MENUITEM_SEARCH_EFFECTS, _("Search Effects"), wxEmptyString, wxITEM_CHECK);
@@ -1418,6 +1421,7 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     Connect(ID_MNU_VALUECURVES, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItem_ValueCurvesSelected);
     Connect(ID_MNU_COLOURDROPPER, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItem_ColourDropperSelected);
     Connect(ID_MENUITEM_EFFECT_ASSIST_WINDOW, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::ShowHideEffectAssistWindow);
+    Connect(ID_MENUITEM_EFFECT_PRESETS, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::ShowHideEffectPresetsWindow);
     Connect(ID_MENUITEM_SELECT_EFFECT, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItemSelectEffectSelected);
     Connect(ID_MENUITEM_SEARCH_EFFECTS, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItemSearchEffectsSelected);
     Connect(ID_MENUITEM_VIDEOPREVIEW, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItemShowHideVideoPreview);
@@ -1984,8 +1988,6 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     spdlog::debug("Effects panel initialised.");
 
     _serviceManager = std::make_unique<ServiceManager>(this);
-    
-    EffectTreeDlg = nullptr; // must be before any call to SetDir
 
     starttime = wxDateTime::UNow();
     ResetEffectsXml();
@@ -9294,14 +9296,17 @@ void xLightsFrame::OnMenuItem_VQuietVolSelected(wxCommandEvent& event)
 
 void xLightsFrame::ShowPresetsPanel()
 {
-    if (CurrentSeqXmlFile == nullptr)
+    InitSequencer();
+    if (EffectTreeDlg == nullptr)
         return;
 
-    if (EffectTreeDlg == nullptr) {
-        EffectTreeDlg = new EffectTreeDialog(this);
+    if (!_effectPresetsInitialized) {
         EffectTreeDlg->InitItems(_effectPresetManager);
+        _effectPresetsInitialized = true;
     }
-    EffectTreeDlg->Show();
+    m_mgr->GetPane("EffectPresets").Show();
+    m_mgr->Update();
+    UpdateViewMenu();
 }
 
 uint64_t xLightsFrame::BadDriveAccess(const std::list<std::string>& files, std::list<std::pair<std::string, uint64_t>>& slow, uint64_t thresholdUS)
@@ -9339,19 +9344,27 @@ uint64_t xLightsFrame::BadDriveAccess(const std::list<std::string>& files, std::
 
 void xLightsFrame::TogglePresetsPanel()
 {
-    if (CurrentSeqXmlFile == nullptr)
+    InitSequencer();
+    if (EffectTreeDlg == nullptr)
         return;
 
-    if (EffectTreeDlg == nullptr) {
-        ShowPresetsPanel();
-    } else if (EffectTreeDlg->IsVisible()) {
-        EffectTreeDlg->Hide();
-        EffectTreeDlg->Close();
-        delete EffectTreeDlg;
-        EffectTreeDlg = nullptr;
-    } else {
-        EffectTreeDlg->Show();
+    if (!_effectPresetsInitialized) {
+        EffectTreeDlg->InitItems(_effectPresetManager);
+        _effectPresetsInitialized = true;
     }
+    bool visible = m_mgr->GetPane("EffectPresets").IsShown();
+    if (visible) {
+        m_mgr->GetPane("EffectPresets").Hide();
+    } else {
+        m_mgr->GetPane("EffectPresets").Show();
+    }
+    m_mgr->Update();
+    UpdateViewMenu();
+}
+
+void xLightsFrame::ShowHideEffectPresetsWindow(wxCommandEvent& event)
+{
+    TogglePresetsPanel();
 }
 
 void xLightsFrame::OnMenuItemSelectEffectSelected(wxCommandEvent& event)
@@ -10520,6 +10533,7 @@ void xLightsFrame::UpdateViewMenu()
         { "ValueCurveDropper", MenuItemValueCurves },
         { "ColourDropper", MenuItemColourDropper },
         { "EffectAssist", MenuItemEffectAssist },
+        { "EffectPresets", MenuItemEffectPresets },
         { "SelectEffect", MenuItemSelectEffect },
         { "SequenceVideo", MenuItemVideoPreview },
         { "Jukebox", MenuItemJukebox },

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -561,6 +561,7 @@ public:
     void ShowHidePerspectivesWindow(wxCommandEvent& event);
     void ShowHideDisplayElementsWindow(wxCommandEvent& event);
     void ShowHideEffectAssistWindow(wxCommandEvent& event);
+    void ShowHideEffectPresetsWindow(wxCommandEvent& event);
     void OnMenuItem_File_SaveAs_SequenceSelected(wxCommandEvent& event);
     void OnMenuDockAllSelected(wxCommandEvent& event);
     void ShowHideBufferSettingsWindow(wxCommandEvent& event);
@@ -853,6 +854,7 @@ public:
     static const wxWindowID ID_MNU_VALUECURVES;
     static const wxWindowID ID_MNU_COLOURDROPPER;
     static const wxWindowID ID_MENUITEM_EFFECT_ASSIST_WINDOW;
+    static const wxWindowID ID_MENUITEM_EFFECT_PRESETS;
     static const wxWindowID ID_MENUITEM_SELECT_EFFECT;
     static const wxWindowID ID_MENUITEM_SEARCH_EFFECTS;
     static const wxWindowID ID_MENUITEM_VIDEOPREVIEW;
@@ -985,6 +987,7 @@ public:
     wxMenuItem* MenuItemDisplayElements;
     wxMenuItem* MenuItemEffectAssist;
     wxMenuItem* MenuItemEffectDropper;
+    wxMenuItem* MenuItemEffectPresets;
     wxMenuItem* MenuItemEffectSettings;
     wxMenuItem* MenuItemFindData;
     wxMenuItem* MenuItemFindShowFolder;
@@ -2041,6 +2044,7 @@ public:
     ColorManager color_mgr;
     ViewpointMgr viewpoint_mgr;
     EffectTreeDialog *EffectTreeDlg = nullptr;
+    bool _effectPresetsInitialized = false;
 
     ModelGroup* GetSelectedModelGroup() const;
     static pugi::xml_node FindNode(pugi::xml_node parent, const std::string& tag, const std::string& attr, const std::string& value, bool create = false);


### PR DESCRIPTION
Converts EffectTreeDialog from a wxDialog to a wxPanel hosted in the AUI manager, making it dockable/floatable like other sequencer panels. Adds a View menu item to show/hide it and a lazy-init flag so presets are only loaded when first shown.