### PR TITLE
DmxMovingHeadAdv: Position Zones enhancements - spinner inputs, instructions, preview indicator, and preferences

### DIFF
--- a/src-core/graphics/IModelPreview.h
+++ b/src-core/graphics/IModelPreview.h
@@ -77,4 +77,5 @@ public:
     // --- State queries ---
     virtual bool Is3D() const = 0;
     virtual bool IsNoCurrentModel() = 0;
+    virtual bool GetShowZoneIndicator() const { return false; }
 };

--- a/src-core/models/DMX/DmxMovingHeadAdv.cpp
+++ b/src-core/models/DMX/DmxMovingHeadAdv.cpp
@@ -597,6 +597,36 @@ void DmxMovingHeadAdv::DrawModel(IModelPreview* preview, xlGraphicsContext* ctx,
         pan_angle_raw -= 360.0f;
     pan_angle_raw = 360.0f - pan_angle_raw;
 
+    // draw zone-active indicator ring at fixture base when a position zone is being applied
+    if (active && !position_zones.empty() && preview->GetShowZoneIndicator()) {
+        int panCoarse = pan_motor->GetChannelCoarse();
+        int tiltCoarse = tilt_motor->GetChannelCoarse();
+        int panVal = (panCoarse > 0 && panCoarse <= (int)Nodes.size()) ? GetChannelValue(panCoarse - 1, false) : -1;
+        int tiltVal = (tiltCoarse > 0 && tiltCoarse <= (int)Nodes.size()) ? GetChannelValue(tiltCoarse - 1, false) : -1;
+        bool zoneActive = false;
+        for (const auto& zone : position_zones) {
+            if (panVal >= zone.pan_min && panVal <= zone.pan_max &&
+                tiltVal >= zone.tilt_min && tiltVal <= zone.tilt_max) {
+                zoneActive = true;
+                break;
+            }
+        }
+        if (zoneActive) {
+            xlColor ringColor(255, 140, 0, 220);
+            float zOff = sbl * 0.5f;
+            float ro = sbl * 0.45f;
+            float ri = sbl * 0.34f;
+            auto svac = sprogram->getAccumulator();
+            int rs = svac->getCount();
+            svac->AddCircleAsTriangles(0, 0, zOff,          ro, ringColor, ringColor, 0, 48);
+            svac->AddCircleAsTriangles(0, 0, zOff + 0.01f, ri, xlBLACK,   xlBLACK,   0, 48);
+            int re = svac->getCount();
+            sprogram->addStep([=](xlGraphicsContext* ctx) {
+                ctx->drawTriangles(svac, rs, re - rs);
+            });
+        }
+    }
+
     auto vac = tprogram->getAccumulator();
     int start = vac->getCount();
     Draw3DBeam(vac, beam_color, beam_length_displayed, pan_angle_raw, tilt_angle, shutter_open, beam_ability->GetBeamYOffset());

--- a/src-core/render/RenderContext.h
+++ b/src-core/render/RenderContext.h
@@ -86,6 +86,8 @@ public:
     // ---- misc ----
     virtual void SuspendAutoSave(bool suspend) = 0;
     virtual bool IsLowDefinitionRender() const { return false; }
+    virtual bool GetEnablePositionZones() const { return true; }
+    virtual bool GetShowZoneIndicator() const { return false; }
 
     // ---- UI callbacks (nullptr when running headless) ----
     virtual UICallbacks* GetUICallbacks() { return nullptr; }

--- a/src-core/render/RenderEngine.cpp
+++ b/src-core/render/RenderEngine.cpp
@@ -769,11 +769,13 @@ public:
             buffer->GetColors(&((*seqData)[frame][0]), rangeRestriction);
 
             // Position Zone processing (DMX)
-            const Model* model = buffer->GetModel();
-            if (model != nullptr && model->GetDisplayAs() == DisplayAsType::DmxMovingHeadAdv) {
-                const DmxMovingHeadAdv* mh = dynamic_cast<const DmxMovingHeadAdv*>(model);
-                if (mh != nullptr) {
-                    mh->ApplyPositionZones(&((*seqData)[frame][0]), mh->GetFirstChannel());
+            if (_ctx->GetEnablePositionZones()) {
+                const Model* model = buffer->GetModel();
+                if (model != nullptr && model->GetDisplayAs() == DisplayAsType::DmxMovingHeadAdv) {
+                    const DmxMovingHeadAdv* mh = dynamic_cast<const DmxMovingHeadAdv*>(model);
+                    if (mh != nullptr) {
+                        mh->ApplyPositionZones(&((*seqData)[frame][0]), mh->GetFirstChannel());
+                    }
                 }
             }
         }

--- a/src-ui-wx/layout/ModelPreview.cpp
+++ b/src-ui-wx/layout/ModelPreview.cpp
@@ -1609,5 +1609,9 @@ void ModelPreview::AddGridToAccumulator(const glm::mat4& ViewScale)
             ctx->drawLines(grid2d, xlGREENTRANSLUCENT, grid2d->getCount() - 8, 8);
         });
     }
-    
+
+}
+
+bool ModelPreview::GetShowZoneIndicator() const {
+    return xlights != nullptr && xlights->GetShowZoneIndicator();
 }

--- a/src-ui-wx/layout/ModelPreview.h
+++ b/src-ui-wx/layout/ModelPreview.h
@@ -151,6 +151,7 @@ public:
     void SetDisplay2DCenter0(bool bb) { _center2D0 = bb; grid2dValid=false; }
 
     bool IsNoCurrentModel() override { return currentModel == "&---none---&"; }
+    bool GetShowZoneIndicator() const override;
 
     void AddBoundingBoxToAccumulator(int x1, int y1, int x2, int y2);
 

--- a/src-ui-wx/modelproperties/adapters/PositionZoneDialog.cpp
+++ b/src-ui-wx/modelproperties/adapters/PositionZoneDialog.cpp
@@ -5,6 +5,7 @@
 #include <wx/string.h>
 //*)
 #include <wx/msgdlg.h>
+#include <wx/stattext.h>
 
 //(*IdInit(PositionZoneDialog)
 const wxWindowID PositionZoneDialog::ID_GRID_Zones = wxNewId();
@@ -58,14 +59,28 @@ PositionZoneDialog::PositionZoneDialog(std::vector<PositionZone>& zones, wxWindo
     Connect(ID_BUTTON_DeleteZone, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&PositionZoneDialog::OnButton_DeleteZoneClick);
     //*)
 
-    // restrict all columns to integer input
-    Grid_Zones->SetDefaultEditor(new wxGridCellNumberEditor());
-    Grid_Zones->SetColFormatNumber(0);
-    Grid_Zones->SetColFormatNumber(1);
-    Grid_Zones->SetColFormatNumber(2);
-    Grid_Zones->SetColFormatNumber(3);
-    Grid_Zones->SetColFormatNumber(4);
-    Grid_Zones->SetColFormatNumber(5);
+    // instruction text above the grid
+    wxStaticText* helpText = new wxStaticText(this, wxID_ANY,
+        "Define zones that trigger a DMX channel output when the moving head enters that pan/tilt range.\n"
+        "  \u2022  Pan Min/Max: pan channel value range (0-255) that defines this zone\n"
+        "  \u2022  Tilt Min/Max: tilt channel value range (0-255) that defines this zone\n"
+        "  \u2022  Channel: DMX channel number to set when the head is inside this zone\n"
+        "  \u2022  Value: DMX value (0-255) to send on that channel");
+    FlexGridSizer1->Prepend(helpText, 0, wxALL | wxEXPAND, 8);
+
+    // per-column spin editors with min/max ranges
+    auto makeAttr = [](int min, int max) {
+        wxGridCellAttr* attr = new wxGridCellAttr();
+        attr->SetEditor(new wxGridCellNumberEditor(min, max));
+        attr->SetRenderer(new wxGridCellNumberRenderer());
+        return attr;
+    };
+    Grid_Zones->SetColAttr(0, makeAttr(0, 255));   // Pan Min
+    Grid_Zones->SetColAttr(1, makeAttr(0, 255));   // Pan Max
+    Grid_Zones->SetColAttr(2, makeAttr(0, 255));   // Tilt Min
+    Grid_Zones->SetColAttr(3, makeAttr(0, 255));   // Tilt Max
+    Grid_Zones->SetColAttr(4, makeAttr(1, 512));   // Channel
+    Grid_Zones->SetColAttr(5, makeAttr(0, 255));   // Value
 
     for (const auto& zone : _zones) {
         int row = Grid_Zones->GetNumberRows();

--- a/src-ui-wx/modelproperties/adapters/PositionZoneDialog.cpp
+++ b/src-ui-wx/modelproperties/adapters/PositionZoneDialog.cpp
@@ -60,13 +60,18 @@ PositionZoneDialog::PositionZoneDialog(std::vector<PositionZone>& zones, wxWindo
     //*)
 
     // instruction text above the grid
-    wxStaticText* helpText = new wxStaticText(this, wxID_ANY,
-        "Define zones that trigger a DMX channel output when the moving head enters that pan/tilt range.\n"
-        "  \u2022  Pan Min/Max: pan channel value range (0-255) that defines this zone\n"
-        "  \u2022  Tilt Min/Max: tilt channel value range (0-255) that defines this zone\n"
-        "  \u2022  Channel: DMX channel number to set when the head is inside this zone\n"
-        "  \u2022  Value: DMX value (0-255) to send on that channel");
+    const wxString bullet(wxUniChar(0x2022));
+    const wxString helpTextLabel = wxString::Format(
+        _("Define zones that trigger a DMX channel output when the moving head enters that pan/tilt range.\n"
+          "  %s  Pan Min/Max: pan channel value range (0-255) that defines this zone\n"
+          "  %s  Tilt Min/Max: tilt channel value range (0-255) that defines this zone\n"
+          "  %s  Channel: DMX channel number to set when the head is inside this zone\n"
+          "  %s  Value: DMX value (0-255) to send on that channel"),
+        bullet, bullet, bullet, bullet);
+    wxStaticText* helpText = new wxStaticText(this, wxID_ANY, helpTextLabel);
     FlexGridSizer1->Prepend(helpText, 0, wxALL | wxEXPAND, 8);
+    FlexGridSizer1->RemoveGrowableRow(0);
+    FlexGridSizer1->AddGrowableRow(1);
 
     // per-column spin editors with min/max ranges
     auto makeAttr = [](int min, int max) {

--- a/src-ui-wx/preferences/OtherSettingsPanel.cpp
+++ b/src-ui-wx/preferences/OtherSettingsPanel.cpp
@@ -56,6 +56,8 @@ const wxWindowID OtherSettingsPanel::ID_TEXTCTRL1 = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_CHECKBOX9 = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_STATICTEXT7 = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_CTRLPINGINTERVAL = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHECKBOX10 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHECKBOX11 = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(OtherSettingsPanel,wxPanel)
@@ -70,6 +72,7 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     wxFlexGridSizer* FlexGridSizer1;
     wxFlexGridSizer* FlexGridSizer2;
     wxFlexGridSizer* FlexGridSizer3;
+    wxFlexGridSizer* FlexGridSizer4;
     wxFlexGridSizer* FlexGridSizer5;
     wxFlexGridSizer* FlexGridSizer6;
     wxFlexGridSizer* FlexGridSizer7;
@@ -79,6 +82,7 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     wxStaticBoxSizer* StaticBoxSizer1;
     wxStaticBoxSizer* StaticBoxSizer2;
     wxStaticBoxSizer* StaticBoxSizer3;
+    wxStaticBoxSizer* StaticBoxSizer4;
     wxStaticText* StaticText1;
 
     Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("wxID_ANY"));
@@ -189,6 +193,16 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     CtrlPingInterval->SetValue(_T("0"));
     FlexGridSizer8->Add(CtrlPingInterval, 1, wxALL|wxEXPAND, 5);
     GridBagSizer1->Add(FlexGridSizer8, wxGBPosition(10, 0), wxDefaultSpan, wxALL, 0);
+    StaticBoxSizer4 = new wxStaticBoxSizer(wxHORIZONTAL, this, _("Moving Head Adv - Position Zones"));
+    FlexGridSizer4 = new wxFlexGridSizer(0, 1, 0, 0);
+    CheckBox_EnablePositionZones = new wxCheckBox(this, ID_CHECKBOX10, _("Enable Position Zones"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX10"));
+    CheckBox_EnablePositionZones->SetValue(true);
+    FlexGridSizer4->Add(CheckBox_EnablePositionZones, 1, wxALL, 5);
+    CheckBox_ShowZoneIndicator = new wxCheckBox(this, ID_CHECKBOX11, _("Show Zone Indicator in Preview"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX11"));
+    CheckBox_ShowZoneIndicator->SetValue(false);
+    FlexGridSizer4->Add(CheckBox_ShowZoneIndicator, 1, wxALL, 5);
+    StaticBoxSizer4->Add(FlexGridSizer4, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    GridBagSizer1->Add(StaticBoxSizer4, wxGBPosition(11, 0), wxGBSpan(2, 1), wxALL|wxEXPAND, 0);
     SetSizer(GridBagSizer1);
 
     Connect(ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
@@ -209,6 +223,8 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     Connect(ID_TEXTCTRL1, wxEVT_COMMAND_TEXT_ENTER, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
     Connect(ID_CHECKBOX9, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
     Connect(ID_CTRLPINGINTERVAL, wxEVT_SPINCTRLDOUBLE, (wxObjectEventFunction)&OtherSettingsPanel::OnSpinCtrlDoubleBitrateChange);
+    Connect(ID_CHECKBOX10, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHECKBOX11, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
     Connect(wxEVT_PAINT, (wxObjectEventFunction)&OtherSettingsPanel::OnPaint);
     //*)
 
@@ -257,6 +273,8 @@ bool OtherSettingsPanel::TransferDataFromWindow() {
     frame->SetVideoExportBitrate(SpinCtrlDoubleBitrate->GetValue());
     frame->SetMinTipLevel(Choice_MinTipLevel->GetStringSelection());
     frame->SetRecycleTips(!CheckBox_RecycleTips->GetValue());
+    frame->SetEnablePositionZones(CheckBox_EnablePositionZones->GetValue());
+    frame->SetShowZoneIndicator(CheckBox_ShowZoneIndicator->GetValue());
     return true;
 }
 
@@ -281,6 +299,8 @@ bool OtherSettingsPanel::TransferDataToWindow() {
     SpinCtrlDoubleBitrate->SetValue(frame->GetVideoExportBitrate());
     Choice_MinTipLevel->SetStringSelection(frame->GetMinTipLevel());
     CheckBox_RecycleTips->SetValue(!frame->GetRecycleTips());
+    CheckBox_EnablePositionZones->SetValue(frame->GetEnablePositionZones());
+    CheckBox_ShowZoneIndicator->SetValue(frame->GetShowZoneIndicator());
 
 // Remove attempt to sneak functionality into the windows build
 #ifndef __WXMSW__

--- a/src-ui-wx/preferences/OtherSettingsPanel.h
+++ b/src-ui-wx/preferences/OtherSettingsPanel.h
@@ -34,9 +34,11 @@ class OtherSettingsPanel: public wxPanel
 
 		//(*Declarations(OtherSettingsPanel)
 		wxCheckBox* CheckBox_BatchRenderPromptIssues;
+		wxCheckBox* CheckBox_EnablePositionZones;
 		wxCheckBox* CheckBox_IgnoreVendorModelRecommendations;
 		wxCheckBox* CheckBox_PurgeDownloadCache;
 		wxCheckBox* CheckBox_RecycleTips;
+		wxCheckBox* CheckBox_ShowZoneIndicator;
 		wxCheckBox* ExcludeAudioCheckBox;
 		wxCheckBox* ExcludePresetsCheckBox;
 		wxCheckBox* GPURenderCheckbox;
@@ -87,6 +89,8 @@ class OtherSettingsPanel: public wxPanel
 		static const wxWindowID ID_CHECKBOX9;
 		static const wxWindowID ID_STATICTEXT7;
 		static const wxWindowID ID_CTRLPINGINTERVAL;
+		static const wxWindowID ID_CHECKBOX10;
+		static const wxWindowID ID_CHECKBOX11;
 		//*)
 
 	private:

--- a/src-ui-wx/wxsmith/OtherSettingsPanel.wxs
+++ b/src-ui-wx/wxsmith/OtherSettingsPanel.wxs
@@ -371,6 +371,43 @@
 				<flag>wxALL</flag>
 				<option>1</option>
 			</object>
+			<object class="sizeritem">
+				<object class="wxStaticBoxSizer" variable="StaticBoxSizer4" member="no">
+					<label>Moving Head Adv - Position Zones</label>
+					<object class="sizeritem">
+						<object class="wxFlexGridSizer" variable="FlexGridSizer4" member="no">
+							<cols>1</cols>
+							<object class="sizeritem">
+								<object class="wxCheckBox" name="ID_CHECKBOX10" variable="CheckBox_EnablePositionZones" member="yes">
+									<label>Enable Position Zones</label>
+									<checked>1</checked>
+									<handler function="OnControlChanged" entry="EVT_CHECKBOX" />
+								</object>
+								<flag>wxALL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxCheckBox" name="ID_CHECKBOX11" variable="CheckBox_ShowZoneIndicator" member="yes">
+									<label>Show Zone Indicator in Preview</label>
+									<handler function="OnControlChanged" entry="EVT_CHECKBOX" />
+								</object>
+								<flag>wxALL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<rowspan>2</rowspan>
+				<col>0</col>
+				<row>11</row>
+				<flag>wxALL|wxEXPAND</flag>
+				<option>1</option>
+			</object>
 		</object>
 	</object>
 </wxsmith>

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -1831,6 +1831,8 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
 
     config->Read("xLightsPurgeDownloadCacheOnStart", &_purgeDownloadCacheOnStart, false);
     spdlog::debug("Purge download cache on start: {}.", toStr(_purgeDownloadCacheOnStart));
+    config->Read("xLightsEnablePositionZones", &_enablePositionZones, true);
+    config->Read("xLightsShowZoneIndicator", &_showZoneIndicator, false);
 
     config->Read("xLightsVideoExportCodec", &_videoExportCodec, "H.264");
     spdlog::debug("Video Export Codec: {}.", (const char*)_videoExportCodec.c_str());
@@ -2437,6 +2439,8 @@ xLightsFrame::~xLightsFrame()
     config->Write("xLightsIgnoreVendorModelRecommendations2", _ignoreVendorModelRecommendations);
     config->Write("xLightsControllerPingInterval", _controllerPingInterval);
     config->Write("xLightsPurgeDownloadCacheOnStart", _purgeDownloadCacheOnStart);
+    config->Write("xLightsEnablePositionZones", _enablePositionZones);
+    config->Write("xLightsShowZoneIndicator", _showZoneIndicator);
     config->Write("xLightsExcludeAudioPkgSeq", _excludeAudioFromPackagedSequences);
     config->Write("xLightsShowACLights", _showACLights);
     config->Write("xLightsShowACRamps", _showACRamps);

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -1161,6 +1161,8 @@ public:
     bool _renderBellEnabled = false;
     bool _ignoreVendorModelRecommendations = false;
     bool _purgeDownloadCacheOnStart = false;
+    bool _enablePositionZones = true;
+    bool _showZoneIndicator = false;
     int _controllerPingInterval = 0;
     int _fseqVersion;
     int _timelineZooming;
@@ -1324,6 +1326,10 @@ public:
 
     bool GetPurgeDownloadCacheOnStart() const { return _purgeDownloadCacheOnStart; }
     void SetPurgeDownloadCacheOnStart(bool b) { _purgeDownloadCacheOnStart = b; }
+    bool GetEnablePositionZones() const { return _enablePositionZones; }
+    void SetEnablePositionZones(bool b) { _enablePositionZones = b; }
+    bool GetShowZoneIndicator() const { return _showZoneIndicator; }
+    void SetShowZoneIndicator(bool b) { _showZoneIndicator = b; }
 
     bool GetRecycleTips() const;
     void SetRecycleTips(bool b);


### PR DESCRIPTION
 - **Spinner inputs**: All grid columns in the Position Zones dialog now use spin controls
    with appropriate min/max ranges (0-255 for pan/tilt/value, 1-512 for channel)
  - **Help text**: Added a brief description and bullet points at the top of the dialog
    explaining what each column means, for users unfamiliar with the feature
  - **Zone active indicator**: An orange ring is drawn on the moving head in the house
    preview when the head's current pan/tilt position falls within an active zone
  - **Preferences**: Two new options under Other Settings:
    - *Enable Position Zones* — globally enables/disables zone processing during render
    - *Show Zone Indicator in Preview* — controls whether the orange ring appears in
      the house preview (off by default)

<img width="730" height="344" alt="image" src="https://github.com/user-attachments/assets/a3e0e77f-ecb3-4ac1-938e-966d5bf66211" />

<img width="912" height="772" alt="image" src="https://github.com/user-attachments/assets/59f34018-fb0c-43ac-9dee-7198617e242e" />

<img width="515" height="1267" alt="image" src="https://github.com/user-attachments/assets/ddc25fd7-d76a-46df-92a4-2925fe3f23cf" />

