### PR TITLE
Fix ON effect resetting the intensity values (#6233)

### DIFF
--- a/src-ui-wx/effectpanels/JsonEffectPanel.cpp
+++ b/src-ui-wx/effectpanels/JsonEffectPanel.cpp
@@ -2112,6 +2112,15 @@ void JsonEffectPanel::SetDefaultParameters() {
             } else {
                 if (info.slider) {
                     SetSliderValue(info.slider, info.defaultValue.get<int>());
+                } else if (info.settingPrefix == "TEXTCTRL") {
+                    // TEXTCTRL primary: text control holds the value, slider is a visual buddy
+                    int ival = info.defaultValue.get<int>();
+                    if (info.textCtrl) {
+                        SetTextValue(info.textCtrl, wxString::Format("%d", ival).ToStdString());
+                    }
+                    if (info.buddySlider) {
+                        static_cast<wxSlider*>(info.buddySlider)->SetValue(ival);
+                    }
                 }
             }
         } else if (info.controlType == "checkbox") {


### PR DESCRIPTION
When setting intensity to a value then switching onto another effect and back it would revert to default values.