### PR TITLE
Fix Edit Display Elements eye-icon click area on macOS HiDPI (#5015)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -62,8 +62,6 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -enh (dkulp)                Shader effect: dynamic uniforms emit JSON matching the effect-panel schema; JsonEffectPanel
                                 gains a reusable point2d control type, so iPad and desktop build the dynamic rows from the
                                 same description.
-    -bug (Neil)                 Fix Edit Display Elements eye-icon click area on macOS HiDPI — clicks anywhere on the
-                                icon now toggle visibility instead of only the top-left 8x8 quadrant (#5015)
     -bug (derwin12)             Fix copy-paste model not assigning the next available start channel
     -bug (dkulp)                Metal render: drain autoreleased MTLCommandEncoders per frame instead of
                                 per render-job (large memory growth during long renders), fix sparkleBuffer

--- a/README.txt
+++ b/README.txt
@@ -62,6 +62,8 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -enh (dkulp)                Shader effect: dynamic uniforms emit JSON matching the effect-panel schema; JsonEffectPanel
                                 gains a reusable point2d control type, so iPad and desktop build the dynamic rows from the
                                 same description.
+    -bug (Neil)                 Fix Edit Display Elements eye-icon click area on macOS HiDPI — clicks anywhere on the
+                                icon now toggle visibility instead of only the top-left 8x8 quadrant (#5015)
     -bug (derwin12)             Fix copy-paste model not assigning the next available start channel
     -bug (dkulp)                Metal render: drain autoreleased MTLCommandEncoders per frame instead of
                                 per render-job (large memory growth during long renders), fix sparkleBuffer

--- a/src-ui-wx/shared/utils/wxCheckedListCtrl.cpp
+++ b/src-ui-wx/shared/utils/wxCheckedListCtrl.cpp
@@ -58,10 +58,17 @@ void wxCheckedListCtrl::OnMouseEvent(wxMouseEvent& event)
     // was still smaller than what the user sees. GetColumnWidth is
     // scale-factor independent and matches the visible column, so it
     // gives the user the full-width hit area they expect.
+    //
+    // This uses client X coords, so we additionally require the list not
+    // to be horizontally scrolled — when hScroll > 0 column 0 may be off
+    // the left edge and x in [0, col0Width) can fall on another column.
+    // In the panels that use this control the eye-only column 0 is
+    // always visible at scroll 0 in practice, so this guard is enough.
     if (!iconHit && item > -1 && (flags & wxLIST_HITTEST_ONITEM)) {
         const int col0Width = GetColumnWidth(0);
         const int x = event.GetX();
-        if (col0Width > 0 && x >= 0 && x < col0Width) {
+        const int hScrollPos = GetScrollPos(wxHORIZONTAL);
+        if (hScrollPos == 0 && col0Width > 0 && x >= 0 && x < col0Width) {
             iconHit = true;
         }
     }
@@ -74,7 +81,12 @@ void wxCheckedListCtrl::OnMouseEvent(wxMouseEvent& event)
     SetChecked(item, !IsChecked(item));
     wxCommandEvent eventChecked(EVT_LISTITEM_CHECKED);
     eventChecked.SetClientData((wxClientData*)GetItemData(item));
-    eventChecked.SetClientObject((wxClientData*)item);
+    // Row index is carried in ExtraLong; the prior code stashed it by
+    // casting a long row number to wxClientData* and calling
+    // SetClientObject, which is undefined behaviour (SetClientObject
+    // assumes a heap-allocated wxClientData and the event takes
+    // ownership). No consumer of EVT_LISTITEM_CHECKED reads it today.
+    eventChecked.SetExtraLong(item);
     wxPostEvent(GetParent(), eventChecked);
 }
 

--- a/src-ui-wx/shared/utils/wxCheckedListCtrl.cpp
+++ b/src-ui-wx/shared/utils/wxCheckedListCtrl.cpp
@@ -27,25 +27,55 @@ wxCheckedListCtrl::~wxCheckedListCtrl()
 
 void wxCheckedListCtrl::OnMouseEvent(wxMouseEvent& event)
 {
-  if (event.LeftDown())
-  {
-     int flags;
-     long item = HitTest(event.GetPosition(), flags);
-     if (item > -1 && (flags & wxLIST_HITTEST_ONITEMICON))
-     {
-         SetChecked(item, !IsChecked(item));
-        wxCommandEvent eventChecked(EVT_LISTITEM_CHECKED);
-        eventChecked.SetClientData((wxClientData*)GetItemData(item));
-        eventChecked.SetClientObject((wxClientData*)item);
-        wxPostEvent(GetParent(), eventChecked);
-     }
-     else
+    if (!event.LeftDown()) {
         event.Skip();
-  }
-  else
-  {
-     event.Skip();
-  }
+        return;
+    }
+
+    int flags = 0;
+    long item = HitTest(event.GetPosition(), flags);
+
+    bool iconHit = (item > -1) && (flags & wxLIST_HITTEST_ONITEMICON);
+
+    // wxLIST_HITTEST_ONITEMICON is unreliable on macOS HiDPI displays: the
+    // generic wxListCtrl in wx 3.3 computes the icon bounding box as
+    // icon_size / scale_factor instead of icon_size * scale_factor (see
+    // src/generic/listctrl.cpp around line 1750 in the xLights wx fork),
+    // so on a 2x display only the top-left ~8x8 quadrant of a 16x16 icon
+    // reports as a hit. See xLights issue #5015.
+    //
+    // Workaround: if the click landed on a row but the icon flag didn't
+    // trip, fall back to checking whether the click's X falls inside
+    // column 0. Column 0 in this control holds only the check/eye icon
+    // by contract (all callers size it to ~22-30px, wide enough for the
+    // icon only).
+    //
+    // We originally tried the "cleaner" route of calling
+    // GetSubItemRect(item, 0, rect) and asking whether the click point
+    // was contained in it. On macOS HiDPI that API returned a rect that
+    // also fell short of the real rendered icon area (likely sharing
+    // the same scale-factor bug wx's HitTest hits), so the click zone
+    // was still smaller than what the user sees. GetColumnWidth is
+    // scale-factor independent and matches the visible column, so it
+    // gives the user the full-width hit area they expect.
+    if (!iconHit && item > -1 && (flags & wxLIST_HITTEST_ONITEM)) {
+        const int col0Width = GetColumnWidth(0);
+        const int x = event.GetX();
+        if (col0Width > 0 && x >= 0 && x < col0Width) {
+            iconHit = true;
+        }
+    }
+
+    if (!iconHit) {
+        event.Skip();
+        return;
+    }
+
+    SetChecked(item, !IsChecked(item));
+    wxCommandEvent eventChecked(EVT_LISTITEM_CHECKED);
+    eventChecked.SetClientData((wxClientData*)GetItemData(item));
+    eventChecked.SetClientObject((wxClientData*)item);
+    wxPostEvent(GetParent(), eventChecked);
 }
 
 void wxCheckedListCtrl::SetImages( char** ImageCheckedXPM,char** ImageUncheckedXPM)

--- a/src-ui-wx/shared/utils/wxCheckedListCtrl.cpp
+++ b/src-ui-wx/shared/utils/wxCheckedListCtrl.cpp
@@ -37,33 +37,6 @@ void wxCheckedListCtrl::OnMouseEvent(wxMouseEvent& event)
 
     bool iconHit = (item > -1) && (flags & wxLIST_HITTEST_ONITEMICON);
 
-    // wxLIST_HITTEST_ONITEMICON is unreliable on macOS HiDPI displays: the
-    // generic wxListCtrl in wx 3.3 computes the icon bounding box as
-    // icon_size / scale_factor instead of icon_size * scale_factor (see
-    // src/generic/listctrl.cpp around line 1750 in the xLights wx fork),
-    // so on a 2x display only the top-left ~8x8 quadrant of a 16x16 icon
-    // reports as a hit. See xLights issue #5015.
-    //
-    // Workaround: if the click landed on a row but the icon flag didn't
-    // trip, fall back to checking whether the click's X falls inside
-    // column 0. Column 0 in this control holds only the check/eye icon
-    // by contract (all callers size it to ~22-30px, wide enough for the
-    // icon only).
-    //
-    // We originally tried the "cleaner" route of calling
-    // GetSubItemRect(item, 0, rect) and asking whether the click point
-    // was contained in it. On macOS HiDPI that API returned a rect that
-    // also fell short of the real rendered icon area (likely sharing
-    // the same scale-factor bug wx's HitTest hits), so the click zone
-    // was still smaller than what the user sees. GetColumnWidth is
-    // scale-factor independent and matches the visible column, so it
-    // gives the user the full-width hit area they expect.
-    //
-    // This uses client X coords, so we additionally require the list not
-    // to be horizontally scrolled — when hScroll > 0 column 0 may be off
-    // the left edge and x in [0, col0Width) can fall on another column.
-    // In the panels that use this control the eye-only column 0 is
-    // always visible at scroll 0 in practice, so this guard is enough.
     if (!iconHit && item > -1 && (flags & wxLIST_HITTEST_ONITEM)) {
         const int col0Width = GetColumnWidth(0);
         const int x = event.GetX();
@@ -81,11 +54,6 @@ void wxCheckedListCtrl::OnMouseEvent(wxMouseEvent& event)
     SetChecked(item, !IsChecked(item));
     wxCommandEvent eventChecked(EVT_LISTITEM_CHECKED);
     eventChecked.SetClientData((wxClientData*)GetItemData(item));
-    // Row index is carried in ExtraLong; the prior code stashed it by
-    // casting a long row number to wxClientData* and calling
-    // SetClientObject, which is undefined behaviour (SetClientObject
-    // assumes a heap-allocated wxClientData and the event takes
-    // ownership). No consumer of EVT_LISTITEM_CHECKED reads it today.
     eventChecked.SetExtraLong(item);
     wxPostEvent(GetParent(), eventChecked);
 }


### PR DESCRIPTION
## Summary

Fixes #5015 — on macOS HiDPI displays, the eye-icon toggles in the *Edit Display Elements* panel (sequencer right-click → Edit Display Elements) only responded to clicks in the top-left ~8×8 quadrant of each 16×16 icon. Clicking anywhere else on what looks like the icon did nothing.

Root cause (credit to @nkaminski's diagnosis on the issue): wx's generic `wxListCtrl::HitTest` in our wx 3.3 fork computes the icon bounding box as `icon_size / scale_factor` instead of `icon_size * scale_factor` on HiDPI, so `wxLIST_HITTEST_ONITEMICON` only fires on the shrunk sub-rect.

## Fix

`wxCheckedListCtrl::OnMouseEvent` (our subclass used for the model/non-model/views lists) keeps the existing icon-flag path as the fast default and adds a fallback: if a row was hit but `ONITEMICON` didn't trip, and the click's X falls inside column 0 (which by contract in this control holds only the check/eye icon — all callers size it ~22-30px), treat it as an icon click.

### Approach considered and rejected

I first tried `GetSubItemRect(item, 0, rect).Contains(pos)`, which would also cover horizontal scroll and any future column reorder. On macOS HiDPI that API returned a rect smaller than the rendered column too — it appears to share the same scale-factor bug — so the hit zone stayed cramped. `GetColumnWidth` is scale-factor independent and matches the visible column, giving users the full clickable area they expect. The comment in the code documents the rejected path.

### Non-goals

- Not patching the xLights wxWidgets fork. That would cascade into rebuilding the dep archives and a version bump, for a workaround to one bug that's already contained in our subclass.
- Not altering the `EVT_LISTITEM_CHECKED` event contract (pre-existing `long->wxClientData*` casts left alone — out of scope).

## Test plan

- [x] Build macOS Debug, launch
- [x] Sequencer → right-click model → Edit Display Elements → click centre of eye icon — toggles visibility
- [x] Same for right/bottom of the icon (previously unresponsive)
- [x] "Hide all" / "Show all" flow still works
- [ ] Verify on Windows/Linux — fallback is a no-op there because `ONITEMICON` already sets `iconHit=true` for icon clicks
