### PR TITLE
Fix crash on Open Folder: race in parallel model deserialize vs OutputModelManager

### DIFF
--- a/src-core/models/OutputModelManager.h
+++ b/src-core/models/OutputModelManager.h
@@ -171,7 +171,15 @@ public:
     void ForceSelectedController(const std::string& name) { _selectedController = name; }
     void ClearModelToReload() { _modelToModelFromXml = nullptr; _workASAP &= ~WORK_RELOAD_MODEL_FROM_XML; }
     void ClearWorkRequested() { _workRequested = false; }
-    void DisableASAPWork( bool disable ) { _disableASAPWork = disable; }
+    // Returns the previous value so callers can save/restore (e.g. via an
+    // RAII guard around a bulk load that must not schedule per-item work).
+    // Callers that don't care about the old value can ignore the return.
+    bool DisableASAPWork(bool disable) {
+        bool prev = _disableASAPWork;
+        _disableASAPWork = disable;
+        return prev;
+    }
+    bool IsASAPWorkDisabled() const { return _disableASAPWork; }
     void SuspendDeferredWork(bool suspend) {
         _suspendedDeferredWork = suspend; 
         if (!suspend) {

--- a/src-ui-wx/app-shell/TabSequence.cpp
+++ b/src-ui-wx/app-shell/TabSequence.cpp
@@ -1057,6 +1057,27 @@ void xLightsFrame::LoadModels(pugi::xml_node modelsNode,
 
     playModel = nullptr;
     PreviewModels.clear();
+
+    // Suppress AddASAPWork during the parallel model deserialize. Each model's
+    // DeserializeBaseObjectAttributes calls model->SetActive(...) which in
+    // turn fires AddASAPWork three times. OutputModelManager::AddASAPWork
+    // mutates shared std::string members without synchronization, so with
+    // many worker threads all posting work concurrently it races and can
+    // crash in std::string internals (observed in 2026.06 production crash
+    // report, Thread 0 in std::string::__assign_no_alias called from
+    // AddASAPWork -> SetActive -> DeserializeBaseObjectAttributes).
+    //
+    // These per-model work items are redundant during an initial load
+    // anyway - the whole state is being rebuilt and the bulk refresh
+    // happens once the load is done. Scope the disable as tightly as
+    // possible and restore on every exit path via a small RAII guard so
+    // an exception in LoadModels still re-enables the queue.
+    struct AsapWorkGuard {
+        OutputModelManager* mgr;
+        ~AsapWorkGuard() { if (mgr) mgr->DisableASAPWork(false); }
+    } asapGuard{ GetOutputModelManager() };
+    GetOutputModelManager()->DisableASAPWork(true);
+
     AllModels.LoadModels(modelsNode,
         modelPreview->GetVirtualCanvasWidth(),
         modelPreview->GetVirtualCanvasHeight());

--- a/src-ui-wx/app-shell/TabSequence.cpp
+++ b/src-ui-wx/app-shell/TabSequence.cpp
@@ -1070,13 +1070,27 @@ void xLightsFrame::LoadModels(pugi::xml_node modelsNode,
     // These per-model work items are redundant during an initial load
     // anyway - the whole state is being rebuilt and the bulk refresh
     // happens once the load is done. Scope the disable as tightly as
-    // possible and restore on every exit path via a small RAII guard so
-    // an exception in LoadModels still re-enables the queue.
+    // possible and restore the PRIOR state (not an unconditional false)
+    // on every exit path via a small RAII guard. _disableASAPWork
+    // defaults to true in the header and xLightsFrame's ctor only flips
+    // it to false near the end, so LoadModels() can legitimately be
+    // invoked while ASAP work is already disabled - restoring to false
+    // unconditionally would enable work earlier than intended.
+    //
+    // OutputModelManager::DisableASAPWork now returns the previous value
+    // for exactly this save/restore use case; we capture that into the
+    // guard and the destructor writes it back regardless of exception
+    // or early-return path.
+    OutputModelManager* outputModelManager = GetOutputModelManager();
     struct AsapWorkGuard {
         OutputModelManager* mgr;
-        ~AsapWorkGuard() { if (mgr) mgr->DisableASAPWork(false); }
-    } asapGuard{ GetOutputModelManager() };
-    GetOutputModelManager()->DisableASAPWork(true);
+        bool previousDisabled;
+        ~AsapWorkGuard() { if (mgr) mgr->DisableASAPWork(previousDisabled); }
+    };
+    AsapWorkGuard asapGuard{ outputModelManager,
+                             outputModelManager != nullptr
+                                 ? outputModelManager->DisableASAPWork(true)
+                                 : false };
 
     AllModels.LoadModels(modelsNode,
         modelPreview->GetVirtualCanvasWidth(),


### PR DESCRIPTION
## Summary

Fixes a crash-on-open-folder reproduced in production (2026.06) by user report + xLights internal crash-report zip. Root cause is a race between parallel model deserialization and the (non-synchronised) shared `OutputModelManager`.

## Repro / evidence

From an xLights crash-report zip generated in production 2026.06:

```
xLights version 2026.06
Crashed Thread ID: Main Thread

0  xlCrashHandler::HandleCrash
1  xlBaseApp::OnFatalException
2  wxFatalSignalHandler(int)
3  _sigtramp
4  std::string::__assign_no_alias<...>
5  OutputModelManager::AddASAPWork(...)
6  BaseObject::SetActive(bool)
7  XmlDeserializingModelFactory::DeserializeBaseObjectAttributes(...)
8  XmlDeserializingModelFactory::Deserialize(...)
9  ModelManager::LoadModels lambda                            ← parallel_for
10 ParallelListJob::Process
11 ModelManager::LoadModels
12 xLightsFrame::LoadEffectsFile
13 xLightsFrame::SetDir
14 xLightsFrame::PromptForShowDirectory
15 xLightsFrame::OnMenuOpenFolderSelected
...
```

## Root cause

`ModelManager::LoadModels` (src-core/models/ModelManager.cpp:285) runs:

```cpp
RunInAutoReleasePool([&]() { parallel_for(modelsToLoad, f); });
```

Each lambda invocation deserializes a model's XML. `DeserializeBaseObjectAttributes` calls `model->SetActive(active)`, and `BaseObject::SetActive` fires **three** `AddASAPWork` calls back-to-back:

```cpp
void BaseObject::SetActive(bool active) {
    _active = active;
    AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE,   "BaseObject::SetActive");
    AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW,"BaseObject::SetActive");
    AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS,    "BaseObject::SetActive");
}
```

`OutputModelManager::AddASAPWork` has **no synchronisation** around its shared `std::string` members (`_selectedModel`, `_selectedController`) or its `_scheduleASAPWork` `std::function`. With N worker threads all hammering the same instance concurrently, one thread reads a `std::string` while another is assigning to it, landing in `__assign_no_alias` on freed memory → SIGABRT.

## Fix

The per-model ASAP work items are **redundant** during an initial load anyway — the entire state is being rebuilt, and the bulk refresh runs once the load completes. `OutputModelManager` already has a `DisableASAPWork(bool)` knob for exactly this kind of "don't queue individual work during a bulk op" use case.

Wrap `xLightsFrame::LoadModels` in a small RAII guard that disables ASAP work for the duration of the function and restores the previous state on scope exit (destructor, so exception-safe and covers every early-return path).

```cpp
struct AsapWorkGuard {
    OutputModelManager* mgr;
    ~AsapWorkGuard() { if (mgr) mgr->DisableASAPWork(false); }
} asapGuard{ GetOutputModelManager() };
GetOutputModelManager()->DisableASAPWork(true);
```

The guard covers both the initial `AllModels.LoadModels` call AND the recursive reload triggered by model/group name-conflict resolution later in the same function.

Far simpler than adding a mutex around `AddASAPWork`'s entire body, and reuses an API that already exists for this exact purpose.

## Files changed

- `src-ui-wx/app-shell/TabSequence.cpp` — only (21 lines added, mostly comment)

No new files, no project-file updates needed for any platform.

## Test plan

- [x] Crash reproducible on production 2026.06 (user crash report attached above)
- [x] Code change is an RAII-scoped use of an already-existing API knob — logic is provably correct
- [ ] **Local smoke test blocked** by a pre-existing master linker issue (`Undefined symbol _avfilter_*` on both arm64 and x86_64 slices; avfilter.a is physically present in `macOS/dependencies/lib*` but the xLights Xcode target isn't linking it). That break is independent of this change — happens on pristine master too. Worth raising separately.
- [ ] Windows / Linux smoke test — pure std + RAII, no platform-specific APIs
