### PR TITLE
Layout: auto-clear model filter when clicking a hidden model in the preview

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -6695,6 +6695,19 @@ Model* LayoutPanel::GetModelFromTreeItem(wxTreeListItem treeItem) {
 
 // Select a Model in the tree, currently only selects top level model if found
 void LayoutPanel::SelectModelInTree(Model* modelToSelect) {
+    // If a filter is active and the target model is hidden by it
+    // (e.g. user clicked a model in the preview that doesn't match
+    // the typed filter), clear the filter so the tree shows all
+    // models and the selection has somewhere to land.
+    if (modelToSelect != nullptr && !_filterString.IsEmpty() && !ModelMatchesFilter(modelToSelect)) {
+        if (ModelFilterCtrl != nullptr) {
+            ModelFilterCtrl->ChangeValue("");
+        }
+        _filterString = "";
+        _filterRegexValid = false;
+        UpdateModelList(true);
+    }
+
     for ( wxTreeListItem item = TreeListViewModels->GetFirstItem();
           item.IsOk();
           item = TreeListViewModels->GetNextSibling(item) )

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -6698,14 +6698,11 @@ void LayoutPanel::SelectModelInTree(Model* modelToSelect) {
     // If a filter is active and the target model is hidden by it
     // (e.g. user clicked a model in the preview that doesn't match
     // the typed filter), clear the filter so the tree shows all
-    // models and the selection has somewhere to land.
+    // models and the selection has somewhere to land. Reuse the
+    // cancel-button handler so the clear path stays in one place.
     if (modelToSelect != nullptr && !_filterString.IsEmpty() && !ModelMatchesFilter(modelToSelect)) {
-        if (ModelFilterCtrl != nullptr) {
-            ModelFilterCtrl->ChangeValue("");
-        }
-        _filterString = "";
-        _filterRegexValid = false;
-        UpdateModelList(true);
+        wxCommandEvent dummy;
+        OnModelFilterCancelBtn(dummy);
     }
 
     for ( wxTreeListItem item = TreeListViewModels->GetFirstItem();


### PR DESCRIPTION
## Summary
When the user types a filter into the layout panel's model list and then clicks on a model in the layout preview that doesn't match the filter, the click silently fails — `SelectModelInTree` walks the tree's visible items and the target isn't there because it was filtered out.

Auto-clear the filter (matching the cancel-button behavior) at the top of `SelectModelInTree` when the target model exists but doesn't match the active filter, so the click always lands without the user manually clearing the filter first.

## Test plan
- [ ] Open Layout, type a filter that hides most models (e.g. `magical`)
- [ ] Click on a hidden model in the preview/canvas
- [ ] Filter clears automatically and the model becomes selected in the tree
- [ ] Typing a filter and clicking a *visible* (matching) model leaves the filter alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)