### PR TITLE
Fix Windows hang when adding shader from disk (#6308)

### DIFF
--- a/src-ui-wx/app-shell/TabConvert.cpp
+++ b/src-ui-wx/app-shell/TabConvert.cpp
@@ -880,6 +880,9 @@ std::vector<std::shared_ptr<xlImage>> xLightsFrame::RenderEffectToFrames(
 
     while (!renderComplete) {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
+#ifdef _WIN32
+        wxSafeYield(nullptr, true);
+#endif
         UpdateRenderStatus();
     }
 
@@ -1347,6 +1350,9 @@ void xLightsFrame::WriteGIFForPreset(const std::string& preset)
                        0, frames - 1, nullptr, true, [](bool) {});
                 while (!_renderEngine->IsRenderDone()) {
                     std::this_thread::sleep_for(std::chrono::milliseconds(1));
+#ifdef _WIN32
+                    wxSafeYield(nullptr, true);
+#endif
                     UpdateRenderStatus();
                 }
                 _presetRendering = false;


### PR DESCRIPTION
Fix Windows hang when adding shader from disk: wxSafeYield in render spin loop allows GLContextManager bootstrap CallAfter to execute on the main thread. (#6308)