### PR TITLE
Vendor catalog search: Search button, native selection highlight

### DIFF
--- a/src-ui-wx/import_export/VendorModelDialog.cpp
+++ b/src-ui-wx/import_export/VendorModelDialog.cpp
@@ -827,7 +827,7 @@ VendorModelDialog::VendorModelDialog(wxWindow* parent, const std::string& showFo
     TextCtrl_Search->SetDescriptiveText("Search models...");
     TextCtrl_Search->ShowCancelButton(true);
     FlexGridSizer9->Add(TextCtrl_Search, 1, wxALL|wxEXPAND, 5);
-    Button_Search = new wxButton(Panel3, ID_BUTTON4, _("Next"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON4"));
+    Button_Search = new wxButton(Panel3, ID_BUTTON4, _("Search"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON4"));
     FlexGridSizer9->Add(Button_Search, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
     FlexGridSizer2->Add(FlexGridSizer9, 1, wxALL|wxEXPAND, 5);
     Panel3->SetSizer(FlexGridSizer2);
@@ -1472,7 +1472,6 @@ void VendorModelDialog::OnTreeCtrl_NavigatorSelectionChanged(wxTreeEvent& event)
     // User manually selected a different item — clear the search bold/cursor.
     if (_lastSearchItem.IsOk() && startid != _lastSearchItem) {
         TreeCtrl_Navigator->SetItemBold(_lastSearchItem, false);
-        TreeCtrl_Navigator->SetItemBackgroundColour(_lastSearchItem, wxNullColour);
         _lastSearchItem = wxTreeItemId();
     }
     UpdatePanelForItem(startid);
@@ -1941,7 +1940,6 @@ void VendorModelDialog::OnTextCtrl_SearchText(wxCommandEvent& event)
 {
 	if (_lastSearchItem.IsOk()) {
 		TreeCtrl_Navigator->SetItemBold(_lastSearchItem, false);
-		TreeCtrl_Navigator->SetItemBackgroundColour(_lastSearchItem, wxNullColour);
 	}
 	_lastSearchItem = wxTreeItemId();
 	ValidateWindow();
@@ -1951,7 +1949,6 @@ void VendorModelDialog::OnSearchCancelClick(wxCommandEvent& event)
 {
 	if (_lastSearchItem.IsOk()) {
 		TreeCtrl_Navigator->SetItemBold(_lastSearchItem, false);
-		TreeCtrl_Navigator->SetItemBackgroundColour(_lastSearchItem, wxNullColour);
 	}
 	_lastSearchItem = wxTreeItemId();
 	TextCtrl_Search->SetValue("");
@@ -2037,17 +2034,34 @@ void VendorModelDialog::OnButton_SearchClick(wxCommandEvent& event)
 
 			if (current != TreeCtrl_Navigator->GetRootItem() && TreeCtrl_Navigator->GetItemText(current).Lower().Contains(TextCtrl_Search->GetValue().Lower()))
 			{
-				// Bold the found item for visual feedback without touching the
-				// selection — SelectItem on wxTR_MULTIPLE clears all other selections
-				// on Windows, which would wipe out the user's Ctrl+click choices.
+				// Snapshot the user's manual (Ctrl+click) selections.
+				// Capture the prior search item BEFORE _lastSearchItem
+				// is overwritten so we can filter it out of the re-add
+				// loop — otherwise successive Search presses pile every
+				// prior find onto the selection.
+				wxArrayTreeItemIds priorSels;
+				TreeCtrl_Navigator->GetSelections(priorSels);
+				wxTreeItemId oldSearchItem = _lastSearchItem;
 				if (_lastSearchItem.IsOk()) {
 					TreeCtrl_Navigator->SetItemBold(_lastSearchItem, false);
-					TreeCtrl_Navigator->SetItemBackgroundColour(_lastSearchItem, wxNullColour);
+					TreeCtrl_Navigator->UnselectItem(_lastSearchItem);
 				}
 				_lastSearchItem = current;
 				TreeCtrl_Navigator->SetItemBold(current, true);
-				TreeCtrl_Navigator->SetItemBackgroundColour(current, wxColour(255, 235, 130));
 				TreeCtrl_Navigator->EnsureVisible(current);
+				// On Windows native wxTR_MULTIPLE, SelectItem replaces
+				// the entire selection — re-add the user's Ctrl+click
+				// items so they survive the search.
+				TreeCtrl_Navigator->SelectItem(current, true);
+				for (size_t i = 0; i < priorSels.GetCount(); ++i) {
+					if (priorSels[i] != current && priorSels[i] != oldSearchItem) {
+						TreeCtrl_Navigator->SelectItem(priorSels[i], true);
+					}
+				}
+				// Give the tree keyboard focus so the selection renders
+				// with the system focused-selection colours (blue/white)
+				// instead of the muted unfocused colours.
+				TreeCtrl_Navigator->SetFocus();
 				UpdatePanelForItem(current);
 				if (current == start)
 				{

--- a/src-ui-wx/import_export/VendorModelDialog.cpp
+++ b/src-ui-wx/import_export/VendorModelDialog.cpp
@@ -1476,6 +1476,11 @@ void VendorModelDialog::OnTreeCtrl_NavigatorSelectionChanged(wxTreeEvent& event)
     // _lastSearchItem we just set.
     if (!_searchInProgress && _lastSearchItem.IsOk() && startid != _lastSearchItem) {
         TreeCtrl_Navigator->SetItemBold(_lastSearchItem, false);
+        // Also drop the search-driven selection on the prior search item.
+        // No-op if the user already deselected it; only stomps a manual
+        // Ctrl-click selection in the contrived case where the user
+        // explicitly multi-selected the same row the search had highlighted.
+        TreeCtrl_Navigator->UnselectItem(_lastSearchItem);
         _lastSearchItem = wxTreeItemId();
     }
     UpdatePanelForItem(startid);
@@ -1944,6 +1949,7 @@ void VendorModelDialog::OnTextCtrl_SearchText(wxCommandEvent& event)
 {
 	if (_lastSearchItem.IsOk()) {
 		TreeCtrl_Navigator->SetItemBold(_lastSearchItem, false);
+		TreeCtrl_Navigator->UnselectItem(_lastSearchItem);
 	}
 	_lastSearchItem = wxTreeItemId();
 	ValidateWindow();
@@ -1953,6 +1959,7 @@ void VendorModelDialog::OnSearchCancelClick(wxCommandEvent& event)
 {
 	if (_lastSearchItem.IsOk()) {
 		TreeCtrl_Navigator->SetItemBold(_lastSearchItem, false);
+		TreeCtrl_Navigator->UnselectItem(_lastSearchItem);
 	}
 	_lastSearchItem = wxTreeItemId();
 	TextCtrl_Search->SetValue("");

--- a/src-ui-wx/import_export/VendorModelDialog.cpp
+++ b/src-ui-wx/import_export/VendorModelDialog.cpp
@@ -1471,7 +1471,10 @@ void VendorModelDialog::OnTreeCtrl_NavigatorSelectionChanged(wxTreeEvent& event)
         startid = GetFocusedItem();
     }
     // User manually selected a different item — clear the search bold/cursor.
-    if (_lastSearchItem.IsOk() && startid != _lastSearchItem) {
+    // The _searchInProgress guard prevents the re-add loop in OnButton_SearchClick
+    // (which fires SEL_CHANGED for each prior selection it restores) from clearing
+    // _lastSearchItem we just set.
+    if (!_searchInProgress && _lastSearchItem.IsOk() && startid != _lastSearchItem) {
         TreeCtrl_Navigator->SetItemBold(_lastSearchItem, false);
         _lastSearchItem = wxTreeItemId();
     }
@@ -2043,6 +2046,10 @@ void VendorModelDialog::OnButton_SearchClick(wxCommandEvent& event)
 				wxArrayTreeItemIds priorSels;
 				TreeCtrl_Navigator->GetSelections(priorSels);
 				wxTreeItemId oldSearchItem = _lastSearchItem;
+				// Suppress the SEL_CHANGED handler's _lastSearchItem
+				// clearing while we re-add prior selections — each
+				// SelectItem call below fires the handler.
+				_searchInProgress = true;
 				if (_lastSearchItem.IsOk()) {
 					TreeCtrl_Navigator->SetItemBold(_lastSearchItem, false);
 					TreeCtrl_Navigator->UnselectItem(_lastSearchItem);
@@ -2059,6 +2066,7 @@ void VendorModelDialog::OnButton_SearchClick(wxCommandEvent& event)
 						TreeCtrl_Navigator->SelectItem(priorSels[i], true);
 					}
 				}
+				_searchInProgress = false;
 				// Give the tree keyboard focus so the selection renders
 				// with the system focused-selection colours (blue/white)
 				// instead of the muted unfocused colours.

--- a/src-ui-wx/import_export/VendorModelDialog.cpp
+++ b/src-ui-wx/import_export/VendorModelDialog.cpp
@@ -908,6 +908,7 @@ VendorModelDialog::VendorModelDialog(wxWindow* parent, const std::string& showFo
     Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_ITEM_ACTIVATED, (wxObjectEventFunction)&VendorModelDialog::OnTreeCtrl_NavigatorItemActivated);
     Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_SEL_CHANGED, (wxObjectEventFunction)&VendorModelDialog::OnTreeCtrl_NavigatorSelectionChanged);
     TextCtrl_Search->Bind(wxEVT_TEXT, &VendorModelDialog::OnTextCtrl_SearchText, this);
+    TextCtrl_Search->Bind(wxEVT_TEXT_ENTER, &VendorModelDialog::OnButton_SearchClick, this);
     TextCtrl_Search->Bind(wxEVT_SEARCHCTRL_SEARCH_BTN, &VendorModelDialog::OnButton_SearchClick, this);
     TextCtrl_Search->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN, &VendorModelDialog::OnSearchCancelClick, this);
     Connect(ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&VendorModelDialog::OnCheckBox_DontDownloadClick);

--- a/src-ui-wx/import_export/VendorModelDialog.cpp
+++ b/src-ui-wx/import_export/VendorModelDialog.cpp
@@ -771,6 +771,7 @@ const wxWindowID VendorModelDialog::ID_BUTTON2 = wxNewId();
 const wxWindowID VendorModelDialog::ID_STATICBITMAP2 = wxNewId();
 const wxWindowID VendorModelDialog::ID_ANIMATIONCTRL1 = wxNewId();
 const wxWindowID VendorModelDialog::ID_BUTTON3 = wxNewId();
+const wxWindowID VendorModelDialog::ID_BUTTON4 = wxNewId();
 const wxWindowID VendorModelDialog::ID_PANEL5 = wxNewId();
 const wxWindowID VendorModelDialog::ID_TEXTCTRL2 = wxNewId();
 const wxWindowID VendorModelDialog::ID_STATICTEXT7 = wxNewId();
@@ -801,6 +802,7 @@ VendorModelDialog::VendorModelDialog(wxWindow* parent, const std::string& showFo
     wxFlexGridSizer* FlexGridSizer6;
     wxFlexGridSizer* FlexGridSizer7;
     wxFlexGridSizer* FlexGridSizer8;
+    wxFlexGridSizer* FlexGridSizer9;
 
 
     Create(parent, id, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxCAPTION|wxRESIZE_BORDER|wxCLOSE_BOX|wxMAXIMIZE_BOX, _T("id"));
@@ -819,10 +821,15 @@ VendorModelDialog::VendorModelDialog(wxWindow* parent, const std::string& showFo
     FlexGridSizer2->AddGrowableRow(0);
     TreeCtrl_Navigator = new wxTreeCtrl(Panel3, ID_TREECTRL1, wxDefaultPosition, wxSize(200,-1), wxTR_FULL_ROW_HIGHLIGHT|wxTR_HIDE_ROOT|wxTR_ROW_LINES|wxTR_MULTIPLE|wxTR_DEFAULT_STYLE|wxVSCROLL|wxHSCROLL, wxDefaultValidator, _T("ID_TREECTRL1"));
     FlexGridSizer2->Add(TreeCtrl_Navigator, 1, wxALL|wxEXPAND, 5);
+    FlexGridSizer9 = new wxFlexGridSizer(0, 2, 0, 0);
+    FlexGridSizer9->AddGrowableCol(0);
     TextCtrl_Search = new wxSearchCtrl(Panel3, ID_TEXTCTRL3, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
     TextCtrl_Search->SetDescriptiveText("Search models...");
     TextCtrl_Search->ShowCancelButton(true);
-    FlexGridSizer2->Add(TextCtrl_Search, 0, wxALL|wxEXPAND, 5);
+    FlexGridSizer9->Add(TextCtrl_Search, 1, wxALL|wxEXPAND, 5);
+    Button_Search = new wxButton(Panel3, ID_BUTTON4, _("Next"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON4"));
+    FlexGridSizer9->Add(Button_Search, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    FlexGridSizer2->Add(FlexGridSizer9, 1, wxALL|wxEXPAND, 5);
     Panel3->SetSizer(FlexGridSizer2);
     Panel1 = new wxPanel(SplitterWindow1, ID_PANEL1, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("ID_PANEL1"));
     FlexGridSizer3 = new wxFlexGridSizer(0, 1, 0, 0);
@@ -908,6 +915,7 @@ VendorModelDialog::VendorModelDialog(wxWindow* parent, const std::string& showFo
     Connect(ID_HYPERLINKCTRL2, wxEVT_COMMAND_HYPERLINK, (wxObjectEventFunction)&VendorModelDialog::OnHyperlinkCtrl_WebsiteClick);
     Connect(ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&VendorModelDialog::OnButton_PriorClick);
     Connect(ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&VendorModelDialog::OnButton_NextClick);
+    Connect(ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&VendorModelDialog::OnButton_SearchClick);
     Connect(ID_HYPERLINKCTRL3, wxEVT_COMMAND_HYPERLINK, (wxObjectEventFunction)&VendorModelDialog::OnHyperlinkCtrl_ModelWebLinkClick);
     Connect(ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&VendorModelDialog::OnButton_InsertModelClick);
     Connect(ID_NOTEBOOK1, wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED, (wxObjectEventFunction)&VendorModelDialog::OnNotebookPanelsPageChanged);
@@ -1464,6 +1472,7 @@ void VendorModelDialog::OnTreeCtrl_NavigatorSelectionChanged(wxTreeEvent& event)
     // User manually selected a different item — clear the search bold/cursor.
     if (_lastSearchItem.IsOk() && startid != _lastSearchItem) {
         TreeCtrl_Navigator->SetItemBold(_lastSearchItem, false);
+        TreeCtrl_Navigator->SetItemBackgroundColour(_lastSearchItem, wxNullColour);
         _lastSearchItem = wxTreeItemId();
     }
     UpdatePanelForItem(startid);
@@ -1932,6 +1941,7 @@ void VendorModelDialog::OnTextCtrl_SearchText(wxCommandEvent& event)
 {
 	if (_lastSearchItem.IsOk()) {
 		TreeCtrl_Navigator->SetItemBold(_lastSearchItem, false);
+		TreeCtrl_Navigator->SetItemBackgroundColour(_lastSearchItem, wxNullColour);
 	}
 	_lastSearchItem = wxTreeItemId();
 	ValidateWindow();
@@ -1941,6 +1951,7 @@ void VendorModelDialog::OnSearchCancelClick(wxCommandEvent& event)
 {
 	if (_lastSearchItem.IsOk()) {
 		TreeCtrl_Navigator->SetItemBold(_lastSearchItem, false);
+		TreeCtrl_Navigator->SetItemBackgroundColour(_lastSearchItem, wxNullColour);
 	}
 	_lastSearchItem = wxTreeItemId();
 	TextCtrl_Search->SetValue("");
@@ -2031,9 +2042,11 @@ void VendorModelDialog::OnButton_SearchClick(wxCommandEvent& event)
 				// on Windows, which would wipe out the user's Ctrl+click choices.
 				if (_lastSearchItem.IsOk()) {
 					TreeCtrl_Navigator->SetItemBold(_lastSearchItem, false);
+					TreeCtrl_Navigator->SetItemBackgroundColour(_lastSearchItem, wxNullColour);
 				}
 				_lastSearchItem = current;
 				TreeCtrl_Navigator->SetItemBold(current, true);
+				TreeCtrl_Navigator->SetItemBackgroundColour(current, wxColour(255, 235, 130));
 				TreeCtrl_Navigator->EnsureVisible(current);
 				UpdatePanelForItem(current);
 				if (current == start)

--- a/src-ui-wx/import_export/VendorModelDialog.h
+++ b/src-ui-wx/import_export/VendorModelDialog.h
@@ -61,6 +61,7 @@ class VendorModelDialog: public wxDialog
 	int _modelDepthMM = -1;
     std::vector<DownloadedModelInfo> _downloadedModels;
     wxTreeItemId _lastSearchItem;
+    bool _searchInProgress = false;
 
     [[nodiscard]] pugi::xml_document* GetXMLFromURL(wxURI url, std::string& filename, wxProgressDialog* prog, int low, int high, bool keepProgress) const;
     [[nodiscard]] bool LoadTree(wxProgressDialog* prog, int low = 0, int high = 100);

--- a/src-ui-wx/import_export/VendorModelDialog.h
+++ b/src-ui-wx/import_export/VendorModelDialog.h
@@ -101,6 +101,7 @@ class VendorModelDialog: public wxDialog
 		wxButton* Button_InsertModel;
 		wxButton* Button_Next;
 		wxButton* Button_Prior;
+		wxButton* Button_Search;
 		wxCheckBox* CheckBox_DontDownload;
 		wxHyperlinkCtrl* HyperlinkCtrl_Facebook;
 		wxHyperlinkCtrl* HyperlinkCtrl_ModelWebLink;
@@ -141,6 +142,7 @@ class VendorModelDialog: public wxDialog
 		static const wxWindowID ID_STATICBITMAP2;
 		static const wxWindowID ID_ANIMATIONCTRL1;
 		static const wxWindowID ID_BUTTON3;
+		static const wxWindowID ID_BUTTON4;
 		static const wxWindowID ID_PANEL5;
 		static const wxWindowID ID_TEXTCTRL2;
 		static const wxWindowID ID_STATICTEXT7;

--- a/src-ui-wx/wxsmith/VendorModelDialog.wxs
+++ b/src-ui-wx/wxsmith/VendorModelDialog.wxs
@@ -34,7 +34,7 @@
 										<item2>&lt;none&gt;</item2>
 									</items_text>
 									<size>200,-1</size>
-									<style>wxTR_FULL_ROW_HIGHLIGHT|wxTR_HIDE_ROOT|wxTR_ROW_LINES|wxTR_SINGLE|wxTR_DEFAULT_STYLE|wxVSCROLL|wxHSCROLL</style>
+									<style>wxTR_FULL_ROW_HIGHLIGHT|wxTR_HIDE_ROOT|wxTR_ROW_LINES|wxTR_MULTIPLE|wxTR_DEFAULT_STYLE|wxVSCROLL|wxHSCROLL</style>
 									<handler function="OnTreeCtrl_NavigatorItemActivated" entry="EVT_TREE_ITEM_ACTIVATED" />
 									<handler function="OnTreeCtrl_NavigatorSelectionChanged" entry="EVT_TREE_SEL_CHANGED" />
 								</object>

--- a/src-ui-wx/wxsmith/VendorModelDialog.wxs
+++ b/src-ui-wx/wxsmith/VendorModelDialog.wxs
@@ -60,7 +60,7 @@
 									</object>
 									<object class="sizeritem">
 										<object class="wxButton" name="ID_BUTTON4" variable="Button_Search" member="yes">
-											<label>Next</label>
+											<label>Search</label>
 											<handler function="OnButton_SearchClick" entry="EVT_BUTTON" />
 										</object>
 										<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>

--- a/src-ui-wx/wxsmith/VendorModelDialog.wxs
+++ b/src-ui-wx/wxsmith/VendorModelDialog.wxs
@@ -51,6 +51,7 @@
 											<hint>Search models...</hint>
 											<style>wxTE_PROCESS_ENTER</style>
 											<handler function="OnTextCtrl_SearchText" entry="EVT_TEXT" />
+											<handler function="OnButton_SearchClick" entry="EVT_TEXT_ENTER" />
 											<handler function="OnButton_SearchClick" entry="EVT_SEARCHCTRL_SEARCH_BTN" />
 											<handler function="OnSearchCancelClick" entry="EVT_SEARCHCTRL_CANCEL_BTN" />
 										</object>

--- a/src-ui-wx/wxsmith/VendorModelDialog.wxs
+++ b/src-ui-wx/wxsmith/VendorModelDialog.wxs
@@ -47,8 +47,12 @@
 									<cols>2</cols>
 									<growablecols>0</growablecols>
 									<object class="sizeritem">
-										<object class="wxTextCtrl" name="ID_TEXTCTRL3" variable="TextCtrl_Search" member="yes">
+										<object class="wxSearchCtrl" name="ID_TEXTCTRL3" variable="TextCtrl_Search" member="yes">
+											<hint>Search models...</hint>
+											<style>wxTE_PROCESS_ENTER</style>
 											<handler function="OnTextCtrl_SearchText" entry="EVT_TEXT" />
+											<handler function="OnButton_SearchClick" entry="EVT_SEARCHCTRL_SEARCH_BTN" />
+											<handler function="OnSearchCancelClick" entry="EVT_SEARCHCTRL_CANCEL_BTN" />
 										</object>
 										<flag>wxALL|wxEXPAND</flag>
 										<border>5</border>
@@ -56,7 +60,7 @@
 									</object>
 									<object class="sizeritem">
 										<object class="wxButton" name="ID_BUTTON4" variable="Button_Search" member="yes">
-											<label>Search</label>
+											<label>Next</label>
 											<handler function="OnButton_SearchClick" entry="EVT_BUTTON" />
 										</object>
 										<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>


### PR DESCRIPTION
## Summary
- **Vendor catalog dialog**: add a visible **Search** button to the right of the search field; the in-field magnifier icon was easy to miss, especially on macOS. Bind `wxEVT_TEXT_ENTER` so pressing Enter also advances to the next match.
- **Vendor catalog dialog**: when Search finds a match, make that item the active selection (instead of just bold text) and call `SetFocus()` on the tree so it renders with the system focused-selection colours (blue+white) rather than the muted unfocused colours. Successive Search presses remove the prior find from the selection so matches don't pile up; manual Ctrl+click selections survive.
- **Vendor catalog dialog**: reconcile `VendorModelDialog.wxs` with the cpp guards — the .wxs had been left out of sync after #6267 swapped `TextCtrl_Search` to a `wxSearchCtrl`.

(The layout-panel filter auto-clear is split out into #6271.)

## Test plan
- [ ] Open Import → Download Models, type a search term — Search button visible to right of the field
- [ ] Press Search (or Enter, or the in-field magnifier) — found item is the active selection, scrolled into view, blue+white styling
- [ ] Press Search again — previous highlight cleared, next match becomes the selection
- [ ] Ctrl+click extra items in tree — manual selections preserved across Search presses
- [ ] Cancel (X) — clears highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)