### PR TITLE
Fix the issue with the extra comma in submodel dialog

### DIFF
--- a/src-core/utils/string_utils.h
+++ b/src-core/utils/string_utils.h
@@ -231,6 +231,8 @@ extern const std::string xlEMPTY_STRING;
     }
     inline void Split(const std::string &frag, char splitBy, std::vector<std::string>& tokens, bool trim = false)
     {
+        if (frag.empty())
+            return;
         // Loop infinitely - break is internal.
         size_t lastIdx = 0;
         while (true) {


### PR DESCRIPTION
From the intern:
 The affected callers in SubModelsDialog.cpp are SelectAllInBoundingRect, RemoveNodes, OnPreviewLeftDClick, RemoveDuplicates, RemoveAllDuplicates, and others — all added in commit e749b62c when wxSplit was
  replaced with Split. Fixing Split itself is the cleanest approach since it corrects the root cause for all call sites at once