### PR TITLE
Fix crash when escape pressed mid-selection in States/SubModels dialogs

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -1277,6 +1277,21 @@ void LayoutPanel::OnPropertyGridChange(wxPropertyGridEvent& event) {
     else {
         if (editing_models) {
             xlights->AbortRender();
+            // Guard against a dangling selectedBaseObject. A modal dialog that
+            // was cancelled mid-edit (ModelStateDialog / SubModelsDialog with an
+            // active node-selection in progress, escape pressed before the
+            // selection is released) can free the model the cache pointed at
+            // without notifying us. The plain != nullptr check below would then
+            // pass and the dynamic_cast / SaveDisplayDimensions call that
+            // follows would crash on freed memory.
+            if (selectedBaseObject != nullptr && !IsSelectedBaseObjectValid()) {
+                spdlog::warn("LayoutPanel::OnPropertyGridChange: selectedBaseObject was stale; clearing cached selection.");
+                selectedBaseObject = nullptr;
+                highlightedBaseObject = nullptr;
+                _propertyAdapter.reset();
+                updatingProperty = false;
+                return;
+            }
             if (selectedBaseObject != nullptr) {
                 Model* selectedModel = dynamic_cast<Model*>(selectedBaseObject);
                 //model property
@@ -1344,6 +1359,14 @@ void LayoutPanel::SetDisplay2DCenter0(bool bb) {
 void LayoutPanel::OnPropertyGridChanging(wxPropertyGridEvent& event) {
     std::string name = event.GetPropertyName().ToStdString();
     xlights->AddTraceMessage("LayoutPanel::OnPropertyGridChanging  Property: " + name);
+    // Same dangling-pointer guard as OnPropertyGridChange - see IsSelectedBaseObjectValid.
+    if (selectedBaseObject != nullptr && !IsSelectedBaseObjectValid()) {
+        spdlog::warn("LayoutPanel::OnPropertyGridChanging: selectedBaseObject was stale; clearing cached selection.");
+        selectedBaseObject = nullptr;
+        highlightedBaseObject = nullptr;
+        _propertyAdapter.reset();
+        return;
+    }
     if (selectedBaseObject != nullptr) {
         if( editing_models ) {
             xlights->AbortRender();
@@ -8135,6 +8158,36 @@ void LayoutPanel::DoUndo(wxCommandEvent& event) {
 
         undoBuffer.resize(sz);
     }
+}
+
+bool LayoutPanel::IsSelectedBaseObjectValid() const {
+    // Pointer-address comparison only - never dereferences selectedBaseObject.
+    // selectedBaseObject can be left pointing to freed memory if a modal dialog
+    // (e.g. ModelStateDialog or SubModelsDialog) was cancelled mid-edit while
+    // a node selection was in progress: the dialog tears down the model it was
+    // editing without invalidating the LayoutPanel cache. Without this guard,
+    // OnPropertyGridChange's null check passes (the pointer isn't literally
+    // nullptr) and a subsequent dynamic_cast / dereference crashes on the
+    // dangling pointer.
+    if (selectedBaseObject == nullptr) {
+        return false;
+    }
+    for (auto it = xlights->AllModels.begin(); it != xlights->AllModels.end(); ++it) {
+        if (static_cast<BaseObject*>(it->second) == selectedBaseObject) {
+            return true;
+        }
+        for (auto* sm : it->second->GetSubModels()) {
+            if (static_cast<BaseObject*>(sm) == selectedBaseObject) {
+                return true;
+            }
+        }
+    }
+    for (auto it = xlights->AllObjects.begin(); it != xlights->AllObjects.end(); ++it) {
+        if (static_cast<BaseObject*>(it->second) == selectedBaseObject) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void LayoutPanel::CreateUndoPoint(const std::string &tp, const std::string &model, const std::string &key, const std::string &data) {

--- a/src-ui-wx/layout/LayoutPanel.h
+++ b/src-ui-wx/layout/LayoutPanel.h
@@ -537,6 +537,14 @@ class LayoutPanel: public wxPanel
         };
         std::vector<UndoStep> undoBuffer;
         void CreateUndoPoint(const std::string &type, const std::string &model, const std::string &key = "", const std::string &data = "");
+
+        // Returns true only if selectedBaseObject is currently a live pointer in
+        // either AllModels (incl. submodels) or AllObjects. Performs pointer-address
+        // comparison only, never dereferences selectedBaseObject - so it is safe to
+        // call when the cached pointer may already be dangling (e.g. after a modal
+        // dialog cancelled mid-edit and tore down the model it was editing). When it
+        // returns false the caller should treat the selection as cleared.
+        bool IsSelectedBaseObjectValid() const;
     public:
         xLightsFrame *xlights = nullptr;
         void UpdateModelList(bool full_refresh);


### PR DESCRIPTION
Fixes #5910

## Summary

Fixes a 100%-reproducible `EXC_BAD_ACCESS` crash when a user starts a node-selection in the States or SubModels dialog and presses **escape before releasing the selection**.

## Reproduction (per #5910)

1. Select a model in the Layout tab
2. Open **States** (or **SubModels**) — both embed `NodeSelectGrid`
3. Start picking nodes/pixels — get some highlighted
4. Hit **escape** before releasing the mouse selection

→ Hard crash, every time on master.

## Root cause

When the dialog is cancelled mid-edit, it tears down the model it was editing without notifying `LayoutPanel`. The cached `selectedBaseObject` is left pointing to freed memory.

A subsequent property-grid event (which the crash report shows being routed via `DoUndo` → `xLightsFrame::DoMenuAction`) reaches `OnPropertyGridChange`. The existing `selectedBaseObject != nullptr` check passes (the pointer isn't literally null — it just points to freed memory). The very next line does `dynamic_cast<Model*>(selectedBaseObject)`, which reads the vtable pointer of the freed object → garbage → `KERN_INVALID_ADDRESS at 0x0`.

## Crash report

```
Exception:    EXC_BAD_ACCESS / KERN_INVALID_ADDRESS at 0x0000000000000000
Crashed at:   LayoutPanel.cpp:1313  selectedModel->SaveDisplayDimensions()
Called from:  LayoutPanel.cpp:8107  LayoutPanel::DoUndo
Routed via:   xLightsMain.cpp:2828  xLightsFrame::DoMenuAction
```

## Fix

New private helper `IsSelectedBaseObjectValid()` scans `AllModels` (including submodels) and `AllObjects` by **pointer-address comparison only** — never dereferences `selectedBaseObject`, so it is safe to call when the cached pointer may already be dangling.

Both `OnPropertyGridChange` and `OnPropertyGridChanging` now consult it and, when the selection is invalid, clear the cache (`selectedBaseObject = nullptr`, `highlightedBaseObject = nullptr`, `_propertyAdapter.reset()`) and early-return instead of crashing.

A `spdlog::warn` is emitted when the guard fires so the underlying root cause stays visible in logs (rather than being silently swallowed).

## Scope

Only `src-ui-wx/layout/LayoutPanel.{cpp,h}` — defensive fix on the LayoutPanel side. The deeper root cause (the dialog cancel-mid-edit path that frees the model without invalidating the parent's selection cache) likely deserves a separate follow-up in `ModelStateDialog` / `SubModelsDialog` / `NodeSelectGrid`.

## Test plan

- [x] Was 100% reproducible on master before the fix (matches #5910)
- [x] Cannot reproduce on Release build with the fix applied (3+ attempts)
- [x] Build green on macOS Release (universal arm64 + x86_64)
- [x] No new files added — no project file updates needed
- [ ] Windows / Linux smoke test (code is pure wx + std + xLights internals; no platform-specific APIs)
