### PR TITLE
macOS: open .xsqz in a new xLights instance instead of replacing the current show

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,11 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.09  May ??, 2026
+    -bug (Neil)                 macOS: opening a .xsqz package while a sequence was already loaded replaced the
+                                current show folder in-place instead of launching a separate instance like Windows
+                                does. Now spawns a new xLights process for the package via `open -n`, leaving the
+                                current sequence untouched. The pre-existing File menu "Open New xLights Instance"
+                                also now uses the running bundle path so Debug builds spawn Debug builds.
 
 2026.08  May 7, 2026
     -enh (dkulp)                When a JobPool worker thread dies from an unhandled C++ exception, the log now

--- a/src-ui-wx/xLightsApp.cpp
+++ b/src-ui-wx/xLightsApp.cpp
@@ -187,16 +187,23 @@ bool SpawnNewXLightsInstance(const wxString& fileToOpen) {
     std::string sArgs = "--args";
     std::string sFile(fileToOpen.ToUTF8().data());
 
+    long pid = 0;
     if (fileToOpen.IsEmpty()) {
         char* argv[] = { sOpen.data(), sN.data(), sA.data(), sBundle.data(), nullptr };
         spdlog::info("Spawning new xLights instance: open -n -a '{}'", sBundle);
-        wxExecute(argv, wxEXEC_ASYNC);
+        pid = wxExecute(argv, wxEXEC_ASYNC);
     } else {
         char* argv[] = { sOpen.data(), sN.data(), sA.data(), sBundle.data(),
                          sArgs.data(), sFile.data(), nullptr };
         spdlog::info("Spawning new xLights instance: open -n -a '{}' --args '{}'",
                      sBundle, sFile);
-        wxExecute(argv, wxEXEC_ASYNC);
+        pid = wxExecute(argv, wxEXEC_ASYNC);
+    }
+    // wxExecute async returns 0 on launch failure; non-zero is the child PID.
+    if (pid == 0) {
+        spdlog::warn("wxExecute failed to launch new xLights instance for '{}'",
+                     sFile.empty() ? sBundle : sFile);
+        return false;
     }
     return true;
 }

--- a/src-ui-wx/xLightsApp.cpp
+++ b/src-ui-wx/xLightsApp.cpp
@@ -146,6 +146,62 @@
 
 xLightsFrame* xLightsApp::__frame = nullptr;
 
+#ifdef __WXOSX__
+// Resolve the .app bundle path of the currently-running xLights process by
+// walking up from the executable. Returns empty if the layout doesn't match
+// the expected `<Bundle>.app/Contents/MacOS/<exe>` shape (e.g. unbundled dev
+// run). Callers must check for empty before using the result.
+wxString GetRunningAppBundlePath() {
+    wxString exePath = wxStandardPaths::Get().GetExecutablePath();
+    wxFileName fn(exePath);
+    if (fn.GetDirCount() < 2) {
+        spdlog::warn("Cannot resolve .app bundle: executable path too shallow: {}",
+                     exePath.ToStdString());
+        return wxEmptyString;
+    }
+    fn.RemoveLastDir(); // strip MacOS
+    fn.RemoveLastDir(); // strip Contents
+    wxString candidate = fn.GetPath();
+    if (!candidate.EndsWith(".app")) {
+        spdlog::warn("Cannot resolve .app bundle from executable path '{}' (got '{}')",
+                     exePath.ToStdString(), candidate.ToStdString());
+        return wxEmptyString;
+    }
+    return candidate;
+}
+
+// Spawn a new xLights instance using `open -n -a <bundle> [--args <file>]`.
+// Uses the argv form of wxExecute to avoid shell quoting / escaping issues
+// for paths containing spaces, quotes, or other shell metacharacters.
+// Returns false if the bundle path cannot be resolved.
+bool SpawnNewXLightsInstance(const wxString& fileToOpen) {
+    wxString bundle = GetRunningAppBundlePath();
+    if (bundle.IsEmpty()) {
+        return false;
+    }
+    // Keep backing storage alive for the duration of the wxExecute call.
+    std::string sOpen = "/usr/bin/open";
+    std::string sN = "-n";
+    std::string sA = "-a";
+    std::string sBundle(bundle.ToUTF8().data());
+    std::string sArgs = "--args";
+    std::string sFile(fileToOpen.ToUTF8().data());
+
+    if (fileToOpen.IsEmpty()) {
+        char* argv[] = { sOpen.data(), sN.data(), sA.data(), sBundle.data(), nullptr };
+        spdlog::info("Spawning new xLights instance: open -n -a '{}'", sBundle);
+        wxExecute(argv, wxEXEC_ASYNC);
+    } else {
+        char* argv[] = { sOpen.data(), sN.data(), sA.data(), sBundle.data(),
+                         sArgs.data(), sFile.data(), nullptr };
+        spdlog::info("Spawning new xLights instance: open -n -a '{}' --args '{}'",
+                     sBundle, sFile);
+        wxExecute(argv, wxEXEC_ASYNC);
+    }
+    return true;
+}
+#endif
+
 void InitialiseLogging(bool fromMain)
 {
     static bool loggingInitialised = false;
@@ -453,8 +509,18 @@ void xLightsApp::MacOpenFiles(const wxArrayString &fileNames) {
     if (__frame) {
         xLightsFrame* frame = __frame;
         frame->CallAfter([showDir, fileName, frame] {
-            
+
             if (fileName.EndsWith("xsqz") || fileName.EndsWith("zip")) {
+
+                // If a sequence is already loaded in this instance, spawn a separate
+                // xLights process for the package instead of replacing the current
+                // show. Matches the Windows behavior where double-clicking an xsqz
+                // launches a fresh instance with the package as its show folder.
+                // Falls back to in-place handling if we can't resolve the bundle
+                // (e.g. running unbundled).
+                if (frame->IsSequenceLoaded() && SpawnNewXLightsInstance(fileName)) {
+                    return;
+                }
 
                 SequencePackage xsqPkg(std::filesystem::path(fileName.ToStdString()),
                                        __frame->GetShowDirectory(), __frame->GetSeqXmlFileName().ToStdString(), &__frame->AllModels);

--- a/src-ui-wx/xLightsApp.h
+++ b/src-ui-wx/xLightsApp.h
@@ -46,3 +46,10 @@ public:
     virtual bool ProcessIdle() override;
     uint64_t _nextIdleTime = 0;
 };
+
+#ifdef __WXOSX__
+// Spawn a new xLights process via `/usr/bin/open -n -a <bundle> [--args <file>]`.
+// Pass an empty fileToOpen to launch a blank sibling instance. Returns false if
+// the running app's .app bundle cannot be resolved (unbundled / dev runs).
+bool SpawnNewXLightsInstance(const wxString& fileToOpen);
+#endif

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -5423,7 +5423,11 @@ void xLightsFrame::OnMenuItem_Help_DownloadSelected(wxCommandEvent& event)
 void xLightsFrame::OnMenuItem_File_NewXLightsInstance(wxCommandEvent& event)
 {
 #ifdef __WXOSX__
-    system("open -n /Applications/xLights.app");
+    if (!SpawnNewXLightsInstance(wxEmptyString)) {
+        wxMessageBox(_("Could not locate the xLights application bundle. "
+                       "A new instance can only be launched when xLights is run from a .app bundle."),
+                     _("Open New xLights Instance"), wxOK | wxICON_WARNING, this);
+    }
 #endif
 }
 


### PR DESCRIPTION
## Summary

On Windows, double-clicking a `.xsqz` launches a fresh `xLights.exe` process with the package extracted to a temp folder as the show — leaving any other running xLights instances untouched. On macOS, the running instance hijacked itself in-place via `MacOpenFiles`, replacing whatever the user had loaded with the package's contents. There was no way to open an `.xsqz` on macOS without losing your current sequence.

This PR brings macOS in line with the Windows behavior.

(Replaces #6318. Same fix, but without the extra "Open New xLights Instance From File..." menu item — the double-click flow is sufficient and cleaner.)

## Changes

**`src-ui-wx/xLightsApp.cpp` — `MacOpenFiles()`**
When the file is a `.xsqz` / `.zip` and a sequence is already loaded in this instance, spawn a separate xLights process via `/usr/bin/open -n -a <bundle> --args <file>` and return early. The new process starts cold and the existing argv path (lines 705-811) extracts the package and opens it in read-only mode — same flow as Windows.
- Cold start (no sequence loaded yet) still uses the existing in-place path, which is the correct behavior for the very first `.xsqz` open after launch.
- Bundle path resolved via `wxFileName` walking up from `wxStandardPaths::GetExecutablePath()` and validating the `.app` suffix; returns empty (with logged warning) if the executable isn't inside an app bundle. Callers handle the empty case gracefully.
- Spawn logic uses `wxExecute(char**)` argv form, not the string form, so paths with spaces / quotes / shell metacharacters are safe.
- Centralized in `SpawnNewXLightsInstance()` so future callers share one implementation.

**`src-ui-wx/xLightsMain.cpp` — pre-existing menu item**
The pre-existing macOS-only **File → Open New xLights Instance** item now uses the running bundle path instead of hard-coding `/Applications/xLights.app`. Same fix as above applied to manual launches; Debug builds now spawn Debug builds.

## Behavior matrix after this change

| Scenario | Before | After |
|---|---|---|
| Cold-launch xLights via Finder double-click on .xsqz | Loads xsqz in-place | Loads xsqz in-place (unchanged) |
| Already running, double-click another .xsqz in Finder | Replaces current sequence | Spawns new instance |
| File menu → Open New xLights Instance | Spawns /Applications/xLights.app | Spawns the running bundle |

## Test plan

- [x] macOS Debug build: with a sequence loaded, opening another .xsqz spawns a sibling instance, both windows independent
- [x] macOS Debug build: cold-launch via `open -a <Debug bundle> file.xsqz` still loads in-place
- [x] macOS Debug build: File → Open New xLights Instance launches an empty sibling
- [ ] Windows: untouched (changes are inside `#ifdef __WXOSX__` and `MacOpenFiles` is macOS-only)
- [ ] Linux: untouched (same reason)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
