### PR TITLE
Filter UX: Layout filter realtime, click-out clears filter, Sequencer filter exposed

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -12255,7 +12255,7 @@ int LayoutPanel::calculateNodeCountOfSelected()
 
 void LayoutPanel::OnModelFilterCancelBtn(wxCommandEvent& event) {
     _filterDebounceTimer.Stop();
-    ModelFilterCtrl->SetValue("");
+    ModelFilterCtrl->ChangeValue("");
     _filterString = "";
     _filterRegexValid = false;
     UpdateModelList(true);

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -755,14 +755,16 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
     ModelFilterCtrl->Bind(wxEVT_TEXT_ENTER, &LayoutPanel::OnModelFilterTextChanged, this);
     ModelFilterCtrl->Bind(wxEVT_SEARCHCTRL_SEARCH_BTN, &LayoutPanel::OnModelFilterTextChanged, this);
     ModelFilterCtrl->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN, &LayoutPanel::OnModelFilterCancelBtn, this);
+    // Debounce the realtime tree refresh so fast typing doesn't fire
+    // UpdateModelList on every keystroke.
+    _filterDebounceTimer.SetOwner(this);
+    Bind(wxEVT_TIMER, [this](wxTimerEvent&) { UpdateModelList(true); }, _filterDebounceTimer.GetId());
     ModelFilterCtrl->Bind(wxEVT_TEXT, [this](wxCommandEvent&) {
         _filterString = ModelFilterCtrl->GetValue().Trim();
         _filterRegex.Compile(_filterString, wxRE_ICASE);
         _filterRegexValid = _filterRegex.IsValid();
-        if (_filterString.IsEmpty()) {
-            UpdateModelList(true);
-        }
-        });
+        _filterDebounceTimer.StartOnce(150);
+    });
     filterSizer->Add(ModelFilterCtrl, 1, wxEXPAND | wxTOP, 2);
     sizer1->Add(filterSizer, 0, wxEXPAND);
 
@@ -12252,6 +12254,7 @@ int LayoutPanel::calculateNodeCountOfSelected()
 }
 
 void LayoutPanel::OnModelFilterCancelBtn(wxCommandEvent& event) {
+    _filterDebounceTimer.Stop();
     ModelFilterCtrl->SetValue("");
     _filterString = "";
     _filterRegexValid = false;
@@ -12259,6 +12262,7 @@ void LayoutPanel::OnModelFilterCancelBtn(wxCommandEvent& event) {
 }
 
 void LayoutPanel::OnModelFilterTextChanged(wxCommandEvent& event) {
+    _filterDebounceTimer.Stop();
     _filterString = ModelFilterCtrl->GetValue().Trim();
     _filterRegex.Compile(_filterString, wxRE_ICASE);
     _filterRegexValid = _filterRegex.IsValid();

--- a/src-ui-wx/layout/LayoutPanel.h
+++ b/src-ui-wx/layout/LayoutPanel.h
@@ -683,6 +683,7 @@ class LayoutPanel: public wxPanel
         wxString _filterString;
         wxRegEx  _filterRegex;
         bool     _filterRegexValid = false;
+        wxTimer  _filterDebounceTimer;
 
         class ModelListComparator : public wxTreeListItemComparator
         {

--- a/src-ui-wx/layout/ViewsModelsPanel.cpp
+++ b/src-ui-wx/layout/ViewsModelsPanel.cpp
@@ -35,6 +35,7 @@
 #include "UtilFunctions.h"
 #include "shared/utils/wxUtilities.h"
 #include "models/ModelGroup.h"
+#include "sequencer/MainSequencer.h"
 
 #include <log.h>
 
@@ -1255,6 +1256,9 @@ void ViewsModelsPanel::SelectView(const std::string& view)
     }
 
     _xlFrame->DoForceSequencerRefresh();
+    if (auto* ms = _xlFrame->GetMainSequencer()) {
+        ms->ReApplyCurrentSeqFilter();
+    }
     ValidateWindow();
 }
 

--- a/src-ui-wx/sequencer/MainSequencer.cpp
+++ b/src-ui-wx/sequencer/MainSequencer.cpp
@@ -314,7 +314,7 @@ MainSequencer::MainSequencer(wxWindow* parent, bool smallWaveform, wxWindowID id
     CheckBox_SuspendRender->SetFont(fnt);
 #endif
 
-    // Sequencer prop filter - hidden by default
+    // Sequencer prop filter
     _seqFilterCtrl = new wxSearchCtrl(this, ID_TEXTCTRL_SEQ_FILTER,
         wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
     _seqFilterCtrl->SetDescriptiveText("Filter props...");

--- a/src-ui-wx/sequencer/MainSequencer.cpp
+++ b/src-ui-wx/sequencer/MainSequencer.cpp
@@ -324,11 +324,15 @@ MainSequencer::MainSequencer(wxWindow* parent, bool smallWaveform, wxWindowID id
     _seqFilterCtrl->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN, &MainSequencer::OnSeqFilterCancel, this);
     _seqFilterCtrl->Bind(wxEVT_SEARCHCTRL_SEARCH_BTN, &MainSequencer::OnSeqFilterEnter, this);
     _seqFilterCtrl->Bind(wxEVT_CHAR_HOOK, [this](wxKeyEvent& e) {
-        if (e.GetKeyCode() == WXK_ESCAPE) { ShowSeqFilterPanel(false); }
-        else { e.Skip(); }
+        if (e.GetKeyCode() == WXK_ESCAPE) {
+            _seqFilterCtrl->ChangeValue("");
+            ApplySeqFilter("");
+            if (PanelEffectGrid != nullptr) PanelEffectGrid->SetFocus();
+        } else {
+            e.Skip();
+        }
     });
     FlexGridSizer2->Add(_seqFilterCtrl, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 2);
-    _seqFilterCtrl->Hide();
 
     spdlog::debug("                Create time display control");
     timeDisplay = new TimeDisplayControl(this, wxID_ANY);
@@ -846,7 +850,10 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
                 xLightsApp::GetFrame()->OnMenuItemSelectEffectSelected(e);
             }
             else if (type == "FILTER_SEQUENCER") {
-                ShowSeqFilterPanel(!_seqFilterCtrl->IsShown());
+                if (_seqFilterCtrl != nullptr) {
+                    _seqFilterCtrl->SetFocus();
+                    _seqFilterCtrl->SelectAll();
+                }
             }
             else if (type == "PERSPECTIVES_TOGGLE") {
                 wxCommandEvent e;
@@ -2259,21 +2266,10 @@ void MainSequencer::OnCheckBox_SuspendRenderClick(wxCommandEvent& event)
     ToggleRender(CheckBox_SuspendRender->IsChecked());
 }
 
-void MainSequencer::ShowSeqFilterPanel(bool show)
+void MainSequencer::ReApplyCurrentSeqFilter()
 {
     if (_seqFilterCtrl == nullptr) return;
-    if (show) {
-        _seqFilterCtrl->Show();
-        GetSizer()->Layout();
-        _seqFilterCtrl->SetFocus();
-        _seqFilterCtrl->SelectAll();
-    } else {
-        _seqFilterCtrl->Hide();
-        _seqFilterCtrl->SetValue("");
-        GetSizer()->Layout();
-        ApplySeqFilter("");
-        PanelEffectGrid->SetFocus();
-    }
+    ApplySeqFilter(_seqFilterCtrl->GetValue());
 }
 
 void MainSequencer::ApplySeqFilter(const wxString& filter)
@@ -2320,10 +2316,13 @@ void MainSequencer::OnSeqFilterText(wxCommandEvent& event)
 
 void MainSequencer::OnSeqFilterEnter(wxCommandEvent& event)
 {
-    ShowSeqFilterPanel(false);
+    if (PanelEffectGrid != nullptr) {
+        PanelEffectGrid->SetFocus();
+    }
 }
 
 void MainSequencer::OnSeqFilterCancel(wxCommandEvent& event)
 {
-    ShowSeqFilterPanel(false);
+    _seqFilterCtrl->ChangeValue("");
+    ApplySeqFilter("");
 }

--- a/src-ui-wx/sequencer/MainSequencer.h
+++ b/src-ui-wx/sequencer/MainSequencer.h
@@ -163,8 +163,12 @@ class MainSequencer: public wxPanel
         SequenceElements* mSequenceElements;
         wxSearchCtrl* _seqFilterCtrl = nullptr;
 
-        void ShowSeqFilterPanel(bool show);
         void ApplySeqFilter(const wxString& filter);
+
+    public:
+        void ReApplyCurrentSeqFilter();
+
+    private:
         void OnSeqFilterText(wxCommandEvent& event);
         void OnSeqFilterCancel(wxCommandEvent& event);
         void OnSeqFilterEnter(wxCommandEvent& event);


### PR DESCRIPTION
## Summary

Two UX improvements to the existing filter boxes in the Layout and Sequencer tabs:

1. **Layout model filter — realtime, debounced**
2. **Sequencer prop filter — always visible, Ctrl+F focuses, view-switch reapplies**

(The earlier "clicking a filtered-out model in the preview clears the filter" change was split out and shipped separately via #6271 → master commit `0ba2cf70e`. This PR no longer touches `SelectModelInTree`.)

## 1. Layout model filter narrows live as you type, debounced

`ModelFilterCtrl` already bound `wxEVT_TEXT` and was compiling the regex on every keystroke, but it only refreshed the tree when the filter became empty. Now it kicks a 150ms one-shot `_filterDebounceTimer` so the tree narrows once typing pauses — no full `UpdateModelList(true)` per keystroke, no perceived lag. Enter / search-button still refresh immediately and stop the pending timer to avoid a redundant second refresh.

## 2. Sequencer prop filter exposed + view-switch reapplies

The `_seqFilterCtrl` already filtered rows live on `wxEVT_TEXT`, but it was `Hide()`-ed by default and only reachable through Ctrl+F. Most users never found it. Pressing Enter inside it called `ShowSeqFilterPanel(false)` which cleared the text — the act of "committing" destroyed the filter.

Changes:

- Removed the `Hide()` at construction — filter is always visible above the time display
- `OnSeqFilterEnter` now just moves focus to the effect grid; the live-applied filter stays in place
- `OnSeqFilterCancel` (X button, mouse) clears the text and re-shows all rows but keeps the filter visible — user can immediately type a new filter
- Escape (keyboard) clears AND moves focus to the grid (different from X by design — keyboard user is signaling "done with filter")
- `FILTER_SEQUENCER` Ctrl+F now focuses the always-visible filter and `SelectAll()`s any existing text
- New public `MainSequencer::ReApplyCurrentSeqFilter()` — called from `ViewsModelsPanel::SelectView()` after `DoForceSequencerRefresh()` so the active filter is re-applied against the new view's rows when the user switches views
- Removed dead `ShowSeqFilterPanel(bool)` method

## Files changed

- `src-ui-wx/layout/LayoutPanel.cpp` / `.h` — debounced realtime filter
- `src-ui-wx/sequencer/MainSequencer.cpp` / `.h` — exposed sequencer filter + `ReApplyCurrentSeqFilter`
- `src-ui-wx/layout/ViewsModelsPanel.cpp` — call `ReApplyCurrentSeqFilter` from `SelectView`

## Test plan

- [x] Build green on macOS Debug (universal arm64 + x86_64)
- [x] Layout filter narrows tree on every keystroke without Enter
- [x] Layout filter doesn't fire `UpdateModelList` on every keystroke (debounce verified by typing fast and watching for one refresh)
- [x] Sequencer filter visible above time display by default
- [x] Enter inside sequencer filter keeps the filter and focuses the effect grid
- [x] Escape clears the text and focuses the effect grid
- [x] X button clears the text but leaves focus in the filter
- [x] Ctrl+F focuses the sequencer filter and selects existing text
- [x] Switching views with an active filter re-applies it against the new view's rows
- [ ] Windows / Linux smoke test — code is pure wx + std, no platform-specific APIs