### PR TITLE
Allow one to select the groups to import a model to (#2752)

### DIFF
--- a/src-core/XmlSerializer/XmlDeserializingModelFactory.cpp
+++ b/src-core/XmlSerializer/XmlDeserializingModelFactory.cpp
@@ -62,6 +62,7 @@
 #include "../utils/string_utils.h"
 #include "../utils/FileUtils.h"
 #include <cstring>
+#include <set>
 #include <string_view>
 
 using namespace XmlSerialize;
@@ -322,6 +323,39 @@ void XmlDeserializingModelFactory::DeserializeCommonModelChildElements(Model* mo
     bool merge = false;
     bool showPopup = true;
 
+    // Pre-pass: collect all modelGroup names so user can choose which to import
+    std::set<std::string> selectedGroups;
+    if (importing) {
+        std::vector<std::string> allGroupNames;
+        for (pugi::xml_node c = node.first_child(); c; c = c.next_sibling()) {
+            if (std::string_view(c.name()) == "modelGroup") {
+                std::string gname = c.attribute("name").as_string();
+                if (!gname.empty()) {
+                    allGroupNames.push_back(gname);
+                }
+            }
+        }
+        if (!allGroupNames.empty()) {
+            UICallbacks* uiCb = modelManager.GetUICallbacks();
+            if (uiCb) {
+                std::vector<std::string> chosen = uiCb->ChooseFromList(
+                    "Select Groups to Import",
+                    allGroupNames, allGroupNames);
+                for (const auto& s : chosen) {
+                    selectedGroups.insert(s);
+                }
+            } else {
+                for (const auto& s : allGroupNames) {
+                    selectedGroups.insert(s);
+                }
+            }
+            if (!selectedGroups.empty()) {
+                merge = true;
+                showPopup = false;
+            }
+        }
+    }
+
     pugi::xml_node f = node.first_child();
     while (f) {
         std::string_view fname = f.name();
@@ -340,7 +374,10 @@ void XmlDeserializingModelFactory::DeserializeCommonModelChildElements(Model* mo
         } else if ("subModel" == fname) {
             DeserializeSubModel(model, f);
         } else if ("modelGroup" == fname && importing) {
-            model->AddModelGroups(f, model->GetName(), merge, showPopup);
+            std::string gname = f.attribute("name").as_string();
+            if (selectedGroups.count(gname)) {
+                model->AddModelGroups(f, model->GetName(), merge, showPopup);
+            }
         } else if (strcasecmp(f.name(), "shadowmodels") == 0 && importing) {
             model->ImportExtraModels(f, modelManager, "Unassigned");
         } else if (strcasecmp(f.name(), "associatedmodels") == 0 && importing) {

--- a/src-core/XmlSerializer/XmlDeserializingModelFactory.cpp
+++ b/src-core/XmlSerializer/XmlDeserializingModelFactory.cpp
@@ -349,10 +349,6 @@ void XmlDeserializingModelFactory::DeserializeCommonModelChildElements(Model* mo
                     selectedGroups.insert(s);
                 }
             }
-            if (!selectedGroups.empty()) {
-                merge = true;
-                showPopup = false;
-            }
         }
     }
 

--- a/src-core/XmlSerializer/XmlDeserializingModelFactory.cpp
+++ b/src-core/XmlSerializer/XmlDeserializingModelFactory.cpp
@@ -339,7 +339,7 @@ void XmlDeserializingModelFactory::DeserializeCommonModelChildElements(Model* mo
             UICallbacks* uiCb = modelManager.GetUICallbacks();
             if (uiCb) {
                 std::vector<std::string> chosen = uiCb->ChooseFromList(
-                    "Select Groups to Import",
+                    "Select Groups to Import (Cancel to import no groups)",
                     allGroupNames, allGroupNames);
                 for (const auto& s : chosen) {
                     selectedGroups.insert(s);

--- a/src-ui-wx/shared/dialogs/CheckboxSelectDialog.cpp
+++ b/src-ui-wx/shared/dialogs/CheckboxSelectDialog.cpp
@@ -116,16 +116,7 @@ void CheckboxSelectDialog::OnCheckListBox_ItemsToggled(wxCommandEvent& event)
 
 void CheckboxSelectDialog::ValidateWindow()
 {
-    wxArrayInt items;
-    CheckListBox_Items->GetCheckedItems(items);
-    if (items.Count() == 0)
-    {
-        Button_Ok->Enable(false);
-    }
-    else
-    {
-        Button_Ok->Enable(true);
-    }
+    Button_Ok->Enable(true);
 }
 
 void CheckboxSelectDialog::OnListRClick(wxContextMenuEvent& event)


### PR DESCRIPTION
Also the import dialog is used elsewhere - it enables the OK all the time rather than having to use the cancel to not include them. Simply don't have anything selected if you don't want any items. (#2752)