### PR TITLE
Add File menu "Open New xLights Instance From File..." (macOS + Windows)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,11 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.09  May ??, 2026
+    -enh (Neil)                 Add File menu "Open New xLights Instance From File..." (macOS + Windows). Picks an
+                                .xsqz / .zip / .xsq via a file dialog and launches a new xLights process to open it.
+                                Lets users open zipped sequence packages without renaming .zip to .xsqz first or
+                                relying on OS file associations. The new instance handles the file via the existing
+                                argv launch path so behavior matches Finder / Explorer double-click.
     -bug (scott)                Fix HTDemucs ONNX model download failing: the 12-second total curl timeout set for
                                 short API calls was also killing the large-file download before it could complete.
     -bug (dkulp)                Backup: switch the per-file copy from wxCopyFile to std::filesystem::copy_file so

--- a/src-ui-wx/xLightsApp.cpp
+++ b/src-ui-wx/xLightsApp.cpp
@@ -209,6 +209,39 @@ bool SpawnNewXLightsInstance(const wxString& fileToOpen) {
 }
 #endif
 
+#ifdef __WXMSW__
+// Spawn a new xLights.exe process, optionally passing a file path as the first
+// argv. xLights has no single-instance checker so simply re-running the same
+// executable produces an independent process. Uses the argv form of wxExecute
+// to avoid shell quoting issues for paths with spaces or other special chars.
+bool SpawnNewXLightsInstance(const wxString& fileToOpen) {
+    wxString exePath = wxStandardPaths::Get().GetExecutablePath();
+    if (exePath.IsEmpty()) {
+        spdlog::warn("Cannot resolve xLights executable path; new instance not spawned");
+        return false;
+    }
+    std::string sExe(exePath.ToUTF8().data());
+    std::string sFile(fileToOpen.ToUTF8().data());
+
+    long pid = 0;
+    if (fileToOpen.IsEmpty()) {
+        char* argv[] = { sExe.data(), nullptr };
+        spdlog::info("Spawning new xLights instance: '{}'", sExe);
+        pid = wxExecute(argv, wxEXEC_ASYNC);
+    } else {
+        char* argv[] = { sExe.data(), sFile.data(), nullptr };
+        spdlog::info("Spawning new xLights instance: '{}' '{}'", sExe, sFile);
+        pid = wxExecute(argv, wxEXEC_ASYNC);
+    }
+    if (pid == 0) {
+        spdlog::warn("wxExecute failed to launch new xLights instance for '{}'",
+                     sFile.empty() ? sExe : sFile);
+        return false;
+    }
+    return true;
+}
+#endif
+
 void InitialiseLogging(bool fromMain)
 {
     static bool loggingInitialised = false;

--- a/src-ui-wx/xLightsApp.h
+++ b/src-ui-wx/xLightsApp.h
@@ -47,9 +47,11 @@ public:
     uint64_t _nextIdleTime = 0;
 };
 
-#ifdef __WXOSX__
-// Spawn a new xLights process via `/usr/bin/open -n -a <bundle> [--args <file>]`.
-// Pass an empty fileToOpen to launch a blank sibling instance. Returns false if
-// the running app's .app bundle cannot be resolved (unbundled / dev runs).
+#if defined(__WXOSX__) || defined(__WXMSW__)
+// Spawn a new xLights process. Pass an empty fileToOpen to launch a blank
+// sibling instance, or a path to a sequence/.xsq/.xsqz/.zip to have the new
+// instance open it via the launch-time argv path. Returns false if the spawn
+// could not be initiated (e.g. macOS .app bundle cannot be resolved, or
+// wxExecute failed). Linux is not currently supported.
 bool SpawnNewXLightsInstance(const wxString& fileToOpen);
 #endif

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -2216,6 +2216,23 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     VideoReader::SetHardwareAcceleratedVideo(_hwVideoAccleration);
     VideoReader::SetHardwareRenderType(_hwVideoRenderer);
 #endif
+
+#if defined(__WXOSX__) || defined(__WXMSW__)
+    // Open New xLights Instance From File... — lets users open a packaged
+    // sequence (.xsqz / .zip) without having to rename the file or rely on
+    // OS file associations. The chosen file is passed as argv to a new
+    // xLights process so the existing argv launch path handles extraction.
+#ifdef __WXMSW__
+    MenuFile->AppendSeparator();
+#endif
+    const long newInstFromFileId = wxNewId();
+    wxMenuItem* newInstFromFile = new wxMenuItem(MenuFile, newInstFromFileId,
+        _("Open New xLights Instance From File..."), wxEmptyString, wxITEM_NORMAL);
+    MenuFile->Append(newInstFromFile);
+    Connect(newInstFromFileId, wxEVT_COMMAND_MENU_SELECTED,
+            (wxObjectEventFunction)&xLightsFrame::OnMenuItem_File_NewXLightsInstanceFromFile);
+#endif
+
 #ifdef __WXMSW__
     // make sure Direct2DRenderer is created on the main thread before the other threads need it
     wxGraphicsRenderer::GetDirect2DRenderer();
@@ -5435,6 +5452,29 @@ void xLightsFrame::OnMenuItem_File_NewXLightsInstance(wxCommandEvent& event)
         wxMessageBox(_("Could not locate the xLights application bundle. "
                        "A new instance can only be launched when xLights is run from a .app bundle."),
                      _("Open New xLights Instance"), wxOK | wxICON_WARNING, this);
+    }
+#endif
+}
+
+void xLightsFrame::OnMenuItem_File_NewXLightsInstanceFromFile(wxCommandEvent& event)
+{
+#if defined(__WXOSX__) || defined(__WXMSW__)
+    wxFileDialog fd(this, _("Select sequence package or sequence to open in a new xLights instance"),
+                    CurrentDir, wxEmptyString,
+                    "Sequence files (*.xsqz;*.zip;*.xsq)|*.xsqz;*.zip;*.xsq|All files (*.*)|*.*",
+                    wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+    if (fd.ShowModal() != wxID_OK) {
+        return;
+    }
+    wxString filePath = fd.GetPath();
+    if (!ObtainAccessToURL(filePath)) {
+        wxMessageBox(wxString::Format(_("Could not obtain access to the selected file:\n%s"), filePath),
+                     _("Open New xLights Instance From File"), wxOK | wxICON_ERROR, this);
+        return;
+    }
+    if (!SpawnNewXLightsInstance(filePath)) {
+        wxMessageBox(_("Could not launch a new xLights instance for the selected file."),
+                     _("Open New xLights Instance From File"), wxOK | wxICON_WARNING, this);
     }
 #endif
 }

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -543,6 +543,7 @@ public:
     void OnMenuItem_File_Close_SequenceSelected(wxCommandEvent& event);
     void OnMenuItem_File_Export_VideoSelected(wxCommandEvent& event);
     void OnMenuItem_File_NewXLightsInstance(wxCommandEvent& event);
+    void OnMenuItem_File_NewXLightsInstanceFromFile(wxCommandEvent& event);
     void OnAuiToolBarFirstFrameClick(wxCommandEvent& event);
     void OnAuiToolBarLastFrameClick(wxCommandEvent& event);
     void OnAuiToolBarItemReplaySectionClick(wxCommandEvent& event);


### PR DESCRIPTION
## Summary

Adds a new **File → Open New xLights Instance From File...** menu item on macOS and Windows. Picks a sequence package (`.xsqz` / `.zip` / `.xsq`) via a file dialog and launches a new xLights process to open it.

## Why

On both macOS and Windows, `.zip` files are associated with the OS's archive utility (Archive Utility on macOS, File Explorer's built-in extractor on Windows), not with xLights. When a user receives a zipped sequence from a collaborator — which is the most common form they're shared in — they currently have to either:

1. Rename `.zip` to `.xsqz` to make double-click work, or
2. Extract the zip manually and open the contents through xLights

Neither is great. This menu option lets the user open any zipped or unzipped sequence file directly from inside xLights without having to mess with file associations or rename anything. The chosen file is passed as argv to a new xLights process so the existing launch-time argv path handles extraction exactly like a Finder / Explorer double-click would for `.xsqz`.

## How it works

The new instance always opens the package in **read-only** mode (matches existing `.xsqz` behavior — keeps the original archive intact). The current xLights instance is unaffected; user's open sequence is preserved.

| Platform | Spawn mechanism |
|---|---|
| macOS | `/usr/bin/open -n -a <bundle> --args <file>` (via the existing `SpawnNewXLightsInstance` helper added in #6319) |
| Windows | `wxExecute("xLights.exe <file>")` — xLights has no single-instance checker on Windows so re-running the same executable produces an independent process |

Both platforms use the `wxExecute(char**)` argv form so paths with spaces, quotes, or other shell metacharacters are handled safely.

## Changes

- **`src-ui-wx/xLightsApp.cpp`**: adds a Windows variant of `SpawnNewXLightsInstance()`. The macOS path is unchanged.
- **`src-ui-wx/xLightsApp.h`**: widens the declaration of `SpawnNewXLightsInstance` from `__WXOSX__` to `__WXOSX__ || __WXMSW__`.
- **`src-ui-wx/xLightsMain.cpp` / `.h`**: adds `OnMenuItem_File_NewXLightsInstanceFromFile` handler and wires it to a new menu entry. Both gated on `__WXOSX__ || __WXMSW__`. Honors `ObtainAccessToURL` return value on macOS so we don't spawn a sibling that can't read the file.
- **`README.txt`**: 2026.09 release note.

Linux is not currently supported because there's no `SpawnNewXLightsInstance` implementation for it. Could be added later (probably just `wxExecute(GetExecutablePath())` like Windows) but kept out of scope for this PR.

## Test plan

- [x] **macOS Debug**: File menu shows the new item; pick a `.zip` sequence package → new xLights instance launches and opens the package read-only; original instance unaffected
- [x] **macOS Debug**: pick a `.xsqz` → same flow works
- [x] **macOS Debug**: pick a plain `.xsq` → new instance opens with that file's directory as show folder
- [x] **macOS Debug**: cancel the file dialog → no spawn, no error
- [ ] **Windows**: same matrix on a Windows install (couldn't test locally — would appreciate Windows verification)
- [ ] **Linux**: untouched (gated out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
