### PR TITLE
Fix vendor catalog Search regression after #6073 multi-select

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,11 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.08  May ??, 2026
+    -bug (Neil)                 Vendor model catalog Search regression after #6073 multi-select: button stayed disabled
+                                while typing on Windows (GetFocusedItem() returns invalid when keyboard focus is in the
+                                search box), and stepping through matches added each one to the multi-selection instead
+                                of replacing it. Search button now only requires non-empty text + populated tree, and
+                                each step UnselectAll's before SelectItem so only the current match is highlighted.
     -enh (dkulp)                Linux: text rendering switched from wxGraphicsContext (Cairo+Pango) to a portable
                                 FreeType+HarfBuzz+Fontconfig backend in src-core/. Text and Shape effects can now
                                 render on background threads on Linux (previously forced to the main thread because

--- a/README.txt
+++ b/README.txt
@@ -15,7 +15,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                 while typing on Windows (GetFocusedItem() returns invalid when keyboard focus is in the
                                 search box), and stepping through matches added each one to the multi-selection instead
                                 of replacing it. Search button now only requires non-empty text + populated tree, and
-                                each step UnselectAll's before SelectItem so only the current match is highlighted.
+                                each step calls UnselectAll before SelectItem so only the current match is highlighted.
     -enh (dkulp)                Linux: text rendering switched from wxGraphicsContext (Cairo+Pango) to a portable
                                 FreeType+HarfBuzz+Fontconfig backend in src-core/. Text and Shape effects can now
                                 render on background threads on Linux (previously forced to the main thread because

--- a/src-ui-wx/import_export/VendorModelDialog.cpp
+++ b/src-ui-wx/import_export/VendorModelDialog.cpp
@@ -1472,7 +1472,10 @@ void VendorModelDialog::OnTreeCtrl_NavigatorSelectionChanged(wxTreeEvent& event)
     // Because this code triggers a web download this function can be re-entered and this is not good
     busy = true;
 
-    wxTreeItemId startid = GetFocusedItem();
+    wxTreeItemId startid = event.GetItem();
+    if (!startid.IsOk()) {
+        startid = GetFocusedItem();
+    }
 
     SetCursor(wxCURSOR_WAIT);
 

--- a/src-ui-wx/import_export/VendorModelDialog.cpp
+++ b/src-ui-wx/import_export/VendorModelDialog.cpp
@@ -1563,7 +1563,11 @@ void VendorModelDialog::ValidateWindow()
     // whenever focus is anywhere outside the tree (e.g. while the user is
     // typing in the search box itself), which would leave the button
     // permanently disabled and make the search feature appear broken.
-    bool hasItems = TreeCtrl_Navigator->GetCount() > 0;
+    // Match the click-handler's guard (root must have at least one child)
+    // rather than GetCount() > 0, which is true even with just the hidden
+    // root present and no children to search.
+    wxTreeItemId rootItem = TreeCtrl_Navigator->GetRootItem();
+    bool hasItems = rootItem.IsOk() && TreeCtrl_Navigator->GetChildrenCount(rootItem) > 0;
     if (TextCtrl_Search->GetValue().Trim(true).Trim(false) == "" || !hasItems)
     {
         Button_Search->Disable();
@@ -1974,13 +1978,16 @@ void VendorModelDialog::OnButton_SearchClick(wxCommandEvent& event)
 	// the Search button. Fall back to the first selected item, then to the
 	// root's first child, so the user can always kick off a search from
 	// the top of the tree.
-	if (!current.IsOk()) {
+	if (!current.IsOk())
+	{
 		wxArrayTreeItemIds selections;
-		if (TreeCtrl_Navigator->GetSelections(selections) > 0) {
+		if (TreeCtrl_Navigator->GetSelections(selections) > 0)
+		{
 			current = selections[0];
 		}
 	}
-	if (!current.IsOk()) {
+	if (!current.IsOk())
+	{
 		wxTreeItemIdValue cookie;
 		current = TreeCtrl_Navigator->GetFirstChild(TreeCtrl_Navigator->GetRootItem(), cookie);
 	}

--- a/src-ui-wx/import_export/VendorModelDialog.cpp
+++ b/src-ui-wx/import_export/VendorModelDialog.cpp
@@ -1567,7 +1567,11 @@ void VendorModelDialog::ValidateWindow()
     // rather than GetCount() > 0, which is true even with just the hidden
     // root present and no children to search.
     wxTreeItemId rootItem = TreeCtrl_Navigator->GetRootItem();
-    bool hasItems = rootItem.IsOk() && TreeCtrl_Navigator->GetChildrenCount(rootItem) > 0;
+    // Pass recursive=false: we only need to know if the root has any
+    // direct children, not walk the entire tree. ValidateWindow runs on
+    // every search-text keystroke so the O(1) check matters on big
+    // catalogs.
+    bool hasItems = rootItem.IsOk() && TreeCtrl_Navigator->GetChildrenCount(rootItem, false) > 0;
     if (TextCtrl_Search->GetValue().Trim(true).Trim(false) == "" || !hasItems)
     {
         Button_Search->Disable();
@@ -1983,6 +1987,11 @@ void VendorModelDialog::OnButton_SearchClick(wxCommandEvent& event)
 	// remembered hit yet, fall through to GetFocusedItem -> selection ->
 	// root's first child.
 	wxString currentText = TextCtrl_Search->GetValue();
+	// Lower-case the needle once outside the loop. The traversal below
+	// can visit hundreds of items per click, and the previous code
+	// re-lowered TextCtrl_Search->GetValue() inside the comparison on
+	// every iteration.
+	const wxString needle = currentText.Lower();
 	wxTreeItemId current;
 	if (_lastSearchHit.IsOk() && currentText == _lastSearchText)
 	{
@@ -2061,7 +2070,7 @@ void VendorModelDialog::OnButton_SearchClick(wxCommandEvent& event)
 				}
 			}
 
-			if (current != TreeCtrl_Navigator->GetRootItem() && TreeCtrl_Navigator->GetItemText(current).Lower().Contains(TextCtrl_Search->GetValue().Lower()))
+			if (current != TreeCtrl_Navigator->GetRootItem() && TreeCtrl_Navigator->GetItemText(current).Lower().Contains(needle))
 			{
 				// Search is for stepping through matches one at a time,
 				// not for building a multi-selection. With wxTR_MULTIPLE

--- a/src-ui-wx/import_export/VendorModelDialog.cpp
+++ b/src-ui-wx/import_export/VendorModelDialog.cpp
@@ -1972,48 +1972,33 @@ void VendorModelDialog::OnTextCtrl_SearchText(wxCommandEvent& event)
 void VendorModelDialog::OnButton_SearchClick(wxCommandEvent& event)
 {
 	// cant search if tree is empty
-	if (TreeCtrl_Navigator->GetChildrenCount(TreeCtrl_Navigator->GetRootItem()) == 0)
+	if (TreeCtrl_Navigator->GetChildrenCount(TreeCtrl_Navigator->GetRootItem(), false) == 0)
 	{
 		wxBell();
 		return;
 	}
 
-	// If the user is still searching for the same string, resume from
-	// the last hit so repeated Search clicks step through matches. We
-	// cache this ourselves rather than relying on the tree's
-	// focused-item / selection state, because:
-	//   - On Windows native wxTreeCtrl, GetFocusedItem() returns invalid
-	//     once focus moves to the Search button.
-	//   - GetSelections() after a programmatic SelectItem can behave
-	//     differently across platforms / wxTR_MULTIPLE.
-	// If the search text changed since the last hit, or we don't have a
-	// remembered hit yet, fall through to GetFocusedItem -> selection ->
-	// root's first child.
-	wxString currentText = TextCtrl_Search->GetValue();
-	// Lower-case the needle once outside the loop. The traversal below
-	// can visit hundreds of items per click, and the previous code
-	// re-lowered TextCtrl_Search->GetValue() inside the comparison on
-	// every iteration.
+	// Resume from cached hit when the same query is still active AND
+	// the user hasn't manually picked a different node since.
+	wxString currentText = TextCtrl_Search->GetValue().Trim(true).Trim(false);
 	const wxString needle = currentText.Lower();
-	wxTreeItemId current;
-	if (_lastSearchHit.IsOk() && currentText == _lastSearchText)
-	{
-		current = _lastSearchHit;
-	}
-	if (!current.IsOk())
-	{
-		current = GetFocusedItem();
-	}
-	if (!current.IsOk())
-	{
+
+	wxTreeItemId userPick = GetFocusedItem();
+	if (!userPick.IsOk()) {
 		wxArrayTreeItemIds selections;
-		if (TreeCtrl_Navigator->GetSelections(selections) > 0)
-		{
-			current = selections[0];
+		if (TreeCtrl_Navigator->GetSelections(selections) > 0) {
+			userPick = selections[0];
 		}
 	}
-	if (!current.IsOk())
-	{
+
+	wxTreeItemId current;
+	const bool sameQuery = _lastSearchHit.IsOk() && currentText == _lastSearchText;
+	const bool userMovedSelection = userPick.IsOk() && userPick != _lastSearchHit;
+	if (sameQuery && !userMovedSelection) {
+		current = _lastSearchHit;
+	} else if (userPick.IsOk()) {
+		current = userPick;
+	} else {
 		wxTreeItemIdValue cookie;
 		current = TreeCtrl_Navigator->GetFirstChild(TreeCtrl_Navigator->GetRootItem(), cookie);
 	}

--- a/src-ui-wx/import_export/VendorModelDialog.cpp
+++ b/src-ui-wx/import_export/VendorModelDialog.cpp
@@ -1558,8 +1558,13 @@ void VendorModelDialog::OnHyperlinkCtrl_FacebookClick(wxCommandEvent& event)
 
 void VendorModelDialog::ValidateWindow()
 {
-    wxTreeItemId current = GetFocusedItem();
-    if (TextCtrl_Search->GetValue().Trim(true).Trim(false) == "" || !current.IsOk())
+    // Search just needs non-empty text and a populated tree. Don't gate on
+    // GetFocusedItem() — on Windows the native wxTreeCtrl returns invalid
+    // whenever focus is anywhere outside the tree (e.g. while the user is
+    // typing in the search box itself), which would leave the button
+    // permanently disabled and make the search feature appear broken.
+    bool hasItems = TreeCtrl_Navigator->GetCount() > 0;
+    if (TextCtrl_Search->GetValue().Trim(true).Trim(false) == "" || !hasItems)
     {
         Button_Search->Disable();
     }
@@ -1963,6 +1968,22 @@ void VendorModelDialog::OnButton_SearchClick(wxCommandEvent& event)
 	}
 
 	wxTreeItemId current = GetFocusedItem();
+	// On Windows the native wxTreeCtrl returns invalid from GetFocusedItem()
+	// whenever keyboard focus is outside the tree — which is exactly the
+	// case when the user has just typed in the search text box and clicked
+	// the Search button. Fall back to the first selected item, then to the
+	// root's first child, so the user can always kick off a search from
+	// the top of the tree.
+	if (!current.IsOk()) {
+		wxArrayTreeItemIds selections;
+		if (TreeCtrl_Navigator->GetSelections(selections) > 0) {
+			current = selections[0];
+		}
+	}
+	if (!current.IsOk()) {
+		wxTreeItemIdValue cookie;
+		current = TreeCtrl_Navigator->GetFirstChild(TreeCtrl_Navigator->GetRootItem(), cookie);
+	}
 	wxTreeItemId start = current;
 	if (current.IsOk())
 	{
@@ -2021,6 +2042,14 @@ void VendorModelDialog::OnButton_SearchClick(wxCommandEvent& event)
 
 			if (current != TreeCtrl_Navigator->GetRootItem() && TreeCtrl_Navigator->GetItemText(current).Lower().Contains(TextCtrl_Search->GetValue().Lower()))
 			{
+				// Search is for stepping through matches one at a time,
+				// not for building a multi-selection. With wxTR_MULTIPLE
+				// (added in #6073) SelectItem() *adds* to the selection
+				// set rather than replacing it, so each Search click was
+				// silently piling up selected items. UnselectAll first,
+				// then select only the current match, so each step shows
+				// exactly the one match the user just navigated to.
+				TreeCtrl_Navigator->UnselectAll();
 				TreeCtrl_Navigator->SelectItem(current);
 				TreeCtrl_Navigator->EnsureVisible(current);
 				if (current == start)

--- a/src-ui-wx/import_export/VendorModelDialog.cpp
+++ b/src-ui-wx/import_export/VendorModelDialog.cpp
@@ -1971,13 +1971,27 @@ void VendorModelDialog::OnButton_SearchClick(wxCommandEvent& event)
 		return;
 	}
 
-	wxTreeItemId current = GetFocusedItem();
-	// On Windows the native wxTreeCtrl returns invalid from GetFocusedItem()
-	// whenever keyboard focus is outside the tree — which is exactly the
-	// case when the user has just typed in the search text box and clicked
-	// the Search button. Fall back to the first selected item, then to the
-	// root's first child, so the user can always kick off a search from
-	// the top of the tree.
+	// If the user is still searching for the same string, resume from
+	// the last hit so repeated Search clicks step through matches. We
+	// cache this ourselves rather than relying on the tree's
+	// focused-item / selection state, because:
+	//   - On Windows native wxTreeCtrl, GetFocusedItem() returns invalid
+	//     once focus moves to the Search button.
+	//   - GetSelections() after a programmatic SelectItem can behave
+	//     differently across platforms / wxTR_MULTIPLE.
+	// If the search text changed since the last hit, or we don't have a
+	// remembered hit yet, fall through to GetFocusedItem -> selection ->
+	// root's first child.
+	wxString currentText = TextCtrl_Search->GetValue();
+	wxTreeItemId current;
+	if (_lastSearchHit.IsOk() && currentText == _lastSearchText)
+	{
+		current = _lastSearchHit;
+	}
+	if (!current.IsOk())
+	{
+		current = GetFocusedItem();
+	}
 	if (!current.IsOk())
 	{
 		wxArrayTreeItemIds selections;
@@ -2059,6 +2073,11 @@ void VendorModelDialog::OnButton_SearchClick(wxCommandEvent& event)
 				TreeCtrl_Navigator->UnselectAll();
 				TreeCtrl_Navigator->SelectItem(current);
 				TreeCtrl_Navigator->EnsureVisible(current);
+				// Remember this hit so the next Search click reliably
+				// advances to the next match (see comment above on the
+				// _lastSearchHit cache).
+				_lastSearchHit = current;
+				_lastSearchText = currentText;
 				if (current == start)
 				{
 					wxBell();

--- a/src-ui-wx/import_export/VendorModelDialog.h
+++ b/src-ui-wx/import_export/VendorModelDialog.h
@@ -78,6 +78,15 @@ class VendorModelDialog: public wxDialog
     void DownloadSelectedModels();
     [[nodiscard]] wxTreeItemId GetFocusedItem() const;
 
+    // Tracks the last item the Search button navigated to. Used so
+    // repeated clicks on Search reliably advance to the next match
+    // regardless of platform-specific tree-focus / selection quirks
+    // (Windows native wxTreeCtrl loses focus to the Search button,
+    // and programmatic SelectItem doesn't always show up the way
+    // we'd expect via GetFocusedItem / GetSelections on the next call).
+    wxTreeItemId _lastSearchHit;
+    wxString _lastSearchText;
+
 	public:
 
 		VendorModelDialog(wxWindow* parent, const std::string& showFolder, wxWindowID id=wxID_ANY, const wxPoint& pos=wxDefaultPosition,const wxSize& size=wxDefaultSize);


### PR DESCRIPTION
## Summary

Fixes two regressions in the vendor model catalog Search after PR #6073 (multi-select catalog).

## Bugs

### 1. Search button perma-disabled on Windows
`ValidateWindow` was gating the Search button on `GetFocusedItem().IsOk()`. On the native Windows `wxTreeCtrl`, `GetFocusedItem()` returns invalid whenever keyboard focus is outside the tree — i.e. while the user is typing in the search textbox itself. Result: button stayed greyed out, search was effectively dead on Windows. macOS's generic implementation tracks focused item independently of keyboard focus, so the bug never surfaced there.

**Fix:** drop the focused-item gate. Only require non-empty search text and a populated tree.

### 2. `OnButton_SearchClick` bailed when no focused item
Even if Search was clickable, the search loop returned immediately when `GetFocusedItem()` was invalid (same Windows root cause).

**Fix:** when `GetFocusedItem()` is invalid, fall back to the first selected item, then to the root's first child, so the user can always kick off a search from the top of the tree.

### 3. Stepping through matches accumulated selection
PR #6073 switched the tree to `wxTR_MULTIPLE`. In that mode, `SelectItem()` *adds* to the selection set rather than replacing. Each Search step was silently piling matches into the multi-selection — searching for "pumpkin" and clicking Search repeatedly produced this:

[user's screenshot showing 6 highlighted pumpkin entries]

**Fix:** `UnselectAll()` before `SelectItem()` so each Search step shows exactly one match. This intentionally clears pre-existing user selection — Search is a navigation tool, not a multi-select builder. User can shift-click afterwards to build a download list from the search results.

## Test plan

- [x] macOS: type in search box → Search button enables. Type "pumpkin", click Search → first pumpkin highlights and scrolls into view. Click Search again → previous de-highlights, next pumpkin highlights. Confirmed by user.
- [ ] Windows: same flow. Was broken (button perma-disabled, search did nothing) before this PR.
- [ ] Linux: should match Windows behaviour since both use native wxTreeCtrl. No regression expected.

## Out of scope

The "Search ↔ multi-select for download" interaction has a residual mild UX wart: shift-clicking to build a multi-download from search hits requires the user to keep search results in mind manually. Could be worth a separate enhancement (e.g. "add all matches to selection" button) but that's a feature, not a regression.
