### PR TITLE
3D layout: click another model to switch selection (parity with 2D)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,10 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.09  May ??, 2026
+    -bug (Neil)                 3D layout: clicking a different model now switches the selection directly instead of
+                                requiring the user to first click empty space (or hit Esc) to deselect. Cmd / Ctrl-click
+                                still adds to the selection for multi-select. 2D path was already correct; this brings
+                                3D into parity.
     -bug (scott)                Fix HTDemucs ONNX model download failing: the 12-second total curl timeout set for
                                 short API calls was also killing the large-file download before it could complete.
     -bug (dkulp)                Backup: switch the per-file copy from wxCopyFile to std::filesystem::copy_file so

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -3693,20 +3693,6 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
                 GetMouseLocation(event.GetX(), event.GetY(), ray_origin, ray_direction);
                 selectedBaseObject->GetBaseObjectScreenLocation().CheckIfOverHandles3D(ray_origin, ray_direction, m_over_handle, modelPreview->GetCameraZoomForHandles(), modelPreview->GetHandleScale());
             }
-            // If the click isn't on the current selection's handles, hit-test
-            // the rest of the scene. If the click landed on a *different*
-            // model (or object), switch selection to it directly instead of
-            // forcing the user to first click empty space / Esc / double-
-            // click to deselect. Mirrors what the 2D path already does via
-            // SelectSingleModel + UnSelectAllModelsInTree.
-            //
-            // We do the hit-test here instead of relying on
-            // highlightedBaseObject because OnPreviewMouseMove3D
-            // intentionally does NOT update highlightedBaseObject while a
-            // selection is latched (to keep visual noise down — see the
-            // comment near "require control to be active" in that handler),
-            // so highlightedBaseObject == selectedBaseObject in this state
-            // and we have no other way to know what the cursor is over.
             if (m_over_handle == -1) {
                 glm::vec3 ray_origin;
                 glm::vec3 ray_direction;
@@ -3737,41 +3723,17 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
                     }
                 }
                 if (hit != nullptr) {
-                    // Cmd (Mac) / Ctrl (Win/Linux) preserves the existing
-                    // selection so the user can build a multi-selection by
-                    // clicking additional models. Plain click drops the
-                    // previous selection so the tree doesn't end up
-                    // multi-selected — mirrors what the 2D path does via
-                    // UnSelectAllModelsInTree before SelectSingleModel.
                     const bool addToSelection = event.CmdDown() || event.ControlDown();
                     if (editing_models) {
                         if (!addToSelection) {
                             UnSelectAllModelsInTree();
                         } else if (selectedBaseObject != nullptr) {
-                            // Demote the previously-latched model to a
-                            // group member, then promote the new hit to
-                            // be the active selection BEFORE adding it
-                            // to the tree. SelectBaseObjectInTree fires
-                            // HandleSelectionChanged, which captures the
-                            // CURRENT selectedBaseObject as
-                            // lastSelectedBaseObject and uses that to
-                            // decide which tree row gets to be primary.
-                            // Without this swap, lastSelectedBaseObject
-                            // would still be the OLD model, so the old
-                            // model would re-win primary and we'd end
-                            // up with selectedBaseObject != hit (the
-                            // SetActiveHandle below would then run on
-                            // the wrong model).
                             selectedBaseObject->GroupSelected(true);
                             selectedBaseObject->Selected(false);
                             selectedBaseObject = hit;
                         }
                         SelectBaseObjectInTree(hit);
                     } else {
-                        // ViewObject path: SelectBaseObject -> SelectViewObject
-                        // sets selectedBaseObject directly, no tree
-                        // selection-changed event roundtrip, so the
-                        // primary-pick race above doesn't apply.
                         if (!addToSelection) {
                             UnSelectAllModels();
                         } else if (selectedBaseObject != nullptr) {
@@ -3782,11 +3744,6 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
                     }
                     highlightedBaseObject = hit;
                     selectionLatched = true;
-                    // Defensive: verify selectedBaseObject actually
-                    // ended up as hit before manipulating handles. If
-                    // some future tree handler picks differently, set
-                    // the handle on hit anyway and don't poke whatever
-                    // ended up in selectedBaseObject.
                     if (selectedBaseObject != hit) {
                         selectedBaseObject = hit;
                     }

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -3693,6 +3693,90 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
                 GetMouseLocation(event.GetX(), event.GetY(), ray_origin, ray_direction);
                 selectedBaseObject->GetBaseObjectScreenLocation().CheckIfOverHandles3D(ray_origin, ray_direction, m_over_handle, modelPreview->GetCameraZoomForHandles(), modelPreview->GetHandleScale());
             }
+            // If the click isn't on the current selection's handles, hit-test
+            // the rest of the scene. If the click landed on a *different*
+            // model (or object), switch selection to it directly instead of
+            // forcing the user to first click empty space / Esc / double-
+            // click to deselect. Mirrors what the 2D path already does via
+            // SelectSingleModel + UnSelectAllModelsInTree.
+            //
+            // We do the hit-test here instead of relying on
+            // highlightedBaseObject because OnPreviewMouseMove3D
+            // intentionally does NOT update highlightedBaseObject while a
+            // selection is latched (to keep visual noise down — see the
+            // comment near "require control to be active" in that handler),
+            // so highlightedBaseObject == selectedBaseObject in this state
+            // and we have no other way to know what the cursor is over.
+            if (m_over_handle == -1) {
+                glm::vec3 ray_origin;
+                glm::vec3 ray_direction;
+                GetMouseLocation(event.GetX(), event.GetY(), ray_origin, ray_direction);
+                BaseObject* hit = nullptr;
+                float bestDistance = std::numeric_limits<float>::max();
+                float intersection_distance = bestDistance;
+                if (editing_models) {
+                    for (const auto& it : modelPreview->GetModels()) {
+                        if (it == selectedBaseObject) continue;
+                        if (it->GetBaseObjectScreenLocation().HitTest3D(ray_origin, ray_direction, intersection_distance)) {
+                            if (intersection_distance < bestDistance) {
+                                bestDistance = intersection_distance;
+                                hit = it;
+                            }
+                        }
+                    }
+                } else {
+                    for (const auto& it : xlights->AllObjects) {
+                        ViewObject* view_object = it.second;
+                        if (view_object == selectedBaseObject) continue;
+                        if (view_object->GetBaseObjectScreenLocation().HitTest3D(ray_origin, ray_direction, intersection_distance)) {
+                            if (intersection_distance < bestDistance) {
+                                bestDistance = intersection_distance;
+                                hit = view_object;
+                            }
+                        }
+                    }
+                }
+                if (hit != nullptr) {
+                    // Cmd (Mac) / Ctrl (Win/Linux) preserves the existing
+                    // selection so the user can build a multi-selection by
+                    // clicking additional models. Plain click drops the
+                    // previous selection so the tree doesn't end up
+                    // multi-selected — mirrors what the 2D path does via
+                    // UnSelectAllModelsInTree before SelectSingleModel.
+                    const bool addToSelection = event.CmdDown() || event.ControlDown();
+                    if (editing_models) {
+                        if (!addToSelection) {
+                            UnSelectAllModelsInTree();
+                        } else {
+                            // Keep the already-latched model in the tree
+                            // selection set; mark it as a group member so
+                            // the visual treatment matches a multi-select.
+                            if (selectedBaseObject != nullptr) {
+                                selectedBaseObject->GroupSelected(true);
+                                selectedBaseObject->Selected(false);
+                            }
+                        }
+                        SelectBaseObjectInTree(hit);
+                    } else {
+                        if (!addToSelection) {
+                            UnSelectAllModels();
+                        } else if (selectedBaseObject != nullptr) {
+                            selectedBaseObject->GroupSelected(true);
+                            selectedBaseObject->Selected(false);
+                        }
+                        SelectBaseObject(hit);
+                    }
+                    highlightedBaseObject = hit;
+                    selectionLatched = true;
+                    if (selectedBaseObject != nullptr) {
+                        selectedBaseObject->GetBaseObjectScreenLocation().SetActiveHandle(CENTER_HANDLE);
+                    }
+                    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::ProcessLeftMouseClick3D");
+                    m_last_mouse_x = event.GetX();
+                    m_last_mouse_y = event.GetY();
+                    return;
+                }
+            }
             if (m_over_handle != -1) {
                 if ((m_over_handle & HANDLE_AXIS) > 0) {
                     // an axis was selected

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -33,6 +33,7 @@
 #include <pugixml.hpp>
 #include <fstream>
 #include <functional>
+#include <limits>
 #include <spdlog/fmt/fmt.h>
 #include <regex>
 #include <sstream>
@@ -3730,6 +3731,8 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
                         } else if (selectedBaseObject != nullptr) {
                             selectedBaseObject->GroupSelected(true);
                             selectedBaseObject->Selected(false);
+                            selectedBaseObject->SelectHandle(-1);
+                            selectedBaseObject->GetBaseObjectScreenLocation().SetActiveHandle(-1);
                             selectedBaseObject = hit;
                         }
                         SelectBaseObjectInTree(hit);
@@ -3739,6 +3742,8 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
                         } else if (selectedBaseObject != nullptr) {
                             selectedBaseObject->GroupSelected(true);
                             selectedBaseObject->Selected(false);
+                            selectedBaseObject->SelectHandle(-1);
+                            selectedBaseObject->GetBaseObjectScreenLocation().SetActiveHandle(-1);
                         }
                         SelectBaseObject(hit);
                     }

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -3747,17 +3747,31 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
                     if (editing_models) {
                         if (!addToSelection) {
                             UnSelectAllModelsInTree();
-                        } else {
-                            // Keep the already-latched model in the tree
-                            // selection set; mark it as a group member so
-                            // the visual treatment matches a multi-select.
-                            if (selectedBaseObject != nullptr) {
-                                selectedBaseObject->GroupSelected(true);
-                                selectedBaseObject->Selected(false);
-                            }
+                        } else if (selectedBaseObject != nullptr) {
+                            // Demote the previously-latched model to a
+                            // group member, then promote the new hit to
+                            // be the active selection BEFORE adding it
+                            // to the tree. SelectBaseObjectInTree fires
+                            // HandleSelectionChanged, which captures the
+                            // CURRENT selectedBaseObject as
+                            // lastSelectedBaseObject and uses that to
+                            // decide which tree row gets to be primary.
+                            // Without this swap, lastSelectedBaseObject
+                            // would still be the OLD model, so the old
+                            // model would re-win primary and we'd end
+                            // up with selectedBaseObject != hit (the
+                            // SetActiveHandle below would then run on
+                            // the wrong model).
+                            selectedBaseObject->GroupSelected(true);
+                            selectedBaseObject->Selected(false);
+                            selectedBaseObject = hit;
                         }
                         SelectBaseObjectInTree(hit);
                     } else {
+                        // ViewObject path: SelectBaseObject -> SelectViewObject
+                        // sets selectedBaseObject directly, no tree
+                        // selection-changed event roundtrip, so the
+                        // primary-pick race above doesn't apply.
                         if (!addToSelection) {
                             UnSelectAllModels();
                         } else if (selectedBaseObject != nullptr) {
@@ -3768,9 +3782,15 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
                     }
                     highlightedBaseObject = hit;
                     selectionLatched = true;
-                    if (selectedBaseObject != nullptr) {
-                        selectedBaseObject->GetBaseObjectScreenLocation().SetActiveHandle(CENTER_HANDLE);
+                    // Defensive: verify selectedBaseObject actually
+                    // ended up as hit before manipulating handles. If
+                    // some future tree handler picks differently, set
+                    // the handle on hit anyway and don't poke whatever
+                    // ended up in selectedBaseObject.
+                    if (selectedBaseObject != hit) {
+                        selectedBaseObject = hit;
                     }
+                    selectedBaseObject->GetBaseObjectScreenLocation().SetActiveHandle(CENTER_HANDLE);
                     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::ProcessLeftMouseClick3D");
                     m_last_mouse_x = event.GetX();
                     m_last_mouse_y = event.GetY();


### PR DESCRIPTION
## Summary

In the 3D layout view, clicking a different model when one was already selected did **nothing** — the user had to first hit Esc, or double-click empty space (Mac) / single-click empty space (Windows) to drop the current selection, *then* click the new model. The 2D path has always done click-to-switch via `UnSelectAllModelsInTree + SelectSingleModel`; 3D never grew the equivalent.

This PR brings 3D into parity.

## Why it didn't already work in 3D

- `ProcessLeftMouseClick3D`, when `selectionLatched` is true, only checks if the click landed on the **current** selection's handles. If not, it sets `m_mouse_down = true` and waits for a drag — never considers the click might be on a different model.
- We can't lean on `highlightedBaseObject` either: `OnPreviewMouseMove3D` intentionally does NOT update `highlightedBaseObject` while a selection is latched (to keep visual noise down — see the *"require control to be active"* comment in that handler), so it always reads back as `selectedBaseObject` in the latched state.

## Fix

When `selectionLatched` and the click misses the current selection's handles, do an explicit `HitTest3D` against all models (or view objects, depending on `editing_models`) and:

| Input | Behaviour |
|---|---|
| Plain click on a **different** model | Drop the previous selection via `UnSelectAllModelsInTree` / `UnSelectAllModels` and select the new one. Mirrors the 2D path. |
| **Cmd / Ctrl-click** on a different model | Keep the previous selection in the `GroupSelected` set and add the new one as the active latched selection. Mirrors Ctrl-click multi-select in 2D. |
| Click on **empty space** (no hit) | Falls through to the original `m_mouse_down = true` path so lasso-drag and other modes still work. |
| Click on the **current selection's handles** | Unchanged — still routes through the existing handle-interaction code. |

Behaviour on the *non-latched* path is also unchanged: first click on any model still selects + latches it as before.

## Test plan

- [x] macOS, 3D mode:
    - [x] Click model A → click model B → A deselects, B becomes active
    - [x] Click A → Cmd-click B → both selected, B is active
    - [x] Cmd-click C → A, B, C all selected
    - [x] Click empty space → all deselect (lasso start)
    - [x] Click A's resize handle (not body) → drags handle as before
- [ ] Windows, 3D mode — should behave the same since `event.ControlDown()` covers Win Ctrl
- [ ] 2D mode — unchanged code path, not exercised by this PR
- [ ] Linux 3D — same code path as Windows
