### PR TITLE
Various uploaded crash log crash fixes

### DIFF
--- a/src-core/controllers/Pixlite16.cpp
+++ b/src-core/controllers/Pixlite16.cpp
@@ -1771,16 +1771,14 @@ bool Pixlite16::SetOutputs(ModelManager* allmodels, OutputManager* outputManager
                 _config._outputUniverse[pp - 1] = port->GetUniverse();
                 _config._outputStartChannel[pp - 1] = port->GetUniverseStartChannel();
                 _config._outputPixels[pp - 1] = port->Pixels();
-                _config._outputNullPixels[pp - 1] = port->GetFirstModel()->GetStartNullPixels(0);
-                _config._outputGrouping[pp - 1] = std::max(1, port->GetFirstModel()->GetGroupCount(1));
-                _config._outputBrightness[pp - 1] = port->GetFirstModel()->GetBrightness(100);
-                _config._outputColourOrder[pp - 1] = EncodeColourOrder(port->GetFirstModel()->GetColourOrder("RGB"));
-                _config._outputZigZag[pp - 1] = port->GetFirstModel()->GetZigZag(0);
-                if (port->GetFirstModel()->GetDirection("Forward") == "Reverse") {
-                    _config._outputReverse[pp - 1] = 1;
-                }
-                else {
-                    _config._outputReverse[pp - 1] = 0;
+                auto firstModel = port->GetFirstModel();
+                if (firstModel != nullptr) {
+                    _config._outputNullPixels[pp - 1] = firstModel->GetStartNullPixels(0);
+                    _config._outputGrouping[pp - 1] = std::max(1, firstModel->GetGroupCount(1));
+                    _config._outputBrightness[pp - 1] = firstModel->GetBrightness(100);
+                    _config._outputColourOrder[pp - 1] = EncodeColourOrder(firstModel->GetColourOrder("RGB"));
+                    _config._outputZigZag[pp - 1] = firstModel->GetZigZag(0);
+                    _config._outputReverse[pp - 1] = firstModel->GetDirection("Forward") == "Reverse" ? 1 : 0;
                 }
 
                 port->CreateVirtualStrings(true);

--- a/src-ui-wx/app-shell/TabSetup.cpp
+++ b/src-ui-wx/app-shell/TabSetup.cpp
@@ -1917,6 +1917,7 @@ void xLightsFrame::SetControllersProperties(bool rebuildPropGrid) {
     auto selections = GetSelectedControllerNames();
 
     if (selections.size() != 1 || _outputManager.GetController(selections.front()) == nullptr) {
+        _controllerAdapter.reset();
         Controllers_PropertyEditor->Clear();
         ButtonVisualise->Enable(false);
         ButtonUploadInput->Enable(false);
@@ -2019,7 +2020,7 @@ void xLightsFrame::SetControllersProperties(bool rebuildPropGrid) {
             }
 
             // one item selected - display selected controller properties
-            if (rebuildPropGrid) {
+            if (rebuildPropGrid || !_controllerAdapter || _controllerAdapter->GetController() != controller) {
                 Controllers_PropertyEditor->Clear();
                 _controllerAdapter = ControllerPropertyManager::CreateAdapter(*controller);
                 _controllerAdapter->AddProperties(Controllers_PropertyEditor, &AllModels, expandProperties);

--- a/src-ui-wx/controllerproperties/ControllerPropertyAdapter.h
+++ b/src-ui-wx/controllerproperties/ControllerPropertyAdapter.h
@@ -39,6 +39,8 @@ public:
     static int EncodeChoices(const wxPGChoices& choices, const std::string& choice);
     static std::string DecodeChoices(const wxPGChoices& choices, int choice);
 
+    Controller* GetController() const { return &_controller; }
+
 protected:
     void AddModels(wxPGProperty* property, wxPGProperty* vp);
     void AddVariants(wxPGProperty* property);

--- a/src-ui-wx/controllerproperties/ControllerPropertyAdapter.h
+++ b/src-ui-wx/controllerproperties/ControllerPropertyAdapter.h
@@ -39,7 +39,8 @@ public:
     static int EncodeChoices(const wxPGChoices& choices, const std::string& choice);
     static std::string DecodeChoices(const wxPGChoices& choices, int choice);
 
-    Controller* GetController() const { return &_controller; }
+    Controller* GetController() { return &_controller; }
+    Controller const* GetController() const { return &_controller; }
 
 protected:
     void AddModels(wxPGProperty* property, wxPGProperty* vp);

--- a/src-ui-wx/setup/PixelTestDialog.cpp
+++ b/src-ui-wx/setup/PixelTestDialog.cpp
@@ -3428,7 +3428,8 @@ void PixelTestDialog::OnTimer(long curtime)
                     }
                     if (curtime >= NextSequenceStart) {
                         rgbCycle++;
-                        rgbCycle = rgbCycle % ports;
+                        if (ports > 0) rgbCycle = rgbCycle % ports;
+                        else rgbCycle = 0;
                         NextSequenceStart = curtime + (interval * 2);
                     }
                 } else if (testFunc == PixelTestDialog::TestFunctions::ColorBlocks) {


### PR DESCRIPTION
Fix crash (divide-by-zero) in Pixel Test Dialog when Port Cycle mode has no ports.
Fix crash (access violation) when controller property grid updates a stale adapter after the controller list is rebuilt or selection changes.
Fix crash (access violation) in Pixlite16 upload when a pixel port has no model assigned.