### PR TITLE
Fix state/face definitions copied in layout not rendering in sequence until restart (#6239)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -98,6 +98,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -enh (dkulp)                Shader effect: dynamic uniforms emit JSON matching the effect-panel schema; JsonEffectPanel
                                 gains a reusable point2d control type, so iPad and desktop build the dynamic rows from the
                                 same description.
+    -bug (derwin12)             Fix state/face definitions copied in layout not rendering in sequence until restart (#6239)
     -bug (derwin12)             Layout was sizing groups and model names too quickly (#6236)
     -bug (derwin12)             Fix ON effect was resetting the intensity values (#6233)
     -bug (derwin12)             Fix visualizer clearing all models (#6227)

--- a/src-core/effects/ShockwaveEffect.cpp
+++ b/src-core/effects/ShockwaveEffect.cpp
@@ -153,8 +153,7 @@ void ShockwaveEffect::Render(Effect* effect, const SettingsMap& SettingsMap, Ren
     if (buffer.needToInit) {
         buffer.needToInit = false;
         if (!timingtrack.empty()) {
-            auto* seqEl = GetSequenceElements(buffer);
-            if (seqEl) seqEl->AddRenderDependency(timingtrack, buffer.cur_model);
+            effect->GetParentEffectLayer()->GetParentElement()->GetSequenceElements()->AddRenderDependency(timingtrack, buffer.cur_model);
         }
     }
 
@@ -165,17 +164,7 @@ void ShockwaveEffect::Render(Effect* effect, const SettingsMap& SettingsMap, Ren
     if (timingtrack.empty()) {
         eff_pos = buffer.GetEffectTimeIntervalPosition(cycles);
     } else {
-        EffectLayer* el = nullptr;
-        auto* seqEl = GetSequenceElements(buffer);
-        if (seqEl) {
-            for (size_t i = 0; i < seqEl->GetElementCount(); i++) {
-                Element* e = seqEl->GetElement(i);
-                if (e->GetEffectLayerCount() == 1 && e->GetType() == ElementType::ELEMENT_TYPE_TIMING && e->GetName() == timingtrack) {
-                    el = e->GetEffectLayer(0);
-                    break;
-                }
-            }
-        }
+        EffectLayer* el = GetTiming(timingtrack);
 
         if (el == nullptr) {
             eff_pos = buffer.GetEffectTimeIntervalPosition(cycles);

--- a/src-core/models/Model.h
+++ b/src-core/models/Model.h
@@ -167,9 +167,9 @@ public:
     [[nodiscard]] virtual FaceStateData const& GetStateInfo() const { return stateInfo; };
     [[nodiscard]] virtual FaceStateNodes const& GetStateInfoNodes() const { return stateInfoNodes; };
 
-    virtual void SetFaceInfo(FaceStateData const& info) { faceInfo = info; };
+    virtual void SetFaceInfo(FaceStateData const& info) { faceInfo = info; UpdateFaceInfoNodes(); };
     virtual void SetFaceInfoNodes(FaceStateNodes const& nodes) { faceInfoNodes = nodes; };
-    virtual void SetStateInfo(FaceStateData const& info) { stateInfo = info; };
+    virtual void SetStateInfo(FaceStateData const& info) { stateInfo = info; UpdateStateInfoNodes(); };
     virtual void SetStateInfoNodes(FaceStateNodes const& nodes) { stateInfoNodes = nodes; };
 
     // Add face with data structure-based method


### PR DESCRIPTION
If you added or copied a new face or state, the render engine didnt see the changes until xlights was restarted. (#6239)