### PR TITLE
Update pathing if multiple shaders/images were selected (#6327)

### DIFF
--- a/src-ui-wx/effectpanels/PicturesPanel.cpp
+++ b/src-ui-wx/effectpanels/PicturesPanel.cpp
@@ -27,6 +27,7 @@
 #include "shared/controls/BulkEditControls.h"
 #include "shared/utils/wxUtilities.h"
 #include "media/ManageMediaPanel.h"
+#include "sequencer/MainSequencer.h"
 #include "render/SequenceMedia.h"
 #include "render/SequenceElements.h"
 #include "utils/xlImage.h"
@@ -242,6 +243,10 @@ void PicturesPanel::OnSelectClick(wxCommandEvent& /*event*/) {
 
     UpdatePreviewBitmap(selected);
     FireChangeEvent();
+
+    if (xl->GetMainSequencer() && xl->GetMainSequencer()->GetSelectedEffectCount("Pictures") > 1) {
+        xl->GetMainSequencer()->ApplyEffectSettingToSelected("Pictures", "E_TEXTCTRL_Pictures_Filename", selected, nullptr, "");
+    }
 }
 
 void PicturesPanel::OnAIGenerateClick(wxCommandEvent& /*event*/) {

--- a/src-ui-wx/effectpanels/ShaderPanel.cpp
+++ b/src-ui-wx/effectpanels/ShaderPanel.cpp
@@ -29,6 +29,7 @@
 #include "shared/utils/wxUtilities.h"
 #include "../effects/ShaderDownloadDialog.h"
 #include "../media/ManageMediaPanel.h"
+#include "../sequencer/MainSequencer.h"
 #include "../media/ShaderPreviewGenerator.h"
 #include "../sequencer/BlendingPanel.h"
 #include "../xLightsApp.h"
@@ -268,6 +269,11 @@ void ShaderPanel::OnSelectClicked(wxCommandEvent& /*event*/) {
     // handler chain. Processing on `this` walks ShaderPanel's handlers then
     // propagates up to the parent and never reaches the bound handler.
     _hiddenFilePicker->ProcessWindowEvent(evt);
+
+    if (xl->GetMainSequencer() && xl->GetMainSequencer()->GetSelectedEffectCount("Shader") > 1) {
+        std::string id = FixIdForPanel("Effect", _hiddenFilePicker->GetName().ToStdString());
+        xl->GetMainSequencer()->ApplyEffectSettingToSelected("Shader", id + "_FN", selected, nullptr, "");
+    }
 }
 
 void ShaderPanel::OnClearClicked(wxCommandEvent& /*event*/) {


### PR DESCRIPTION
When you have multiple shaders or images selected, all of them will inherit the media selected. (already does this for videos)