### PR TITLE
Fix the broken multi-timing track ability (#6219)

### DIFF
--- a/src-core/render/SequenceElements.cpp
+++ b/src-core/render/SequenceElements.cpp
@@ -1438,13 +1438,14 @@ int SequenceElements::GetNumberOfActiveTimingEffects()
     return num_timing_effects;
 }
 
-void SequenceElements::DeactivateAllTimingElements()
+void SequenceElements::DeactivateAllTimingElements(bool allViews)
 {
-    for(size_t i=0;i<mAllViews[MASTER_VIEW].size();i++)
+    int view = allViews ? MASTER_VIEW : mCurrentView;
+    for(size_t i=0;i<mAllViews[view].size();i++)
     {
-        if(mAllViews[MASTER_VIEW][i]->GetType()== ElementType::ELEMENT_TYPE_TIMING)
+        if(mAllViews[view][i]->GetType()== ElementType::ELEMENT_TYPE_TIMING)
         {
-            dynamic_cast<TimingElement*>(mAllViews[MASTER_VIEW][i])->SetActive(false);
+            dynamic_cast<TimingElement*>(mAllViews[view][i])->SetActive(false);
         }
     }
 }

--- a/src-core/render/SequenceElements.h
+++ b/src-core/render/SequenceElements.h
@@ -164,7 +164,7 @@ public:
     void SortElements();
     void MoveElement(int index, int destinationIndex);
 
-    void DeactivateAllTimingElements();
+    void DeactivateAllTimingElements(bool allViews = false);
     void SetFrequency(double frequency);
     double GetFrequency();
     int GetFrameMS();

--- a/src-ui-wx/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/sequencer/tabSequencer.cpp
@@ -3510,7 +3510,7 @@ TimingElement* xLightsFrame::AddTimingElement(const std::string& name, const std
     }
 
     // Deactivate active timing mark so new one is selected;
-    _sequenceElements.DeactivateAllTimingElements();
+    _sequenceElements.DeactivateAllTimingElements(true);
     int timingCount = _sequenceElements.GetNumberOfTimingElements();
     std::string type = "timing";
     TimingElement* e = dynamic_cast<TimingElement*>(_sequenceElements.AddElement(timingCount, n, type, true, false, true, false, false));
@@ -3879,7 +3879,7 @@ void xLightsFrame::ExecuteImportNotes(wxCommandEvent& command)
 
     if (dlgNoteImport.ShowModal() == wxID_OK) {
         wxString name = dlgNoteImport.TextCtrl_TimingName->GetValue();
-        _sequenceElements.DeactivateAllTimingElements();
+        _sequenceElements.DeactivateAllTimingElements(true);
         Element* element = AddTimingElement(std::string(name.ToStdString()));
         EffectLayer* effectLayer = element->GetEffectLayer(0);
         // _sequenceElements.AddTimingToCurrentView(name.ToStdString()); I dont think this is necessary
@@ -3977,7 +3977,7 @@ void xLightsFrame::ImportTimingElement()
             } else {
                 CurrentSeqXmlFile->ProcessAudacityTimingFiles( filenames, this);
             }
-            _sequenceElements.DeactivateAllTimingElements();
+            _sequenceElements.DeactivateAllTimingElements(true);
             int timingCount = _sequenceElements.GetNumberOfTimingElements();
             if (timingCount > 0) {
                 TimingElement* te = _sequenceElements.GetTimingElement(timingCount - 1);


### PR DESCRIPTION
Revert and reimplement a fix that would ensure only one timing mark is selected after importing timing tracks while still allowing one to have multiples selected (afterwards).