### PR TITLE
#6182 Pixel Size when zooming in Layout and Sequencer

### DIFF
--- a/src-ui-wx/layout/ModelPreview.cpp
+++ b/src-ui-wx/layout/ModelPreview.cpp
@@ -1227,10 +1227,21 @@ double ModelPreview::calcPixelSize(double i) {
 }
 
 double ModelPreview::getViewScale() const {
-    if (allowSelected && !is3d) {
-        return camera2d->GetZoom() * currentScale2d;
+    static constexpr double kBaseScale = 0.6;
+    if (allowSelected) {
+        if (!is3d) {
+            // 2D zoom increases when zooming in. Cap circles at kBaseScale when zoomed in;
+            // shrink proportionally when zoomed out (zoom < 1).
+            return std::min(kBaseScale, kBaseScale * (double)camera2d->GetZoom());
+        } else {
+            // 3D zoom increases when zooming out (camera moves further away). Keep circles
+            // at kBaseScale when zoomed in (zoom <= 1); shrink proportionally when zoomed out.
+            float z = camera3d->GetZoom();
+            return z > 1.0f ? kBaseScale / z : kBaseScale;
+        }
     }
-    return 1.0;
+    // Non-layout previews (house preview, model preview): shrink with zoom-out, cap when zoomed in.
+    return std::min(kBaseScale, kBaseScale * (double)camera2d->GetZoom());
 }
 
 double ModelPreview::getBackingScaleFactor() const {


### PR DESCRIPTION
 ## Summary
  - Pixel sizes (LED nodes) now scale proportionally when zooming in/out in the 2D and 3D layout views
  - Fixed oversized pixels in the sequencer house preview
  - Pixels shrink when zooming out in all preview types

  ## Details
  `getViewScale()` in `ModelPreview.cpp` applies a `kBaseScale = 0.6` factor to reduce pixel sizes to a visually appropriate size, and scales proportionally with zoom:
  - 2D layout: shrinks when zoomed out, caps at baseline when zoomed in
  - 3D layout: same with inverted zoom direction
  - House preview / all other previews: same zoom-proportional behavior

  ## Test plan
  - [ ] 2D layout — pixels should be small and shrink further when zooming out
  - [ ] 3D layout — pixels should be small and shrink further when zooming out
  - [ ] Sequencer house preview — pixels should no longer appear oversized and should shrink when zooming out