### PR TITLE
5941 Empty Group Imports and logging tweaks

### DIFF
--- a/src-core/media/FFmpegVideoReader.cpp
+++ b/src-core/media/FFmpegVideoReader.cpp
@@ -471,7 +471,7 @@ void FFmpegVideoReader::reopenContext(bool allowHWDecoder) {
         if (IsHardwareAcceleratedVideo() && type != AV_HWDEVICE_TYPE_NONE) {
             const char* opt = nullptr;
             if (av_hwdevice_ctx_create(&_hw_device_ctx, type, opt, nullptr, 0) < 0) {
-                spdlog::debug("Failed to create specified HW device.");
+                spdlog::warn("VideoReader: Failed to create HW device '{}' for {} - falling back to software decode.", av_hwdevice_get_type_name(type), _filename.c_str());
                 type = AV_HWDEVICE_TYPE_NONE;
             } else {
                 _codecContext->hw_device_ctx = av_buffer_ref(_hw_device_ctx);
@@ -503,7 +503,7 @@ void FFmpegVideoReader::reopenContext(bool allowHWDecoder) {
         avcodec_free_context(&_codecContext);
         _codecContext = nullptr;
         if (allowHWDecoder && IsHardwareAcceleratedVideo()) {
-            spdlog::debug("VideoReader: HW decoder '{}' failed to open; falling back to software decode", decoderToUse->name);
+            spdlog::warn("VideoReader: HW decoder '{}' failed to open for {}; falling back to software decode", decoderToUse->name, _filename.c_str());
             reopenContext(false);
         } else {
             spdlog::error("VideoReader: Couldn't open the context with the decoder in {}", _filename.c_str());
@@ -909,7 +909,7 @@ bool FFmpegVideoReader::readFrame(int timestampMS) {
 
                 if (_swsCtx == nullptr) {
                     if (_abandonHardwareDecode) {
-                        spdlog::warn("VideoReader: Hardware decoding abandoned due to directx error.");
+                        spdlog::debug("VideoReader: Using software decode (hardware decoding unavailable for this file).");
                     }
                     if (IsHardwareAcceleratedVideo() && _codecContext->hw_device_ctx != nullptr && _srcFrame->format == __hw_pix_fmt && !_abandonHardwareDecode) {
                         spdlog::debug("Hardware format {} -> Software format {}.", av_get_pix_fmt_name((AVPixelFormat)_srcFrame->format), av_get_pix_fmt_name((AVPixelFormat)_srcFrame2->format));
@@ -1033,7 +1033,9 @@ VideoFrame* FFmpegVideoReader::GetNextFrame(int timestampMS, int gracetime)
                 int ret = avcodec_send_packet(_codecContext, _packet);
                 while (!_abort && ret != 0) {
                     if (ret != AVERROR(EAGAIN) && !_abandonHardwareDecode && (_videoToolboxAccelerated || _hw_device_ctx )) {
-                        spdlog::debug("    Hardware video decoding failed for {}. Reverting to software decoding.", (const char*)_filename.c_str());
+                        char errbuf[AV_ERROR_MAX_STRING_SIZE];
+                        av_strerror(ret, errbuf, sizeof(errbuf));
+                        spdlog::warn("VideoReader: Hardware video decoding failed for {} (error: {}). Reverting to software decoding.", (const char*)_filename.c_str(), errbuf);
                         reopenContext(false);
                         Seek(timestampMS, false);
                         currenttime = GetPos();

--- a/src-core/media/FFmpegVideoReader.cpp
+++ b/src-core/media/FFmpegVideoReader.cpp
@@ -335,6 +335,7 @@ FFmpegVideoReader::FFmpegVideoReader(const std::string& filename, int maxwidth, 
 }
 
 void FFmpegVideoReader::reopenContext(bool allowHWDecoder) {
+    spdlog::info("VideoReader: reopenContext({}) for {}", allowHWDecoder, _filename);
 
 #if LIBAVFORMAT_VERSION_MAJOR > 57
     if (_cudaScaledFrame != nullptr) {
@@ -357,6 +358,10 @@ void FFmpegVideoReader::reopenContext(bool allowHWDecoder) {
         hwDecoderCache = nullptr;
         avcodec_free_context(&_codecContext);
         _codecContext = nullptr;
+    }
+    if (_hw_device_ctx != nullptr) {
+        av_buffer_unref(&_hw_device_ctx);
+        _hw_device_ctx = nullptr;
     }
     enum AVHWDeviceType type = ::AVHWDeviceType::AV_HWDEVICE_TYPE_NONE;
     if (allowHWDecoder && IsHardwareAcceleratedVideo()) {
@@ -486,7 +491,15 @@ void FFmpegVideoReader::reopenContext(bool allowHWDecoder) {
     _videoToolboxAccelerated = SetupVideoToolboxAcceleration(_codecContext, HW_ACCELERATION_ENABLED && allowHWDecoder);
 
     AVDictionary *opts = nullptr;
+    if (usingCuvid) {
+        // Limit NVDEC surface pool: default is max(DPB,20) per decoder instance.
+        // With many models each holding their own VideoReader this multiplies to
+        // several GB.  8 covers H.264 Level 4.1 max DPB (8 ref frames) while
+        // keeping per-instance VRAM well below the 20-surface default.
+        av_dict_set_int(&opts, "surfaces", 8, 0);
+    }
     if (avcodec_open2(_codecContext, decoderToUse, &opts) < 0) {
+        av_dict_free(&opts);
         avcodec_free_context(&_codecContext);
         _codecContext = nullptr;
         if (allowHWDecoder && IsHardwareAcceleratedVideo()) {
@@ -497,6 +510,7 @@ void FFmpegVideoReader::reopenContext(bool allowHWDecoder) {
         }
         return;
     }
+    av_dict_free(&opts);
 }
 
 static int64_t MStoDTS(int ms, double dtspersec)

--- a/src-core/media/FFmpegVideoReader.cpp
+++ b/src-core/media/FFmpegVideoReader.cpp
@@ -335,7 +335,7 @@ FFmpegVideoReader::FFmpegVideoReader(const std::string& filename, int maxwidth, 
 }
 
 void FFmpegVideoReader::reopenContext(bool allowHWDecoder) {
-    spdlog::info("VideoReader: reopenContext({}) for {}", allowHWDecoder, _filename);
+    spdlog::debug("VideoReader: reopenContext({}) for {}", allowHWDecoder, _filename);
 
 #if LIBAVFORMAT_VERSION_MAJOR > 57
     if (_cudaScaledFrame != nullptr) {

--- a/src-core/models/Model.cpp
+++ b/src-core/models/Model.cpp
@@ -2012,9 +2012,9 @@ void Model::InitRenderBufferNodes(const std::string& tp, const std::string& came
             int maxDimension = ((ModelGroup*)this)->GetGridSize();
             if (maxDimension != 0 && (maxX - minX > maxDimension || maxY - minY > maxDimension)) {
                 // we need to resize all the points by this amount
-                spdlog::warn("Model Group ({}), Actual Grid Size of {} exceeded the Max Grid Size of {}.",
-                    (const char*)GetFullName().c_str(), 
-                    ((maxX - minX) > (maxY - minY) ? (maxX - minX) : (maxY - minY)), 
+                spdlog::warn("Model Group ({}), Actual Grid Size of {:.0f} exceeded the Max Grid Size of {}.",
+                    (const char*)GetFullName().c_str(),
+                    ((maxX - minX) > (maxY - minY) ? (maxX - minX) : (maxY - minY)),
                     maxDimension);
                 factor = std::max(((float)(maxX - minX)) / (float)maxDimension, ((float)(maxY - minY)) / (float)maxDimension);
                 // But if it is already smaller we dont want to make it bigger

--- a/src-core/render/FSEQFile.cpp
+++ b/src-core/render/FSEQFile.cpp
@@ -1853,7 +1853,7 @@ void V2FSEQFile::prepareRead(const std::vector<std::pair<uint32_t, uint32_t>>& r
 
     for (auto const& [st, cnt] : ranges) {
         if (!isWithinRange(m_rangesToRead, st, cnt)) {
-            LogErr(VB_SEQUENCE, "Requested range outside Read Ranges. Requested %d channels starting at %d\n", cnt, st);
+            LogErr(VB_SEQUENCE, "Requested range outside Read Ranges. Requested %d channels starting at %d. FSEQ expects %d channels.\n", cnt, st, m_seqChannelCount);
         }
     }
     m_handler->prepareRead(startFrame);

--- a/src-core/render/SequenceFile.cpp
+++ b/src-core/render/SequenceFile.cpp
@@ -476,7 +476,11 @@ std::optional<pugi::xml_document> SequenceFile::LoadSequence(const std::string& 
                                 spdlog::error("LoadSequence: audio file not readable.");
                             }
                         } else {
-                            spdlog::error("LoadSequence: audio file does not exist.");
+                            if (seq_type == "Animation") {
+                                spdlog::debug("LoadSequence: audio file does not exist (ignored for Animation).");
+                            } else {
+                                spdlog::error("LoadSequence: audio file does not exist.");
+                            }
                         }
                     }
                 } else if (name == "altAudioTracks") {

--- a/src-core/utils/SpecialOptions.cpp
+++ b/src-core/utils/SpecialOptions.cpp
@@ -69,10 +69,12 @@ std::string SpecialOptions::GetOption(const std::string& option, const std::stri
         if (!result) {
             spdlog::error("SpecialOptions: failed to parse '{}': {} (offset {})",
                           file, result.description(), result.offset);
+            __loaded = true;
             return defaultValue;
         }
         if (!doc.document_element()) {
             spdlog::error("SpecialOptions: '{}' parsed but has no root element (file may be empty)", file);
+            __loaded = true;
             return defaultValue;
         }
         __loaded = true;

--- a/src-core/utils/SpecialOptions.cpp
+++ b/src-core/utils/SpecialOptions.cpp
@@ -66,26 +66,31 @@ std::string SpecialOptions::GetOption(const std::string& option, const std::stri
     if (!__loaded) {
         pugi::xml_document doc;
         auto result = doc.load_file(file.c_str());
-        if (result && doc.document_element()) {
-            __loaded = true;
-            if (file == showFile) {
-                spdlog::info("SpecialOptions: loaded from show folder '{}'", file);
-            } else {
-                spdlog::info("SpecialOptions: loaded from exe folder '{}'", file);
-            }
-            for (pugi::xml_node n = doc.document_element().first_child(); n; n = n.next_sibling()) {
-                std::string nodeName = n.name();
-                std::transform(nodeName.begin(), nodeName.end(), nodeName.begin(), ::tolower);
-                if (nodeName == "option") {
-                    std::string name = Trim(n.attribute("name").as_string());
-                    std::string value = n.attribute("value").as_string();
-                    if (name != "") {
-                        __cache[name] = value;
-                    }
+        if (!result) {
+            spdlog::error("SpecialOptions: failed to parse '{}': {} (offset {})",
+                          file, result.description(), result.offset);
+            return defaultValue;
+        }
+        if (!doc.document_element()) {
+            spdlog::error("SpecialOptions: '{}' parsed but has no root element (file may be empty)", file);
+            return defaultValue;
+        }
+        __loaded = true;
+        if (file == showFile) {
+            spdlog::info("SpecialOptions: loaded from show folder '{}'", file);
+        } else {
+            spdlog::info("SpecialOptions: loaded from exe folder '{}'", file);
+        }
+        for (pugi::xml_node n = doc.document_element().first_child(); n; n = n.next_sibling()) {
+            std::string nodeName = n.name();
+            std::transform(nodeName.begin(), nodeName.end(), nodeName.begin(), ::tolower);
+            if (nodeName == "option") {
+                std::string name = Trim(n.attribute("name").as_string());
+                std::string value = n.attribute("value").as_string();
+                if (name != "") {
+                    __cache[name] = value;
                 }
             }
-        } else {
-            return defaultValue;
         }
     }
 

--- a/src-ui-wx/app-shell/TabSequence.cpp
+++ b/src-ui-wx/app-shell/TabSequence.cpp
@@ -1723,8 +1723,8 @@ void xLightsFrame::SaveAsSequence()
             wxString showPath = fnDir.GetPath(wxPATH_GET_VOLUME | wxPATH_GET_SEPARATOR);
             if (!filePath.StartsWith(showPath)) {
                 ok = false;
-                DisplayWarning("Sequence files must be saved within the current show directory:\n" + showPath +
-                               "\n\nPlease choose a location inside the show directory.", this);
+                DisplayError("Sequence files must be saved within the current show directory:\n" + showPath +
+                             "\n\nPlease choose a location inside the show directory.", this);
                 fd.SetDirectory(CurrentDir);
             }
         }

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -8941,9 +8941,8 @@ void LayoutPanel::ImportModelsFromPreview(std::list<impTreeItemData*> models, wx
                     return (xlights->AllModels.GetModel(s) == nullptr);
                 }), models.end());
 
-            if (!includeEmptyGroups && models.empty()) {
-                spdlog::warn("Import model group '{}' failed as no models in the group exist in this display.", (const char*)it2->GetName().c_str());
-                continue;
+            if (models.empty()) {
+                spdlog::info("Import model group '{}' has no models in this display, creating empty group.", (const char*)it2->GetName().c_str());
             }
 
             wxString const name = it2->GetName();

--- a/src-ui-wx/xLightsApp.cpp
+++ b/src-ui-wx/xLightsApp.cpp
@@ -679,6 +679,10 @@ bool xLightsApp::OnInit()
             GetXLightsConfig()->Read("LastDir", &lastDir);
             if (lastDir != showDir) {
                 info += _("Setting show directory to ") + showDir + "\n";
+                // re-apply logging with the command-line show dir overriding LastDir
+                SpecialOptions::StashShowDir(showDir.ToStdString());
+                SpecialOptions::GetOption("", "");
+                ApplyLoggingSpecialOptions();
             }
         }
 

--- a/src-ui-wx/xLightsApp.cpp
+++ b/src-ui-wx/xLightsApp.cpp
@@ -202,21 +202,17 @@ void InitialiseLogging(bool fromMain)
 
 void ApplyLoggingSpecialOptions()
 {
-    static bool levelsApplied = false;
-    if (!levelsApplied) {
-        levelsApplied = true;
-        auto applyLevel = [](const std::string& name, const std::string& option, const std::string& defaultLevel) {
-            std::string level = SpecialOptions::GetOption(option, defaultLevel);
-            spdlog::get(name)->set_level(spdlog::level::from_str(level));
-            spdlog::info("Logger '{}' level set to '{}'", name, level);
-        };
-        applyLevel("xLights", "xLights_logger", "info");
-        applyLevel("render", "render_logger", "warn");
-        applyLevel("curl",   "curl_logger",   "info");
-        applyLevel("opengl", "opengl_logger", "info");
-        applyLevel("job",    "job_logger",    "info");
-        applyLevel("work",   "work_logger",   "info");
-    }
+    auto applyLevel = [](const std::string& name, const std::string& option, const std::string& defaultLevel) {
+        std::string level = SpecialOptions::GetOption(option, defaultLevel);
+        spdlog::get(name)->set_level(spdlog::level::from_str(level));
+        spdlog::info("Logger '{}' level set to '{}'", name, level);
+    };
+    applyLevel("xLights", "xLights_logger", "info");
+    applyLevel("render", "render_logger", "warn");
+    applyLevel("curl",   "curl_logger",   "info");
+    applyLevel("opengl", "opengl_logger", "info");
+    applyLevel("job",    "job_logger",    "info");
+    applyLevel("work",   "work_logger",   "info");
 
     if (SpecialOptions::GetOption("console_logger", "false") != "true") return;
 
@@ -552,6 +548,18 @@ bool xLightsApp::OnInit()
     GetResourcesDirectory(); // bootstrap GetResourcesDir() with wx-dependent path lookup
     InitializeXLightsConfig();
     DumpConfig();
+
+    // Stash the remembered show folder so show-folder special.options is applied
+    // before the frame is constructed. InitialiseLogging() only knew the exe folder;
+    // this re-applies logger levels now that the show folder is known.
+    {
+        wxString lastDir;
+        if (GetXLightsConfig()->Read("LastDir", &lastDir) && !lastDir.IsEmpty()) {
+            SpecialOptions::StashShowDir(lastDir.ToStdString());
+            SpecialOptions::GetOption("", ""); // reset cache to pick up show folder
+            ApplyLoggingSpecialOptions();
+        }
+    }
 
     int id = (int)wxThread::GetCurrentId();
     spdlog::info("Main thread id: 0x{:x} or {}", id, id);


### PR DESCRIPTION
When you import from another layout dont silently skip the empty groups. Also tweak some of the excess logging.