### PR TITLE
Replace model(s) with this model: multi-target dialog with filter and checkboxes

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -8588,11 +8588,11 @@ public:
         top->Add(new wxStaticText(this, wxID_ANY, "For each replaced model, also:"),
                  0, wxLEFT | wxRIGHT | wxTOP, 8);
         _copyStartChannelCB = new wxCheckBox(this, wxID_ANY,
-            "Copy target's start channel and controller settings");
+            "Keep each target's start channel and controller settings");
         _mergeSubmodelsCB = new wxCheckBox(this, wxID_ANY,
-            "Merge target's submodels into the replacement");
+            "Keep each target's submodels");
         _copySizePosCB = new wxCheckBox(this, wxID_ANY,
-            "Use target's original size and position");
+            "Keep each target's position and size");
         _copyStartChannelCB->SetValue(true);
         _copySizePosCB->SetValue(true);
         const int cbFlags = wxLEFT | wxRIGHT | wxTOP;
@@ -8615,10 +8615,10 @@ public:
             UpdateMasterState();
         });
         _masterCB->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent&) {
-            // wx's default tri-state click cycles 2-state visibly (unchecked
-            // -> checked -> unchecked). IsChecked() reflects the desired new
-            // state after the click - apply to every visible row.
-            const bool shouldCheck = _masterCB->IsChecked();
+            // 3-state checkbox: use Get3StateValue() — IsChecked() asserts
+            // on a 3-state in wxWidgets debug builds. Treat anything that
+            // isn't explicitly "checked" as an uncheck-all.
+            const bool shouldCheck = _masterCB->Get3StateValue() == wxCHK_CHECKED;
             for (const auto& row : _rows) {
                 row.cb->SetValue(shouldCheck);
                 if (shouldCheck) {

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -8766,14 +8766,17 @@ void LayoutPanel::ReplaceModel()
     // temp-name, target trash-name, clone final-name) and the user didn't ask
     // to rename anything - they asked to replace wholesale, so the alias
     // question doesn't apply. Restore the previous setting after the batch so
-    // normal rename operations still obey the user's preference. Uses a
-    // scope_guard-style RAII restore so we don't leak the override on early
-    // return paths.
-    const wxString savedAliasBehavior = xlights->GetRenameModelAliasPromptBehavior();
+    // normal rename operations still obey the user's preference.
+    //
+    // Real RAII guard so the restore is resilient to any early return path
+    // (current or future) - the destructor fires on scope exit regardless of
+    // how we leave this function.
+    struct AliasBehaviorRestore {
+        xLightsFrame* frame;
+        wxString saved;
+        ~AliasBehaviorRestore() { frame->SetRenameModelAliasPromptBehavior(saved); }
+    } aliasGuard{ xlights, xlights->GetRenameModelAliasPromptBehavior() };
     xlights->SetRenameModelAliasPromptBehavior("Always No");
-    auto restoreAliasBehavior = [&]() {
-        xlights->SetRenameModelAliasPromptBehavior(savedAliasBehavior);
-    };
 
     // One undo snapshot for the whole batch so a single Ctrl-Z rolls it all back.
     CreateUndoPoint("All", sourceModel->GetName(), "ReplaceModel");
@@ -8785,8 +8788,7 @@ void LayoutPanel::ReplaceModel()
     if (!sourceXml.IsOk()) {
         wxMessageBox("Failed to serialize the source model; aborting.",
                      "Replace Model", wxOK | wxICON_ERROR, this);
-        restoreAliasBehavior();
-        return;
+        return; // aliasGuard destructor restores the behaviour
     }
 
     int successCount = 0;
@@ -8814,9 +8816,22 @@ void LayoutPanel::ReplaceModel()
             continue;
         }
 
-        // Park the clone under a unique temporary name before registering it so
-        // the rename dance below doesn't collide with existing entries.
-        const std::string tmpNewName = "__xl_rmm_new_" + std::to_string(successCount);
+        // Park the clone under a temporary name that is GUARANTEED not to
+        // collide with any currently-registered model. The double-underscore
+        // prefix makes accidental user collisions extremely unlikely, but
+        // AllModels.AddModel() silently replaces (deletes!) a pre-existing
+        // model with the same name - so we still have to verify uniqueness
+        // before handing the name over. Same goes for trashName below.
+        auto uniqueTempName = [this](const std::string& base, int seedSuffix) {
+            std::string name = base + std::to_string(seedSuffix);
+            int suffix = seedSuffix;
+            while (xlights->AllModels[name] != nullptr) {
+                ++suffix;
+                name = base + std::to_string(suffix);
+            }
+            return name;
+        };
+        const std::string tmpNewName = uniqueTempName("__xl_rmm_new_", successCount);
         clone->Rename(tmpNewName);
         xlights->AllModels.AddModel(clone);
 
@@ -8857,12 +8872,19 @@ void LayoutPanel::ReplaceModel()
         // Rename dance: swap the target out and the clone in under the target's
         // original name, then delete the parked target. Mirrors the approach
         // used by the existing single-replace path.
-        const std::string trashName = "__xl_rmm_old_" + std::to_string(successCount);
+        const std::string trashName = uniqueTempName("__xl_rmm_old_", successCount);
         xlights->AllModels.RenameInListOnly(targetName, trashName);
         target->Rename(trashName);
         xlights->AllModels.RenameInListOnly(tmpNewName, targetName);
         clone->Rename(targetName);
-        xlights->AllModels.Delete(trashName);
+        // Delete returns false if the named model wasn't found - treat as a
+        // failure so we don't silently leave a stray renamed target behind,
+        // and record it in the failures list so the final summary surfaces it.
+        if (!xlights->AllModels.Delete(trashName)) {
+            spdlog::warn("ReplaceModel: failed to delete trashed target '{}'", trashName);
+            failures.push_back(targetName);
+            continue;
+        }
 
         ++successCount;
     }
@@ -8904,7 +8926,7 @@ void LayoutPanel::ReplaceModel()
         wxMessageBox(msg, "Replace Model", wxOK | wxICON_WARNING, this);
     }
 
-    restoreAliasBehavior();
+    // aliasGuard goes out of scope here and restores the user's preference
 }
 
 void LayoutPanel::UnlinkSelectedModels()

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -43,6 +43,7 @@
 #include <wx/treebase.h>
 #include <wx/colordlg.h>
 #include <wx/numdlg.h>
+#include <wx/statline.h>
 
 #include "layout/LayoutPanel.h"
 #include "layout/ModelPreview.h"
@@ -6085,7 +6086,7 @@ void LayoutPanel::AddSingleModelOptionsToBaseMenu(wxMenu &menu) {
         menu.Append(ID_PREVIEW_FLIP_VERTICAL, "Flip Vertical")->Enable(!selectedBaseObject->IsFromBase());
         
         if ((selectedObjectCnt == 1) && (modelPreview->GetModels().size() > 1) && !selectedBaseObject->IsFromBase()) {
-            menu.Append(ID_PREVIEW_REPLACEMODEL, "Replace A Model With This Model");
+            menu.Append(ID_PREVIEW_REPLACEMODEL, "Replace Model(s) With This Model...");
         }
     }
 }
@@ -8501,108 +8502,409 @@ void LayoutPanel::EditSubModelAlias() {
     }
 }
 
+
+namespace {
+
+// Inline multi-select dialog with live filter. Keeps check state persistent
+// across filter changes so the user can type to narrow the list, check
+// things, change the filter, and retain earlier selections. Scoped to this
+// TU since it is only used by LayoutPanel::ReplaceModel.
+class ReplaceModelDialog : public wxDialog {
+public:
+    ReplaceModelDialog(wxWindow* parent,
+                       const wxString& sourceName,
+                       const std::vector<std::string>& candidateNames)
+        : wxDialog(parent, wxID_ANY,
+                   wxString::Format("Replace Model(s) With: %s", sourceName),
+                   wxDefaultPosition, wxSize(460, 560),
+                   wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+          _allCandidates(candidateNames)
+    {
+        auto* top = new wxBoxSizer(wxVERTICAL);
+
+        // Intro: kept short so it fits one line at default dialog width.
+        // Wrap() is still called as a belt-and-suspenders for narrower widths
+        // (user resize, platforms where default font is wider, etc).
+        auto* intro = new wxStaticText(this, wxID_ANY,
+            "Each selected model will be replaced with a copy of the current model.");
+        intro->Wrap(420);
+        top->Add(intro, 0, wxALL, 8);
+
+        auto* filterRow = new wxBoxSizer(wxHORIZONTAL);
+        filterRow->Add(new wxStaticText(this, wxID_ANY, "Filter:"),
+                       0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT, 8);
+        _filterCtrl = new wxTextCtrl(this, wxID_ANY);
+        _filterCtrl->SetHint("type to filter by name...");
+        filterRow->Add(_filterCtrl, 1, wxEXPAND | wxRIGHT, 8);
+        top->Add(filterRow, 0, wxEXPAND | wxBOTTOM, 4);
+
+        // Build the list ourselves instead of using a native list widget. This
+        // gives us:
+        //   - real native wxCheckBox rendering on Windows / macOS / Linux
+        //   - perfect vertical alignment, because the header row and each item
+        //     row share the same 2-column (checkbox + name) sizer layout
+        //   - the "select / clear all visible" master checkbox literally in
+        //     the header cell next to "Model Name" - requested in PR review
+        //
+        // The outer frame is a wxStaticBox for a clean visual border around
+        // the header + rows. The rows go in a scrollable inner wxPanel so the
+        // dialog stays usable with 100+ models.
+        auto* listBox = new wxStaticBox(this, wxID_ANY, wxEmptyString);
+        auto* listBoxSizer = new wxStaticBoxSizer(listBox, wxVERTICAL);
+
+        // Header row: [master checkbox] [bold "Model Name" label]
+        auto* headerPanel = new wxPanel(listBox, wxID_ANY);
+        auto* headerSizer = new wxBoxSizer(wxHORIZONTAL);
+        _masterCB = new wxCheckBox(headerPanel, wxID_ANY, wxEmptyString,
+                                   wxDefaultPosition, wxDefaultSize, wxCHK_3STATE);
+        _masterCB->SetToolTip("Select / clear all currently visible models");
+        auto* headerLabel = new wxStaticText(headerPanel, wxID_ANY, "Model Name");
+        wxFont headerFont = headerLabel->GetFont();
+        headerFont.SetWeight(wxFONTWEIGHT_BOLD);
+        headerLabel->SetFont(headerFont);
+        headerSizer->Add(_masterCB, 0, wxALIGN_CENTER_VERTICAL | wxALL, 4);
+        headerSizer->Add(headerLabel, 1, wxALIGN_CENTER_VERTICAL | wxLEFT, 6);
+        headerPanel->SetSizer(headerSizer);
+        listBoxSizer->Add(headerPanel, 0, wxEXPAND | wxBOTTOM, 2);
+
+        // Thin separator so the header reads as a proper column header.
+        auto* separator = new wxStaticLine(listBox, wxID_ANY,
+                                           wxDefaultPosition, wxDefaultSize,
+                                           wxLI_HORIZONTAL);
+        listBoxSizer->Add(separator, 0, wxEXPAND | wxBOTTOM, 2);
+
+        // Scrollable rows. Each row is its own wxCheckBox (native look) sized
+        // to match the header's checkbox column, followed by the name text.
+        _rowsWindow = new wxScrolledWindow(listBox, wxID_ANY,
+                                           wxDefaultPosition, wxDefaultSize,
+                                           wxVSCROLL | wxBORDER_NONE);
+        _rowsWindow->SetScrollRate(0, 16);
+        _rowsSizer = new wxBoxSizer(wxVERTICAL);
+        _rowsWindow->SetSizer(_rowsSizer);
+        listBoxSizer->Add(_rowsWindow, 1, wxEXPAND);
+
+        top->Add(listBoxSizer, 1, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 8);
+
+        top->Add(new wxStaticText(this, wxID_ANY, "For each replaced model, also:"),
+                 0, wxLEFT | wxRIGHT | wxTOP, 8);
+        _copyStartChannelCB = new wxCheckBox(this, wxID_ANY,
+            "Copy target's start channel and controller settings");
+        _mergeSubmodelsCB = new wxCheckBox(this, wxID_ANY,
+            "Merge target's submodels into the replacement");
+        _copySizePosCB = new wxCheckBox(this, wxID_ANY,
+            "Use target's original size and position");
+        _copyStartChannelCB->SetValue(true);
+        _copySizePosCB->SetValue(true);
+        const int cbFlags = wxLEFT | wxRIGHT | wxTOP;
+        const int cbPad = 4;
+        top->Add(_copyStartChannelCB, 0, cbFlags, cbPad);
+        top->Add(_mergeSubmodelsCB,   0, cbFlags, cbPad);
+        top->Add(_copySizePosCB,      0, cbFlags, cbPad);
+
+        auto* btnRow = CreateButtonSizer(wxOK | wxCANCEL);
+        if (btnRow != nullptr) {
+            top->Add(btnRow, 0, wxEXPAND | wxALL, 8);
+        }
+        SetSizer(top);
+
+        RepopulateRows();
+        UpdateMasterState();
+
+        _filterCtrl->Bind(wxEVT_TEXT, [this](wxCommandEvent&) {
+            RepopulateRows();
+            UpdateMasterState();
+        });
+        _masterCB->Bind(wxEVT_CHECKBOX, [this](wxCommandEvent&) {
+            // wx's default tri-state click cycles 2-state visibly (unchecked
+            // -> checked -> unchecked). IsChecked() reflects the desired new
+            // state after the click - apply to every visible row.
+            const bool shouldCheck = _masterCB->IsChecked();
+            for (const auto& row : _rows) {
+                row.cb->SetValue(shouldCheck);
+                if (shouldCheck) {
+                    _checkedSet.insert(row.name);
+                } else {
+                    _checkedSet.erase(row.name);
+                }
+            }
+            UpdateMasterState();
+        });
+    }
+
+    std::vector<std::string> GetSelectedNames() const {
+        std::vector<std::string> out(_checkedSet.begin(), _checkedSet.end());
+        std::sort(out.begin(), out.end());
+        return out;
+    }
+
+    bool CopyStartChannel() const { return _copyStartChannelCB->IsChecked(); }
+    bool MergeSubmodels()   const { return _mergeSubmodelsCB->IsChecked(); }
+    bool CopySizePos()      const { return _copySizePosCB->IsChecked(); }
+
+private:
+    // Filter is case-insensitive substring match.
+    static bool PassesFilter(const std::string& name, const std::string& filterLower) {
+        if (filterLower.empty()) return true;
+        std::string lower = name;
+        std::transform(lower.begin(), lower.end(), lower.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+        return lower.find(filterLower) != std::string::npos;
+    }
+
+    void RepopulateRows() {
+        std::string filterLower = _filterCtrl->GetValue().ToStdString();
+        std::transform(filterLower.begin(), filterLower.end(), filterLower.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+
+        _rowsWindow->Freeze();
+        _rowsSizer->Clear(true); // deletes existing row widgets
+        _rows.clear();
+
+        for (const auto& name : _allCandidates) {
+            if (!PassesFilter(name, filterLower)) continue;
+            auto* cb = new wxCheckBox(_rowsWindow, wxID_ANY, name);
+            cb->SetValue(_checkedSet.count(name) > 0);
+            _rowsSizer->Add(cb, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 2);
+            _rows.push_back({ name, cb });
+
+            // When an individual row checkbox is toggled, mirror the change
+            // into _checkedSet and re-evaluate the master tri-state.
+            const std::string capturedName = name;
+            cb->Bind(wxEVT_CHECKBOX, [this, capturedName, cb](wxCommandEvent&) {
+                if (cb->GetValue()) {
+                    _checkedSet.insert(capturedName);
+                } else {
+                    _checkedSet.erase(capturedName);
+                }
+                UpdateMasterState();
+            });
+        }
+
+        _rowsWindow->FitInside();
+        _rowsWindow->Layout();
+        _rowsWindow->Thaw();
+    }
+
+    void UpdateMasterState() {
+        // Aggregate state of currently visible rows -> master checkbox tri-state.
+        if (_rows.empty()) {
+            _masterCB->Set3StateValue(wxCHK_UNCHECKED);
+            _masterCB->Enable(false);
+            return;
+        }
+        _masterCB->Enable(true);
+        size_t checked = 0;
+        for (const auto& r : _rows) {
+            if (r.cb->GetValue()) ++checked;
+        }
+        if (checked == 0) {
+            _masterCB->Set3StateValue(wxCHK_UNCHECKED);
+        } else if (checked == _rows.size()) {
+            _masterCB->Set3StateValue(wxCHK_CHECKED);
+        } else {
+            _masterCB->Set3StateValue(wxCHK_UNDETERMINED);
+        }
+    }
+
+    struct RowEntry {
+        std::string name;
+        wxCheckBox* cb;
+    };
+
+    wxTextCtrl* _filterCtrl = nullptr;
+    wxCheckBox* _masterCB = nullptr;
+    wxScrolledWindow* _rowsWindow = nullptr;
+    wxBoxSizer* _rowsSizer = nullptr;
+    wxCheckBox* _copyStartChannelCB = nullptr;
+    wxCheckBox* _mergeSubmodelsCB = nullptr;
+    wxCheckBox* _copySizePosCB = nullptr;
+
+    std::vector<std::string> _allCandidates;
+    std::vector<RowEntry> _rows;
+    std::set<std::string> _checkedSet;
+};
+
+} // namespace
+
 void LayoutPanel::ReplaceModel()
 {
     if (selectedBaseObject == nullptr) return;
+    Model* sourceModel = dynamic_cast<Model*>(selectedBaseObject);
+    if (sourceModel == nullptr) return;
 
-    Model* modelToReplaceItWith = dynamic_cast<Model*>(selectedBaseObject);
-
-    wxArrayString choices;
-
-    for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-    {
-        if (modelPreview->GetModels()[i]->GetName() != selectedBaseObject->GetName())
-        {
-            choices.Add(modelPreview->GetModels()[i]->GetName());
+    // Build alphabetised candidate list - everything in the preview except the source itself.
+    std::vector<std::string> candidates;
+    candidates.reserve(modelPreview->GetModels().size());
+    for (auto* m : modelPreview->GetModels()) {
+        if (m != nullptr && m != sourceModel) {
+            candidates.push_back(m->GetName());
         }
     }
+    if (candidates.empty()) {
+        wxMessageBox("There are no other models in the layout to replace.",
+                     "Replace Model", wxOK | wxICON_INFORMATION, this);
+        return;
+    }
+    std::sort(candidates.begin(), candidates.end());
 
-    wxSingleChoiceDialog dlg(this, "", "Select the model to replace with this model.", choices);
-    dlg.SetSelection(0);
+    ReplaceModelDialog dlg(this, sourceModel->GetName(), candidates);
     OptimiseDialogPosition(&dlg);
+    if (dlg.ShowModal() != wxID_OK) return;
 
-    if (dlg.ShowModal() == wxID_OK)
-    {
-        xlights->UnselectEffect(); // we do this just in case the effect is on the model we are deleting
-        xlights->AbortRender(); // we dont want to be rendering when we do this
+    auto targetNames = dlg.GetSelectedNames();
+    if (targetNames.empty()) return;
 
-        Model* replaceModel = nullptr;
-        for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
-        {
-            if (modelPreview->GetModels()[i]->GetName() == dlg.GetStringSelection())
-            {
-                replaceModel = modelPreview->GetModels()[i];
-            }
-        }
+    const bool copyStartCh = dlg.CopyStartChannel();
+    const bool mergeSubs   = dlg.MergeSubmodels();
+    const bool copySizePos = dlg.CopySizePos();
 
-        if (replaceModel == nullptr) return;
+    xlights->UnselectEffect(); // in case an effect lives on one of the targets
+    xlights->AbortRender();
 
-        CreateUndoPoint("All", "", "");
+    // Suppress Model::Rename's "Save old name as alias?" prompt for the duration
+    // of this batch. Each target triggers several intermediate renames (clone
+    // temp-name, target trash-name, clone final-name) and the user didn't ask
+    // to rename anything - they asked to replace wholesale, so the alias
+    // question doesn't apply. Restore the previous setting after the batch so
+    // normal rename operations still obey the user's preference. Uses a
+    // scope_guard-style RAII restore so we don't leak the override on early
+    // return paths.
+    const wxString savedAliasBehavior = xlights->GetRenameModelAliasPromptBehavior();
+    xlights->SetRenameModelAliasPromptBehavior("Always No");
+    auto restoreAliasBehavior = [&]() {
+        xlights->SetRenameModelAliasPromptBehavior(savedAliasBehavior);
+    };
 
-        // Prompt user to copy the target models start channel ...but only if
-        // they are not already the same and the new model uses a chaining start
-        // channel ... the theory being if you took time to set the start channel
-        // you probably want to keep it and so a prompt will just be annoying
-        if ((replaceModel->ModelStartChannel !=
-            modelToReplaceItWith->ModelStartChannel &&
-            wxString(modelToReplaceItWith->ModelStartChannel).StartsWith(">")) ||
-            (replaceModel->GetControllerName() != modelToReplaceItWith->GetControllerName() && (modelToReplaceItWith->GetControllerName() == "" || modelToReplaceItWith->GetControllerName() == NO_CONTROLLER)))
-        {
-            auto msg = wxString::Format("Should I copy the replaced models start channel '%s' to the replacement model whose start channel is currently '%s'?", replaceModel->ModelStartChannel, modelToReplaceItWith->ModelStartChannel);
-            if (wxMessageBox(msg, "Update Start Channel", wxYES_NO) == wxYES)
-            {
-                modelToReplaceItWith->SetStartChannel(replaceModel->ModelStartChannel);
+    // One undo snapshot for the whole batch so a single Ctrl-Z rolls it all back.
+    CreateUndoPoint("All", sourceModel->GetName(), "ReplaceModel");
 
-                modelToReplaceItWith->SetControllerProtocol(replaceModel->GetControllerProtocol());
-                modelToReplaceItWith->SetControllerPort(replaceModel->GetControllerPort());
-                modelToReplaceItWith->SetControllerName(replaceModel->GetControllerName());
-                modelToReplaceItWith->SetSmartRemote(replaceModel->GetSmartRemote());
-                modelToReplaceItWith->SetSmartRemoteType(replaceModel->GetSmartRemoteType());
-                modelToReplaceItWith->SetSRMaxCascade(replaceModel->GetSRMaxCascade());
-                modelToReplaceItWith->SetSRCascadeOnPort(replaceModel->GetSRCascadeOnPort());
-            }
-        }
-
-        if (replaceModel->GetNumSubModels() > 0 ) {
-            if (wxMessageBox("Merge The Submodels", "Merge The Submodels", wxYES_NO) == wxYES) {
-                for (int i = 0; i < replaceModel->GetNumSubModels(); ++i) {
-                    auto name{ replaceModel->GetSubModel(i)->Name() };
-                    if (modelToReplaceItWith->GetSubModel(name) != nullptr) {
-                        continue;
-                    }
-                    
-                    // Create SubModel using copy constructor
-                    const SubModel* sourceSubModel = dynamic_cast<const SubModel*>(replaceModel->GetSubModel(i));
-                    SubModel* sm = new SubModel(modelToReplaceItWith, sourceSubModel);
-                    modelToReplaceItWith->AddSubmodel(sm);
-                }
-            }
-        }
-
-        auto rmn = replaceModel->GetName();
-        auto riw = modelToReplaceItWith->GetName();
-
-        if (wxMessageBox("Use original size and position of " + rmn, "Use original size and position", wxYES_NO) == wxYES) {
-            modelToReplaceItWith->GetModelScreenLocation().SetRotation(replaceModel->GetModelScreenLocation().GetRotation());
-            modelToReplaceItWith->SetHcenterPos(replaceModel->GetHcenterPos());
-            modelToReplaceItWith->SetVcenterPos(replaceModel->GetVcenterPos());
-            modelToReplaceItWith->SetDcenterPos(replaceModel->GetDcenterPos());       
-            modelToReplaceItWith->SetHeight(replaceModel->GetHeight());       
-            modelToReplaceItWith->SetWidth(replaceModel->GetWidth());    
-            modelToReplaceItWith->SetDepth(replaceModel->GetDepth());    
-        }
-
-        xlights->AllModels.RenameInListOnly(dlg.GetStringSelection().ToStdString(), "Iamgoingtodeletethismodel");
-        replaceModel->Rename("Iamgoingtodeletethismodel");
-        xlights->AllModels.RenameInListOnly(modelToReplaceItWith->GetName(), dlg.GetStringSelection().ToStdString());
-        modelToReplaceItWith->Rename(dlg.GetStringSelection().ToStdString());
-        xlights->AllModels.Delete("Iamgoingtodeletethismodel");
-        xlights->ReplaceModelWithModelFixGroups(rmn, riw);
-        xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS |
-                                                      OutputModelManager::WORK_RGBEFFECTS_CHANGE |
-                                                      OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS |
-                                                      OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "ReplaceModel", nullptr, nullptr, dlg.GetStringSelection().ToStdString());
+    // Capture the source's XML ONCE. Each iteration builds a fresh clone from this
+    // snapshot so the original source stays intact across the whole batch.
+    CopyPasteBaseObject sourceXml;
+    sourceXml.SetBaseObject(sourceModel);
+    if (!sourceXml.IsOk()) {
+        wxMessageBox("Failed to serialize the source model; aborting.",
+                     "Replace Model", wxOK | wxICON_ERROR, this);
+        restoreAliasBehavior();
+        return;
     }
+
+    int successCount = 0;
+    std::vector<std::string> failures;
+
+    for (const auto& targetName : targetNames) {
+        // Re-resolve the target from the model manager each iteration - names
+        // are stable but pointers may have changed due to earlier iterations.
+        Model* target = xlights->AllModels[targetName];
+        if (target == nullptr) {
+            failures.push_back(targetName);
+            continue;
+        }
+
+        auto owned = sourceXml.GetBaseObjectXml();
+        pugi::xml_node nd = owned;
+        if (!nd) {
+            failures.push_back(targetName);
+            continue;
+        }
+
+        Model* clone = xlights->AllModels.CreateModel(nd);
+        if (clone == nullptr) {
+            failures.push_back(targetName);
+            continue;
+        }
+
+        // Park the clone under a unique temporary name before registering it so
+        // the rename dance below doesn't collide with existing entries.
+        const std::string tmpNewName = "__xl_rmm_new_" + std::to_string(successCount);
+        clone->Rename(tmpNewName);
+        xlights->AllModels.AddModel(clone);
+
+        // Per-target carryovers. These match the semantics of the three Yes/No
+        // prompts in the existing single-replace flow (see ReplaceModel()).
+        if (copyStartCh) {
+            clone->SetStartChannel(target->ModelStartChannel);
+            clone->SetControllerProtocol(target->GetControllerProtocol());
+            clone->SetControllerPort(target->GetControllerPort());
+            clone->SetControllerName(target->GetControllerName());
+            clone->SetSmartRemote(target->GetSmartRemote());
+            clone->SetSmartRemoteType(target->GetSmartRemoteType());
+            clone->SetSRMaxCascade(target->GetSRMaxCascade());
+            clone->SetSRCascadeOnPort(target->GetSRCascadeOnPort());
+        }
+        if (mergeSubs) {
+            for (int i = 0; i < target->GetNumSubModels(); ++i) {
+                const auto smName = target->GetSubModel(i)->Name();
+                if (clone->GetSubModel(smName) != nullptr) {
+                    continue; // clone already has a submodel with this name - skip
+                }
+                const SubModel* srcSub = dynamic_cast<const SubModel*>(target->GetSubModel(i));
+                if (srcSub == nullptr) continue;
+                SubModel* sm = new SubModel(clone, srcSub);
+                clone->AddSubmodel(sm);
+            }
+        }
+        if (copySizePos) {
+            clone->GetModelScreenLocation().SetRotation(target->GetModelScreenLocation().GetRotation());
+            clone->SetHcenterPos(target->GetHcenterPos());
+            clone->SetVcenterPos(target->GetVcenterPos());
+            clone->SetDcenterPos(target->GetDcenterPos());
+            clone->SetHeight(target->GetHeight());
+            clone->SetWidth(target->GetWidth());
+            clone->SetDepth(target->GetDepth());
+        }
+
+        // Rename dance: swap the target out and the clone in under the target's
+        // original name, then delete the parked target. Mirrors the approach
+        // used by the existing single-replace path.
+        const std::string trashName = "__xl_rmm_old_" + std::to_string(successCount);
+        xlights->AllModels.RenameInListOnly(targetName, trashName);
+        target->Rename(trashName);
+        xlights->AllModels.RenameInListOnly(tmpNewName, targetName);
+        clone->Rename(targetName);
+        xlights->AllModels.Delete(trashName);
+
+        ++successCount;
+    }
+
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS |
+                                                  OutputModelManager::WORK_RGBEFFECTS_CHANGE |
+                                                  OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS |
+                                                  OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER,
+                                                  "ReplaceModel");
+
+    // Always show a confirmation so the user knows the operation finished,
+    // even when it was a silent full success. The icon makes the outcome
+    // obvious at a glance (info / warning / error).
+    if (successCount == static_cast<int>(targetNames.size()) && failures.empty()) {
+        wxMessageBox(
+            wxString::Format("Successfully replaced %d model%s.",
+                             successCount, successCount == 1 ? "" : "s"),
+            "Replace Model", wxOK | wxICON_INFORMATION, this);
+    } else if (successCount == 0) {
+        wxString msg = "No models were replaced.";
+        if (!failures.empty()) {
+            msg += "\n\nFailed: ";
+            for (size_t i = 0; i < failures.size(); ++i) {
+                if (i > 0) msg += ", ";
+                msg += failures[i];
+            }
+        }
+        wxMessageBox(msg, "Replace Model", wxOK | wxICON_ERROR, this);
+    } else {
+        wxString msg = wxString::Format("Replaced %d of %zu model(s).",
+                                        successCount, targetNames.size());
+        if (!failures.empty()) {
+            msg += "\n\nFailed: ";
+            for (size_t i = 0; i < failures.size(); ++i) {
+                if (i > 0) msg += ", ";
+                msg += failures[i];
+            }
+        }
+        wxMessageBox(msg, "Replace Model", wxOK | wxICON_WARNING, this);
+    }
+
+    restoreAliasBehavior();
 }
 
 void LayoutPanel::UnlinkSelectedModels()

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -8607,6 +8607,12 @@ public:
         }
         SetSizer(top);
 
+        // Disable OK until the user has actually picked at least one target —
+        // OK with an empty selection is a confusing no-op for a destructive
+        // batch operation.
+        _okBtn = static_cast<wxButton*>(FindWindow(wxID_OK));
+        if (_okBtn != nullptr) _okBtn->Disable();
+
         RepopulateRows();
         UpdateMasterState();
 
@@ -8642,19 +8648,16 @@ public:
     bool CopySizePos()      const { return _copySizePosCB->IsChecked(); }
 
 private:
-    // Filter is case-insensitive substring match.
-    static bool PassesFilter(const std::string& name, const std::string& filterLower) {
-        if (filterLower.empty()) return true;
-        std::string lower = name;
-        std::transform(lower.begin(), lower.end(), lower.begin(),
-                       [](unsigned char c) { return std::tolower(c); });
-        return lower.find(filterLower) != std::string::npos;
+    // Filter is case-insensitive substring match. wxString::Lower() handles
+    // Unicode correctly via the platform's locale; std::tolower / std::string
+    // would byte-fold and mishandle non-ASCII model names.
+    static bool PassesFilter(const std::string& name, const wxString& filterLower) {
+        if (filterLower.IsEmpty()) return true;
+        return wxString::FromUTF8(name).Lower().Contains(filterLower);
     }
 
     void RepopulateRows() {
-        std::string filterLower = _filterCtrl->GetValue().ToStdString();
-        std::transform(filterLower.begin(), filterLower.end(), filterLower.begin(),
-                       [](unsigned char c) { return std::tolower(c); });
+        const wxString filterLower = _filterCtrl->GetValue().Lower();
 
         _rowsWindow->Freeze();
         _rowsSizer->Clear(true); // deletes existing row widgets
@@ -8690,6 +8693,7 @@ private:
         if (_rows.empty()) {
             _masterCB->Set3StateValue(wxCHK_UNCHECKED);
             _masterCB->Enable(false);
+            if (_okBtn != nullptr) _okBtn->Enable(!_checkedSet.empty());
             return;
         }
         _masterCB->Enable(true);
@@ -8704,6 +8708,10 @@ private:
         } else {
             _masterCB->Set3StateValue(wxCHK_UNDETERMINED);
         }
+        // OK is enabled iff at least one target is checked anywhere in the
+        // full set (not just visible ones — a user could filter, check
+        // something, then change the filter so it's hidden but still selected).
+        if (_okBtn != nullptr) _okBtn->Enable(!_checkedSet.empty());
     }
 
     struct RowEntry {
@@ -8718,6 +8726,7 @@ private:
     wxCheckBox* _copyStartChannelCB = nullptr;
     wxCheckBox* _mergeSubmodelsCB = nullptr;
     wxCheckBox* _copySizePosCB = nullptr;
+    wxButton*   _okBtn = nullptr;
 
     std::vector<std::string> _allCandidates;
     std::vector<RowEntry> _rows;
@@ -8877,11 +8886,20 @@ void LayoutPanel::ReplaceModel()
         target->Rename(trashName);
         xlights->AllModels.RenameInListOnly(tmpNewName, targetName);
         clone->Rename(targetName);
-        // Delete returns false if the named model wasn't found - treat as a
-        // failure so we don't silently leave a stray renamed target behind,
-        // and record it in the failures list so the final summary surfaces it.
+        // If Delete fails, we'd otherwise leave the layout half-updated: the
+        // clone is now under targetName but the original is still sitting in
+        // the model list as trashName. Roll back the rename so the original
+        // is restored and the clone gets removed, then record the failure.
         if (!xlights->AllModels.Delete(trashName)) {
-            spdlog::warn("ReplaceModel: failed to delete trashed target '{}'", trashName);
+            spdlog::warn("ReplaceModel: failed to delete trashed target '{}', rolling back swap", trashName);
+            // Best-effort rollback. Worst case (also fails): record failure
+            // and continue — manual cleanup may be needed, but the partial-
+            // state we leave is no worse than before this rollback path.
+            xlights->AllModels.RenameInListOnly(targetName, tmpNewName);
+            clone->Rename(tmpNewName);
+            xlights->AllModels.RenameInListOnly(trashName, targetName);
+            target->Rename(targetName);
+            xlights->AllModels.Delete(tmpNewName); // remove the clone we couldn't swap in
             failures.push_back(targetName);
             continue;
         }
@@ -8889,11 +8907,17 @@ void LayoutPanel::ReplaceModel()
         ++successCount;
     }
 
+    // Pass the source model name + replaced count as context so logs and any
+    // downstream observers can scope the change instead of seeing a bare
+    // "ReplaceModel" token.
+    const std::string workCtx = wxString::Format(
+        "ReplaceModel: source='%s' replaced=%d",
+        sourceModel->GetName(), successCount).ToStdString();
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS |
                                                   OutputModelManager::WORK_RGBEFFECTS_CHANGE |
                                                   OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS |
                                                   OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER,
-                                                  "ReplaceModel");
+                                                  workCtx);
 
     // Always show a confirmation so the user knows the operation finished,
     // even when it was a silent full success. The icon makes the outcome


### PR DESCRIPTION
Fixes #4462
Ref: [comment on the issue](https://github.com/xLightsSequencer/xLights/issues/4462#issuecomment-3793533322)

## Summary

Replaces the old `wxSingleChoiceDialog`-based "Replace A Model With This Model" flow with a richer dialog that can replace **multiple** target models with a copy of the current one in a single operation. The single-select case still works — you just tick one checkbox instead of picking from a radio list.

## What's new

- **Filtered model picker** — live, case-insensitive substring filter. Check state persists across filter changes so you can narrow down one subset, check those, narrow down another, and keep both groups selected.
- **Tri-state master checkbox in the header** — sits next to the bold "Model Name" label. Clicking it selects/clears every currently visible row in one action, and reflects the aggregate state (all / none / mixed).
- **Three batch options** replace the three separate Yes/No prompts of the old flow — asked once, applied to every replaced target:
  - Copy target's start channel + controller settings to the replacement
  - Merge target's submodels into the replacement
  - Use target's original size and position
- **Result confirmation** — info / warning / error `wxMessageBox` at the end summarising how many models were replaced and naming any that failed, so the user knows the operation completed.

## Implementation notes

- Source model's XML is snapshotted once via `CopyPasteBaseObject`; each target gets a fresh `AllModels.CreateModel()` clone from that snapshot. The original source stays intact across the whole batch.
- The per-target rename dance (park target under a unique trash name → rename the clone into the target's original name → delete the trashed target) mirrors the existing single-replace pattern, extended to N targets in a loop.
- The alias-prompt behaviour ("Save old name as alias?") is saved and set to `"Always No"` for the duration of the batch, then restored on every exit path. Prevents the user from being asked N × 3 times about aliasing when they're conceptually **replacing** models rather than renaming them. Global preference is untouched for subsequent rename operations.
- Single `CreateUndoPoint("All", ...)` snapshot before any change — one Ctrl-Z rolls the entire batch back.
- Dialog's list is built from real `wxCheckBox` + `wxStaticText` widgets inside a `wxScrolledWindow`. Every row (including the header) uses the same 2-column sizer pattern, so alignment between the header checkbox and list rows is automatic. Gives native `wxCheckBox` rendering on Windows, macOS, and Linux — no custom drawing.

## Scope

- Only `src-ui-wx/layout/LayoutPanel.{cpp,h}` changed
- No new source files → no project file updates needed for `Xlights.vcxproj` / `xLights.cbp` / Xcode pbxproj
- Pure wxWidgets + STL, cross-platform
- The old `ReplaceModel()` body was removed; the new `ReplaceModel()` handles both single and multi-target cases

## Test plan

- [x] Build green on macOS Debug and Release (universal arm64 + x86_64)
- [x] Single-target replace works end-to-end (verified from preview right-click menu)
- [x] Multi-target replace (2+ selections) works
- [x] Filter narrows the list and check state persists across filter changes
- [x] Master tri-state checkbox correctly reflects and drives row state
- [x] Each of the three batch options is honoured (start channel / submodel merge / size+pos)
- [x] No alias prompts appear during the batch (preference is restored afterward)
- [x] Ctrl-Z reverts the entire batch in one step
- [x] Confirmation box appears at the end in all three outcome shapes
- [ ] Windows / Linux smoke test — code is pure wx + std, no platform-specific APIs, but a Windows reviewer confirming would be appreciated
