### PR TITLE
Add filter to Edit Display Elements Available list

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -86,6 +86,9 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -enh (dkulp)                Shader effect: dynamic uniforms emit JSON matching the effect-panel schema; JsonEffectPanel
                                 gains a reusable point2d control type, so iPad and desktop build the dynamic rows from the
                                 same description.
+    -enh (Neil)                 Edit Display Elements: add a filter box above the Available list so large shows can
+                                quickly find a model/timing/group to add. Filter clears automatically when items are
+                                moved into the view.
     -bug (dkulp)                Replaced throwing std::stoi calls in OutputManager / xxxSerialOutput / HinksPix with
                                 non-throwing std::strtol so corrupt config or controller responses no longer crash.
     -bug (dkulp)                State / Faces / Shockwave / VUMeter / Lyric / MatrixModel: added div-by-zero and

--- a/src-ui-wx/layout/ViewsModelsPanel.cpp
+++ b/src-ui-wx/layout/ViewsModelsPanel.cpp
@@ -254,18 +254,23 @@ ViewsModelsPanel::ViewsModelsPanel(xLightsFrame *frame, wxWindow* parent, wxWind
     _viewButtonsSizer = FlexGridSizer8;
 
     // Insert a filter control above the "Available" (non-models) list.
-    // The wxSmith block put ListCtrlNonModels at (1, 0) spanning rows 1-3.
-    // Detach it, drop the filter into row 1, and re-attach the list to
-    // rows 2-3 so the bottom row stays the growable one.
+    // The wxSmith block put ListCtrlNonModels at (1, 0) span(3, 1).
+    // Detach it, build a vertical box sizer holding [filter, listctrl],
+    // and put the whole sizer back at the original GB position. We need
+    // to wrap them in a sizer (not put the filter in its own GB row)
+    // because row 1 of the GridBagSizer is stretched by ListCtrlViews
+    // on the right, which would leave a tall gap between the filter
+    // and the list.
     GridBagSizer1->Detach(ListCtrlNonModels);
     TextCtrl_NonModelsFilter = new wxSearchCtrl(this, wxID_ANY, wxEmptyString,
                                                 wxDefaultPosition, wxDefaultSize,
                                                 wxTE_PROCESS_ENTER);
     TextCtrl_NonModelsFilter->SetDescriptiveText(_("Filter models..."));
     TextCtrl_NonModelsFilter->ShowCancelButton(true);
-    GridBagSizer1->Add(TextCtrl_NonModelsFilter, wxGBPosition(1, 0), wxDefaultSpan,
-                       wxALL | wxEXPAND, 2);
-    GridBagSizer1->Add(ListCtrlNonModels, wxGBPosition(2, 0), wxGBSpan(2, 1),
+    auto* nonModelsSizer = new wxBoxSizer(wxVERTICAL);
+    nonModelsSizer->Add(TextCtrl_NonModelsFilter, 0, wxBOTTOM | wxEXPAND, 2);
+    nonModelsSizer->Add(ListCtrlNonModels, 1, wxEXPAND, 0);
+    GridBagSizer1->Add(nonModelsSizer, wxGBPosition(1, 0), wxGBSpan(3, 1),
                        wxALL | wxEXPAND, 2);
     TextCtrl_NonModelsFilter->Bind(wxEVT_TEXT,
         &ViewsModelsPanel::OnNonModelsFilterText, this);
@@ -575,13 +580,20 @@ void ViewsModelsPanel::PopulateModels(const std::string& selectModels)
                 if (topM + visibileM - 1 < ListCtrlModels->GetItemCount()) {
                     ListCtrlModels->EnsureVisible(topM + visibileM - 1);
                 }
-                ListCtrlModels->EnsureVisible(topM);
+                if (topM >= 0 && topM < ListCtrlModels->GetItemCount()) {
+                    ListCtrlModels->EnsureVisible(topM);
+                }
             }
             if (ListCtrlNonModels->GetItemCount() > 0) {
                 if (topN + visibileN - 1 < ListCtrlNonModels->GetItemCount()) {
                     ListCtrlNonModels->EnsureVisible(topN + visibileN - 1);
                 }
-                ListCtrlNonModels->EnsureVisible(topN);
+                // Filtering can shrink the non-models list below topN, so
+                // clamp before calling EnsureVisible to avoid the wx
+                // generic listctrl assert.
+                if (topN >= 0 && topN < ListCtrlNonModels->GetItemCount()) {
+                    ListCtrlNonModels->EnsureVisible(topN);
+                }
             }
         }
 

--- a/src-ui-wx/layout/ViewsModelsPanel.cpp
+++ b/src-ui-wx/layout/ViewsModelsPanel.cpp
@@ -18,6 +18,7 @@
 #include <pugixml.hpp>
 #include <wx/artprov.h>
 #include <wx/dnd.h>
+#include <wx/srchctrl.h>
 
 #include "model-16.xpm"
 #include "timing-16.xpm"
@@ -252,7 +253,25 @@ ViewsModelsPanel::ViewsModelsPanel(xLightsFrame *frame, wxWindow* parent, wxWind
     _gridBagSizer = GridBagSizer1;
     _viewButtonsSizer = FlexGridSizer8;
 
-    
+    // Insert a filter control above the "Available" (non-models) list.
+    // The wxSmith block put ListCtrlNonModels at (1, 0) spanning rows 1-3.
+    // Detach it, drop the filter into row 1, and re-attach the list to
+    // rows 2-3 so the bottom row stays the growable one.
+    GridBagSizer1->Detach(ListCtrlNonModels);
+    TextCtrl_NonModelsFilter = new wxSearchCtrl(this, wxID_ANY, wxEmptyString,
+                                                wxDefaultPosition, wxDefaultSize,
+                                                wxTE_PROCESS_ENTER);
+    TextCtrl_NonModelsFilter->SetDescriptiveText(_("Filter models..."));
+    TextCtrl_NonModelsFilter->ShowCancelButton(true);
+    GridBagSizer1->Add(TextCtrl_NonModelsFilter, wxGBPosition(1, 0), wxDefaultSpan,
+                       wxALL | wxEXPAND, 2);
+    GridBagSizer1->Add(ListCtrlNonModels, wxGBPosition(2, 0), wxGBSpan(2, 1),
+                       wxALL | wxEXPAND, 2);
+    TextCtrl_NonModelsFilter->Bind(wxEVT_TEXT,
+        &ViewsModelsPanel::OnNonModelsFilterText, this);
+    TextCtrl_NonModelsFilter->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN,
+        &ViewsModelsPanel::OnNonModelsFilterCancel, this);
+
     GridBagSizer1->AddGrowableCol(0, 2);
     GridBagSizer1->AddGrowableCol(2, 1);
     GridBagSizer1->AddGrowableRow(3);
@@ -889,6 +908,14 @@ void ViewsModelsPanel::AddSelectedModels(int pos)
     }
 
     MarkViewsChanged();
+
+    // Clear the Available filter so the user sees the full list again
+    // after moving items to the right (consistent with what we agreed —
+    // filter served its purpose, reset state).
+    if (TextCtrl_NonModelsFilter != nullptr && !_nonModelFilter.empty()) {
+        TextCtrl_NonModelsFilter->ChangeValue(wxEmptyString);
+        _nonModelFilter.clear();
+    }
     PopulateModels(wxJoin(addedModels, ',').ToStdString());
 
     // Update Grid
@@ -1438,9 +1465,22 @@ void ViewsModelsPanel::OnLeftUp(wxMouseEvent& event)
 
 #pragma region Non Models
 
+bool ViewsModelsPanel::IsFilteredOutOfNonModels(const std::string& name) const
+{
+    if (_nonModelFilter.empty()) {
+        return false;
+    }
+    // Case-insensitive substring match. _nonModelFilter is already lower.
+    wxString lname = wxString::FromUTF8(name).Lower();
+    return lname.Find(wxString::FromUTF8(_nonModelFilter)) == wxNOT_FOUND;
+}
+
 void ViewsModelsPanel::AddTimingToNotList(Element* timing)
 {
     if (timing != nullptr) {
+        if (IsFilteredOutOfNonModels(timing->GetName())) {
+            return;
+        }
         wxListItem li;
         li.SetId(_numNonModels);
         li.SetText(_(""));
@@ -1455,6 +1495,9 @@ void ViewsModelsPanel::AddTimingToNotList(Element* timing)
 void ViewsModelsPanel::AddModelToNotList(Element* model)
 {
     if (model != nullptr) {
+        if (IsFilteredOutOfNonModels(model->GetName())) {
+            return;
+        }
         wxListItem li;
         li.SetId(_numNonModels);
         li.SetText(_(""));
@@ -1469,6 +1512,19 @@ void ViewsModelsPanel::AddModelToNotList(Element* model)
 
         _numNonModels++;
     }
+}
+
+void ViewsModelsPanel::OnNonModelsFilterText(wxCommandEvent& /*event*/)
+{
+    _nonModelFilter = TextCtrl_NonModelsFilter->GetValue().Lower().ToStdString();
+    PopulateModels();
+}
+
+void ViewsModelsPanel::OnNonModelsFilterCancel(wxCommandEvent& /*event*/)
+{
+    TextCtrl_NonModelsFilter->ChangeValue(wxEmptyString);
+    _nonModelFilter.clear();
+    PopulateModels();
 }
 
 void ViewsModelsPanel::OnListCtrlNonModelsItemSelect(wxListEvent& event)

--- a/src-ui-wx/layout/ViewsModelsPanel.cpp
+++ b/src-ui-wx/layout/ViewsModelsPanel.cpp
@@ -945,14 +945,19 @@ void ViewsModelsPanel::AddSelectedModels(int pos)
 
     MarkViewsChanged();
 
+    // Stop any pending debounce regardless of whether the filter
+    // currently looks empty. The user could have typed into the box,
+    // backspaced to empty, then immediately added items — that leaves
+    // a pending one-shot timer that would fire after our PopulateModels
+    // call below and re-rebuild the list, clobbering the selection /
+    // highlight we're about to set. Always stop first.
+    if (_filterDebounceTimer != nullptr) {
+        _filterDebounceTimer->Stop();
+    }
     // Clear the Available filter so the user sees the full list again
     // after moving items to the right (filter served its purpose, reset
-    // state). Also stop any pending debounce so the upcoming
-    // PopulateModels call doesn't get re-run a moment later.
+    // state).
     if (TextCtrl_NonModelsFilter != nullptr && !_nonModelFilter.IsEmpty()) {
-        if (_filterDebounceTimer != nullptr) {
-            _filterDebounceTimer->Stop();
-        }
         TextCtrl_NonModelsFilter->ChangeValue(wxEmptyString);
         _nonModelFilter.Clear();
     }

--- a/src-ui-wx/layout/ViewsModelsPanel.cpp
+++ b/src-ui-wx/layout/ViewsModelsPanel.cpp
@@ -19,6 +19,7 @@
 #include <wx/artprov.h>
 #include <wx/dnd.h>
 #include <wx/srchctrl.h>
+#include <wx/timer.h>
 
 #include "model-16.xpm"
 #include "timing-16.xpm"
@@ -277,6 +278,12 @@ ViewsModelsPanel::ViewsModelsPanel(xLightsFrame *frame, wxWindow* parent, wxWind
     TextCtrl_NonModelsFilter->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN,
         &ViewsModelsPanel::OnNonModelsFilterCancel, this);
 
+    // Debounce keystrokes so PopulateModels (full rebuild of both lists)
+    // doesn't run on every character on large shows.
+    _filterDebounceTimer = new wxTimer(this);
+    Bind(wxEVT_TIMER, &ViewsModelsPanel::OnFilterDebounceTimer, this,
+         _filterDebounceTimer->GetId());
+
     GridBagSizer1->AddGrowableCol(0, 2);
     GridBagSizer1->AddGrowableCol(2, 1);
     GridBagSizer1->AddGrowableRow(3);
@@ -418,6 +425,12 @@ ViewsModelsPanel::~ViewsModelsPanel()
 {
     //(*Destroy(ViewsModelsPanel)
     //*)
+
+    if (_filterDebounceTimer != nullptr) {
+        _filterDebounceTimer->Stop();
+        delete _filterDebounceTimer;
+        _filterDebounceTimer = nullptr;
+    }
 
     //for (int i = 0; i < ListCtrlNonModels->GetItemCount(); ++i)
     //{
@@ -934,8 +947,12 @@ void ViewsModelsPanel::AddSelectedModels(int pos)
 
     // Clear the Available filter so the user sees the full list again
     // after moving items to the right (filter served its purpose, reset
-    // state).
+    // state). Also stop any pending debounce so the upcoming
+    // PopulateModels call doesn't get re-run a moment later.
     if (TextCtrl_NonModelsFilter != nullptr && !_nonModelFilter.IsEmpty()) {
+        if (_filterDebounceTimer != nullptr) {
+            _filterDebounceTimer->Stop();
+        }
         TextCtrl_NonModelsFilter->ChangeValue(wxEmptyString);
         _nonModelFilter.Clear();
     }
@@ -1542,14 +1559,30 @@ void ViewsModelsPanel::AddModelToNotList(Element* model)
 
 void ViewsModelsPanel::OnNonModelsFilterText(wxCommandEvent& /*event*/)
 {
+    // Capture the current text immediately so the cached filter stays
+    // in sync with what the user sees, but debounce the expensive
+    // PopulateModels rebuild — restart the one-shot timer on each
+    // keystroke and only rebuild after the user pauses for ~150 ms.
     _nonModelFilter = TextCtrl_NonModelsFilter->GetValue().Lower();
-    PopulateModels();
+    if (_filterDebounceTimer != nullptr) {
+        _filterDebounceTimer->Start(kFilterDebounceMs, wxTIMER_ONE_SHOT);
+    }
 }
 
 void ViewsModelsPanel::OnNonModelsFilterCancel(wxCommandEvent& /*event*/)
 {
+    // Explicit cancel — rebuild immediately so the user sees the full
+    // list without waiting for the debounce window.
+    if (_filterDebounceTimer != nullptr) {
+        _filterDebounceTimer->Stop();
+    }
     TextCtrl_NonModelsFilter->ChangeValue(wxEmptyString);
     _nonModelFilter.Clear();
+    PopulateModels();
+}
+
+void ViewsModelsPanel::OnFilterDebounceTimer(wxTimerEvent& /*event*/)
+{
     PopulateModels();
 }
 

--- a/src-ui-wx/layout/ViewsModelsPanel.cpp
+++ b/src-ui-wx/layout/ViewsModelsPanel.cpp
@@ -374,6 +374,12 @@ void ViewsModelsPanel::SetEffectSequenceMode(bool effectSeq)
         // Expand ListCtrlModels to cover the right side
         _gridBagSizer->SetItemPosition(ListCtrlModels, wxGBPosition(0, 2));
         _gridBagSizer->SetItemSpan(ListCtrlModels, wxGBSpan(4, 1));
+        // Row 1 is shared with the [filter + ListCtrlNonModels] box sizer
+        // on the left (col 0). Making row 1 growable lets the right-side
+        // ListCtrlModels (rows 0-3) get a fair vertical share. The filter
+        // itself does NOT stretch because inside the box sizer it sits at
+        // proportion 0; the listctrl below it (proportion 1) absorbs all
+        // row growth.
         _gridBagSizer->AddGrowableRow(1);
         _gridBagSizer->RemoveGrowableCol(2);
         _gridBagSizer->AddGrowableCol(2, 2);
@@ -555,10 +561,14 @@ void ViewsModelsPanel::PopulateModels(const std::string& selectModels)
             }
         }
 
-        // Add model groups not already in the sequence elements list
+        // Add model groups not already in the sequence elements list.
+        // Check the Available filter BEFORE allocating the ModelElement -
+        // AddModelToNotList drops filtered items without inserting, so an
+        // up-front allocation would leak per keystroke on a filtered list.
         for (const auto& it : _xlFrame->AllModels) {
             if (it.second->GetDisplayAs() == DisplayAsType::ModelGroup) {
-                if (!_sequenceElements->ElementExists(it.first, 0)) {
+                if (!_sequenceElements->ElementExists(it.first, 0) &&
+                    !IsFilteredOutOfNonModels(it.first)) {
                     ModelElement* me = new ModelElement(it.first);
                     if (me != nullptr) AddModelToNotList(me);
                 }
@@ -568,7 +578,8 @@ void ViewsModelsPanel::PopulateModels(const std::string& selectModels)
         // Add regular models not already in the sequence elements list
         for (const auto& it : _xlFrame->AllModels) {
             if (it.second->GetDisplayAs() != DisplayAsType::ModelGroup) {
-                if (!_sequenceElements->ElementExists(it.first, 0)) {
+                if (!_sequenceElements->ElementExists(it.first, 0) &&
+                    !IsFilteredOutOfNonModels(it.first)) {
                     ModelElement* me = new ModelElement(it.first);
                     if (me != nullptr) AddModelToNotList(me);
                 }
@@ -922,11 +933,11 @@ void ViewsModelsPanel::AddSelectedModels(int pos)
     MarkViewsChanged();
 
     // Clear the Available filter so the user sees the full list again
-    // after moving items to the right (consistent with what we agreed —
-    // filter served its purpose, reset state).
-    if (TextCtrl_NonModelsFilter != nullptr && !_nonModelFilter.empty()) {
+    // after moving items to the right (filter served its purpose, reset
+    // state).
+    if (TextCtrl_NonModelsFilter != nullptr && !_nonModelFilter.IsEmpty()) {
         TextCtrl_NonModelsFilter->ChangeValue(wxEmptyString);
-        _nonModelFilter.clear();
+        _nonModelFilter.Clear();
     }
     PopulateModels(wxJoin(addedModels, ',').ToStdString());
 
@@ -1479,12 +1490,15 @@ void ViewsModelsPanel::OnLeftUp(wxMouseEvent& event)
 
 bool ViewsModelsPanel::IsFilteredOutOfNonModels(const std::string& name) const
 {
-    if (_nonModelFilter.empty()) {
+    if (_nonModelFilter.IsEmpty()) {
         return false;
     }
-    // Case-insensitive substring match. _nonModelFilter is already lower.
+    // Case-insensitive substring match. _nonModelFilter is already
+    // lower-cased and held as wxString so we stay encoding-consistent
+    // (avoids std::string round-trips through ToStdString/FromUTF8 that
+    // can break non-ASCII names on non-UTF-8 wx builds).
     wxString lname = wxString::FromUTF8(name).Lower();
-    return lname.Find(wxString::FromUTF8(_nonModelFilter)) == wxNOT_FOUND;
+    return lname.Find(_nonModelFilter) == wxNOT_FOUND;
 }
 
 void ViewsModelsPanel::AddTimingToNotList(Element* timing)
@@ -1528,14 +1542,14 @@ void ViewsModelsPanel::AddModelToNotList(Element* model)
 
 void ViewsModelsPanel::OnNonModelsFilterText(wxCommandEvent& /*event*/)
 {
-    _nonModelFilter = TextCtrl_NonModelsFilter->GetValue().Lower().ToStdString();
+    _nonModelFilter = TextCtrl_NonModelsFilter->GetValue().Lower();
     PopulateModels();
 }
 
 void ViewsModelsPanel::OnNonModelsFilterCancel(wxCommandEvent& /*event*/)
 {
     TextCtrl_NonModelsFilter->ChangeValue(wxEmptyString);
-    _nonModelFilter.clear();
+    _nonModelFilter.Clear();
     PopulateModels();
 }
 

--- a/src-ui-wx/layout/ViewsModelsPanel.h
+++ b/src-ui-wx/layout/ViewsModelsPanel.h
@@ -263,10 +263,18 @@ private:
     // wxSmith block so the .wxs file does not need to know about it.
     // Held as wxString (already lower-cased) so encoding stays consistent
     // with the wxString-based names we compare against.
+    //
+    // PopulateModels is O(N+M) and rebuilds both list controls plus the
+    // model-group heap allocations. wxEVT_TEXT fires on every keystroke,
+    // so we debounce: keystrokes restart a one-shot timer; the rebuild
+    // only fires once the user pauses for kFilterDebounceMs.
     wxSearchCtrl* TextCtrl_NonModelsFilter = nullptr;
     wxString _nonModelFilter;
+    wxTimer* _filterDebounceTimer = nullptr;
+    static constexpr int kFilterDebounceMs = 150;
     void OnNonModelsFilterText(wxCommandEvent& event);
     void OnNonModelsFilterCancel(wxCommandEvent& event);
+    void OnFilterDebounceTimer(wxTimerEvent& event);
     bool IsFilteredOutOfNonModels(const std::string& name) const;
 
     DECLARE_EVENT_TABLE()

--- a/src-ui-wx/layout/ViewsModelsPanel.h
+++ b/src-ui-wx/layout/ViewsModelsPanel.h
@@ -25,6 +25,9 @@
 #include "render/SequenceData.h"
 #include <list>
 #include <map>
+#include <string>
+
+class wxSearchCtrl;
 
 class SequenceElements;
 class xLightsFrame;
@@ -255,6 +258,14 @@ private:
     void OnDrop(wxCommandEvent& event);
     void OnModelsPopup(wxCommandEvent& event);
     void OnImportBtnPopup(wxCommandEvent& event);
+
+    // Filter for the "Available" (non-models) list. Created outside the
+    // wxSmith block so the .wxs file does not need to know about it.
+    wxSearchCtrl* TextCtrl_NonModelsFilter = nullptr;
+    std::string _nonModelFilter;
+    void OnNonModelsFilterText(wxCommandEvent& event);
+    void OnNonModelsFilterCancel(wxCommandEvent& event);
+    bool IsFilteredOutOfNonModels(const std::string& name) const;
 
     DECLARE_EVENT_TABLE()
 };

--- a/src-ui-wx/layout/ViewsModelsPanel.h
+++ b/src-ui-wx/layout/ViewsModelsPanel.h
@@ -261,8 +261,10 @@ private:
 
     // Filter for the "Available" (non-models) list. Created outside the
     // wxSmith block so the .wxs file does not need to know about it.
+    // Held as wxString (already lower-cased) so encoding stays consistent
+    // with the wxString-based names we compare against.
     wxSearchCtrl* TextCtrl_NonModelsFilter = nullptr;
-    std::string _nonModelFilter;
+    wxString _nonModelFilter;
     void OnNonModelsFilterText(wxCommandEvent& event);
     void OnNonModelsFilterCancel(wxCommandEvent& event);
     bool IsFilteredOutOfNonModels(const std::string& name) const;


### PR DESCRIPTION
## Summary

Adds a filter box above the **Available** list in *Edit Display Elements* (sequencer right-click → Edit Display Elements). Large shows can have hundreds of models/groups/timings, and scrolling to find the one you want to add to a view is tedious.

Same `wxSearchCtrl` pattern we already use in:
- ControllerModelDialog model filter
- Controllers tab visualizer filter (#6191)

so users get consistent UX across the app.

## Behaviour

- **Filter type:** case-insensitive substring match against the model/timing/group name.
- **Placeholder text:** "Filter models..."
- **Cancel button (×):** clears the filter.
- **Auto-clear on Add:** moving items into the view (Add Selected / Add All / drag-to-right / arrow-key right) clears the filter automatically — after moving, users almost always want the full list back to pick the next item. If they need the same filter, retyping is one click.
- **Scope:** Available list only, as agreed. Added list is unfiltered.

## Implementation notes

- All new UI/state lives **outside** the wxSmith generated block, so the `.wxs` file does not change.
- `ListCtrlNonModels` was at `GBPosition(1, 0) span(3, 1)`. We detach it, drop the search ctrl at `(1, 0)`, and re-attach the list at `(2, 0) span(2, 1)`. The growable row stays at row 3 so the list still fills the column.
- The filter is enforced inside `AddModelToNotList` / `AddTimingToNotList` (both gateways into the visible list), so any code path that calls `PopulateModels()` automatically respects the current filter without needing to know about it.
- New helper `IsFilteredOutOfNonModels(name)` does the comparison.

## Test plan

- [x] Build (Debug) macOS — clean compile, my files have zero warnings; only the pre-existing CoreML/SoundAnalysis link error which is unrelated and a separate Xcode-project regression.
- [x] Sequencer → right-click model → Edit Display Elements:
    - [x] Filter box appears above Available list with "Filter models..." placeholder
    - [x] Typing filters the list as you type (case-insensitive)
    - [x] × button clears
    - [x] Add Selected / Add All clears the filter and shows full list
    - [x] Drag to right clears the filter
    - [x] Right-arrow key on selected items clears the filter
- [ ] Verify on Windows/Linux — should work identically; `wxSearchCtrl` is cross-platform.
- [ ] Verify with views switching — `PopulateModels` is called on view switch, so the filter persists across views as long as the dialog is open.
