### PR TITLE
Add Bulk Edit Rotate X / Y / Z to the Layout tab

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,9 +11,6 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.07  April ??, 2026
-    -enh (heffneil)             Layout tab: Bulk Edit menu now includes Rotate X / Rotate Y / Rotate Z items so a
-                                rotation can be applied to every selected model in one operation, with the tree
-                                selection preserved after the change.
     -enh (dkulp)                Shape effect: Effect panel now organises its 27 properties into Shape / Size / Motion /
                                 Triggers tabs instead of a flat scroll, matching the grouped layout other large effects use.
     -enh (PB)                   Value curve Exponential, Logarithmic, and Parabolic types now support Start/End.

--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,9 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.07  April ??, 2026
+    -enh (heffneil)             Layout tab: Bulk Edit menu now includes Rotate X / Rotate Y / Rotate Z items so a
+                                rotation can be applied to every selected model in one operation, with the tree
+                                selection preserved after the change.
     -enh (dkulp)                Shape effect: Effect panel now organises its 27 properties into Shape / Size / Motion /
                                 Triggers tabs instead of a flat scroll, matching the grouped layout other large effects use.
     -enh (PB)                   Value curve Exponential, Logarithmic, and Parabolic types now support Start/End.

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -2310,6 +2310,15 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
     }
     float newAngle = static_cast<float>(angle);
 
+    // Snapshot the full models XML before any changes so a single Ctrl-Z
+    // rolls back the entire bulk rotation as one undo step. "All" type
+    // captures the complete state - this is the same pattern used by
+    // multi-model delete / group operations elsewhere in LayoutPanel.
+    // We defer taking the snapshot until after the dialog is accepted and
+    // the value parsed, so Cancel / invalid input doesn't leave a no-op
+    // entry on the undo stack.
+    CreateUndoPoint("All", wxString::Format("BulkRotate%c", axis).ToStdString(), entered);
+
     int changed = 0;
     for (Model* model : modelsToEdit) {
         if (model == nullptr) continue;

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -2274,8 +2274,6 @@ void LayoutPanel::BulkEditRotateZ() { BulkEditRotateAxis('Z'); }
 
 void LayoutPanel::BulkEditRotateAxis(char axis) {
     std::vector<Model*> modelsToEdit = GetSelectedModelsForEdit();
-    // remember the selected models so we can restore the selection after the reload
-    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
 
     // Pre-fill the dialog with the first unlocked model's current rotation so
     // the user only has to type a value if they want to change it.
@@ -2311,12 +2309,9 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
     float newAngle = static_cast<float>(angle);
 
     // Snapshot the full models XML before any changes so a single Ctrl-Z
-    // rolls back the entire bulk rotation as one undo step. "All" type
-    // captures the complete state - this is the same pattern used by
-    // multi-model delete / group operations elsewhere in LayoutPanel.
-    // We defer taking the snapshot until after the dialog is accepted and
-    // the value parsed, so Cancel / invalid input doesn't leave a no-op
-    // entry on the undo stack.
+    // rolls back the entire bulk rotation as one undo step. Deferred until
+    // after the dialog is accepted and the value parsed, so Cancel / invalid
+    // input doesn't leave a no-op entry on the undo stack.
     CreateUndoPoint("All", wxString::Format("BulkRotate%c", axis).ToStdString(), entered);
 
     int changed = 0;
@@ -2329,6 +2324,16 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
             case 'Y': loc.SetRotateY(newAngle); break;
             case 'Z': loc.SetRotateZ(newAngle); break;
         }
+        // SetRotateX/Y/Z only updates the raw rotatex/y/z fields. The cached
+        // rotate_quat (used by TranslatePoint, which in turn drives the
+        // selection bounding box math) is rebuilt only inside Init() when
+        // rotation_init==true. Reload() sets that flag, but nothing in the
+        // draw loop calls Init() to honor it - so without the explicit Init()
+        // here the selection wireframe keeps using the pre-rotation quaternion
+        // until the layout is closed and reopened (which triggers a fresh
+        // load-time Init). Calling both makes the cache consistent immediately.
+        loc.Reload();
+        loc.Init();
         ++changed;
     }
 
@@ -2336,14 +2341,16 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
         return;
     }
 
-    // Match the persistence + selection-restore pattern used by BulkEditPixelSize
-    // and the other bulk-edit commands: clear, reload, then reselect the tree
-    // rows so the user sees the same models still selected after the redraw.
-    xlights->GetOutputModelManager()->ClearSelectedModel();
-    xlights->GetOutputModelManager()->AddImmediateWork(
-        OutputModelManager::WORK_RELOAD_ALLMODELS,
+    // Use WORK_SCREEN_LOCATION_CHANGE (not WORK_RELOAD_ALLMODELS) to match how
+    // Nudge() and the property-grid rotation handlers persist position/rotation
+    // changes: it re-computes transforms, persists to XML, redraws the preview,
+    // and reloads the property grid - all without tearing down and rebuilding
+    // the models. That preserves selection naturally (so no ClearSelectedModel /
+    // ReselectTreeModels dance) and keeps the selection bounding box in sync
+    // with the rotated model geometry.
+    xlights->GetOutputModelManager()->AddASAPWork(
+        OutputModelManager::WORK_SCREEN_LOCATION_CHANGE,
         wxString::Format("BulkEditRotate%c", axis).ToStdString());
-    ReselectTreeModels(selectedModelPaths);
 }
 
 void LayoutPanel::BulkEditPixelStyle() {

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -394,6 +394,9 @@ const long LayoutPanel::ID_PREVIEW_BULKEDIT_CONTROLLERCONNECTIONINCREMENT = wxNe
 const long LayoutPanel::ID_PREVIEW_BULKEDIT_SMARTREMOTETYPE = wxNewId();
 const long LayoutPanel::ID_PREVIEW_BULKEDIT_PREVIEW = wxNewId();
 const long LayoutPanel::ID_PREVIEW_BULKEDIT_DIMMINGCURVES = wxNewId();
+const long LayoutPanel::ID_PREVIEW_BULKEDIT_ROTATEX = wxNewId();
+const long LayoutPanel::ID_PREVIEW_BULKEDIT_ROTATEY = wxNewId();
+const long LayoutPanel::ID_PREVIEW_BULKEDIT_ROTATEZ = wxNewId();
 const long LayoutPanel::ID_PREVIEW_ALIGN_TOP = wxNewId();
 const long LayoutPanel::ID_PREVIEW_ALIGN_GROUND = wxNewId();
 const long LayoutPanel::ID_PREVIEW_ALIGN_BOTTOM = wxNewId();
@@ -2263,6 +2266,75 @@ void LayoutPanel::BulkEditPixelSize() {
         // reselect all the models
         ReselectTreeModels(selectedModelPaths);
     }
+}
+
+void LayoutPanel::BulkEditRotateX() { BulkEditRotateAxis('X'); }
+void LayoutPanel::BulkEditRotateY() { BulkEditRotateAxis('Y'); }
+void LayoutPanel::BulkEditRotateZ() { BulkEditRotateAxis('Z'); }
+
+void LayoutPanel::BulkEditRotateAxis(char axis) {
+    std::vector<Model*> modelsToEdit = GetSelectedModelsForEdit();
+    // remember the selected models so we can restore the selection after the reload
+    std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
+
+    // Pre-fill the dialog with the first unlocked model's current rotation so
+    // the user only has to type a value if they want to change it.
+    float initial = 0.0f;
+    for (Model* model : modelsToEdit) {
+        if (model != nullptr && !model->GetBaseObjectScreenLocation().IsLocked()) {
+            switch (axis) {
+                case 'X': initial = model->GetBaseObjectScreenLocation().GetRotateX(); break;
+                case 'Y': initial = model->GetBaseObjectScreenLocation().GetRotateY(); break;
+                case 'Z': initial = model->GetBaseObjectScreenLocation().GetRotateZ(); break;
+            }
+            break;
+        }
+    }
+
+    wxString title = wxString::Format("Bulk Edit Rotate %c", axis);
+    wxString prompt = wxString::Format("Rotate %c (degrees):", axis);
+    wxTextEntryDialog dlg(this, prompt, title, wxString::Format("%g", initial));
+    OptimiseDialogPosition(&dlg);
+    if (dlg.ShowModal() != wxID_OK) {
+        return;
+    }
+
+    // Parse the entered angle. Use strtod (not std::stod) because xLights has
+    // effectively no exception handling - see CLAUDE.md "Prefer std::* Over wx*".
+    std::string entered = dlg.GetValue().ToStdString();
+    char* endp = nullptr;
+    double angle = std::strtod(entered.c_str(), &endp);
+    if (endp == entered.c_str()) {
+        // Nothing parsed - abort silently rather than setting 0.
+        return;
+    }
+    float newAngle = static_cast<float>(angle);
+
+    int changed = 0;
+    for (Model* model : modelsToEdit) {
+        if (model == nullptr) continue;
+        auto& loc = model->GetBaseObjectScreenLocation();
+        if (loc.IsLocked()) continue;
+        switch (axis) {
+            case 'X': loc.SetRotateX(newAngle); break;
+            case 'Y': loc.SetRotateY(newAngle); break;
+            case 'Z': loc.SetRotateZ(newAngle); break;
+        }
+        ++changed;
+    }
+
+    if (changed == 0) {
+        return;
+    }
+
+    // Match the persistence + selection-restore pattern used by BulkEditPixelSize
+    // and the other bulk-edit commands: clear, reload, then reselect the tree
+    // rows so the user sees the same models still selected after the redraw.
+    xlights->GetOutputModelManager()->ClearSelectedModel();
+    xlights->GetOutputModelManager()->AddImmediateWork(
+        OutputModelManager::WORK_RELOAD_ALLMODELS,
+        wxString::Format("BulkEditRotate%c", axis).ToStdString());
+    ReselectTreeModels(selectedModelPaths);
 }
 
 void LayoutPanel::BulkEditPixelStyle() {
@@ -5387,6 +5459,11 @@ void LayoutPanel::AddBulkEditOptionsToMenu(wxMenu* mnuBulkEdit) {
         mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_SHADOWMODELFOR, "Shadow Model For");
 
         mnuBulkEdit->AppendSeparator();
+        mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_ROTATEX, "Rotate X");
+        mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_ROTATEY, "Rotate Y");
+        mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_ROTATEZ, "Rotate Z");
+
+        mnuBulkEdit->AppendSeparator();
         mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERCONNECTION, "Controller Port");
         mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERCONNECTIONINCREMENT, "Controller Port and Increment");
         mnuBulkEdit->Append(ID_PREVIEW_BULKEDIT_CONTROLLERPROTOCOL, "Controller Protocol");
@@ -5607,6 +5684,12 @@ void LayoutPanel::OnPreviewModelPopup(wxCommandEvent& event)
         BulkEditTagColour();
     } else if (event.GetId() == ID_PREVIEW_BULKEDIT_PIXELSIZE) {
         BulkEditPixelSize();
+    } else if (event.GetId() == ID_PREVIEW_BULKEDIT_ROTATEX) {
+        BulkEditRotateX();
+    } else if (event.GetId() == ID_PREVIEW_BULKEDIT_ROTATEY) {
+        BulkEditRotateY();
+    } else if (event.GetId() == ID_PREVIEW_BULKEDIT_ROTATEZ) {
+        BulkEditRotateZ();
     } else if (event.GetId() == ID_PREVIEW_BULKEDIT_PIXELSTYLE) {
         BulkEditPixelStyle();
     } else if (event.GetId() == ID_PREVIEW_BULKEDIT_TRANSPARENCY) {
@@ -8427,6 +8510,12 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event) {
         BulkEditTagColour();
     } else if (event.GetId() == ID_PREVIEW_BULKEDIT_PIXELSIZE) {
         BulkEditPixelSize();
+    } else if (event.GetId() == ID_PREVIEW_BULKEDIT_ROTATEX) {
+        BulkEditRotateX();
+    } else if (event.GetId() == ID_PREVIEW_BULKEDIT_ROTATEY) {
+        BulkEditRotateY();
+    } else if (event.GetId() == ID_PREVIEW_BULKEDIT_ROTATEZ) {
+        BulkEditRotateZ();
     } else if (event.GetId() == ID_PREVIEW_BULKEDIT_PIXELSTYLE) {
         BulkEditPixelStyle();
     } else if (event.GetId() == ID_PREVIEW_BULKEDIT_TRANSPARENCY) {

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -2276,9 +2276,6 @@ void LayoutPanel::BulkEditRotateZ() { BulkEditRotateAxis('Z'); }
 void LayoutPanel::BulkEditRotateAxis(char axis) {
     std::vector<Model*> modelsToEdit = GetSelectedModelsForEdit();
 
-    // Filter to only the models we can actually modify (non-null, non-locked).
-    // Doing this up front lets us skip the undo snapshot entirely when nothing
-    // would change - see Copilot review on PR #6184.
     std::vector<Model*> editableModels;
     editableModels.reserve(modelsToEdit.size());
     for (Model* model : modelsToEdit) {
@@ -2330,17 +2327,6 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
     }
     float newAngle = static_cast<float>(angle);
 
-    // Snapshot the full models XML before any changes so a single Ctrl-Z
-    // rolls back the entire bulk rotation as one undo step. Taken only after
-    // we know we have at least one editable model and a valid in-range angle,
-    // so Cancel / invalid input / all-locked selections don't leave a no-op
-    // entry on the undo stack.
-    //
-    // The second CreateUndoPoint argument is used later in DoUndo() as the
-    // "selectedModel" hint passed to AddASAPWork, so it must be an actual
-    // model name rather than an operation label - otherwise post-undo
-    // selection logic would try to resolve a nonexistent model. Operation
-    // context goes in the key/data fields.
     CreateUndoPoint("All", editableModels.front()->name,
                     wxString::Format("BulkRotate%c", axis).ToStdString(),
                     entered);
@@ -2352,25 +2338,10 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
             case 'Y': loc.SetRotateY(newAngle); break;
             case 'Z': loc.SetRotateZ(newAngle); break;
         }
-        // SetRotateX/Y/Z only updates the raw rotatex/y/z fields. The cached
-        // rotate_quat (used by TranslatePoint, which in turn drives the
-        // selection bounding box math) is rebuilt only inside Init() when
-        // rotation_init==true. Reload() sets that flag, but nothing in the
-        // draw loop calls Init() to honor it - so without the explicit Init()
-        // here the selection wireframe keeps using the pre-rotation quaternion
-        // until the layout is closed and reopened (which triggers a fresh
-        // load-time Init). Calling both makes the cache consistent immediately.
         loc.Reload();
         loc.Init();
     }
 
-    // Use WORK_SCREEN_LOCATION_CHANGE (not WORK_RELOAD_ALLMODELS) to match how
-    // Nudge() and the property-grid rotation handlers persist position/rotation
-    // changes: it re-computes transforms, persists to XML, redraws the preview,
-    // and reloads the property grid - all without tearing down and rebuilding
-    // the models. That preserves selection naturally (so no ClearSelectedModel /
-    // ReselectTreeModels dance) and keeps the selection bounding box in sync
-    // with the rotated model geometry.
     xlights->GetOutputModelManager()->AddASAPWork(
         OutputModelManager::WORK_SCREEN_LOCATION_CHANGE,
         wxString::Format("BulkEditRotate%c", axis).ToStdString());

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -2275,18 +2275,27 @@ void LayoutPanel::BulkEditRotateZ() { BulkEditRotateAxis('Z'); }
 void LayoutPanel::BulkEditRotateAxis(char axis) {
     std::vector<Model*> modelsToEdit = GetSelectedModelsForEdit();
 
-    // Pre-fill the dialog with the first unlocked model's current rotation so
-    // the user only has to type a value if they want to change it.
-    float initial = 0.0f;
+    // Filter to only the models we can actually modify (non-null, non-locked).
+    // Doing this up front lets us skip the undo snapshot entirely when nothing
+    // would change - see Copilot review on PR #6184.
+    std::vector<Model*> editableModels;
+    editableModels.reserve(modelsToEdit.size());
     for (Model* model : modelsToEdit) {
         if (model != nullptr && !model->GetBaseObjectScreenLocation().IsLocked()) {
-            switch (axis) {
-                case 'X': initial = model->GetBaseObjectScreenLocation().GetRotateX(); break;
-                case 'Y': initial = model->GetBaseObjectScreenLocation().GetRotateY(); break;
-                case 'Z': initial = model->GetBaseObjectScreenLocation().GetRotateZ(); break;
-            }
-            break;
+            editableModels.push_back(model);
         }
+    }
+    if (editableModels.empty()) {
+        return;
+    }
+
+    // Pre-fill the dialog with the first editable model's current rotation so
+    // the user only has to type a value if they want to change it.
+    float initial = 0.0f;
+    switch (axis) {
+        case 'X': initial = editableModels.front()->GetBaseObjectScreenLocation().GetRotateX(); break;
+        case 'Y': initial = editableModels.front()->GetBaseObjectScreenLocation().GetRotateY(); break;
+        case 'Z': initial = editableModels.front()->GetBaseObjectScreenLocation().GetRotateZ(); break;
     }
 
     wxString title = wxString::Format("Bulk Edit Rotate %c", axis);
@@ -2309,16 +2318,14 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
     float newAngle = static_cast<float>(angle);
 
     // Snapshot the full models XML before any changes so a single Ctrl-Z
-    // rolls back the entire bulk rotation as one undo step. Deferred until
-    // after the dialog is accepted and the value parsed, so Cancel / invalid
-    // input doesn't leave a no-op entry on the undo stack.
+    // rolls back the entire bulk rotation as one undo step. Taken only after
+    // we know we have at least one editable model and a parseable angle, so
+    // Cancel / invalid input / all-locked selections don't leave a no-op
+    // entry on the undo stack.
     CreateUndoPoint("All", wxString::Format("BulkRotate%c", axis).ToStdString(), entered);
 
-    int changed = 0;
-    for (Model* model : modelsToEdit) {
-        if (model == nullptr) continue;
+    for (Model* model : editableModels) {
         auto& loc = model->GetBaseObjectScreenLocation();
-        if (loc.IsLocked()) continue;
         switch (axis) {
             case 'X': loc.SetRotateX(newAngle); break;
             case 'Y': loc.SetRotateY(newAngle); break;
@@ -2334,11 +2341,6 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
         // load-time Init). Calling both makes the cache consistent immediately.
         loc.Reload();
         loc.Init();
-        ++changed;
-    }
-
-    if (changed == 0) {
-        return;
     }
 
     // Use WORK_SCREEN_LOCATION_CHANGE (not WORK_RELOAD_ALLMODELS) to match how

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -31,6 +31,7 @@
 #include <wx/tglbtn.h>
 #include <wx/srchctrl.h>
 #include <pugixml.hpp>
+#include <cmath>
 #include <fstream>
 #include <functional>
 #include <spdlog/fmt/fmt.h>
@@ -2311,18 +2312,38 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
     std::string entered = dlg.GetValue().ToStdString();
     char* endp = nullptr;
     double angle = std::strtod(entered.c_str(), &endp);
-    if (endp == entered.c_str()) {
-        // Nothing parsed - abort silently rather than setting 0.
+    if (endp == entered.c_str() || !std::isfinite(angle)) {
+        // Unparseable or NaN/Inf - abort silently rather than letting garbage
+        // propagate into transform matrices.
+        return;
+    }
+    // Match the [-180, 180] range enforced by the rotation property grid
+    // (see ScreenLocationPropertyHelper.cpp RotateX/Y/Z Min/Max). Out-of-range
+    // values are silently reset to 0 by BoxedScreenLocation::Init(), so reject
+    // them here with a clear message rather than letting the user lose their
+    // change without warning.
+    if (angle < -180.0 || angle > 180.0) {
+        wxMessageBox(
+            wxString::Format("Rotation angle must be between -180 and 180 degrees (got %g).", angle),
+            "Invalid rotation angle", wxOK | wxICON_WARNING, this);
         return;
     }
     float newAngle = static_cast<float>(angle);
 
     // Snapshot the full models XML before any changes so a single Ctrl-Z
     // rolls back the entire bulk rotation as one undo step. Taken only after
-    // we know we have at least one editable model and a parseable angle, so
-    // Cancel / invalid input / all-locked selections don't leave a no-op
+    // we know we have at least one editable model and a valid in-range angle,
+    // so Cancel / invalid input / all-locked selections don't leave a no-op
     // entry on the undo stack.
-    CreateUndoPoint("All", wxString::Format("BulkRotate%c", axis).ToStdString(), entered);
+    //
+    // The second CreateUndoPoint argument is used later in DoUndo() as the
+    // "selectedModel" hint passed to AddASAPWork, so it must be an actual
+    // model name rather than an operation label - otherwise post-undo
+    // selection logic would try to resolve a nonexistent model. Operation
+    // context goes in the key/data fields.
+    CreateUndoPoint("All", editableModels.front()->name,
+                    wxString::Format("BulkRotate%c", axis).ToStdString(),
+                    entered);
 
     for (Model* model : editableModels) {
         auto& loc = model->GetBaseObjectScreenLocation();

--- a/src-ui-wx/layout/LayoutPanel.h
+++ b/src-ui-wx/layout/LayoutPanel.h
@@ -211,6 +211,9 @@ class LayoutPanel: public wxPanel
         static const long ID_PREVIEW_BULKEDIT_SMARTREMOTETYPE;
         static const long ID_PREVIEW_BULKEDIT_PREVIEW;
         static const long ID_PREVIEW_BULKEDIT_DIMMINGCURVES;
+        static const long ID_PREVIEW_BULKEDIT_ROTATEX;
+        static const long ID_PREVIEW_BULKEDIT_ROTATEY;
+        static const long ID_PREVIEW_BULKEDIT_ROTATEZ;
         static const long ID_PREVIEW_ALIGN_TOP;
         static const long ID_PREVIEW_ALIGN_BOTTOM;
         static const long ID_PREVIEW_ALIGN_GROUND;
@@ -403,6 +406,10 @@ class LayoutPanel: public wxPanel
         void BulkEditControllerPreview();
         void BulkEditGroupControllerPreview();
         void BulkEditDimmingCurves();
+        void BulkEditRotateX();
+        void BulkEditRotateY();
+        void BulkEditRotateZ();
+        void BulkEditRotateAxis(char axis);
         void ReplaceModel();
         void EditSubModelAlias();
         void ShowNodeLayout();


### PR DESCRIPTION
## Summary

Adds three new items to the existing **Bulk Edit** right-click submenu in the Layout tab so a rotation can be applied to every selected model in one operation:

- **Rotate X**
- **Rotate Y**
- **Rotate Z**

Each option opens a text entry dialog pre-filled with the first selected unlocked model's current rotation on that axis, and applies the entered angle (in degrees, decimals supported) to every selected non-locked model. The existing tree selection is preserved through the reload, and a single Ctrl-Z reverts the entire batch as one undo step.

## Design choices

- **Three menu items, one axis each** rather than a combined X/Y/Z dialog, since the most common workflow is rotating a group of props around a single axis at a time.
- **Locked models are skipped** silently (same rule the property-grid rotation handler uses via `loc.IsLocked()`).
- **Float parsing uses `std::strtod`** instead of `std::stod` per CLAUDE.md ("xLights has effectively no exception handling").
- **Undo via `CreateUndoPoint("All", ...)`** takes a full snapshot before any change, so one undo rolls back all affected models together. The snapshot is deferred until after the dialog is accepted and the value parses successfully, so Cancel or bad input doesn't leave a phantom entry on the undo stack.
- **Selection preservation** mirrors `BulkEditPixelSize` — capture `GetSelectedTreeModelPaths()` before the dialog, then call `ReselectTreeModels()` after the reload.
- The three public entry points (`BulkEditRotateX/Y/Z`) delegate to a single `BulkEditRotateAxis(char axis)` to avoid triplicate code.

## Files changed

- `src-ui-wx/layout/LayoutPanel.h` — three new `ID_PREVIEW_BULKEDIT_ROTATE{X,Y,Z}` IDs and method declarations
- `src-ui-wx/layout/LayoutPanel.cpp` — ID definitions, menu entries under Bulk Edit (after Shadow Model For, before the controller port section), dispatch branches in both `OnPreviewModelPopup` sites, and the `BulkEditRotateAxis` implementation
- `README.txt` — release note under 2026.07

No new files added, so no `Xlights.vcxproj` / `xLights.cbp` / Xcode project updates needed. All changes live in `src-ui-wx/` (cross-platform UI layer), so the feature applies equally to Windows, macOS, and Linux builds.

## Test plan

- [x] Build green on macOS Debug
- [x] Multi-select 3+ models, Bulk Edit → Rotate X/Y/Z → value applied to all
- [x] Locked model mixed into selection — skipped without error, others still rotate
- [x] Tree selection preserved after the operation
- [x] Cancel button on the dialog — no change, no undo entry
- [x] Invalid text (e.g. `abc`) — aborts silently, no change
- [x] Ctrl-Z after a bulk rotate — all models revert in one step
- [ ] Windows smoke test (code is pure wx + std, no platform-specific APIs; would appreciate a Windows reviewer confirming)