### PR TITLE
Fix video export color accuracy and Windows GPU encoder selection

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,9 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.08  May ??, 2026
+    -bug (MrPierreB)            Fix house-preview video export producing dark/washed-out colors on Windows
+                                and when uploaded to YouTube. Also fixes Windows GPU encoder selection to prefer
+                                the correct hardware encoder (NVIDIA, AMD, or Intel) for faster exports.
     -enh (agfazio)              Add "Also add alias to model" checkbox to the Select Model dialog shown when
                                 renaming a missing submodel during sequence load. When checked, subsequent
                                 sequences with the same old submodel name are auto-remapped without prompting.

--- a/src-ui-wx/media/VideoExporter.cpp
+++ b/src-ui-wx/media/VideoExporter.cpp
@@ -160,6 +160,16 @@ void GenericVideoExporter::initialize()
         enum AVCodecID best = _outParams.videoCodec.find("H.264") != std::string::npos ? AV_CODEC_ID_H264 : AV_CODEC_ID_H265;
         // Note: H.264 High/High10 profiles support up to 4096x2304 (Level 5.2),
         // so we no longer force HEVC for height > 1080. The user's codec choice wins.
+#ifdef _WIN32
+        // Prefer GPU encoders: NVENC (NVIDIA) → AMF (AMD) → QSV (Intel) → software
+        auto findWindowsEncoder = [](AVCodecID id) -> const AVCodec* {
+            const AVCodec* c = ::avcodec_find_encoder_by_name((id == AV_CODEC_ID_H265) ? "hevc_nvenc" : "h264_nvenc");
+            if (c == nullptr) c = ::avcodec_find_encoder_by_name((id == AV_CODEC_ID_H265) ? "hevc_amf" : "h264_amf");
+            if (c == nullptr) c = ::avcodec_find_encoder_by_name((id == AV_CODEC_ID_H265) ? "hevc_qsv" : "h264_qsv");
+            if (c == nullptr) c = ::avcodec_find_encoder(id);
+            return c;
+        };
+#endif
 #if defined(__APPLE__)
         // Prefer the Apple hardware encoder on macOS. avcodec_find_encoder()
         // returns whichever encoder FFmpeg registered first for the codec ID,
@@ -171,16 +181,7 @@ void GenericVideoExporter::initialize()
             videoCodec = ::avcodec_find_encoder(best);
         }
 #elif defined(_WIN32)
-        {
-            // Prefer GPU encoders: NVENC (NVIDIA) → AMF (AMD) → QSV (Intel) → software
-            const char* nvenc = (best == AV_CODEC_ID_H265) ? "hevc_nvenc" : "h264_nvenc";
-            const char* amf   = (best == AV_CODEC_ID_H265) ? "hevc_amf"   : "h264_amf";
-            const char* qsv   = (best == AV_CODEC_ID_H265) ? "hevc_qsv"   : "h264_qsv";
-            videoCodec = ::avcodec_find_encoder_by_name(nvenc);
-            if (videoCodec == nullptr) videoCodec = ::avcodec_find_encoder_by_name(amf);
-            if (videoCodec == nullptr) videoCodec = ::avcodec_find_encoder_by_name(qsv);
-            if (videoCodec == nullptr) videoCodec = ::avcodec_find_encoder(best);
-        }
+        videoCodec = findWindowsEncoder(best);
 #else
         videoCodec = ::avcodec_find_encoder(best);
 #endif
@@ -194,15 +195,7 @@ void GenericVideoExporter::initialize()
                 videoCodec = ::avcodec_find_encoder(best);
             }
 #elif defined(_WIN32)
-            {
-                const char* nvenc = (best == AV_CODEC_ID_H265) ? "hevc_nvenc" : "h264_nvenc";
-                const char* amf   = (best == AV_CODEC_ID_H265) ? "hevc_amf"   : "h264_amf";
-                const char* qsv   = (best == AV_CODEC_ID_H265) ? "hevc_qsv"   : "h264_qsv";
-                videoCodec = ::avcodec_find_encoder_by_name(nvenc);
-                if (videoCodec == nullptr) videoCodec = ::avcodec_find_encoder_by_name(amf);
-                if (videoCodec == nullptr) videoCodec = ::avcodec_find_encoder_by_name(qsv);
-                if (videoCodec == nullptr) videoCodec = ::avcodec_find_encoder(best);
-            }
+            videoCodec = findWindowsEncoder(best);
 #else
             videoCodec = ::avcodec_find_encoder(best);
 #endif
@@ -542,10 +535,12 @@ void GenericVideoExporter::initializeFrames()
         // Output full-range BT.709 YUV (Y: 0-255) to match the source sRGB pixels.
         // Without this, sws_scale squeezes Y to 16-235 (studio swing) and the
         // exported video looks dark on players that treat it as full range.
-        ::sws_setColorspaceDetails(_swsContext,
-            ::sws_getCoefficients(SWS_CS_ITU709), 1,
-            ::sws_getCoefficients(SWS_CS_ITU709), 1,
-            0, 1 << 16, 1 << 16);
+        if (::sws_setColorspaceDetails(_swsContext,
+                ::sws_getCoefficients(SWS_CS_ITU709), 1,
+                ::sws_getCoefficients(SWS_CS_ITU709), 1,
+                0, 1 << 16, 1 << 16) < 0) {
+            spdlog::warn("VideoExporter - sws_setColorspaceDetails failed; export may have limited-range color");
+        }
     }
     if (_audioCodecContext != nullptr) {
         _audioFrame = ::av_frame_alloc();

--- a/src-ui-wx/media/VideoExporter.cpp
+++ b/src-ui-wx/media/VideoExporter.cpp
@@ -416,16 +416,28 @@ bool GenericVideoExporter::initializeVideo(const AVCodec* codec)
                      codecName.find("_amf")  != std::string::npos ||
                      codecName.find("_qsv")  != std::string::npos);
         if (isHw) {
-            spdlog::warn("VideoExporter - Windows HW encoder '{}' failed ({}), falling back to software",
+            spdlog::warn("VideoExporter - Windows HW encoder '{}' failed ({}), trying lower-priority encoders",
                          codecName, status);
             ::avcodec_free_context(&_videoCodecContext);
             _videoCodecContext = nullptr;
-            const char* swName = (codec->id == AV_CODEC_ID_H265) ? "libx265" : "libx264";
-            const AVCodec* swCodec = ::avcodec_find_encoder_by_name(swName);
-            if (swCodec != nullptr && swCodec != codec) {
-                return initializeVideo(swCodec);
+            bool isH265 = (codec->id == AV_CODEC_ID_H265);
+            const char* const candidates[] = {
+                isH265 ? "hevc_nvenc" : "h264_nvenc",
+                isH265 ? "hevc_amf"   : "h264_amf",
+                isH265 ? "hevc_qsv"   : "h264_qsv",
+                isH265 ? "libx265"    : "libx264",
+            };
+            bool foundFailed = false;
+            for (const char* name : candidates) {
+                if (codecName == name) { foundFailed = true; continue; }
+                if (!foundFailed) continue;
+                const AVCodec* next = ::avcodec_find_encoder_by_name(name);
+                if (next != nullptr) {
+                    spdlog::info("VideoExporter - Retrying with encoder '{}'", name);
+                    return initializeVideo(next);
+                }
             }
-            spdlog::error("VideoExporter - No software fallback encoder available after '{}' failed", codecName);
+            spdlog::error("VideoExporter - No fallback encoder available after '{}' failed", codecName);
             return false;
         }
     }

--- a/src-ui-wx/media/VideoExporter.cpp
+++ b/src-ui-wx/media/VideoExporter.cpp
@@ -170,6 +170,17 @@ void GenericVideoExporter::initialize()
         if (videoCodec == nullptr) {
             videoCodec = ::avcodec_find_encoder(best);
         }
+#elif defined(_WIN32)
+        {
+            // Prefer GPU encoders: NVENC (NVIDIA) → AMF (AMD) → QSV (Intel) → software
+            const char* nvenc = (best == AV_CODEC_ID_H265) ? "hevc_nvenc" : "h264_nvenc";
+            const char* amf   = (best == AV_CODEC_ID_H265) ? "hevc_amf"   : "h264_amf";
+            const char* qsv   = (best == AV_CODEC_ID_H265) ? "hevc_qsv"   : "h264_qsv";
+            videoCodec = ::avcodec_find_encoder_by_name(nvenc);
+            if (videoCodec == nullptr) videoCodec = ::avcodec_find_encoder_by_name(amf);
+            if (videoCodec == nullptr) videoCodec = ::avcodec_find_encoder_by_name(qsv);
+            if (videoCodec == nullptr) videoCodec = ::avcodec_find_encoder(best);
+        }
 #else
         videoCodec = ::avcodec_find_encoder(best);
 #endif
@@ -181,6 +192,16 @@ void GenericVideoExporter::initialize()
             videoCodec = ::avcodec_find_encoder_by_name(hwName2);
             if (videoCodec == nullptr) {
                 videoCodec = ::avcodec_find_encoder(best);
+            }
+#elif defined(_WIN32)
+            {
+                const char* nvenc = (best == AV_CODEC_ID_H265) ? "hevc_nvenc" : "h264_nvenc";
+                const char* amf   = (best == AV_CODEC_ID_H265) ? "hevc_amf"   : "h264_amf";
+                const char* qsv   = (best == AV_CODEC_ID_H265) ? "hevc_qsv"   : "h264_qsv";
+                videoCodec = ::avcodec_find_encoder_by_name(nvenc);
+                if (videoCodec == nullptr) videoCodec = ::avcodec_find_encoder_by_name(amf);
+                if (videoCodec == nullptr) videoCodec = ::avcodec_find_encoder_by_name(qsv);
+                if (videoCodec == nullptr) videoCodec = ::avcodec_find_encoder(best);
             }
 #else
             videoCodec = ::avcodec_find_encoder(best);
@@ -273,6 +294,13 @@ bool GenericVideoExporter::initializeVideo(const AVCodec* codec)
         _videoCodecContext->rc_max_rate = _outParams.videoBitrate * 1000;
     }
 
+    if (codec->id == AV_CODEC_ID_H264 || codec->id == AV_CODEC_ID_H265) {
+        _videoCodecContext->color_range     = AVCOL_RANGE_JPEG;
+        _videoCodecContext->color_primaries = AVCOL_PRI_BT709;
+        _videoCodecContext->color_trc       = AVCOL_TRC_BT709;
+        _videoCodecContext->colorspace      = AVCOL_SPC_BT709;
+    }
+
     if (codec->pix_fmts[0] == AV_PIX_FMT_VIDEOTOOLBOX) {
 #if defined(__APPLE__)
         // Set up a VideoToolbox hardware frames context so the encoder can
@@ -322,8 +350,37 @@ bool GenericVideoExporter::initializeVideo(const AVCodec* codec)
         ::av_opt_set_int(_videoCodecContext->priv_data, "prio_speed", 1, AV_OPT_SEARCH_CHILDREN);
         ::av_opt_set_int(_videoCodecContext->priv_data, "frames_before", 0, AV_OPT_SEARCH_CHILDREN);
     } else {
+#ifdef _WIN32
+        std::string codecName = codec->name ? codec->name : "";
+        bool isNvenc = (codecName.find("nvenc") != std::string::npos);
+        bool isAmf   = (codecName.find("_amf")  != std::string::npos);
+        bool isQsv   = (codecName.find("_qsv")  != std::string::npos);
+        if (isNvenc) {
+            if (_outParams.videoBitrate == 0) {
+                ::av_opt_set(_videoCodecContext->priv_data, "rc", "vbr", 0);
+                ::av_opt_set(_videoCodecContext->priv_data, "cq", "18", 0);
+            }
+            if (::av_opt_set(_videoCodecContext->priv_data, "preset", "p4", 0) != 0)
+                ::av_opt_set(_videoCodecContext->priv_data, "preset", "medium", 0);
+        } else if (isAmf) {
+            ::av_opt_set(_videoCodecContext->priv_data, "quality", "quality", 0);
+            if (_outParams.videoBitrate == 0) {
+                ::av_opt_set(_videoCodecContext->priv_data, "rc", "cqp", 0);
+                ::av_opt_set_int(_videoCodecContext->priv_data, "qp_i", 18, 0);
+                ::av_opt_set_int(_videoCodecContext->priv_data, "qp_p", 18, 0);
+            }
+        } else if (isQsv) {
+            ::av_opt_set(_videoCodecContext->priv_data, "preset", "medium", 0);
+            if (_outParams.videoBitrate == 0)
+                ::av_opt_set_int(_videoCodecContext->priv_data, "global_quality", 18, 0);
+        } else {
+            ::av_opt_set(_videoCodecContext->priv_data, "preset", "fast", 0);
+            ::av_opt_set(_videoCodecContext->priv_data, "crf", "18", AV_OPT_SEARCH_CHILDREN);
+        }
+#else
         ::av_opt_set(_videoCodecContext->priv_data, "preset", "fast", 0);
         ::av_opt_set(_videoCodecContext->priv_data, "crf", "18", AV_OPT_SEARCH_CHILDREN);
+#endif
     }
     if (_formatContext->oformat->flags & AVFMT_GLOBALHEADER) {
         _videoCodecContext->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
@@ -359,12 +416,32 @@ bool GenericVideoExporter::initializeVideo(const AVCodec* codec)
             return initializeVideo(codec);
         }
     }
+#ifdef _WIN32
+    if (status != 0) {
+        std::string codecName = codec->name ? codec->name : "";
+        bool isHw = (codecName.find("nvenc") != std::string::npos ||
+                     codecName.find("_amf")  != std::string::npos ||
+                     codecName.find("_qsv")  != std::string::npos);
+        if (isHw) {
+            spdlog::warn("VideoExporter - Windows HW encoder '{}' failed ({}), falling back to software",
+                         codecName, status);
+            ::avcodec_free_context(&_videoCodecContext);
+            _videoCodecContext = nullptr;
+            const char* swName = (codec->id == AV_CODEC_ID_H265) ? "libx265" : "libx264";
+            const AVCodec* swCodec = ::avcodec_find_encoder_by_name(swName);
+            if (swCodec == nullptr)
+                swCodec = ::avcodec_find_encoder(codec->id);
+            if (swCodec != nullptr)
+                return initializeVideo(swCodec);
+        }
+    }
+#endif
     if (status != 0) {
         if (_videoCodecContext) {
             ::avcodec_free_context(&_videoCodecContext);
             _videoCodecContext = nullptr;
         }
-        
+
         spdlog::info("VideoExporter - Error opening video codec context: {}", status);
         return false;
     }
@@ -461,6 +538,13 @@ void GenericVideoExporter::initializeFrames()
         if (_swsContext == nullptr) {
             throw std::runtime_error("VideoExporter - Error initializing color-converter");
         }
+        // Output full-range BT.709 YUV (Y: 0-255) to match the source sRGB pixels.
+        // Without this, sws_scale squeezes Y to 16-235 (studio swing) and the
+        // exported video looks dark on players that treat it as full range.
+        ::sws_setColorspaceDetails(_swsContext,
+            ::sws_getCoefficients(SWS_CS_ITU709), 1,
+            ::sws_getCoefficients(SWS_CS_ITU709), 1,
+            0, 1 << 16, 1 << 16);
     }
     if (_audioCodecContext != nullptr) {
         _audioFrame = ::av_frame_alloc();

--- a/src-ui-wx/media/VideoExporter.cpp
+++ b/src-ui-wx/media/VideoExporter.cpp
@@ -429,10 +429,11 @@ bool GenericVideoExporter::initializeVideo(const AVCodec* codec)
             _videoCodecContext = nullptr;
             const char* swName = (codec->id == AV_CODEC_ID_H265) ? "libx265" : "libx264";
             const AVCodec* swCodec = ::avcodec_find_encoder_by_name(swName);
-            if (swCodec == nullptr)
-                swCodec = ::avcodec_find_encoder(codec->id);
-            if (swCodec != nullptr)
+            if (swCodec != nullptr && swCodec != codec) {
                 return initializeVideo(swCodec);
+            }
+            spdlog::error("VideoExporter - No software fallback encoder available after '{}' failed", codecName);
+            return false;
         }
     }
 #endif


### PR DESCRIPTION
sws_scale was converting the captured OpenGL RGB pixels (full-range 0–255) to limited-range YUV (Y: 16–235) by default, and the H.264/H.265 codec context was leaving all color metadata as UNSPECIFIED. The result was an MP4 whose colr box was meaningless, causing players and YouTube's transcoder to misinterpret the brightness range and display a dark/washed-out video. Fixed by calling sws_setColorspaceDetails with BT.709 coefficients and full-range flags (srcRange=1, dstRange=1) so Y stays 0–255, and setting color_range = AVCOL_RANGE_JPEG, color_primaries/trc/colorspace = BT709 on the codec context so the colr box correctly declares full-range BT.709 — matching YouTube's recommended SDR upload spec.

On Windows the encoder was selected via avcodec_find_encoder() which returns whichever encoder FFmpeg registered first (often AMD AMF regardless of the user's GPU). Selection now explicitly tries h264_nvenc/hevc_nvenc → h264_amf/hevc_amf → h264_qsv/hevc_qsv → software, mirroring the existing macOS VideoToolbox preference. Each hardware encoder receives appropriate quality options (rc=vbr+cq for NVENC, rc=cqp+qp for AMF, global_quality for QSV) instead of libx264-specific preset/crf flags that silently failed on hardware encoders. Hardware encoders fall back to libx264/libx265 on open failure rather than falling all the way to MPEG-4.