### PR TITLE
Show Face/State/SubModel/Node count badges on the Model pane

### DIFF
--- a/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
+++ b/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
@@ -389,15 +389,38 @@ void ModelPropertyAdapter::AddProperties(wxPropertyGridInterface* grid, OutputMa
     grid->Append(new wxStringProperty("Description", "Description", _model.GetDescription()));
     grid->Append(new wxEnumProperty("Preview", "ModelLayoutGroup", LAYOUT_GROUPS, wxArrayInt(), layout_group_number));
 
-    p = grid->Append(new PopupDialogProperty(&_model, outputManager, "Strand/Node Names", "ModelStrandNodeNames", CLICK_TO_EDIT, 1));
+    // Decorate the popup-dialog rows with "(N)" counts so the user can see
+    // at a glance how many Faces / States / Submodels / Nodes a model has
+    // without having to open each editor. Requested in issue #5905.
+    // The INTERNAL name (second arg) stays unchanged so property lookups by
+    // name elsewhere in the codebase keep working - only the display label
+    // (first arg) gets the count suffix.
+    const auto nodeCount   = _model.GetNodeCount();
+    const auto faceCount   = _model.GetFaceInfo().size();
+    const auto stateCount  = _model.GetStateInfo().size();
+    const auto subCount    = _model.GetNumSubModels();
+
+    p = grid->Append(new PopupDialogProperty(
+        &_model, outputManager,
+        wxString::Format("Strand/Node Names (%u nodes)", nodeCount).ToStdString(),
+        "ModelStrandNodeNames", CLICK_TO_EDIT, 1));
     grid->LimitPropertyEditing(p);
-    p = grid->Append(new PopupDialogProperty(&_model, outputManager, "Faces", "ModelFaces", CLICK_TO_EDIT, 2));
+    p = grid->Append(new PopupDialogProperty(
+        &_model, outputManager,
+        wxString::Format("Faces (%zu)", faceCount).ToStdString(),
+        "ModelFaces", CLICK_TO_EDIT, 2));
     grid->LimitPropertyEditing(p);
     p = grid->Append(new PopupDialogProperty(&_model, outputManager, "Dimming Curves", "ModelDimmingCurves", CLICK_TO_EDIT, 3));
     grid->LimitPropertyEditing(p);
-    p = grid->Append(new PopupDialogProperty(&_model, outputManager, "States", "ModelStates", CLICK_TO_EDIT, 4));
+    p = grid->Append(new PopupDialogProperty(
+        &_model, outputManager,
+        wxString::Format("States (%zu)", stateCount).ToStdString(),
+        "ModelStates", CLICK_TO_EDIT, 4));
     grid->LimitPropertyEditing(p);
-    p = grid->Append(new PopupDialogProperty(&_model, outputManager, "SubModels", "SubModels", CLICK_TO_EDIT, 5));
+    p = grid->Append(new PopupDialogProperty(
+        &_model, outputManager,
+        wxString::Format("SubModels (%d)", subCount).ToStdString(),
+        "SubModels", CLICK_TO_EDIT, 5));
     grid->LimitPropertyEditing(p);
     p = grid->Append(new PopupDialogProperty(&_model, outputManager, "Aliases", "Aliases", CLICK_TO_EDIT, 6));
     grid->LimitPropertyEditing(p);

--- a/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
+++ b/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
@@ -241,9 +241,6 @@ protected:
     int m_tp = 0;
 };
 
-// Helpers to format the popup-dialog row labels with their current counts.
-// Kept free functions so AddProperties and UpdateProperties can both reuse
-// them without duplicating the format strings. See issue #5905.
 namespace {
 wxString FormatStrandNodeNamesLabel(const Model& m) {
     const auto nodes = m.GetNodeCount();
@@ -409,16 +406,6 @@ void ModelPropertyAdapter::AddProperties(wxPropertyGridInterface* grid, OutputMa
     grid->Append(new wxStringProperty("Description", "Description", _model.GetDescription()));
     grid->Append(new wxEnumProperty("Preview", "ModelLayoutGroup", LAYOUT_GROUPS, wxArrayInt(), layout_group_number));
 
-    // Decorate the popup-dialog rows with "(N)" counts so the user can see
-    // at a glance how many Faces / States / Submodels / Nodes a model has
-    // without having to open each editor. Requested in issue #5905.
-    // The INTERNAL name (second arg to PopupDialogProperty) stays unchanged
-    // so property lookups by name elsewhere in the codebase keep working -
-    // only the display label (first arg) gets the count suffix.
-    //
-    // PopupDialogProperty takes a wxString label, so pass the formatted
-    // wxString directly - no ToStdString round-trip. Label refresh after
-    // the user edits any of these lists lives in UpdateProperties() below.
     p = grid->Append(new PopupDialogProperty(
         &_model, outputManager,
         FormatStrandNodeNamesLabel(_model),
@@ -548,10 +535,6 @@ void ModelPropertyAdapter::AddProperties(wxPropertyGridInterface* grid, OutputMa
 void ModelPropertyAdapter::UpdateProperties(wxPropertyGridInterface* grid, OutputManager* outputManager) {
     UpdateTypeProperties(grid);
 
-    // Refresh the "(N)" count suffixes on the popup-dialog rows so that
-    // after the user opens one of those editors and adds/removes entries
-    // the count in the label stays accurate instead of reflecting
-    // whatever was there when the property grid was first built. #5905.
     if (auto* pp = grid->GetPropertyByName("ModelStrandNodeNames")) {
         pp->SetLabel(FormatStrandNodeNamesLabel(_model));
     }

--- a/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
+++ b/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
@@ -241,6 +241,26 @@ protected:
     int m_tp = 0;
 };
 
+// Helpers to format the popup-dialog row labels with their current counts.
+// Kept free functions so AddProperties and UpdateProperties can both reuse
+// them without duplicating the format strings. See issue #5905.
+namespace {
+wxString FormatStrandNodeNamesLabel(const Model& m) {
+    const auto nodes = m.GetNodeCount();
+    return wxString::Format("Strand/Node Names (%u %s)",
+                            nodes, nodes == 1 ? "node" : "nodes");
+}
+wxString FormatFacesLabel(const Model& m) {
+    return wxString::Format("Faces (%zu)", m.GetFaceInfo().size());
+}
+wxString FormatStatesLabel(const Model& m) {
+    return wxString::Format("States (%zu)", m.GetStateInfo().size());
+}
+wxString FormatSubModelsLabel(const Model& m) {
+    return wxString::Format("SubModels (%d)", m.GetNumSubModels());
+}
+} // namespace
+
 class StartChannelProperty : public wxStringProperty {
 public:
     StartChannelProperty(Model* m, int strand, const wxString& label, const wxString& name,
@@ -392,34 +412,33 @@ void ModelPropertyAdapter::AddProperties(wxPropertyGridInterface* grid, OutputMa
     // Decorate the popup-dialog rows with "(N)" counts so the user can see
     // at a glance how many Faces / States / Submodels / Nodes a model has
     // without having to open each editor. Requested in issue #5905.
-    // The INTERNAL name (second arg) stays unchanged so property lookups by
-    // name elsewhere in the codebase keep working - only the display label
-    // (first arg) gets the count suffix.
-    const auto nodeCount   = _model.GetNodeCount();
-    const auto faceCount   = _model.GetFaceInfo().size();
-    const auto stateCount  = _model.GetStateInfo().size();
-    const auto subCount    = _model.GetNumSubModels();
-
+    // The INTERNAL name (second arg to PopupDialogProperty) stays unchanged
+    // so property lookups by name elsewhere in the codebase keep working -
+    // only the display label (first arg) gets the count suffix.
+    //
+    // PopupDialogProperty takes a wxString label, so pass the formatted
+    // wxString directly - no ToStdString round-trip. Label refresh after
+    // the user edits any of these lists lives in UpdateProperties() below.
     p = grid->Append(new PopupDialogProperty(
         &_model, outputManager,
-        wxString::Format("Strand/Node Names (%u nodes)", nodeCount).ToStdString(),
+        FormatStrandNodeNamesLabel(_model),
         "ModelStrandNodeNames", CLICK_TO_EDIT, 1));
     grid->LimitPropertyEditing(p);
     p = grid->Append(new PopupDialogProperty(
         &_model, outputManager,
-        wxString::Format("Faces (%zu)", faceCount).ToStdString(),
+        FormatFacesLabel(_model),
         "ModelFaces", CLICK_TO_EDIT, 2));
     grid->LimitPropertyEditing(p);
     p = grid->Append(new PopupDialogProperty(&_model, outputManager, "Dimming Curves", "ModelDimmingCurves", CLICK_TO_EDIT, 3));
     grid->LimitPropertyEditing(p);
     p = grid->Append(new PopupDialogProperty(
         &_model, outputManager,
-        wxString::Format("States (%zu)", stateCount).ToStdString(),
+        FormatStatesLabel(_model),
         "ModelStates", CLICK_TO_EDIT, 4));
     grid->LimitPropertyEditing(p);
     p = grid->Append(new PopupDialogProperty(
         &_model, outputManager,
-        wxString::Format("SubModels (%d)", subCount).ToStdString(),
+        FormatSubModelsLabel(_model),
         "SubModels", CLICK_TO_EDIT, 5));
     grid->LimitPropertyEditing(p);
     p = grid->Append(new PopupDialogProperty(&_model, outputManager, "Aliases", "Aliases", CLICK_TO_EDIT, 6));
@@ -528,6 +547,23 @@ void ModelPropertyAdapter::AddProperties(wxPropertyGridInterface* grid, OutputMa
 
 void ModelPropertyAdapter::UpdateProperties(wxPropertyGridInterface* grid, OutputManager* outputManager) {
     UpdateTypeProperties(grid);
+
+    // Refresh the "(N)" count suffixes on the popup-dialog rows so that
+    // after the user opens one of those editors and adds/removes entries
+    // the count in the label stays accurate instead of reflecting
+    // whatever was there when the property grid was first built. #5905.
+    if (auto* pp = grid->GetPropertyByName("ModelStrandNodeNames")) {
+        pp->SetLabel(FormatStrandNodeNamesLabel(_model));
+    }
+    if (auto* pp = grid->GetPropertyByName("ModelFaces")) {
+        pp->SetLabel(FormatFacesLabel(_model));
+    }
+    if (auto* pp = grid->GetPropertyByName("ModelStates")) {
+        pp->SetLabel(FormatStatesLabel(_model));
+    }
+    if (auto* pp = grid->GetPropertyByName("SubModels")) {
+        pp->SetLabel(FormatSubModelsLabel(_model));
+    }
 
     if (grid->GetPropertyByName("Controller") != nullptr) {
         grid->GetPropertyByName("Controller")->Enable(outputManager->GetAutoLayoutControllerNames().size() > 0);


### PR DESCRIPTION
Fixes #5905

## Summary

Adds `(N)` count badges to the Layout tab model-property popup-dialog rows so the user can see at a glance how many Faces / States / SubModels / Nodes a model has, without having to open each editor.

## Before / after

**Before:**
```
Strand/Node Names     <Click To Edit>
Faces                 <Click To Edit>
Dimming Curves        <Click To Edit>
States                <Click To Edit>
SubModels             <Click To Edit>
```

**After:**
```
Strand/Node Names (123 nodes)   <Click To Edit>
Faces (4)                       <Click To Edit>
Dimming Curves                  <Click To Edit>
States (2)                      <Click To Edit>
SubModels (3)                   <Click To Edit>
```

Rows still open the same editor dialogs when clicked — only the display label changed. (Dimming Curves has no obvious count to show, left as-is.)

## Implementation

One-file change in `src-ui-wx/modelproperties/ModelPropertyAdapter.cpp`. The `PopupDialogProperty` constructor already takes a label and a name as separate args — the internal **name** stays `"ModelStrandNodeNames"` / `"ModelFaces"` / `"ModelStates"` / `"SubModels"` so every property-by-name lookup elsewhere in the codebase keeps working. Only the display **label** picks up the count suffix at property-construction time.

Counts come from existing `Model` accessors:
- `GetNodeCount()` → `uint32_t`
- `GetFaceInfo().size()` → `size_t`
- `GetStateInfo().size()` → `size_t`
- `GetNumSubModels()` → `int`

No new allocations, no new public API.

## Files changed

- `src-ui-wx/modelproperties/ModelPropertyAdapter.cpp` — only

No new files, no project-file updates for Windows / macOS / Linux.

## Test plan

- [x] Models with varying counts show correct numbers
- [x] Models with zero of something show `"(0)"` (intentional — lets the user notice the absence at a glance)
- [x] Clicking each row still opens its editor dialog
- [x] Build green on macOS Release

## Closes

Closes #5905 per the issue request.
