### PR TITLE
#4482 New submodel with alias caused crash

### DIFF
--- a/src-ui-wx/ui/model/SubModelsDialog.cpp
+++ b/src-ui-wx/ui/model/SubModelsDialog.cpp
@@ -2675,6 +2675,13 @@ void SubModelsDialog::Aliases()
     if (submodelname.empty()) {
         return;
     }
+
+    // Newly created submodels only exist in SubModelInfo until the dialog is saved.
+    // Flush the current state to the live model so the alias dialog can find the submodel.
+    if (model->GetSubModel(submodelname) == nullptr) {
+        SaveSubModelInfoIntoThisModel(model);
+    }
+
     if (model->GetSubModel(submodelname) == nullptr)
         return;
 


### PR DESCRIPTION
Add submodel alias without crash or having to leave submodel window.