### PR TITLE
Add node animation playback to SubModels dialog

### DIFF
--- a/src-ui-wx/model/SubModelsDialog.cpp
+++ b/src-ui-wx/model/SubModelsDialog.cpp
@@ -427,7 +427,7 @@ SubModelsDialog::SubModelsDialog(wxWindow* parent, OutputManager* om) :
     Connect(subBufferPanel->GetId(),SUBBUFFER_RANGE_CHANGED,(wxObjectEventFunction)&SubModelsDialog::OnSubBufferRangeChange);
     subBufferPanel->Connect(wxEVT_SIZE, (wxObjectEventFunction)&SubModelsDialog::OnSubbufferSize, nullptr, this);
 
-    wxStaticBox* animBox = new wxStaticBox(Panel2, wxID_ANY, _("Node Animation"));
+    wxStaticBox* animBox = new wxStaticBox(ModelPreviewPanelLocation, wxID_ANY, _("Node Animation"));
     wxStaticBoxSizer* animSizer = new wxStaticBoxSizer(animBox, wxVERTICAL);
 
     Button_PlayAnim = new wxButton(animBox, ID_BUTTON_PLAY_ANIM, _("Play"));
@@ -442,8 +442,8 @@ SubModelsDialog::SubModelsDialog(wxWindow* parent, OutputManager* om) :
     controlsRow->Add(Spin_AnimTrail, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5);
     animSizer->Add(controlsRow, 0, wxEXPAND);
 
-    wxStaticCast(Panel2->GetSizer(), wxFlexGridSizer)->SetRows(0);
-    Panel2->GetSizer()->Add(animSizer, 0, wxALL | wxEXPAND, 5);
+    PreviewSizer->SetRows(0);
+    PreviewSizer->Add(animSizer, 0, wxALL | wxEXPAND, 5);
 
     Connect(ID_BUTTON_PLAY_ANIM, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnPlayAnimClick);
     Connect(ID_SLIDER_ANIM_SPEED, wxEVT_SPINCTRL, (wxObjectEventFunction)&SubModelsDialog::OnAnimSpeedChange);

--- a/src-ui-wx/model/SubModelsDialog.cpp
+++ b/src-ui-wx/model/SubModelsDialog.cpp
@@ -425,7 +425,7 @@ SubModelsDialog::SubModelsDialog(wxWindow* parent, OutputManager* om) :
     Connect(subBufferPanel->GetId(),SUBBUFFER_RANGE_CHANGED,(wxObjectEventFunction)&SubModelsDialog::OnSubBufferRangeChange);
     subBufferPanel->Connect(wxEVT_SIZE, (wxObjectEventFunction)&SubModelsDialog::OnSubbufferSize, nullptr, this);
 
-    wxStaticBox* animBox = new wxStaticBox(this, wxID_ANY, _("Node Animation"));
+    wxStaticBox* animBox = new wxStaticBox(Panel2, wxID_ANY, _("Node Animation"));
     wxStaticBoxSizer* animSizer = new wxStaticBoxSizer(animBox, wxHORIZONTAL);
 
     Button_PlayAnim = new wxButton(animBox, ID_BUTTON_PLAY_ANIM, _("Play"));
@@ -439,7 +439,8 @@ SubModelsDialog::SubModelsDialog(wxWindow* parent, OutputManager* om) :
     Slider_AnimTrail = new wxSlider(animBox, ID_SLIDER_ANIM_TRAIL, 5, 1, 20, wxDefaultPosition, wxSize(FromDIP(120), -1));
     animSizer->Add(Slider_AnimTrail, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 
-    FlexGridSizer1->Insert(1, animSizer, 0, wxALL | wxEXPAND, 5);
+    wxStaticCast(Panel2->GetSizer(), wxFlexGridSizer)->SetRows(0);
+    Panel2->GetSizer()->Add(animSizer, 0, wxALL | wxEXPAND, 5);
 
     Connect(ID_BUTTON_PLAY_ANIM, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnPlayAnimClick);
     Connect(ID_SLIDER_ANIM_SPEED, wxEVT_SLIDER, (wxObjectEventFunction)&SubModelsDialog::OnAnimSpeedChange);

--- a/src-ui-wx/model/SubModelsDialog.cpp
+++ b/src-ui-wx/model/SubModelsDialog.cpp
@@ -31,6 +31,7 @@
 #include <wx/mimetype.h>
 #include <wx/msgdlg.h>
 #include <wx/numdlg.h>
+#include <wx/spinctrl.h>
 #include <wx/tokenzr.h>
 #include <wx/textfile.h>
 
@@ -426,24 +427,25 @@ SubModelsDialog::SubModelsDialog(wxWindow* parent, OutputManager* om) :
     subBufferPanel->Connect(wxEVT_SIZE, (wxObjectEventFunction)&SubModelsDialog::OnSubbufferSize, nullptr, this);
 
     wxStaticBox* animBox = new wxStaticBox(Panel2, wxID_ANY, _("Node Animation"));
-    wxStaticBoxSizer* animSizer = new wxStaticBoxSizer(animBox, wxHORIZONTAL);
+    wxStaticBoxSizer* animSizer = new wxStaticBoxSizer(animBox, wxVERTICAL);
 
     Button_PlayAnim = new wxButton(animBox, ID_BUTTON_PLAY_ANIM, _("Play"));
-    animSizer->Add(Button_PlayAnim, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    animSizer->Add(Button_PlayAnim, 0, wxALL | wxEXPAND, 5);
 
-    animSizer->Add(new wxStaticText(animBox, wxID_ANY, _("Speed:")), 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-    Slider_AnimSpeed = new wxSlider(animBox, ID_SLIDER_ANIM_SPEED, 90, 1, 100, wxDefaultPosition, wxSize(FromDIP(120), -1));
-    animSizer->Add(Slider_AnimSpeed, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-
-    animSizer->Add(new wxStaticText(animBox, wxID_ANY, _("Trail:")), 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
-    Slider_AnimTrail = new wxSlider(animBox, ID_SLIDER_ANIM_TRAIL, 5, 1, 20, wxDefaultPosition, wxSize(FromDIP(120), -1));
-    animSizer->Add(Slider_AnimTrail, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    wxBoxSizer* controlsRow = new wxBoxSizer(wxHORIZONTAL);
+    controlsRow->Add(new wxStaticText(animBox, wxID_ANY, _("Speed:")), 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    Spin_AnimSpeed = new wxSpinCtrl(animBox, ID_SLIDER_ANIM_SPEED, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 10, 9);
+    controlsRow->Add(Spin_AnimSpeed, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    controlsRow->Add(new wxStaticText(animBox, wxID_ANY, _("Trail:")), 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    Spin_AnimTrail = new wxSpinCtrl(animBox, ID_SLIDER_ANIM_TRAIL, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 10, 5);
+    controlsRow->Add(Spin_AnimTrail, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    animSizer->Add(controlsRow, 0, wxEXPAND);
 
     wxStaticCast(Panel2->GetSizer(), wxFlexGridSizer)->SetRows(0);
     Panel2->GetSizer()->Add(animSizer, 0, wxALL | wxEXPAND, 5);
 
     Connect(ID_BUTTON_PLAY_ANIM, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnPlayAnimClick);
-    Connect(ID_SLIDER_ANIM_SPEED, wxEVT_SLIDER, (wxObjectEventFunction)&SubModelsDialog::OnAnimSpeedChange);
+    Connect(ID_SLIDER_ANIM_SPEED, wxEVT_SPINCTRL, (wxObjectEventFunction)&SubModelsDialog::OnAnimSpeedChange);
 
     _animTimer.SetOwner(this, ID_ANIM_TIMER);
     Connect(ID_ANIM_TIMER, wxEVT_TIMER, (wxObjectEventFunction)&SubModelsDialog::OnAnimTimerTick);
@@ -5021,21 +5023,21 @@ void SubModelsDialog::OnPlayAnimClick(wxCommandEvent& event)
     Button_PlayAnim->SetLabel(_("Stop"));
     NodesGrid->EnableEditing(false);
 
-    int interval = 520 - 5 * Slider_AnimSpeed->GetValue();
+    int interval = 520 - 50 * Spin_AnimSpeed->GetValue();
     _animTimer.Start(interval);
 }
 
-void SubModelsDialog::OnAnimSpeedChange(wxCommandEvent& event)
+void SubModelsDialog::OnAnimSpeedChange(wxSpinEvent& event)
 {
     if (_animPlaying) {
-        int interval = 520 - 5 * Slider_AnimSpeed->GetValue();
+        int interval = 520 - 50 * Spin_AnimSpeed->GetValue();
         _animTimer.Start(interval);
     }
 }
 
 void SubModelsDialog::OnAnimTimerTick(wxTimerEvent& event)
 {
-    int trail = std::min(Slider_AnimTrail->GetValue(), _animTotalSteps);
+    int trail = std::min(Spin_AnimTrail->GetValue(), _animTotalSteps);
 
     // reset only submodel nodes to white — non-submodel nodes stay dark from play-start
     for (int n : _animSubmodelNodes)
@@ -5059,6 +5061,6 @@ void SubModelsDialog::OnAnimTimerTick(wxTimerEvent& event)
 
     model->DisplayEffectOnWindow(modelPreview, mPointSize);
     _animStep = (_animStep + 1) % _animMaxSteps;
-    if (_animTotalSteps < Slider_AnimTrail->GetMax())
+    if (_animTotalSteps < Spin_AnimTrail->GetMax())
         ++_animTotalSteps;
 }

--- a/src-ui-wx/model/SubModelsDialog.cpp
+++ b/src-ui-wx/model/SubModelsDialog.cpp
@@ -551,6 +551,7 @@ SubModelsDialog::~SubModelsDialog()
     config->Write("SubModelsDialogSashPosition", i);
     config->Flush();
 
+    _animTimer.Stop();
     StopOutputToLights();
     if (_oldOutputToLights) {
         if (_outputManager->StartOutput()) SetConfigBool("OutputActive", true);
@@ -4941,14 +4942,20 @@ void SubModelsDialog::ParseAnimRows()
             wxString token = wtkz.GetNextToken().Trim(true).Trim(false);
             if (token.Contains("-")) {
                 int idx = token.Index('-');
-                int start = wxAtoi(token.Left(idx)) - 1;
-                int end = wxAtoi(token.Right(token.size() - idx - 1)) - 1;
-                int step = (start <= end) ? 1 : -1;
-                for (int n = start; n != end + step; n += step) {
-                    std::vector<int> slot;
-                    if (n >= 0 && n < nodeCount)
-                        slot.push_back(n);
-                    rowSlots.push_back(std::move(slot));
+                int startRaw = wxAtoi(token.Left(idx));
+                int endRaw   = wxAtoi(token.Right(token.size() - idx - 1));
+                if (startRaw > 0 && endRaw > 0) {
+                    int start = startRaw - 1;
+                    int end   = endRaw - 1;
+                    int step  = (start <= end) ? 1 : -1;
+                    for (int n = start; n != end + step; n += step) {
+                        std::vector<int> slot;
+                        if (n < nodeCount)
+                            slot.push_back(n);
+                        rowSlots.push_back(std::move(slot));
+                    }
+                } else {
+                    rowSlots.push_back({});
                 }
             } else {
                 std::vector<int> slot;
@@ -4964,6 +4971,17 @@ void SubModelsDialog::ParseAnimRows()
         _animMaxSteps = std::max(_animMaxSteps, (int)rowSlots.size());
         _animRows.push_back(std::move(rowSlots));
     }
+
+    // build flat deduplicated node list for efficient per-tick resets
+    _animSubmodelNodes.clear();
+    for (auto const& row : _animRows)
+        for (auto const& slot : row)
+            for (int n : slot)
+                _animSubmodelNodes.push_back(n);
+    std::sort(_animSubmodelNodes.begin(), _animSubmodelNodes.end());
+    _animSubmodelNodes.erase(
+        std::unique(_animSubmodelNodes.begin(), _animSubmodelNodes.end()),
+        _animSubmodelNodes.end());
 }
 
 void SubModelsDialog::StopAnimation()
@@ -4991,6 +5009,11 @@ void SubModelsDialog::OnPlayAnimClick(wxCommandEvent& event)
     if (_animMaxSteps == 0)
         return;
 
+    // one-time clear: set all nodes dark, then paint submodel white
+    ClearNodeColor(model);
+    for (int n : _animSubmodelNodes)
+        model->SetNodeColor(n, xlWHITE);
+
     _animPlaying = true;
     _animStep = 0;
     _animTotalSteps = 0;
@@ -5013,19 +5036,15 @@ void SubModelsDialog::OnAnimTimerTick(wxTimerEvent& event)
 {
     int trail = std::min(Slider_AnimTrail->GetValue(), _animTotalSteps);
 
-    ClearNodeColor(model);
-
-    // paint all submodel rows white so the full submodel stays visible
-    for (int i = 0; i < NodesGrid->GetNumberRows(); ++i)
-        SetNodeColor(i, xlWHITE, false);
+    // reset only submodel nodes to white — non-submodel nodes stay dark from play-start
+    for (int n : _animSubmodelNodes)
+        model->SetNodeColor(n, xlWHITE);
 
     // paint trail first, head last — blue head fades back to white
     static const xlColor animHead(0, 120, 255);
     for (int offset = trail; offset >= 0; --offset) {
         int step = ((_animStep - offset) % _animMaxSteps + _animMaxSteps) % _animMaxSteps;
-        float frac = (offset == 0) ? 1.0f : (float)(trail - offset) / trail;
-        if (frac == 0.0f)
-            continue;
+        float frac = (float)(trail - offset + 1) / (trail + 1);
         xlColor c((uint8_t)(animHead.red   * frac + 255.0f * (1.0f - frac)),
                   (uint8_t)(animHead.green * frac + 255.0f * (1.0f - frac)),
                   (uint8_t)(animHead.blue  * frac + 255.0f * (1.0f - frac)));

--- a/src-ui-wx/model/SubModelsDialog.cpp
+++ b/src-ui-wx/model/SubModelsDialog.cpp
@@ -371,6 +371,7 @@ SubModelsDialog::SubModelsDialog(wxWindow* parent, OutputManager* om) :
     Connect(ID_GRID1, wxEVT_GRID_CELL_CHANGED,(wxObjectEventFunction)&SubModelsDialog::OnNodesGridCellChange);
     Connect(wxID_ANY, wxEVT_CLOSE_WINDOW, (wxObjectEventFunction)&SubModelsDialog::OnCancel);
     Connect(wxID_CANCEL, wxEVT_BUTTON, (wxObjectEventFunction)&SubModelsDialog::OnCancel);
+    Connect(wxID_OK, wxEVT_BUTTON, (wxObjectEventFunction)&SubModelsDialog::OnOK);
     Connect(ID_TEXTCTRL_NAME, wxEVT_COMMAND_TEXT_ENTER, (wxObjectEventFunction)&SubModelsDialog::ApplySubmodelName);
 
     TextCtrl_Name->Bind(wxEVT_KILL_FOCUS, &SubModelsDialog::OnTextCtrl_NameText_KillFocus, this);
@@ -538,6 +539,12 @@ void SubModelsDialog::OnCancel(wxCloseEvent& event)
     SubModelsDialog::EndDialog(wxID_CANCEL);
 }
 
+void SubModelsDialog::OnOK(wxCommandEvent& event)
+{
+    StopAnimation();
+    SubModelsDialog::EndDialog(wxID_OK);
+}
+
 SubModelsDialog::~SubModelsDialog()
 {
     //(*Destroy(SubModelsDialog)
@@ -554,7 +561,7 @@ SubModelsDialog::~SubModelsDialog()
     config->Write("SubModelsDialogSashPosition", i);
     config->Flush();
 
-    _animTimer.Stop();
+    StopAnimation();
     StopOutputToLights();
     if (_oldOutputToLights) {
         if (_outputManager->StartOutput()) SetConfigBool("OutputActive", true);
@@ -2459,7 +2466,7 @@ void SubModelsDialog::ValidateWindow()
 
     Button_PlayAnim->Enable(
         _animPlaying ||
-        (ListCtrl_SubModels->GetSelectedItemCount() > 0 && TypeNotebook->GetSelection() == 0)
+        (ListCtrl_SubModels->GetSelectedItemCount() == 1 && TypeNotebook->GetSelection() == 0)
     );
 }
 
@@ -5005,7 +5012,7 @@ void SubModelsDialog::OnPlayAnimClick(wxCommandEvent& event)
         return;
     }
 
-    if (TypeNotebook->GetSelection() != 0)
+    if (TypeNotebook->GetSelection() != 0 || ListCtrl_SubModels->GetSelectedItemCount() != 1)
         return;
 
     ParseAnimRows();

--- a/src-ui-wx/model/SubModelsDialog.cpp
+++ b/src-ui-wx/model/SubModelsDialog.cpp
@@ -146,6 +146,11 @@ const long SubModelsDialog::SUBMODEL_DIALOG_BLANKS_AS_ZERO = wxNewId();
 const long SubModelsDialog::SUBMODEL_DIALOG_BLANKS_AS_EMPTY = wxNewId();
 const long SubModelsDialog::SUBMODEL_DIALOG_REMOVE_BLANKS_ZEROS = wxNewId();
 
+const long SubModelsDialog::ID_BUTTON_PLAY_ANIM = wxNewId();
+const long SubModelsDialog::ID_SLIDER_ANIM_SPEED = wxNewId();
+const long SubModelsDialog::ID_SLIDER_ANIM_TRAIL = wxNewId();
+const long SubModelsDialog::ID_ANIM_TIMER = wxNewId();
+
 
 BEGIN_EVENT_TABLE(SubModelsDialog,wxDialog)
 	//(*EventTable(SubModelsDialog)
@@ -420,6 +425,28 @@ SubModelsDialog::SubModelsDialog(wxWindow* parent, OutputManager* om) :
     Connect(subBufferPanel->GetId(),SUBBUFFER_RANGE_CHANGED,(wxObjectEventFunction)&SubModelsDialog::OnSubBufferRangeChange);
     subBufferPanel->Connect(wxEVT_SIZE, (wxObjectEventFunction)&SubModelsDialog::OnSubbufferSize, nullptr, this);
 
+    wxStaticBox* animBox = new wxStaticBox(this, wxID_ANY, _("Node Animation"));
+    wxStaticBoxSizer* animSizer = new wxStaticBoxSizer(animBox, wxHORIZONTAL);
+
+    Button_PlayAnim = new wxButton(animBox, ID_BUTTON_PLAY_ANIM, _("Play"));
+    animSizer->Add(Button_PlayAnim, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+    animSizer->Add(new wxStaticText(animBox, wxID_ANY, _("Speed:")), 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    Slider_AnimSpeed = new wxSlider(animBox, ID_SLIDER_ANIM_SPEED, 90, 1, 100, wxDefaultPosition, wxSize(FromDIP(120), -1));
+    animSizer->Add(Slider_AnimSpeed, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+    animSizer->Add(new wxStaticText(animBox, wxID_ANY, _("Trail:")), 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+    Slider_AnimTrail = new wxSlider(animBox, ID_SLIDER_ANIM_TRAIL, 5, 1, 20, wxDefaultPosition, wxSize(FromDIP(120), -1));
+    animSizer->Add(Slider_AnimTrail, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5);
+
+    FlexGridSizer1->Insert(1, animSizer, 0, wxALL | wxEXPAND, 5);
+
+    Connect(ID_BUTTON_PLAY_ANIM, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SubModelsDialog::OnPlayAnimClick);
+    Connect(ID_SLIDER_ANIM_SPEED, wxEVT_SLIDER, (wxObjectEventFunction)&SubModelsDialog::OnAnimSpeedChange);
+
+    _animTimer.SetOwner(this, ID_ANIM_TIMER);
+    Connect(ID_ANIM_TIMER, wxEVT_TIMER, (wxObjectEventFunction)&SubModelsDialog::OnAnimTimerTick);
+
     FlexGridSizer1->Fit(this);
     FlexGridSizer1->SetSizeHints(this);
 
@@ -504,6 +531,7 @@ void SubModelsDialog::OnCancel(wxCloseEvent& event)
     if (wxMessageBox("Are you sure you want to close the Submodels window?", "Are you sure?", wxYES_NO | wxCENTER, this) == wxNO) {
         return;
     }
+    StopAnimation();
     SubModelsDialog::EndDialog(wxID_CANCEL);
 }
 
@@ -1223,6 +1251,7 @@ void SubModelsDialog::OnLayoutCheckboxClick(wxCommandEvent& event)
 
 void SubModelsDialog::OnTypeNotebookPageChanged(wxBookCtrlEvent& event)
 {
+    StopAnimation();
     wxString name = GetSelectedName();
     if (name == "") {
         return;
@@ -1409,6 +1438,7 @@ void SubModelsDialog::OnButton_ReverseNodesClick(wxCommandEvent& event)
 
 void SubModelsDialog::OnListCtrl_SubModelsItemSelect(wxListEvent& event)
 {
+    StopAnimation();
     shouldProcessGridCellChanged = false;
     if (ListCtrl_SubModels->GetSelectedItemCount() == 1)
     {
@@ -2422,6 +2452,11 @@ void SubModelsDialog::ValidateWindow()
         TypeNotebook->Disable();
         ChoiceBufferStyle->Disable();
     }
+
+    Button_PlayAnim->Enable(
+        _animPlaying ||
+        (ListCtrl_SubModels->GetSelectedItemCount() > 0 && TypeNotebook->GetSelection() == 0)
+    );
 }
 
 void SubModelsDialog::UnSelectAll()
@@ -4889,4 +4924,121 @@ wxString SubModelsDialog::GetDownloadSubmodels() {
         }
     }
     return wxString();
+}
+
+void SubModelsDialog::ParseAnimRows()
+{
+    _animRows.clear();
+    _animMaxSteps = 0;
+
+    int nodeCount = (int)model->GetNodeCount();
+    for (int row = 0; row < NodesGrid->GetNumberRows(); ++row) {
+        wxString v = NodesGrid->GetCellValue(row, 0);
+        AnimRows::value_type rowSlots;
+
+        wxStringTokenizer wtkz(v, ",", wxTOKEN_RET_EMPTY_ALL);
+        while (wtkz.HasMoreTokens()) {
+            wxString token = wtkz.GetNextToken().Trim(true).Trim(false);
+            if (token.Contains("-")) {
+                int idx = token.Index('-');
+                int start = wxAtoi(token.Left(idx)) - 1;
+                int end = wxAtoi(token.Right(token.size() - idx - 1)) - 1;
+                int step = (start <= end) ? 1 : -1;
+                for (int n = start; n != end + step; n += step) {
+                    std::vector<int> slot;
+                    if (n >= 0 && n < nodeCount)
+                        slot.push_back(n);
+                    rowSlots.push_back(std::move(slot));
+                }
+            } else {
+                std::vector<int> slot;
+                if (!token.empty()) {
+                    int n = wxAtoi(token) - 1;
+                    if (n >= 0 && n < nodeCount)
+                        slot.push_back(n);
+                }
+                rowSlots.push_back(std::move(slot));
+            }
+        }
+
+        _animMaxSteps = std::max(_animMaxSteps, (int)rowSlots.size());
+        _animRows.push_back(std::move(rowSlots));
+    }
+}
+
+void SubModelsDialog::StopAnimation()
+{
+    if (!_animPlaying)
+        return;
+    _animTimer.Stop();
+    _animPlaying = false;
+    Button_PlayAnim->SetLabel(_("Play"));
+    NodesGrid->EnableEditing(true);
+    SelectRow(NodesGrid->GetGridCursorRow());
+}
+
+void SubModelsDialog::OnPlayAnimClick(wxCommandEvent& event)
+{
+    if (_animPlaying) {
+        StopAnimation();
+        return;
+    }
+
+    if (TypeNotebook->GetSelection() != 0)
+        return;
+
+    ParseAnimRows();
+    if (_animMaxSteps == 0)
+        return;
+
+    _animPlaying = true;
+    _animStep = 0;
+    _animTotalSteps = 0;
+    Button_PlayAnim->SetLabel(_("Stop"));
+    NodesGrid->EnableEditing(false);
+
+    int interval = 520 - 5 * Slider_AnimSpeed->GetValue();
+    _animTimer.Start(interval);
+}
+
+void SubModelsDialog::OnAnimSpeedChange(wxCommandEvent& event)
+{
+    if (_animPlaying) {
+        int interval = 520 - 5 * Slider_AnimSpeed->GetValue();
+        _animTimer.Start(interval);
+    }
+}
+
+void SubModelsDialog::OnAnimTimerTick(wxTimerEvent& event)
+{
+    int trail = std::min(Slider_AnimTrail->GetValue(), _animTotalSteps);
+
+    ClearNodeColor(model);
+
+    // paint all submodel rows white so the full submodel stays visible
+    for (int i = 0; i < NodesGrid->GetNumberRows(); ++i)
+        SetNodeColor(i, xlWHITE, false);
+
+    // paint trail first, head last — blue head fades back to white
+    static const xlColor animHead(0, 120, 255);
+    for (int offset = trail; offset >= 0; --offset) {
+        int step = ((_animStep - offset) % _animMaxSteps + _animMaxSteps) % _animMaxSteps;
+        float frac = (offset == 0) ? 1.0f : (float)(trail - offset) / trail;
+        if (frac == 0.0f)
+            continue;
+        xlColor c((uint8_t)(animHead.red   * frac + 255.0f * (1.0f - frac)),
+                  (uint8_t)(animHead.green * frac + 255.0f * (1.0f - frac)),
+                  (uint8_t)(animHead.blue  * frac + 255.0f * (1.0f - frac)));
+        for (auto const& row : _animRows) {
+            if (step < (int)row.size()) {
+                for (int node : row[step])
+                    model->SetNodeColor(node, c);
+            }
+        }
+    }
+
+    model->DisplayEffectOnWindow(modelPreview, mPointSize);
+    _animStep = (_animStep + 1) % _animMaxSteps;
+    if (_animTotalSteps < Slider_AnimTrail->GetMax())
+        ++_animTotalSteps;
 }

--- a/src-ui-wx/model/SubModelsDialog.h
+++ b/src-ui-wx/model/SubModelsDialog.h
@@ -16,6 +16,7 @@
 #include <wx/dnd.h>
 #include <wx/listctrl.h>
 #include <wx/regex.h>
+#include <wx/spinctrl.h>
 #include <wx/timer.h>
 #include <glm/glm.hpp>
 
@@ -181,8 +182,8 @@ public:
     //*)
 
     wxButton* Button_PlayAnim = nullptr;
-    wxSlider* Slider_AnimSpeed = nullptr;
-    wxSlider* Slider_AnimTrail = nullptr;
+    wxSpinCtrl* Spin_AnimSpeed = nullptr;
+    wxSpinCtrl* Spin_AnimTrail = nullptr;
 
 protected:
 
@@ -407,7 +408,7 @@ private:
     void OnTimer1Trigger(wxTimerEvent& event);
     void OnAnimTimerTick(wxTimerEvent& event);
     void OnPlayAnimClick(wxCommandEvent& event);
-    void OnAnimSpeedChange(wxCommandEvent& event);
+    void OnAnimSpeedChange(wxSpinEvent& event);
 
     void ParseAnimRows();
     void StopAnimation();

--- a/src-ui-wx/model/SubModelsDialog.h
+++ b/src-ui-wx/model/SubModelsDialog.h
@@ -400,6 +400,7 @@ private:
     //*)
 
     void OnCancel(wxCloseEvent& event);
+    void OnOK(wxCommandEvent& event);
     void OnPreviewLeftUp(wxMouseEvent& event);
     void OnPreviewMouseLeave(wxMouseEvent& event);
     void OnPreviewLeftDown(wxMouseEvent& event);

--- a/src-ui-wx/model/SubModelsDialog.h
+++ b/src-ui-wx/model/SubModelsDialog.h
@@ -120,6 +120,7 @@ class SubModelsDialog : public wxDialog
     int _animTotalSteps = 0;
     int _animMaxSteps = 0;
     AnimRows _animRows;
+    std::vector<int> _animSubmodelNodes;
 
     bool m_creating_bound_rect;
     int m_bound_start_x;

--- a/src-ui-wx/model/SubModelsDialog.h
+++ b/src-ui-wx/model/SubModelsDialog.h
@@ -112,6 +112,15 @@ class SubModelsDialog : public wxDialog
     SubBufferPanel *subBufferPanel = nullptr;
     bool _isMatrix = false;
 
+    using AnimRows = std::vector<std::vector<std::vector<int>>>;
+
+    wxTimer _animTimer;
+    bool _animPlaying = false;
+    int _animStep = 0;
+    int _animTotalSteps = 0;
+    int _animMaxSteps = 0;
+    AnimRows _animRows;
+
     bool m_creating_bound_rect;
     int m_bound_start_x;
     int m_bound_start_y;
@@ -169,6 +178,10 @@ public:
     wxStaticText* StaticTextName;
     wxTextCtrl* TextCtrl_Name;
     //*)
+
+    wxButton* Button_PlayAnim = nullptr;
+    wxSlider* Slider_AnimSpeed = nullptr;
+    wxSlider* Slider_AnimTrail = nullptr;
 
 protected:
 
@@ -250,6 +263,11 @@ protected:
     static const long SUBMODEL_DIALOG_BLANKS_AS_ZERO;
     static const long SUBMODEL_DIALOG_BLANKS_AS_EMPTY;
     static const long SUBMODEL_DIALOG_REMOVE_BLANKS_ZEROS;
+
+    static const long ID_BUTTON_PLAY_ANIM;
+    static const long ID_SLIDER_ANIM_SPEED;
+    static const long ID_SLIDER_ANIM_TRAIL;
+    static const long ID_ANIM_TIMER;
 
     void SaveSubModelInfoIntoThisModel(Model* m);
     wxString GetSelectedName() const;
@@ -386,6 +404,12 @@ private:
     void OnPreviewLeftDClick(wxMouseEvent& event);
     void OnPreviewMouseMove(wxMouseEvent& event);
     void OnTimer1Trigger(wxTimerEvent& event);
+    void OnAnimTimerTick(wxTimerEvent& event);
+    void OnPlayAnimClick(wxCommandEvent& event);
+    void OnAnimSpeedChange(wxCommandEvent& event);
+
+    void ParseAnimRows();
+    void StopAnimation();
 
     void OnImportBtnPopup(wxCommandEvent& event);
     void OnEditBtnPopup(wxCommandEvent& event);


### PR DESCRIPTION
Adds a "Node Animation" panel to the SubModels dialog that lets users visually verify node ordering and direction in their submodel definitions. Clicking Play steps through each slot position simultaneously across all rows — individual nodes, ranges expanded node-by-node, and blank/zero slots preserved as timing placeholders — so the animation cadence exactly matches the Line Count column. The head node is highlighted in electric blue and trails off with a fade back to white, keeping the full submodel visible at all times. A Speed slider controls the tick interval and a Trail slider controls how many nodes illuminate behind the head. The trail builds up naturally over the first pass rather than wrapping artificially, and loops continuously until stopped. Animation auto-stops when switching submodels, changing tabs, or closing the dialog.

<img width="2287" height="1362" alt="image" src="https://github.com/user-attachments/assets/61de188f-6ec0-447b-9664-9bd605b0ff12" />
