### PR TITLE
Fix copy/paste: intelligent placement + only new copy selected after paste

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -7904,23 +7904,6 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
 
                 if (nd)
                 {
-                    // Clear any existing selection ONLY after we've confirmed the
-                    // clipboard has valid paste data - otherwise a failed paste
-                    // (empty clipboard, bad XML) would wipe the user's selection
-                    // for nothing. See Copilot review on PR #6192.
-                    //
-                    // UnSelectAllModels() clears the per-Model Selected() flags
-                    // and our own tracking vectors. It does NOT clear the
-                    // wxTreeListCtrl widget's native selection though - on a
-                    // multi-select tree (wxTL_MULTIPLE) the old row lingers and
-                    // the post-reload SelectBaseObject->SelectModelInTree adds
-                    // the new row to it instead of replacing it. Hence we also
-                    // need UnSelectAllModelsInTree() to call
-                    // TreeListViewModels->UnselectAll() so only the new copy
-                    // ends up highlighted.
-                    UnSelectAllModels();
-                    UnSelectAllModelsInTree();
-
                     auto nda = DisplayAsTypeFromString(nd.attribute("DisplayAs").as_string());
                     auto nx = (int)nd.attribute("WorldPosX").as_double();
                     auto ny = (int)nd.attribute("WorldPosY").as_double();
@@ -7962,31 +7945,25 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
                     {
                         bool moved = true;
                         int loopGuard = 0;
-                        while (moved && loopGuard++ < PASTE_LOOP_MAX)
+                        bool hitCap = false;
+                        while (moved)
                         {
+                            if (loopGuard >= PASTE_LOOP_MAX) { hitCap = true; break; }
+                            ++loopGuard;
                             moved = false;
                             for (const auto& it : xlights->AllModels)
                             {
                                 if (nda != it.second->GetDisplayAs()) continue;
 
                                 auto pos = it.second->GetBaseObjectScreenLocation().GetWorldPosition();
-                                float itWidth = std::max(it.second->GetRestorableMWidth(), PASTE_MIN_OFFSET);
+                                float itWidth = it.second->GetRestorableMWidth();
+                                if (itWidth <= 0) itWidth = PASTE_MIN_OFFSET;
                                 float itHalf = itWidth * 0.5f;
 
-                                // Centre-distance overlap along X, exact match along Y/Z.
-                                // The paste is being offset along X only (historical
-                                // behaviour) so Y/Z still use the integer centre match.
                                 if ((int)pos.y == ny &&
                                     (int)pos.z == nz &&
                                     std::abs(static_cast<float>(nx) - pos.x) < itHalf)
                                 {
-                                    // Move our centre clear of BOTH halves: past the old
-                                    // model's right edge by approximately one full width
-                                    // (old half + ours, assuming similar size since we
-                                    // already filtered by matching DisplayAs above) plus
-                                    // a padding gap. The previous formula only added
-                                    // half + padding, which left our left half sliding
-                                    // back into the old model's body.
                                     nx = static_cast<int>(pos.x + itWidth + PASTE_PADDING);
                                     SetXmlNodeAttribute(nd, "WorldPosX",
                                                         fmt::format("{:6.4f}", (float)nx));
@@ -7995,12 +7972,7 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
                                 }
                             }
                         }
-                        // Surface the pathological case in the log rather than
-                        // silently pasting a potentially still-overlapping copy.
-                        // PASTE_LOOP_MAX is a very high ceiling (500 collisions
-                        // in a row) so hitting it likely indicates a bug in the
-                        // position math or a genuinely saturated layout.
-                        if (loopGuard >= PASTE_LOOP_MAX) {
+                        if (hitCap) {
                             spdlog::warn("LayoutPanel::DoPaste: collision-avoidance "
                                          "loop hit the {}-iteration safety cap; the "
                                          "pasted copy may still visually overlap an "
@@ -8014,6 +7986,9 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
 					{
 						if (!editing_models)//dont paste model in View Object mode
 							return;
+
+						UnSelectAllModels();
+						UnSelectAllModelsInTree();
 
 						Model *newModel = xlights->AllModels.CreateModel(nd);
 
@@ -8041,6 +8016,9 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
 					{
 						if (editing_models)//dont paste view objects in model editing mode
 							return;
+
+						UnSelectAllModels();
+						UnSelectAllModelsInTree();
 
 						ViewObject *newViewObject = xlights->AllObjects.CreateObject(nd);
 						name = xlights->AllObjects.GenerateObjectName(newViewObject->name);

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -7910,33 +7910,6 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
                     auto nz = (int)nd.attribute("WorldPosZ").as_double();
                     source_model_name = nd.attribute("name").as_string();
 
-                    // Push the paste out of the way of anything it would visually
-                    // overlap. Two improvements over the old center-point + fixed
-                    // 40-unit bump:
-                    //
-                    //   1. Step size is the COLLIDED model's width (plus a small
-                    //      padding) so the paste actually clears that model's
-                    //      bounding box. A fixed bump was fine for small arches
-                    //      but left large matrices visually overlapping.
-                    //
-                    //   2. Overlap test uses the collided model's half-width
-                    //      either side of centre rather than requiring an exact
-                    //      integer-truncated centre match. This catches copies
-                    //      that land inside a wide model without being on its
-                    //      exact centre, which is the common case when pasting
-                    //      repeatedly (clipboard keeps the original position;
-                    //      the bump from the previous paste may land inside the
-                    //      next model's bbox but not on its exact centre).
-                    //
-                    // Only same-type models are considered "colliding" - same
-                    // behaviour as before, so e.g. an Arches paste doesn't get
-                    // pushed past unrelated Pixel Matrixes that happen to be
-                    // nearby.
-                    //
-                    // ViewObject pastes (Images / Meshes) use a separate
-                    // coordinate space and overlap detection isn't meaningful
-                    // against AllModels entries, so we scope the loop to the
-                    // Model paste path only. See Copilot review on PR #6192.
                     constexpr float PASTE_PADDING = 20.0f; // extra gap between copies
                     constexpr float PASTE_MIN_OFFSET = 80.0f; // guard against zero-width edge case
                     constexpr int   PASTE_LOOP_MAX  = 500; // safety cap
@@ -7971,12 +7944,6 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
                                     break;
                                 }
                             }
-                        }
-                        if (hitCap) {
-                            spdlog::warn("LayoutPanel::DoPaste: collision-avoidance "
-                                         "loop hit the {}-iteration safety cap; the "
-                                         "pasted copy may still visually overlap an "
-                                         "existing model at x={}.", PASTE_LOOP_MAX, nx);
                         }
                     }
 

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -7889,6 +7889,23 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
         if (wxTheClipboard->Open()) {
             CreateUndoPoint("All", selectedBaseObject == nullptr ? "" : selectedBaseObject->name);
 
+            // Clear any existing selection before creating the new model. Without
+            // this the original (source) model stays Selected() from the Ctrl-C
+            // action, and when WORK_RELOAD_MODELLIST fires with the new model's
+            // name as a selection hint BOTH end up highlighted in the preview.
+            // Users expect only the freshly-pasted model to be selected.
+            //
+            // UnSelectAllModels() clears the per-Model Selected() flags and our
+            // own selection tracking vectors, but does NOT clear the
+            // wxTreeListCtrl widget's native selection. On a multi-select tree
+            // (wxTL_MULTIPLE) an old selected row lingers, and when
+            // SelectBaseObject -> SelectModelInTree -> TreeListViewModels->Select()
+            // runs after reload it ADDS to the existing tree selection rather
+            // than replacing it - which is why the original still looks
+            // selected after paste. Clear both.
+            UnSelectAllModels();
+            UnSelectAllModelsInTree();
+
             wxTextDataObject data;
             wxTheClipboard->GetData(data);
 
@@ -7910,28 +7927,56 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
                     auto nz = (int)nd.attribute("WorldPosZ").as_double();
                     source_model_name = nd.attribute("name").as_string();
 
+                    // Push the paste out of the way of anything it would visually
+                    // overlap. Two improvements over the old center-point + fixed
+                    // 40-unit bump:
+                    //
+                    //   1. Step size is the COLLIDED model's width (plus a small
+                    //      padding) so the paste actually clears that model's
+                    //      bounding box. A fixed bump was fine for small arches
+                    //      but left large matrices visually overlapping.
+                    //
+                    //   2. Overlap test uses the collided model's half-width
+                    //      either side of centre rather than requiring an exact
+                    //      integer-truncated centre match. This catches copies
+                    //      that land inside a wide model without being on its
+                    //      exact centre, which is the common case when pasting
+                    //      repeatedly (clipboard keeps the original position;
+                    //      the bump from the previous paste may land inside the
+                    //      next model's bbox but not on its exact centre).
+                    //
+                    // Only same-type models are considered "colliding" - same
+                    // behaviour as before, so e.g. an Arches paste doesn't get
+                    // pushed past unrelated Pixel Matrixes that happen to be
+                    // nearby.
+                    constexpr float PASTE_PADDING = 20.0f; // extra gap between copies
+                    constexpr float PASTE_MIN_OFFSET = 80.0f; // guard against zero-width edge case
+
                     bool moved = true;
-                    while (moved)
+                    int loopGuard = 0; // belt-and-suspenders against an impossible infinite loop
+                    while (moved && loopGuard++ < 500)
                     {
                         moved = false;
-                        // is there a model in the same location of the same type ... if so offset the pasting of the model
                         for (const auto& it : xlights->AllModels)
                         {
-                            if (nda == it.second->GetDisplayAs())
+                            if (nda != it.second->GetDisplayAs()) continue;
+
+                            auto pos = it.second->GetBaseObjectScreenLocation().GetWorldPosition();
+                            float itWidth = std::max(it.second->GetRestorableMWidth(), PASTE_MIN_OFFSET);
+                            float itHalf = itWidth * 0.5f;
+
+                            // Centre-distance overlap along X, exact match along Y/Z.
+                            // The paste is being offset along X only (historical
+                            // behaviour) so Y/Z still use the integer centre match.
+                            if ((int)pos.y == ny &&
+                                (int)pos.z == nz &&
+                                std::abs(static_cast<float>(nx) - pos.x) < itHalf)
                             {
-                                auto pos = it.second->GetBaseObjectScreenLocation().GetWorldPosition();
-                                auto x = (int)pos.x;
-                                auto y = (int)pos.y;
-                                auto z = (int)pos.z;
-                                if (nx == x &&
-                                    ny == y &&
-                                    nz == z)
-                                {
-                                    nx += 40;
-                                    SetXmlNodeAttribute(nd, "WorldPosX", fmt::format("{:6.4f}", (float)nx));
-                                    moved = true;
-                                    break;
-                                }
+                                nx = static_cast<int>(pos.x + itHalf + PASTE_PADDING);
+                                SetXmlNodeAttribute(nd, "WorldPosX",
+                                                    fmt::format("{:6.4f}", (float)nx));
+                                moved = true;
+                                break;
                             }
                         }
                     }

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -7980,7 +7980,14 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
                                     (int)pos.z == nz &&
                                     std::abs(static_cast<float>(nx) - pos.x) < itHalf)
                                 {
-                                    nx = static_cast<int>(pos.x + itHalf + PASTE_PADDING);
+                                    // Move our centre clear of BOTH halves: past the old
+                                    // model's right edge by approximately one full width
+                                    // (old half + ours, assuming similar size since we
+                                    // already filtered by matching DisplayAs above) plus
+                                    // a padding gap. The previous formula only added
+                                    // half + padding, which left our left half sliding
+                                    // back into the old model's body.
+                                    nx = static_cast<int>(pos.x + itWidth + PASTE_PADDING);
                                     SetXmlNodeAttribute(nd, "WorldPosX",
                                                         fmt::format("{:6.4f}", (float)nx));
                                     moved = true;

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -7889,23 +7889,6 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
         if (wxTheClipboard->Open()) {
             CreateUndoPoint("All", selectedBaseObject == nullptr ? "" : selectedBaseObject->name);
 
-            // Clear any existing selection before creating the new model. Without
-            // this the original (source) model stays Selected() from the Ctrl-C
-            // action, and when WORK_RELOAD_MODELLIST fires with the new model's
-            // name as a selection hint BOTH end up highlighted in the preview.
-            // Users expect only the freshly-pasted model to be selected.
-            //
-            // UnSelectAllModels() clears the per-Model Selected() flags and our
-            // own selection tracking vectors, but does NOT clear the
-            // wxTreeListCtrl widget's native selection. On a multi-select tree
-            // (wxTL_MULTIPLE) an old selected row lingers, and when
-            // SelectBaseObject -> SelectModelInTree -> TreeListViewModels->Select()
-            // runs after reload it ADDS to the existing tree selection rather
-            // than replacing it - which is why the original still looks
-            // selected after paste. Clear both.
-            UnSelectAllModels();
-            UnSelectAllModelsInTree();
-
             wxTextDataObject data;
             wxTheClipboard->GetData(data);
 
@@ -7921,6 +7904,23 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
 
                 if (nd)
                 {
+                    // Clear any existing selection ONLY after we've confirmed the
+                    // clipboard has valid paste data - otherwise a failed paste
+                    // (empty clipboard, bad XML) would wipe the user's selection
+                    // for nothing. See Copilot review on PR #6192.
+                    //
+                    // UnSelectAllModels() clears the per-Model Selected() flags
+                    // and our own tracking vectors. It does NOT clear the
+                    // wxTreeListCtrl widget's native selection though - on a
+                    // multi-select tree (wxTL_MULTIPLE) the old row lingers and
+                    // the post-reload SelectBaseObject->SelectModelInTree adds
+                    // the new row to it instead of replacing it. Hence we also
+                    // need UnSelectAllModelsInTree() to call
+                    // TreeListViewModels->UnselectAll() so only the new copy
+                    // ends up highlighted.
+                    UnSelectAllModels();
+                    UnSelectAllModelsInTree();
+
                     auto nda = DisplayAsTypeFromString(nd.attribute("DisplayAs").as_string());
                     auto nx = (int)nd.attribute("WorldPosX").as_double();
                     auto ny = (int)nd.attribute("WorldPosY").as_double();
@@ -7949,35 +7949,55 @@ void LayoutPanel::DoPaste(wxCommandEvent& event) {
                     // behaviour as before, so e.g. an Arches paste doesn't get
                     // pushed past unrelated Pixel Matrixes that happen to be
                     // nearby.
+                    //
+                    // ViewObject pastes (Images / Meshes) use a separate
+                    // coordinate space and overlap detection isn't meaningful
+                    // against AllModels entries, so we scope the loop to the
+                    // Model paste path only. See Copilot review on PR #6192.
                     constexpr float PASTE_PADDING = 20.0f; // extra gap between copies
                     constexpr float PASTE_MIN_OFFSET = 80.0f; // guard against zero-width edge case
+                    constexpr int   PASTE_LOOP_MAX  = 500; // safety cap
 
-                    bool moved = true;
-                    int loopGuard = 0; // belt-and-suspenders against an impossible infinite loop
-                    while (moved && loopGuard++ < 500)
+                    if (!copyData.IsViewObject())
                     {
-                        moved = false;
-                        for (const auto& it : xlights->AllModels)
+                        bool moved = true;
+                        int loopGuard = 0;
+                        while (moved && loopGuard++ < PASTE_LOOP_MAX)
                         {
-                            if (nda != it.second->GetDisplayAs()) continue;
-
-                            auto pos = it.second->GetBaseObjectScreenLocation().GetWorldPosition();
-                            float itWidth = std::max(it.second->GetRestorableMWidth(), PASTE_MIN_OFFSET);
-                            float itHalf = itWidth * 0.5f;
-
-                            // Centre-distance overlap along X, exact match along Y/Z.
-                            // The paste is being offset along X only (historical
-                            // behaviour) so Y/Z still use the integer centre match.
-                            if ((int)pos.y == ny &&
-                                (int)pos.z == nz &&
-                                std::abs(static_cast<float>(nx) - pos.x) < itHalf)
+                            moved = false;
+                            for (const auto& it : xlights->AllModels)
                             {
-                                nx = static_cast<int>(pos.x + itHalf + PASTE_PADDING);
-                                SetXmlNodeAttribute(nd, "WorldPosX",
-                                                    fmt::format("{:6.4f}", (float)nx));
-                                moved = true;
-                                break;
+                                if (nda != it.second->GetDisplayAs()) continue;
+
+                                auto pos = it.second->GetBaseObjectScreenLocation().GetWorldPosition();
+                                float itWidth = std::max(it.second->GetRestorableMWidth(), PASTE_MIN_OFFSET);
+                                float itHalf = itWidth * 0.5f;
+
+                                // Centre-distance overlap along X, exact match along Y/Z.
+                                // The paste is being offset along X only (historical
+                                // behaviour) so Y/Z still use the integer centre match.
+                                if ((int)pos.y == ny &&
+                                    (int)pos.z == nz &&
+                                    std::abs(static_cast<float>(nx) - pos.x) < itHalf)
+                                {
+                                    nx = static_cast<int>(pos.x + itHalf + PASTE_PADDING);
+                                    SetXmlNodeAttribute(nd, "WorldPosX",
+                                                        fmt::format("{:6.4f}", (float)nx));
+                                    moved = true;
+                                    break;
+                                }
                             }
+                        }
+                        // Surface the pathological case in the log rather than
+                        // silently pasting a potentially still-overlapping copy.
+                        // PASTE_LOOP_MAX is a very high ceiling (500 collisions
+                        // in a row) so hitting it likely indicates a bug in the
+                        // position math or a genuinely saturated layout.
+                        if (loopGuard >= PASTE_LOOP_MAX) {
+                            spdlog::warn("LayoutPanel::DoPaste: collision-avoidance "
+                                         "loop hit the {}-iteration safety cap; the "
+                                         "pasted copy may still visually overlap an "
+                                         "existing model at x={}.", PASTE_LOOP_MAX, nx);
                         }
                     }
 


### PR DESCRIPTION
## Summary

Fixes two related user-visible bugs in copy/paste on the Layout tab:

1. **Copy lands on top of (or inside) another model** — previously the paste bumped the XML position by a fixed 40 world units when an exact integer-centre match was detected. Both parts were too weak: small enough not to matter visually against a wide matrix, and exact-centre matching missed the common case where the paste lands inside a wide model's bounding box without being on its exact centre.

2. **Both the original and the new copy were left selected** after a paste. The user expects only the fresh copy to be highlighted.

## Fix #1 — offset by the collided model's own width

The overlap test is now:

```cpp
|paste_x - other.pos.x| < other.GetRestorableMWidth() / 2
```

(plus exact integer match on Y/Z, which are historically not bumped). When a collision is detected, the bump is `other.width + 20 padding`. So:

- A small 50-unit arch bumps by ~70 world units
- A large 600-unit matrix bumps by ~620 world units
- The copy always lands *just past* whatever it would overlap, regardless of size

This also fixes the repeated-paste cascade: each subsequent `Ctrl-V` steps past the full extent of every already-placed copy, so stacking copies run out to the right in clean single-model-width increments instead of occasionally landing inside a neighbour.

A small `loopGuard` caps the search at 500 iterations as a belt-and-suspenders against pathological cases (no real layout has 500 identical models in a straight row).

## Fix #2 — clear the tree-widget selection before paste

Root cause: the models tree is a `wxTreeListCtrl` with `wxTL_MULTIPLE` style. `UnSelectAllModels()` clears our per-Model `Selected()` bools and internal tracking vectors but does **not** call `TreeListViewModels->UnselectAll()`. So when `WORK_RELOAD_MODELLIST` eventually runs `SelectBaseObject -> SelectModelInTree -> TreeListViewModels->Select(newItem)` on the new copy, the native widget **adds** the new row to the existing selection rather than replacing it — leaving both highlighted.

Fix: call both `UnSelectAllModels()` and `UnSelectAllModelsInTree()` at the start of `DoPaste`. The latter invokes `TreeListViewModels->UnselectAll() + PlatformHandleSelectionChanged()`, so the post-reload selection starts from a clean slate.

## Files changed

- `src-ui-wx/layout/LayoutPanel.cpp` — only

No new files, no project file updates needed for Windows / macOS / Linux.

## Test plan

- [x] Build green on macOS Debug and Release (universal arm64 + x86_64)
- [x] Select a prop, Ctrl-C, Ctrl-V — copy lands clearly beside original, not overlapping
- [x] Press Ctrl-V repeatedly — each copy cascades further right, no stacking
- [x] Works for small props (arches) and large matrices alike — offset scales to each model's width
- [x] Only the newly-pasted copy is selected after paste (both in tree and preview)
- [ ] Windows / Linux smoke test — code is pure wx + std, no platform-specific APIs
