### PR TITLE
Addressing Media classification on "Add..." button

### DIFF
--- a/src-core/render/SequenceMedia.cpp
+++ b/src-core/render/SequenceMedia.cpp
@@ -662,6 +662,7 @@ void SequenceMedia::Clear()
     _shaderCache.clear();
     _binaryCache.clear();
     _videoCache.clear();
+    _audioCache.clear();
 }
 
 void SequenceMedia::EmbedImage(const std::string& filepath)
@@ -808,6 +809,7 @@ bool SequenceMedia::RenameMedia(const std::string& oldPath, const std::string& n
     if (rekey(_textCache))   return true;
     if (rekey(_binaryCache)) return true;
     if (rekey(_videoCache))  return true;
+    if (rekey(_audioCache))  return true;
     return false;
 }
 
@@ -826,6 +828,7 @@ bool SequenceMedia::LoadFromXml(const pugi::xml_node& node)
     _shaderCache.clear();
     _binaryCache.clear();
     _videoCache.clear();
+    _audioCache.clear();
 
     for (auto child : node.children()) {
         std::string name = child.name();
@@ -861,6 +864,11 @@ bool SequenceMedia::LoadFromXml(const pugi::xml_node& node)
             if (entry->LoadFromXml(child)) {
                 _videoCache[entry->GetFilePath()] = entry;
             }
+        } else if (name == "Audio") {
+            auto entry = std::make_shared<AudioMediaCacheEntry>();
+            if (entry->LoadFromXml(child)) {
+                _audioCache[entry->GetFilePath()] = entry;
+            }
         }
     }
 
@@ -889,6 +897,13 @@ void SequenceMedia::SaveToXml(pugi::xml_node& parent) const
 
     // Videos are path-only (not embedded) — only save used entries
     for (const auto& pair : _videoCache) {
+        if (pair.second->IsUsed()) {
+            pair.second->SaveToXml(node);
+        }
+    }
+
+    // Audio files are path-only — only save used entries
+    for (const auto& pair : _audioCache) {
         if (pair.second->IsUsed()) {
             pair.second->SaveToXml(node);
         }
@@ -943,6 +958,9 @@ void SequenceMedia::MarkAllUnused() {
         pair.second->MarkIsUsed(false);
     }
     for (const auto& pair : _videoCache) {
+        pair.second->MarkIsUsed(false);
+    }
+    for (const auto& pair : _audioCache) {
         pair.second->MarkIsUsed(false);
     }
 }
@@ -1391,6 +1409,34 @@ void VideoMediaCacheEntry::SaveToXml(pugi::xml_node& parent) const {
 }
 
 // =====================================================================
+// AudioMediaCacheEntry Implementation
+// =====================================================================
+
+AudioMediaCacheEntry::AudioMediaCacheEntry()
+    : MediaCacheEntry(MediaType::Audio) {}
+
+AudioMediaCacheEntry::AudioMediaCacheEntry(const std::string& filePath)
+    : MediaCacheEntry(MediaType::Audio, filePath) {}
+
+void AudioMediaCacheEntry::Load() {
+    // Audio data is loaded by AudioManager in SequenceFile, not here.
+    // Just mark loading done so IsOk() returns true for path-valid entries.
+    _loadingDone = true;
+}
+
+bool AudioMediaCacheEntry::LoadFromXml(const pugi::xml_node& node) {
+    if (!node || strcmp(node.name(), "Audio") != 0) return false;
+    _filePath = node.attribute("path").as_string("");
+    return !_filePath.empty();
+}
+
+void AudioMediaCacheEntry::SaveToXml(pugi::xml_node& parent) const {
+    // Audio files are never embedded — track by path only
+    auto node = parent.append_child("Audio");
+    node.append_attribute("path") = _filePath;
+}
+
+// =====================================================================
 // SequenceMedia — New type-specific retrieval methods
 // =====================================================================
 
@@ -1548,6 +1594,20 @@ std::shared_ptr<VideoMediaCacheEntry> SequenceMedia::GetVideo(const std::string&
     return np;
 }
 
+std::shared_ptr<AudioMediaCacheEntry> SequenceMedia::GetAudio(const std::string& filepath) {
+    if (filepath.empty()) return nullptr;
+    std::unique_lock lock(_cacheMutex);
+    auto it = _audioCache.find(filepath);
+    if (it != _audioCache.end()) {
+        return it->second;
+    }
+    auto np = std::make_shared<AudioMediaCacheEntry>(filepath);
+    _audioCache.emplace(filepath, np);
+    lock.unlock();
+    np->Load();
+    return np;
+}
+
 // =====================================================================
 // SequenceMedia — Cross-type queries
 // =====================================================================
@@ -1556,7 +1616,8 @@ bool SequenceMedia::HasMedia(const std::string& filepath) const {
     std::scoped_lock lock(_cacheMutex);
     return _imageCache.count(filepath) || _textCache.count(filepath) ||
            _svgCache.count(filepath) || _shaderCache.count(filepath) ||
-           _binaryCache.count(filepath) || _videoCache.count(filepath);
+           _binaryCache.count(filepath) || _videoCache.count(filepath) ||
+           _audioCache.count(filepath);
 }
 
 std::pair<bool, bool> SequenceMedia::GetMediaEmbedState(const std::string& filepath) const {
@@ -1573,6 +1634,7 @@ std::pair<bool, bool> SequenceMedia::GetMediaEmbedState(const std::string& filep
     if (auto r = checkCache(_shaderCache)) return *r;
     if (auto r = checkCache(_binaryCache)) return *r;
     if (auto r = checkCache(_videoCache)) return *r;
+    if (auto r = checkCache(_audioCache)) return *r;
     return { false, false };
 }
 
@@ -1584,6 +1646,7 @@ void SequenceMedia::RemoveMedia(const std::string& filepath) {
     _shaderCache.erase(filepath);
     _binaryCache.erase(filepath);
     _videoCache.erase(filepath);
+    _audioCache.erase(filepath);
 }
 
 bool SequenceMedia::ReloadMedia(const std::string& filepath) {
@@ -1628,26 +1691,34 @@ bool SequenceMedia::ReloadMedia(const std::string& filepath) {
         GetVideo(filepath);
         return true;
     }
+    if (found(_audioCache)) {
+        _audioCache.erase(filepath);
+        GetAudio(filepath);
+        return true;
+    }
     return false;
 }
 
 size_t SequenceMedia::GetMediaCount() const {
     std::scoped_lock lock(_cacheMutex);
     return _imageCache.size() + _textCache.size() + _svgCache.size() +
-           _shaderCache.size() + _binaryCache.size() + _videoCache.size();
+           _shaderCache.size() + _binaryCache.size() + _videoCache.size() +
+           _audioCache.size();
 }
 
 std::vector<std::pair<std::string, MediaType>> SequenceMedia::GetAllMediaPaths() const {
     std::scoped_lock lock(_cacheMutex);
     std::vector<std::pair<std::string, MediaType>> paths;
     paths.reserve(_imageCache.size() + _textCache.size() + _svgCache.size() +
-                   _shaderCache.size() + _binaryCache.size() + _videoCache.size());
+                   _shaderCache.size() + _binaryCache.size() + _videoCache.size() +
+                   _audioCache.size());
     for (const auto& p : _imageCache) paths.emplace_back(p.first, MediaType::Image);
     for (const auto& p : _svgCache) paths.emplace_back(p.first, MediaType::SVG);
     for (const auto& p : _shaderCache) paths.emplace_back(p.first, MediaType::Shader);
     for (const auto& p : _textCache) paths.emplace_back(p.first, MediaType::TextFile);
     for (const auto& p : _binaryCache) paths.emplace_back(p.first, MediaType::BinaryFile);
     for (const auto& p : _videoCache) paths.emplace_back(p.first, MediaType::Video);
+    for (const auto& p : _audioCache) paths.emplace_back(p.first, MediaType::Audio);
     return paths;
 }
 

--- a/src-core/render/SequenceMedia.cpp
+++ b/src-core/render/SequenceMedia.cpp
@@ -1599,7 +1599,22 @@ std::shared_ptr<AudioMediaCacheEntry> SequenceMedia::GetAudio(const std::string&
     std::unique_lock lock(_cacheMutex);
     auto it = _audioCache.find(filepath);
     if (it != _audioCache.end()) {
-        return it->second;
+        auto ret = it->second;
+        if (!ret->isLoaded()) {
+            lock.unlock();
+            ret->Load();
+        }
+        ret->ReloadIfChanged();
+        return ret;
+    }
+    // Check if the resolved path matches an existing entry
+    std::string resolved = ResolvePath(filepath);
+    for (auto& [key, entry] : _audioCache) {
+        if (entry->GetFilePath() == resolved || ResolvePath(key) == resolved) {
+            if (!entry->isLoaded()) { lock.unlock(); entry->Load(); }
+            entry->ReloadIfChanged();
+            return entry;
+        }
     }
     auto np = std::make_shared<AudioMediaCacheEntry>(filepath);
     _audioCache.emplace(filepath, np);

--- a/src-core/render/SequenceMedia.h
+++ b/src-core/render/SequenceMedia.h
@@ -33,7 +33,8 @@ enum class MediaType {
     Shader,
     TextFile,
     BinaryFile,
-    Video
+    Video,
+    Audio
 };
 
 /**
@@ -346,6 +347,27 @@ private:
 };
 
 /**
+ * AudioMediaCacheEntry - Path-only entry for audio files (too large to embed)
+ *
+ * Audio files are never embedded in the sequence — they are always referenced
+ * by path. Loading the actual audio data is handled separately by AudioManager
+ * in SequenceFile; this entry exists purely for inventory and file management
+ * purposes within the media panel.
+ */
+class AudioMediaCacheEntry : public MediaCacheEntry
+{
+public:
+    AudioMediaCacheEntry();
+    explicit AudioMediaCacheEntry(const std::string& filePath);
+
+    bool IsEmbeddable() const override { return false; }
+
+    void Load() override;
+    bool LoadFromXml(const pugi::xml_node& node) override;
+    void SaveToXml(pugi::xml_node& parent) const override;
+};
+
+/**
  * SequenceMedia - Manages all media caching for a sequence
  *
  * Provides unified access to images, SVGs, shaders, text files, binary files,
@@ -383,6 +405,7 @@ public:
     std::shared_ptr<ShaderMediaCacheEntry> GetShader(const std::string& filepath);
     std::shared_ptr<BinaryMediaCacheEntry> GetBinaryFile(const std::string& filepath, const std::string& subtype = "");
     std::shared_ptr<VideoMediaCacheEntry> GetVideo(const std::string& filepath);
+    std::shared_ptr<AudioMediaCacheEntry> GetAudio(const std::string& filepath);
 
     // === Cross-type queries ===
     bool HasMedia(const std::string& filepath) const;
@@ -429,6 +452,7 @@ private:
     std::map<std::string, std::shared_ptr<ShaderMediaCacheEntry>> _shaderCache;
     std::map<std::string, std::shared_ptr<BinaryMediaCacheEntry>> _binaryCache;
     std::map<std::string, std::shared_ptr<VideoMediaCacheEntry>> _videoCache;
+    std::map<std::string, std::shared_ptr<AudioMediaCacheEntry>> _audioCache;
 
     mutable std::recursive_mutex _cacheMutex;
 };

--- a/src-ui-wx/media/ManageMediaPanel.cpp
+++ b/src-ui-wx/media/ManageMediaPanel.cpp
@@ -2554,7 +2554,9 @@ void SelectMediaDialog::OnAddFromDisk(wxCommandEvent& event)
     GetXLightsConfig()->Write(LastDirConfigKey(_filterType), wxFileName(path).GetPath());
     const std::string sep(1, wxFileName::GetPathSeparator());
 
-    // Determine which MediaType to register as
+    // Determine which MediaType to register as. When no explicit filter is set,
+    // infer from the selected path; this can legitimately produce Audio and
+    // downstream registration logic must handle that case as well.
     MediaType regType = _filterType.has_value() ? *_filterType : MediaTypeFromPath(path);
 
     // For videos, check AVFoundation compatibility up front and offer to

--- a/src-ui-wx/media/ManageMediaPanel.cpp
+++ b/src-ui-wx/media/ManageMediaPanel.cpp
@@ -53,6 +53,22 @@ static std::string MediaTypeName(MediaType t) {
     return "Unknown";
 }
 
+// Filesystem subdirectory name for copying files into the show folder.
+// Separate from MediaTypeName so display labels and path segments stay consistent
+// with established show-folder conventions (Images/, Videos/, Shaders/, Glediators/, …).
+static std::string SubdirForMediaType(MediaType t) {
+    switch (t) {
+        case MediaType::Image:      return "Images";
+        case MediaType::SVG:        return "SVGs";
+        case MediaType::Shader:     return "Shaders";
+        case MediaType::TextFile:   return "Text";
+        case MediaType::BinaryFile: return "Glediators";
+        case MediaType::Video:      return "Videos";
+        case MediaType::Audio:      return "Audio";
+    }
+    return "Media";
+}
+
 // Returns <showDirectory>/ImportedMedia/<seqStem>/<subFolder>, or empty if no
 // sequence is loaded or no show directory is set.
 // NOTE: GetSeqXmlFileName() may return the show directory path when the sequence
@@ -95,18 +111,19 @@ static wxString WildcardForMediaType(std::optional<MediaType> type) {
         return "All Media Files|*.png;*.jpg;*.jpeg;*.bmp;*.gif;*.tiff;*.tga;*.pcx;*.ico;"
                "*.avi;*.mp4;*.mkv;*.mov;*.asf;*.flv;*.mpg;*.mpeg;*.m4v;*.wmv;"
                "*.mp3;*.ogg;*.m4a;*.wav;*.flac;*.aac;*.wma;"
-               "*.svg;*.fs;*.txt|"
+               "*.svg;*.fs;*.txt;*.gled;*.out;*.csv|"
                "Image Files|*.png;*.jpg;*.jpeg;*.bmp;*.gif;*.tiff;*.tga;*.pcx;*.ico|"
                "Video Files|*.avi;*.mp4;*.mkv;*.mov;*.asf;*.flv;*.mpg;*.mpeg;*.m4v;*.wmv|"
                "Audio Files|*.mp3;*.ogg;*.m4a;*.wav;*.flac;*.aac;*.wma|"
                "SVG Files|*.svg|"
                "Shader Files|*.fs|"
                "Text Files|*.txt|"
+               "Glediator Files|*.gled;*.out;*.csv|"
                "All files (*.*)|*.*";
     }
     switch (*type) {
         case MediaType::Image: return wxImage::GetImageExtWildcard();
-        case MediaType::Video: return "Video Files|*.avi;*.mp4;*.mkv;*.mov;*.asf;*.flv;*.mpg;*.mpeg;*.m4v;*.wmv;*.gif";
+        case MediaType::Video: return "Video Files|*.avi;*.mp4;*.mkv;*.mov;*.asf;*.flv;*.mpg;*.mpeg;*.m4v;*.wmv";
         case MediaType::Shader: return "Shader Files (*.fs)|*.fs";
         case MediaType::SVG: return "SVG Files (*.svg)|*.svg";
         case MediaType::TextFile: return "Text Files (*.txt)|*.txt";
@@ -210,6 +227,8 @@ static MediaType MediaTypeFromPath(const std::string& path)
         return MediaType::SVG;
     if (ext == "txt")
         return MediaType::TextFile;
+    if (ext == "gled" || ext == "out" || ext == "csv")
+        return MediaType::BinaryFile;
     if (ext == "avi" || ext == "mp4" || ext == "mkv" || ext == "mov" ||
         ext == "asf" || ext == "flv" || ext == "mpg" || ext == "mpeg" ||
         ext == "m4v" || ext == "wmv")
@@ -1797,7 +1816,7 @@ void ManageMediaPanel::OnAddButtonClick(wxCommandEvent& event)
     for (const auto& p : paths) {
         std::string path = ToStdString(p);
         MediaType type = MediaTypeFromPath(path);
-        std::string subDirName = MediaTypeName(type);
+        std::string subDirName = SubdirForMediaType(type);
 
         // For videos, check AVFoundation compatibility up front.
         if (type == MediaType::Video) {
@@ -1806,7 +1825,7 @@ void ManageMediaPanel::OnAddButtonClick(wxCommandEvent& event)
             path = maybe;
             // Re-detect after transcoding in case the output extension changed
             type = MediaTypeFromPath(path);
-            subDirName = MediaTypeName(type);
+            subDirName = SubdirForMediaType(type);
         }
 
         // If the file is outside the show/media folders, require the user to
@@ -1827,13 +1846,18 @@ void ManageMediaPanel::OnAddButtonClick(wxCommandEvent& event)
                 }
             }
 
-            // Shaders are always loaded from disk; no ImportedMedia option for them
+            // Shaders are always loaded from disk; no ImportedMedia option for them.
+            // Non-embeddable types (Video/Audio/BinaryFile) skip the embed option.
+            bool typeIsEmbeddable = (type != MediaType::Video &&
+                                     type != MediaType::Audio &&
+                                     type != MediaType::BinaryFile);
             std::string importedMediaDir;
             if (type != MediaType::Shader)
                 importedMediaDir = ImportedMediaPath(_xlFrame, _showDirectory, subDirName);
 
             wxArrayString choices;
-            choices.Add("Embed in sequence");
+            if (typeIsEmbeddable)
+                choices.Add("Embed in sequence");
             if (!importedMediaDir.empty())
                 choices.Add("Copy to ImportedMedia: " + wxString(importedMediaDir));
             for (const auto& dir : copyTargets)
@@ -1847,10 +1871,10 @@ void ManageMediaPanel::OnAddButtonClick(wxCommandEvent& event)
 
             int sel = choiceDlg.GetSelection();
             bool hasImported = !importedMediaDir.empty();
-            // choices: 0=Embed, 1=ImportedMedia (if present), 1or2+=Copy to dirs
-            int copyOffset = 1 + (hasImported ? 1 : 0);
+            int embedOffset = typeIsEmbeddable ? 1 : 0;
+            int copyOffset = embedOffset + (hasImported ? 1 : 0);
 
-            if (sel == 0) {
+            if (typeIsEmbeddable && sel == 0) {
                 // Embed in sequence — images use the typed-key embed scheme;
                 // all other types embed in place via the cross-type API.
                 if (type == MediaType::Image) {
@@ -1899,7 +1923,7 @@ void ManageMediaPanel::OnAddButtonClick(wxCommandEvent& event)
                     lastPath = path;
                 }
                 continue;
-            } else if (hasImported && sel == 1) {
+            } else if (hasImported && sel == embedOffset) {
                 // Copy to ImportedMedia/<seqStem>/<type>
                 std::string newPath = CopyToDir(path, importedMediaDir);
                 if (newPath.empty()) {
@@ -2562,13 +2586,18 @@ void SelectMediaDialog::OnAddFromDisk(wxCommandEvent& event)
             }
         }
 
-        // ImportedMedia option is not shown for shaders
+        // ImportedMedia option is not shown for shaders.
+        // Non-embeddable types (Video/Audio/BinaryFile) skip the embed option.
+        bool regTypeIsEmbeddable = (regType != MediaType::Video &&
+                                    regType != MediaType::Audio &&
+                                    regType != MediaType::BinaryFile);
         std::string importedMediaDir;
         if (regType != MediaType::Shader)
-            importedMediaDir = ImportedMediaPath(_panel->_xlFrame, _panel->_showDirectory, MediaTypeName(regType));
+            importedMediaDir = ImportedMediaPath(_panel->_xlFrame, _panel->_showDirectory, SubdirForMediaType(regType));
 
         wxArrayString choices;
-        choices.Add("Embed in sequence");
+        if (regTypeIsEmbeddable)
+            choices.Add("Embed in sequence");
         if (!importedMediaDir.empty())
             choices.Add("Copy to ImportedMedia: " + wxString(importedMediaDir));
         for (const auto& dir : copyTargets)
@@ -2582,9 +2611,10 @@ void SelectMediaDialog::OnAddFromDisk(wxCommandEvent& event)
 
         int sel = choiceDlg.GetSelection();
         bool hasImported = !importedMediaDir.empty();
+        int embedOffset = regTypeIsEmbeddable ? 1 : 0;
         int importedOffset = hasImported ? 1 : 0;
 
-        if (hasImported && sel == 1) {
+        if (hasImported && sel == embedOffset) {
             // Copy to ImportedMedia/<seqStem>/<type>
             std::string newPath = CopyToDir(path, importedMediaDir);
             if (newPath.empty()) {
@@ -2594,10 +2624,9 @@ void SelectMediaDialog::OnAddFromDisk(wxCommandEvent& event)
             }
             path = newPath;
         } else {
-            int adjustedSel = sel - importedOffset;
-            if (adjustedSel == 0) {
+            int adjustedSel = sel - importedOffset - embedOffset;
+            if (regTypeIsEmbeddable && sel == 0) {
                 // Embed in sequence — register, rename to embedded key, embed
-                std::string subdir = MediaTypeName(regType);
                 // Register with original path first
                 switch (regType) {
                     case MediaType::Image:    _panel->_sequenceMedia->GetImage(path); break;
@@ -2628,9 +2657,9 @@ void SelectMediaDialog::OnAddFromDisk(wxCommandEvent& event)
                 return;
             } else {
                 // Copy to one of the folders
-                std::string targetDir = copyTargets[adjustedSel - 1];
+                std::string targetDir = copyTargets[adjustedSel];
                 std::string newPath;
-                std::string subFolder = sep + MediaTypeName(regType);
+                std::string subFolder = sep + SubdirForMediaType(regType);
                 if (_panel->_xlFrame && targetDir == _panel->_showDirectory) {
                     newPath = _panel->_xlFrame->MoveToShowFolder(path, subFolder);
                 } else {

--- a/src-ui-wx/media/ManageMediaPanel.cpp
+++ b/src-ui-wx/media/ManageMediaPanel.cpp
@@ -48,6 +48,7 @@ static std::string MediaTypeName(MediaType t) {
         case MediaType::TextFile: return "Text Files";
         case MediaType::BinaryFile: return "Other Files";
         case MediaType::Video: return "Videos";
+        case MediaType::Audio: return "Audio";
     }
     return "Unknown";
 }
@@ -90,7 +91,19 @@ static std::string CopyToDir(const std::string& srcPath, const std::string& targ
 }
 
 static wxString WildcardForMediaType(std::optional<MediaType> type) {
-    if (!type.has_value()) return "All files (*.*)|*.*";
+    if (!type.has_value()) {
+        return "All Media Files|*.png;*.jpg;*.jpeg;*.bmp;*.gif;*.tiff;*.tga;*.pcx;*.ico;"
+               "*.avi;*.mp4;*.mkv;*.mov;*.asf;*.flv;*.mpg;*.mpeg;*.m4v;*.wmv;"
+               "*.mp3;*.ogg;*.m4a;*.wav;*.flac;*.aac;*.wma;"
+               "*.svg;*.fs;*.txt|"
+               "Image Files|*.png;*.jpg;*.jpeg;*.bmp;*.gif;*.tiff;*.tga;*.pcx;*.ico|"
+               "Video Files|*.avi;*.mp4;*.mkv;*.mov;*.asf;*.flv;*.mpg;*.mpeg;*.m4v;*.wmv|"
+               "Audio Files|*.mp3;*.ogg;*.m4a;*.wav;*.flac;*.aac;*.wma|"
+               "SVG Files|*.svg|"
+               "Shader Files|*.fs|"
+               "Text Files|*.txt|"
+               "All files (*.*)|*.*";
+    }
     switch (*type) {
         case MediaType::Image: return wxImage::GetImageExtWildcard();
         case MediaType::Video: return "Video Files|*.avi;*.mp4;*.mkv;*.mov;*.asf;*.flv;*.mpg;*.mpeg;*.m4v;*.wmv;*.gif";
@@ -98,6 +111,7 @@ static wxString WildcardForMediaType(std::optional<MediaType> type) {
         case MediaType::SVG: return "SVG Files (*.svg)|*.svg";
         case MediaType::TextFile: return "Text Files (*.txt)|*.txt";
         case MediaType::BinaryFile: return "Glediator Files|*.gled;*.out;*.csv";
+        case MediaType::Audio: return "Audio Files|*.mp3;*.ogg;*.m4a;*.wav;*.flac;*.aac;*.wma";
     }
     return "All files (*.*)|*.*";
 }
@@ -172,15 +186,38 @@ static std::string MaybeConvertIncompatibleVideo(wxWindow* parent,
 }
 
 static wxString LastDirConfigKey(std::optional<MediaType> type) {
-    if (!type.has_value()) return "MediaManagerLastImageDir";
+    if (!type.has_value()) return "MediaManagerLastAllMediaDir";
     switch (*type) {
         case MediaType::Video:      return "MediaManagerLastVideoDir";
         case MediaType::Shader:     return "MediaManagerLastShaderDir";
         case MediaType::SVG:        return "MediaManagerLastSVGDir";
         case MediaType::TextFile:   return "MediaManagerLastTextFileDir";
         case MediaType::BinaryFile: return "MediaManagerLastBinaryFileDir";
+        case MediaType::Audio:      return "MediaManagerLastAudioDir";
         default:                    return "MediaManagerLastImageDir";
     }
+}
+
+// Infer MediaType from a file path's extension.
+// .gif is treated as Image because SequenceMedia handles animated GIFs
+// as multi-frame image cache entries.
+static MediaType MediaTypeFromPath(const std::string& path)
+{
+    wxString ext = wxFileName(wxString(path)).GetExt().Lower();
+    if (ext == "fs")
+        return MediaType::Shader;
+    if (ext == "svg")
+        return MediaType::SVG;
+    if (ext == "txt")
+        return MediaType::TextFile;
+    if (ext == "avi" || ext == "mp4" || ext == "mkv" || ext == "mov" ||
+        ext == "asf" || ext == "flv" || ext == "mpg" || ext == "mpeg" ||
+        ext == "m4v" || ext == "wmv")
+        return MediaType::Video;
+    if (ext == "mp3" || ext == "ogg" || ext == "m4a" || ext == "wav" ||
+        ext == "flac" || ext == "aac" || ext == "wma")
+        return MediaType::Audio;
+    return MediaType::Image;
 }
 
 // ---------------------------------------------------------------------------
@@ -312,6 +349,14 @@ void MediaViewModel::Rebuild(SequenceMedia* media, const std::string& showDirect
                     node->statusStr += " (broken)";
             } else if (type == MediaType::Video) {
                 auto entry = media->GetVideo(path);
+                if (!entry) continue;
+                resolvedPath = entry->GetFilePath();
+                node->canLoad = true;
+                node->sizeStr = "-";
+                node->framesStr = "-";
+                node->statusStr = "External";
+            } else if (type == MediaType::Audio) {
+                auto entry = media->GetAudio(path);
                 if (!entry) continue;
                 resolvedPath = entry->GetFilePath();
                 node->canLoad = true;
@@ -645,7 +690,8 @@ void ManageMediaPanel::Populate(const std::string& selectPath)
 
     // Hide embed/extract buttons for non-embeddable types
     bool typeIsEmbeddable = !_filterType.has_value() ||
-        (*_filterType != MediaType::Video && *_filterType != MediaType::BinaryFile);
+        (*_filterType != MediaType::Video && *_filterType != MediaType::BinaryFile &&
+         *_filterType != MediaType::Audio);
     _embedButton->Show(typeIsEmbeddable);
     _extractButton->Show(typeIsEmbeddable);
     _embedAllButton->Show(typeIsEmbeddable);
@@ -688,8 +734,8 @@ void ManageMediaPanel::Populate(const std::string& selectPath)
             if (!entry) continue;
             if (!entry->IsEmbedded() && entry->IsEmbeddable()) hasEmbeddable = true;
             if (entry->IsEmbedded()) hasExtractable = true;
-        } else if (type == MediaType::Video) {
-            // Videos are not embeddable
+        } else if (type == MediaType::Video || type == MediaType::Audio) {
+            // Videos and audio are not embeddable
         } else {
             // For other types, check via the appropriate accessor
             MediaCacheEntry* baseEntry = nullptr;
@@ -819,9 +865,7 @@ void ManageMediaPanel::UpdateButtons()
             if (!entry) continue;
             isEmbedded = entry->IsEmbedded();
             isEmbeddable = entry->IsEmbeddable();
-        } else if (mtype == MediaType::Video) {
-            auto entry = _sequenceMedia->GetVideo(path);
-            if (!entry) continue;
+        } else if (mtype == MediaType::Video || mtype == MediaType::Audio) {
             isEmbedded = false;
             isEmbeddable = false;
         } else {
@@ -1735,23 +1779,35 @@ void ManageMediaPanel::OnAddButtonClick(wxCommandEvent& event)
     wxString defaultDir;
     {
         auto* config = GetXLightsConfig();
-        config->Read(LastDirConfigKey(MediaType::Image), &defaultDir);
+        config->Read(LastDirConfigKey(std::nullopt), &defaultDir);
         if (defaultDir.empty())
             defaultDir = _showDirectory.empty() ? wxString() : wxString(_showDirectory);
     }
-    wxFileDialog dlg(this, "Add Image to Sequence", defaultDir, wxEmptyString,
-                     "Image files (*.png;*.jpg;*.jpeg;*.gif;*.bmp)|*.png;*.jpg;*.jpeg;*.gif;*.bmp|All files (*.*)|*.*",
+    wxFileDialog dlg(this, "Add Media to Sequence", defaultDir, wxEmptyString,
+                     WildcardForMediaType(std::nullopt),
                      wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE);
     if (dlg.ShowModal() != wxID_OK) return;
 
     wxArrayString paths;
     dlg.GetPaths(paths);
     if (!paths.empty())
-        GetXLightsConfig()->Write(LastDirConfigKey(MediaType::Image), wxFileName(paths[0]).GetPath());
+        GetXLightsConfig()->Write(LastDirConfigKey(std::nullopt), wxFileName(paths[0]).GetPath());
     std::string lastPath;
     const std::string sep(1, wxFileName::GetPathSeparator());
     for (const auto& p : paths) {
         std::string path = ToStdString(p);
+        MediaType type = MediaTypeFromPath(path);
+        std::string subDirName = MediaTypeName(type);
+
+        // For videos, check AVFoundation compatibility up front.
+        if (type == MediaType::Video) {
+            std::string maybe = MaybeConvertIncompatibleVideo(this, path);
+            if (maybe.empty()) continue;
+            path = maybe;
+            // Re-detect after transcoding in case the output extension changed
+            type = MediaTypeFromPath(path);
+            subDirName = MediaTypeName(type);
+        }
 
         // If the file is outside the show/media folders, require the user to
         // choose where to place it — no "use original location" option.
@@ -1771,7 +1827,10 @@ void ManageMediaPanel::OnAddButtonClick(wxCommandEvent& event)
                 }
             }
 
-            std::string importedMediaDir = ImportedMediaPath(_xlFrame, _showDirectory, "Images");
+            // Shaders are always loaded from disk; no ImportedMedia option for them
+            std::string importedMediaDir;
+            if (type != MediaType::Shader)
+                importedMediaDir = ImportedMediaPath(_xlFrame, _showDirectory, subDirName);
 
             wxArrayString choices;
             choices.Add("Embed in sequence");
@@ -1792,41 +1851,56 @@ void ManageMediaPanel::OnAddButtonClick(wxCommandEvent& event)
             int copyOffset = 1 + (hasImported ? 1 : 0);
 
             if (sel == 0) {
-                // Embed in sequence
-                _sequenceMedia->GetImage(path);
-                std::string embeddedName = "Images/" + ToStdString(fn.GetFullName());
-                if (_sequenceMedia->HasImage(embeddedName)) {
-                    int answer = wxMessageBox(
-                        wxString::Format("'%s' is already embedded in the sequence.\n\nReplace it with the selected file?",
-                                         fn.GetFullName()),
-                        "Image Already Embedded",
-                        wxYES_NO | wxCANCEL | wxICON_QUESTION, this);
-                    if (answer == wxCANCEL) {
-                        _sequenceMedia->RemoveImage(path);
-                        continue;
+                // Embed in sequence — images use the typed-key embed scheme;
+                // all other types embed in place via the cross-type API.
+                if (type == MediaType::Image) {
+                    _sequenceMedia->GetImage(path);
+                    std::string embeddedName = "Images/" + ToStdString(fn.GetFullName());
+                    if (_sequenceMedia->HasImage(embeddedName)) {
+                        int answer = wxMessageBox(
+                            wxString::Format("'%s' is already embedded in the sequence.\n\nReplace it with the selected file?",
+                                             fn.GetFullName()),
+                            "Already Embedded",
+                            wxYES_NO | wxCANCEL | wxICON_QUESTION, this);
+                        if (answer == wxCANCEL) {
+                            _sequenceMedia->RemoveImage(path);
+                            continue;
+                        }
+                        if (answer == wxYES) {
+                            _sequenceMedia->RemoveImage(embeddedName);
+                            _sequenceMedia->RenameImage(path, embeddedName);
+                            _sequenceMedia->EmbedImage(embeddedName);
+                            lastPath = embeddedName;
+                            continue;
+                        }
                     }
-                    if (answer == wxYES) {
-                        _sequenceMedia->RemoveImage(embeddedName);
-                        _sequenceMedia->RenameImage(path, embeddedName);
-                        _sequenceMedia->EmbedImage(embeddedName);
-                        lastPath = embeddedName;
-                        continue;
+                    int suffix = 1;
+                    std::string candidate = embeddedName;
+                    while (_sequenceMedia->HasImage(candidate)) {
+                        candidate = "Images/" + ToStdString(fn.GetName()) +
+                                    "_" + std::to_string(suffix++) + "." +
+                                    ToStdString(fn.GetExt());
                     }
+                    embeddedName = candidate;
+                    _sequenceMedia->RenameImage(path, embeddedName);
+                    _sequenceMedia->EmbedImage(embeddedName);
+                    lastPath = embeddedName;
+                } else {
+                    switch (type) {
+                        case MediaType::Video:      _sequenceMedia->GetVideo(path); break;
+                        case MediaType::SVG:        _sequenceMedia->GetSVG(path); break;
+                        case MediaType::Shader:     _sequenceMedia->GetShader(path); break;
+                        case MediaType::TextFile:   _sequenceMedia->GetTextFile(path); break;
+                        case MediaType::BinaryFile: _sequenceMedia->GetBinaryFile(path); break;
+                        case MediaType::Audio:      _sequenceMedia->GetAudio(path); break;
+                        default: break;
+                    }
+                    _sequenceMedia->EmbedMedia(path);
+                    lastPath = path;
                 }
-                int suffix = 1;
-                std::string candidate = embeddedName;
-                while (_sequenceMedia->HasImage(candidate)) {
-                    candidate = "Images/" + ToStdString(fn.GetName()) +
-                                "_" + std::to_string(suffix++) + "." +
-                                ToStdString(fn.GetExt());
-                }
-                embeddedName = candidate;
-                _sequenceMedia->RenameImage(path, embeddedName);
-                _sequenceMedia->EmbedImage(embeddedName);
-                lastPath = embeddedName;
                 continue;
             } else if (hasImported && sel == 1) {
-                // Copy to ImportedMedia/<seqStem>/Images
+                // Copy to ImportedMedia/<seqStem>/<type>
                 std::string newPath = CopyToDir(path, importedMediaDir);
                 if (newPath.empty()) {
                     wxMessageBox("Failed to copy file to ImportedMedia folder.", "Error",
@@ -1841,7 +1915,7 @@ void ManageMediaPanel::OnAddButtonClick(wxCommandEvent& event)
                 if (_xlFrame && targetDir == _showDirectory) {
                     // Check if destination exists with different content before MoveToShowFolder
                     // auto-suffixes it.
-                    wxString destDir = wxString(targetDir) + wxString(sep) + "Images";
+                    wxString destDir = wxString(targetDir) + wxString(sep) + wxString(subDirName);
                     wxString destFile = destDir + wxString(sep) + fn.GetFullName();
                     if (wxFileExists(destFile) && !_xlFrame->FilesMatch(path, ToStdString(destFile))) {
                         int answer = wxMessageBox(
@@ -1855,13 +1929,13 @@ void ManageMediaPanel::OnAddButtonClick(wxCommandEvent& event)
                                 newPath = ToStdString(destFile);
                         } else {
                             // Add as New — let MoveToShowFolder generate a suffix name
-                            newPath = _xlFrame->MoveToShowFolder(path, sep + "Images");
+                            newPath = _xlFrame->MoveToShowFolder(path, sep + subDirName);
                         }
                     } else {
-                        newPath = _xlFrame->MoveToShowFolder(path, sep + "Images");
+                        newPath = _xlFrame->MoveToShowFolder(path, sep + subDirName);
                     }
                 } else {
-                    wxString destDir = wxString(targetDir) + wxString(sep) + "Images";
+                    wxString destDir = wxString(targetDir) + wxString(sep) + wxString(subDirName);
                     if (!wxDirExists(destDir)) wxMkdir(destDir);
                     wxString dest = destDir + wxString(sep) + fn.GetFullName();
                     if (wxFileExists(dest) &&
@@ -1902,17 +1976,25 @@ void ManageMediaPanel::OnAddButtonClick(wxCommandEvent& event)
             }
         }
 
-        // For external images now inside a show/media folder, store the relative path
+        // For files now inside a show/media folder, store the relative path
         if (_xlFrame) {
             std::string rel = _xlFrame->MakeRelativePath(path);
             if (!rel.empty()) path = rel;
         }
 
-        // If the path is already in the cache (e.g. same file added again after
-        // being modified on disk), remove it first so GetImage reloads from disk.
-        if (_sequenceMedia->HasImage(path))
-            _sequenceMedia->RemoveImage(path);
-        _sequenceMedia->GetImage(path);
+        // If already in cache (e.g. same file re-added after disk modification),
+        // remove it first so the Get* call reloads from disk.
+        if (_sequenceMedia->HasMedia(path))
+            _sequenceMedia->RemoveMedia(path);
+        switch (type) {
+            case MediaType::Image:      _sequenceMedia->GetImage(path); break;
+            case MediaType::Video:      _sequenceMedia->GetVideo(path); break;
+            case MediaType::SVG:        _sequenceMedia->GetSVG(path); break;
+            case MediaType::Shader:     _sequenceMedia->GetShader(path); break;
+            case MediaType::TextFile:   _sequenceMedia->GetTextFile(path); break;
+            case MediaType::BinaryFile: _sequenceMedia->GetBinaryFile(path); break;
+            case MediaType::Audio:      _sequenceMedia->GetAudio(path); break;
+        }
         lastPath = path;
     }
     Populate(lastPath);
@@ -2449,7 +2531,7 @@ void SelectMediaDialog::OnAddFromDisk(wxCommandEvent& event)
     const std::string sep(1, wxFileName::GetPathSeparator());
 
     // Determine which MediaType to register as
-    MediaType regType = _filterType.has_value() ? *_filterType : MediaType::Image;
+    MediaType regType = _filterType.has_value() ? *_filterType : MediaTypeFromPath(path);
 
     // For videos, check AVFoundation compatibility up front and offer to
     // transcode before any copy/embed handling. Converted output (if any)
@@ -2524,6 +2606,7 @@ void SelectMediaDialog::OnAddFromDisk(wxCommandEvent& event)
                     case MediaType::Shader:   _panel->_sequenceMedia->GetShader(path); break;
                     case MediaType::TextFile: _panel->_sequenceMedia->GetTextFile(path); break;
                     case MediaType::BinaryFile: _panel->_sequenceMedia->GetBinaryFile(path); break;
+                    case MediaType::Audio:    _panel->_sequenceMedia->GetAudio(path); break;
                 }
                 if (regType == MediaType::Image) {
                     std::string embeddedName = "Images/" + ToStdString(fn.GetFullName());

--- a/src-ui-wx/media/ManageMediaPanel.cpp
+++ b/src-ui-wx/media/ManageMediaPanel.cpp
@@ -2694,6 +2694,7 @@ void SelectMediaDialog::OnAddFromDisk(wxCommandEvent& event)
         case MediaType::Shader:   _panel->_sequenceMedia->GetShader(path); break;
         case MediaType::TextFile: _panel->_sequenceMedia->GetTextFile(path); break;
         case MediaType::BinaryFile: _panel->_sequenceMedia->GetBinaryFile(path); break;
+        case MediaType::Audio:    _panel->_sequenceMedia->GetAudio(path); break;
     }
 
     _panel->Populate(path);


### PR DESCRIPTION
When adding media to the media manager, everything was coming in as "Image". Added classifiers based on extension type to handle putting them in correct buckets.

Also added handling for Audio files since they can be added there and _not_ as Audio tracks - though we can discuss if we want this or not.