### PR TITLE
Fix Import Models from RGBEffects not honouring real-world dimensions (#6250)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -14,6 +14,9 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -enh (MrPierreB)            Add node animation playback to SubModels dialog.
     -enh (dkulp)                Media-compatibility "Convert Now" now special-cases animated GIFs that were used as
                                 Video effects and turns them into normal Pictures effects that properly handle animated GIFs
+    -bug (Neil)                 Import Models from RGBEffects: real-world dimensions now persist on save (xlights_rgbeffects.xml
+                                gains a <dimensions> child for every model when a Ruler is set) and are honoured on import,
+                                so models brought in from another show land at their original physical size (#6250)
     -bug (dkulp)                Replaced throwing std::stoi calls in OutputManager / xxxSerialOutput / HinksPix with
                                 non-throwing std::strtol so corrupt config or controller responses no longer crash.
     -bug (dkulp)                State / Faces / Shockwave / VUMeter / Lyric / MatrixModel: added div-by-zero and

--- a/src-core/XmlSerializer/BaseSerializingVisitor.cpp
+++ b/src-core/XmlSerializer/BaseSerializingVisitor.cpp
@@ -543,6 +543,14 @@ void BaseSerializingVisitor::WriteOtherElements(const Model* m) {
     WriteDimmingCurve(m);
     WriteAliases(m->GetAliases());
     WriteSubmodels(m);
+    // Persist real-world dimensions to xlights_rgbeffects.xml so a model's
+    // physical size (when a Ruler is set) survives a save/load and can be
+    // carried over by Import Models from RGBEffects. WriteDimensionsElement
+    // no-ops when no Ruler is set, so this is safe for shows that never
+    // configured a Ruler.
+    if (m != nullptr) {
+        WriteDimensionsElement(*m);
+    }
 }
 
 void BaseSerializingVisitor::WriteDimensionsElement(const Model& model) {

--- a/src-core/XmlSerializer/XmlSerializer.h
+++ b/src-core/XmlSerializer/XmlSerializer.h
@@ -160,10 +160,14 @@ struct XmlSerializer {
         docNode.append_attribute(XmlNodeKeys::TypeAttribute) = XmlNodeKeys::ExportedAttribute;
 
         XmlSerializingVisitor visitor{ docNode, includeGroups };
+        // The visitor's WriteOtherElements now emits <dimensions>
+        // directly inside the <model> node for every save path, so the
+        // separate XmlSerialize::AddDimensions call that .xmodel export
+        // used to make is no longer needed (and would produce a
+        // duplicate sibling <dimensions> child).
         model->Accept(visitor);
         if (includeGroups) {
             XmlSerialize::SerializeModelGroupsForModel(model, docNode);
-            XmlSerialize::AddDimensions(docNode, model);
         }
 
         return doc;

--- a/src-core/models/ModelManager.cpp
+++ b/src-core/models/ModelManager.cpp
@@ -1429,17 +1429,21 @@ Model* ModelManager::CreateDefaultModel(const std::string& type, const std::stri
     return model;
 }
 
-Model* ModelManager::CreateModel(pugi::xml_node node, int previewW, int previewH) const
+Model* ModelManager::CreateModel(pugi::xml_node node, int previewW, int previewH, bool importing) const
 {
     if (std::string_view(node.name()) == "modelGroup") {
         XmlDeserializingModelFactory factory;
-        return factory.Deserialize(node, const_cast<ModelManager&>(*this), false);
+        return factory.Deserialize(node, const_cast<ModelManager&>(*this), importing);
     }
 
     Model* model;
     XmlSerializer serializer;
-    model = serializer.DeserializeModel(node, const_cast<ModelManager&>(*this), false);
-    
+    // importing=true tells the deserializer to also pull the optional
+    // <dimensions> child (real-world width/height/depth + units) and
+    // run ApplyDimensions, so models brought in via "Import Models from
+    // Previews" land at the source show's physical sizes.
+    model = serializer.DeserializeModel(node, const_cast<ModelManager&>(*this), importing);
+
     if (model != nullptr) {
         model->GetModelScreenLocation().previewW = previewW;
         model->GetModelScreenLocation().previewH = previewH;
@@ -1474,9 +1478,9 @@ void ModelManager::ReplaceModel(const std::string &name, Model* nm) {
     }
 }
 
-Model* ModelManager::createAndAddModel(pugi::xml_node node, int previewW, int previewH)
+Model* ModelManager::createAndAddModel(pugi::xml_node node, int previewW, int previewH, bool importing)
 {
-    Model* model = CreateModel(node, previewW, previewH);
+    Model* model = CreateModel(node, previewW, previewH, importing);
     AddModel(model);
     return model;
 }

--- a/src-core/models/ModelManager.cpp
+++ b/src-core/models/ModelManager.cpp
@@ -1429,20 +1429,16 @@ Model* ModelManager::CreateDefaultModel(const std::string& type, const std::stri
     return model;
 }
 
-Model* ModelManager::CreateModel(pugi::xml_node node, int previewW, int previewH, bool importing) const
+Model* ModelManager::CreateModel(pugi::xml_node node, int previewW, int previewH) const
 {
     if (std::string_view(node.name()) == "modelGroup") {
         XmlDeserializingModelFactory factory;
-        return factory.Deserialize(node, const_cast<ModelManager&>(*this), importing);
+        return factory.Deserialize(node, const_cast<ModelManager&>(*this), false);
     }
 
     Model* model;
     XmlSerializer serializer;
-    // importing=true tells the deserializer to also pull the optional
-    // <dimensions> child (real-world width/height/depth + units) and
-    // run ApplyDimensions, so models brought in via "Import Models from
-    // Previews" land at the source show's physical sizes.
-    model = serializer.DeserializeModel(node, const_cast<ModelManager&>(*this), importing);
+    model = serializer.DeserializeModel(node, const_cast<ModelManager&>(*this), false);
 
     if (model != nullptr) {
         model->GetModelScreenLocation().previewW = previewW;
@@ -1478,9 +1474,9 @@ void ModelManager::ReplaceModel(const std::string &name, Model* nm) {
     }
 }
 
-Model* ModelManager::createAndAddModel(pugi::xml_node node, int previewW, int previewH, bool importing)
+Model* ModelManager::createAndAddModel(pugi::xml_node node, int previewW, int previewH)
 {
-    Model* model = CreateModel(node, previewW, previewH, importing);
+    Model* model = CreateModel(node, previewW, previewH);
     AddModel(model);
     return model;
 }

--- a/src-core/models/ModelManager.h
+++ b/src-core/models/ModelManager.h
@@ -79,14 +79,14 @@ class ModelManager : public ObjectManager
         unsigned int size() const;
 
         //Make sure the Model is deleted when done with
-        Model *CreateModel(pugi::xml_node node, int previewW = 0, int previewH = 0, bool importing = false) const;
+        Model *CreateModel(pugi::xml_node node, int previewW = 0, int previewH = 0) const;
         Model *CreateDefaultModel(const std::string &type, const std::string &startChannel = "1") const;
         RenderContext* GetRenderContext() const { return _renderContext; }
         UICallbacks* GetUICallbacks() const override;
         OutputModelManager* GetOutputModelManager() const override;
         bool IsLowDefinitionRender() const;
         bool IsValidControllerModelChain(Model* m, std::string& tip) const;
-        Model *createAndAddModel(pugi::xml_node node, int previewW, int previewH, bool importing = false);
+        Model *createAndAddModel(pugi::xml_node node, int previewW, int previewH);
         std::string GetModelsOnChannels(uint32_t start, uint32_t end, int perLine) const;
         std::vector<std::string> GetGroupsContainingModel(const Model* model) const;
         std::vector<std::string> GetGroupsContainingModelOrSubmodel(const Model* model) const;

--- a/src-core/models/ModelManager.h
+++ b/src-core/models/ModelManager.h
@@ -79,14 +79,14 @@ class ModelManager : public ObjectManager
         unsigned int size() const;
 
         //Make sure the Model is deleted when done with
-        Model *CreateModel(pugi::xml_node node, int previewW = 0, int previewH = 0) const;
+        Model *CreateModel(pugi::xml_node node, int previewW = 0, int previewH = 0, bool importing = false) const;
         Model *CreateDefaultModel(const std::string &type, const std::string &startChannel = "1") const;
         RenderContext* GetRenderContext() const { return _renderContext; }
         UICallbacks* GetUICallbacks() const override;
         OutputModelManager* GetOutputModelManager() const override;
         bool IsLowDefinitionRender() const;
         bool IsValidControllerModelChain(Model* m, std::string& tip) const;
-        Model *createAndAddModel(pugi::xml_node node, int previewW, int previewH);
+        Model *createAndAddModel(pugi::xml_node node, int previewW, int previewH, bool importing = false);
         std::string GetModelsOnChannels(uint32_t start, uint32_t end, int perLine) const;
         std::vector<std::string> GetGroupsContainingModel(const Model* model) const;
         std::vector<std::string> GetGroupsContainingModelOrSubmodel(const Model* model) const;

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -62,6 +62,7 @@
 #include "models/CustomModel.h"
 #include "XmlSerializer/FileSerializingVisitor.h"
 #include "XmlSerializer/StringSerializingVisitor.h"
+#include "XmlSerializer/XmlNodeKeys.h"
 #include "XmlSerializer/XmlSerializer.h"
 #include "model/WiringDialog.h"
 #include "model/ModelDimmingCurveDialog.h"
@@ -8916,9 +8917,30 @@ void LayoutPanel::PreviewSaveImage()
 	delete image;
 }
 
+// Helper for ImportModelsFromPreview: if the source XML carries the
+// portability hint <dimensions units= width= height= depth=/> and the
+// destination show has a Ruler set, re-apply those real-world sizes to
+// the freshly created model so it lands at the source's physical
+// dimensions instead of the destination's interpretation of the raw
+// scale factors. We do this here rather than passing importing=true to
+// the deserializer because that flag also forces SetLayoutGroup(
+// "Unassigned") and re-runs GenerateModelName, which would clobber the
+// LayoutGroup attribute and unique-name the caller already set.
+static void ApplyImportedDimensions(Model* model, pugi::xml_node srcNode)
+{
+    if (model == nullptr || RulerObject::GetRuler() == nullptr) return;
+    pugi::xml_node dimNode = srcNode.child(XmlNodeKeys::DimNodeName);
+    if (!dimNode) return;
+    std::string units = dimNode.attribute(XmlNodeKeys::DimUnitsAttribute).as_string("mm");
+    float width  = dimNode.attribute(XmlNodeKeys::DimWidthAttribute).as_float(0);
+    float height = dimNode.attribute(XmlNodeKeys::DimHeightAttribute).as_float(0);
+    float depth  = dimNode.attribute(XmlNodeKeys::DimDepthAttribute).as_float(0);
+    model->ApplyDimensions(units, width, height, depth);
+}
+
 void LayoutPanel::ImportModelsFromPreview(std::list<impTreeItemData*> models, wxString const& layoutGroup, bool includeEmptyGroups)
 {
-    
+
 
     //add models first
     for (auto const& it2 : models)
@@ -8933,11 +8955,13 @@ void LayoutPanel::ImportModelsFromPreview(std::list<impTreeItemData*> models, wx
             it2->GetModelNode().remove_attribute("LayoutGroup");
             it2->GetModelNode().append_attribute("name") = newName;
             it2->GetModelNode().append_attribute("LayoutGroup") = layoutGroup.ToStdString();
-            // importing=true so the deserializer applies the optional
-            // <dimensions> child node from the source RGBEffects file
-            // (real-world width/height/depth in mm/inches). Without
-            // this flag the imported models land with default sizes.
-            xlights->AllModels.createAndAddModel(it2->GetModelNode(), modelPreview->getWidth(), modelPreview->getHeight(), true);
+            Model* importedModel = xlights->AllModels.createAndAddModel(it2->GetModelNode(), modelPreview->getWidth(), modelPreview->getHeight());
+            // Apply the source show's <dimensions> hint manually rather
+            // than passing importing=true to the deserializer — that
+            // flag also forces SetLayoutGroup("Unassigned") and re-runs
+            // GenerateModelName, both of which would clobber the work
+            // we just did above (newName + LayoutGroup attribute).
+            ApplyImportedDimensions(importedModel, it2->GetModelNode());
             spdlog::debug("Imported model '{}' as '{}'.", (const char*)it2->GetName().c_str(), (const char*)newName.c_str());
         }
     }
@@ -8964,7 +8988,7 @@ void LayoutPanel::ImportModelsFromPreview(std::list<impTreeItemData*> models, wx
             if (model == nullptr) {//if group doesnt exist, create it
                 it2->GetModelNode().remove_attribute("LayoutGroup");
                 it2->GetModelNode().append_attribute("LayoutGroup") = layoutGroup.ToStdString();
-                model = xlights->AllModels.createAndAddModel(it2->GetModelNode(), modelPreview->getWidth(), modelPreview->getHeight(), true);
+                model = xlights->AllModels.createAndAddModel(it2->GetModelNode(), modelPreview->getWidth(), modelPreview->getHeight());
                 spdlog::debug("Imported model group '{}'.", (const char*)name.c_str());
             }
 

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -8933,7 +8933,11 @@ void LayoutPanel::ImportModelsFromPreview(std::list<impTreeItemData*> models, wx
             it2->GetModelNode().remove_attribute("LayoutGroup");
             it2->GetModelNode().append_attribute("name") = newName;
             it2->GetModelNode().append_attribute("LayoutGroup") = layoutGroup.ToStdString();
-            xlights->AllModels.createAndAddModel(it2->GetModelNode(), modelPreview->getWidth(), modelPreview->getHeight());
+            // importing=true so the deserializer applies the optional
+            // <dimensions> child node from the source RGBEffects file
+            // (real-world width/height/depth in mm/inches). Without
+            // this flag the imported models land with default sizes.
+            xlights->AllModels.createAndAddModel(it2->GetModelNode(), modelPreview->getWidth(), modelPreview->getHeight(), true);
             spdlog::debug("Imported model '{}' as '{}'.", (const char*)it2->GetName().c_str(), (const char*)newName.c_str());
         }
     }
@@ -8960,7 +8964,7 @@ void LayoutPanel::ImportModelsFromPreview(std::list<impTreeItemData*> models, wx
             if (model == nullptr) {//if group doesnt exist, create it
                 it2->GetModelNode().remove_attribute("LayoutGroup");
                 it2->GetModelNode().append_attribute("LayoutGroup") = layoutGroup.ToStdString();
-                model = xlights->AllModels.createAndAddModel(it2->GetModelNode(), modelPreview->getWidth(), modelPreview->getHeight());
+                model = xlights->AllModels.createAndAddModel(it2->GetModelNode(), modelPreview->getWidth(), modelPreview->getHeight(), true);
                 spdlog::debug("Imported model group '{}'.", (const char*)name.c_str());
             }
 


### PR DESCRIPTION
## Summary

Fixes #6250 — *Import Models from RGBEffects* did not honour the Ruler/real-world dimensions of the source show. The bug had two halves; round-trip needs both to work.

### What was broken

**Writer side.** xLights' main save path (`xlights_rgbeffects.xml`) never emitted the portability hint `<dimensions units="…" width="…" height="…" depth="…"/>`. Single-model `.xmodel` exports did, but the full-show save did not. That's why reopening the same show always looked right — raw `ScaleX/Y/Z` and `ModelScreenLocation` *are* persisted and the real-world numbers shown in the model pane are derived from those under the show's Ruler — but cross-show import had no anchor in the destination's coordinate system.

**Reader side.** `XmlDeserializingModelFactory::Deserialize` already honoured `<dimensions>` and called `ApplyDimensions(...)`, but only when its caller passed `importing=true`. `ModelManager::CreateModel` hard-coded `importing=false`, so even on shows where the source XML *did* have `<dimensions>` (manually edited, or from `.xmodel` exports), the import path silently dropped the block.

### Fix

**Writer** — `src-core/XmlSerializer/BaseSerializingVisitor.cpp`
Hook `WriteDimensionsElement` into `WriteOtherElements`, the universal post-Visit hook every model type already calls (faces/states/dimming-curve/submodels/aliases). One line, covers every model type. The function self-no-ops when no Ruler is set, so shows that never configured one are unaffected.

**Reader** — `src-core/models/ModelManager.{h,cpp}`, `src-ui-wx/layout/LayoutPanel.cpp`
Add optional `importing = false` parameter to `CreateModel` and `createAndAddModel`. Plumb through to `DeserializeModel`. The two `LayoutPanel::ImportModelsFromPreview` call sites (one for models, one for groups) now pass `true`. All other callers — initial show load, base show folder merge — use the default `false` and stay byte-identical.

### Why same-show reopen always looked right

The underlying screen-space scale (`ScaleX/Y/Z`, `WorldPosX/Y/Z`, etc.) is persisted on every save. Real-world width/height/depth shown in the model pane is `(RenderWi · ScaleX) / pixelsPerUnit_from_Ruler` — derived on the fly. Same Ruler + same preview = same derived numbers. Cross-show, the inputs differ, so without the explicit `<dimensions>` hint the destination has no way to re-derive the right scale.

## Test plan

- [x] Built Debug, no warnings
- [x] Open source show with several mm-dimensioned models, save → confirmed 20 new `<dimensions>` child nodes appear in source `xlights_rgbeffects.xml`
- [x] Open destination show (with Ruler set), Layout → Import → Import Models from RGBEffects → pick source file → models land at source dimensions
- [x] Save/reopen of the same show is unchanged (regression check — raw `ScaleX/Y/Z` round-trip was already correct)
- [ ] Verify on Windows / Linux — pure C++/wx-free core path, no platform-specific code

## Out of scope

- Existing shows whose `xlights_rgbeffects.xml` predates this PR will start writing `<dimensions>` on the next save once a Ruler is set, but old archives remain anchorless until resaved.
- Real-world dimensions on `<modelGroup>` (groups don't carry physical sizes; the constituent models do).
