### PR TITLE
Fix audio not playing on first Play after opening a sequence

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,9 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.09  May ??, 2026
+    -bug (cjd)                  Fix audio not playing on first Play after opening a sequence (had to Stop and Play again
+                                to get audio). AudioManager::Seek() now lazy-adds the audio stream, matching Play()'s
+                                behavior after the deferred-AddAudio change.
     -bug (dkulp)                Generate AI Lyrics now feeds the recogniser whatever waveform the user has currently
                                 selected (RAW, an isolated HTDemucs vocals stem, a band-passed filter, etc.) instead
                                 of always sending the original mix. Previously the in-place stem selection was

--- a/src-core/media/AudioManager.cpp
+++ b/src-core/media/AudioManager.cpp
@@ -100,8 +100,20 @@ void AudioManager::Seek(long pos) const {
         return;
     }
 
-    if (__audioManager.GetOutput(_device) != nullptr)
-        __audioManager.GetOutput(_device)->Seek(_sdlid, pos);
+    auto* out = __audioManager.GetOutput(_device);
+    if (out == nullptr) {
+        return;
+    }
+
+    // Lazy-add: OpenMediaFile() defers AddAudio until first Play() to avoid
+    // spinning up AVAudioEngine for AudioManagers that only decode. Seek()
+    // must do the same lazy-add, otherwise a Seek() before the first Play()
+    // silently no-ops on _sdlid == -1 and the play position is wrong.
+    if (!out->HasAudio(_sdlid)) {
+        const_cast<AudioManager*>(this)->_sdlid = out->AddAudio(_pcmdatasize, _pcmdata, 100, _rate, _trackSize, _lengthMS);
+    }
+
+    out->Seek(_sdlid, pos);
 }
 
 void AudioManager::Pause() {

--- a/src-core/media/AudioManager.cpp
+++ b/src-core/media/AudioManager.cpp
@@ -110,7 +110,7 @@ void AudioManager::Seek(long pos) const {
     // must do the same lazy-add, otherwise a Seek() before the first Play()
     // silently no-ops on _sdlid == -1 and the play position is wrong.
     if (!out->HasAudio(_sdlid)) {
-        const_cast<AudioManager*>(this)->_sdlid = out->AddAudio(_pcmdatasize, _pcmdata, 100, _rate, _trackSize, _lengthMS);
+        _sdlid = out->AddAudio(_pcmdatasize, _pcmdata, 100, _rate, _trackSize, _lengthMS);
     }
 
     out->Seek(_sdlid, pos);

--- a/src-core/media/AudioManager.h
+++ b/src-core/media/AudioManager.h
@@ -123,7 +123,7 @@ class AudioManager {
     std::vector<float> _stemBassL, _stemBassR;
     std::vector<float> _stemOtherL, _stemOtherR;
     std::vector<float> _stemVocalsL, _stemVocalsR;
-    int _sdlid = 0;
+    mutable int _sdlid = 0;
     bool _ok = false;
     std::string _hash;
     std::future<void> _prepFrameData;


### PR DESCRIPTION
## Summary

After opening a sequence and pressing Play, audio does not play on the first attempt — users have to press Stop and then Play again before audio starts.

## Root cause

Commit 667f8e0fe6bee8b43dfc18556d4edfb65d3f098c (\"Defer setting up audio output until play is called. For batch render, no need for it.\") deferred `AddAudio` from `OpenMediaFile()` to `Play()` so batch renders don't spin up `AVAudioEngine` for AudioManagers that only decode. That change updated `Play()` and `AudioDeviceChanged()` to lazy-add, but missed `Seek()`.

`xLightsFrame::DoPlaySequence()` calls `playAudio->Seek(playStartTime)` *before* `playAudio->Play()`. On first play `_sdlid == -1`, so `Seek()` silently no-ops (the underlying output's `GetData(-1)` returns null). The subsequent no-arg `Play()` then adds the stream but never seeks to `playStartTime` — and the engine doesn't actually start producing output for the user. On the second Play, `_sdlid` is already valid (Stop doesn't clear it), so `Seek` works and audio plays.

## Fix

Make `AudioManager::Seek()` do the same lazy `AddAudio` that `Play()` and `AudioDeviceChanged()` already do.

## Test plan

- [x] Build (`xcodebuild -configuration Debug`) succeeds.
- [x] Open a sequence, press Play — audio starts immediately on first try.
- [x] Stop and Play again — still works.
- [x] Batch render path (which was the motivation for 667f8e0f) still avoids AddAudio because batch render never calls Seek/Play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)