### PR TITLE
Add Audio toolbar: Volume slider + Speed -/+ controls

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,16 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.09  May ??, 2026
+    -enh (Neil)                 Play toolbar: add an inline Volume slider (0-100) and a Speed dropdown (1/4x .. 4x)
+                                next to Play/Stop so users no longer have to drill into the Audio menu's discrete
+                                radio presets to change playback volume or speed during a session. Both controls
+                                are bidirectionally synced with the existing Audio menu items (slider snaps to /
+                                unchecks the Loud / Medium / Quiet / Very Quiet / Silent radio as appropriate;
+                                dropdown reflects the current playback rate). Volume still persists across launches
+                                via xLightsPlayVolume; speed still resets to 1.0x each launch. Pure wxWidgets
+                                (wxSlider + wxChoice), no platform-specific code — same UI on Windows / macOS /
+                                Linux. Bumped TOOLBAR_SAVE_VERSION so cached toolbar perspectives don't clip the
+                                new controls.
     -enh (Neil)                 Custom Model Wiring view: header overlay now includes a "Total Nodes: N" line below
                                 Rotation so you can see the model's pixel count at a glance without counting.
     -bug (scott)                Fix HTDemucs ONNX model download failing: the 12-second total curl timeout set for

--- a/README.txt
+++ b/README.txt
@@ -11,16 +11,17 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.09  May ??, 2026
-    -enh (Neil)                 Play toolbar: add an inline Volume slider (0-100) and a Speed dropdown (1/4x .. 4x)
-                                next to Play/Stop so users no longer have to drill into the Audio menu's discrete
-                                radio presets to change playback volume or speed during a session. Both controls
-                                are bidirectionally synced with the existing Audio menu items (slider snaps to /
-                                unchecks the Loud / Medium / Quiet / Very Quiet / Silent radio as appropriate;
-                                dropdown reflects the current playback rate). Volume still persists across launches
-                                via xLightsPlayVolume; speed still resets to 1.0x each launch. Pure wxWidgets
-                                (wxSlider + wxChoice), no platform-specific code — same UI on Windows / macOS /
-                                Linux. Bumped TOOLBAR_SAVE_VERSION so cached toolbar perspectives don't clip the
-                                new controls.
+    -enh (Neil)                 Add a dockable Audio Tool Bar (alongside Play / Edit / View / Windows) with a
+                                Volume slider (0-100) and Speed -/+ buttons walking the existing 8 preset speeds
+                                (1/4x .. 4x) with a current-value label between them. Both controls bidirectionally
+                                synced with the Audio menu's radio items: slider snaps to / unchecks the Loud /
+                                Medium / Quiet / Very Quiet / Silent radio at 100/66/33/10/0; speed buttons step
+                                through and update the radio. Speed buttons each fire a single direct event so the
+                                dispatch path matches the menu bar (no popup that would block the playback timer on
+                                macOS). Volume still persists across launches via xLightsPlayVolume; speed still
+                                resets to 1.0x each launch. Pure wxWidgets (wxAuiToolBar + wxSlider + wxButton +
+                                wxStaticText), no platform-specific code — same UI on Windows / macOS / Linux.
+                                Bumped TOOLBAR_SAVE_VERSION so the new toolbar pane is visible on existing installs.
     -enh (Neil)                 Custom Model Wiring view: header overlay now includes a "Total Nodes: N" line below
                                 Rotation so you can see the model's pixel count at a glance without counting.
     -bug (scott)                Fix HTDemucs ONNX model download failing: the 12-second total curl timeout set for

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -171,7 +171,7 @@
 #include <wx/string.h>
 //*)
 
-#define TOOLBAR_SAVE_VERSION "0003:"
+#define TOOLBAR_SAVE_VERSION "0005:"
 #define MAXBACKUPFILE_MB 30
 
 //(*IdInit(xLightsFrame)
@@ -189,6 +189,10 @@ const wxWindowID xLightsFrame::ID_AUITOOLBAR_FIRST_FRAME = wxNewId();
 const wxWindowID xLightsFrame::ID_AUITOOLBAR_LAST_FRAME = wxNewId();
 const wxWindowID xLightsFrame::ID_AUITOOLBAR_REPLAY_SECTION = wxNewId();
 const wxWindowID xLightsFrame::ID_CHECKBOX_LIGHT_OUTPUT = wxNewId();
+const wxWindowID xLightsFrame::ID_AUITOOLBAR_VOLUME_SLIDER = wxNewId();
+const wxWindowID xLightsFrame::ID_AUITOOLBAR_SPEED_BUTTON = wxNewId();
+const wxWindowID xLightsFrame::ID_AUITOOLBAR_SPEED_DOWN = wxNewId();
+const wxWindowID xLightsFrame::ID_AUITOOLBAR_SPEED_UP = wxNewId();
 const wxWindowID xLightsFrame::ID_AUITOOLBAR_PLAY = wxNewId();
 const wxWindowID xLightsFrame::ID_AUITOOLBARITEM2 = wxNewId();
 const wxWindowID xLightsFrame::ID_AUITOOLBARITEM5 = wxNewId();
@@ -201,6 +205,7 @@ const wxWindowID xLightsFrame::ID_AUITOOLBARITEM8 = wxNewId();
 const wxWindowID xLightsFrame::ID_AUITOOLBARITEM9 = wxNewId();
 const wxWindowID xLightsFrame::ID_AUITOOLBARITEM10 = wxNewId();
 const wxWindowID xLightsFrame::ID_AUIWINDOWTOOLBAR = wxNewId();
+const wxWindowID xLightsFrame::ID_AUITOOLBAR_AUDIO = wxNewId();
 const wxWindowID xLightsFrame::ID_PASTE_BY_TIME = wxNewId();
 const wxWindowID xLightsFrame::ID_PASTE_BY_CELL = wxNewId();
 const wxWindowID xLightsFrame::ID_AUITOOLBAR_EDIT = wxNewId();
@@ -783,6 +788,48 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     PlayToolBar->AddTool(ID_CHECKBOX_LIGHT_OUTPUT, _("Output To Lights"), GetToolbarBitmapBundle("xlART_OUTPUT_LIGHTS"), wxNullBitmap, wxITEM_CHECK, _("Output To Lights"), wxEmptyString, NULL);
     PlayToolBar->Realize();
     MainAuiManager->AddPane(PlayToolBar, wxAuiPaneInfo().Name(_T("Play Tool Bar")).ToolbarPane().Caption(_("Play Tool Bar")).CloseButton(false).Layer(10).Position(11).Top().Gripper());
+
+    // Dedicated Audio toolbar — independently dockable / floatable like
+    // the other toolbars. Holds a volume slider and a speed picker so
+    // users can adjust playback without drilling into the Audio menu's
+    // discrete radio presets. Both controls are bidirectionally synced
+    // with the Audio menu items.
+    AudioToolBar = new xlAuiToolBar(this, ID_AUITOOLBAR_AUDIO, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE);
+    AudioToolBar->AddLabel(wxID_ANY, _("Vol:"));
+    _playVolumeSlider = new wxSlider(AudioToolBar, ID_AUITOOLBAR_VOLUME_SLIDER,
+                                     100, 0, 100,
+                                     wxDefaultPosition, wxSize(90, -1),
+                                     wxSL_HORIZONTAL);
+    _playVolumeSlider->SetToolTip(_("Playback volume (0-100)"));
+    AudioToolBar->AddControl(_playVolumeSlider);
+
+    AudioToolBar->AddSeparator();
+    // Speed control: a pair of small buttons that step through the
+    // existing 8 preset speeds. Each click is a single event that
+    // dispatches via the same path as the Audio menu's radio items, so
+    // no modal popup is ever shown and macOS doesn't pause the playback
+    // timer / restart audio while changing speed.
+    _playSpeedDownButton = new wxButton(AudioToolBar, ID_AUITOOLBAR_SPEED_DOWN,
+                                        _("–"),
+                                        wxDefaultPosition, wxSize(32, -1));
+    _playSpeedDownButton->SetToolTip(_("Slower"));
+    AudioToolBar->AddControl(_playSpeedDownButton);
+
+    _playSpeedLabel = new wxStaticText(AudioToolBar, ID_AUITOOLBAR_SPEED_BUTTON,
+                                       _("1.0x"),
+                                       wxDefaultPosition, wxSize(46, -1),
+                                       wxALIGN_CENTRE_HORIZONTAL);
+    _playSpeedLabel->SetToolTip(_("Current playback speed"));
+    AudioToolBar->AddControl(_playSpeedLabel);
+
+    _playSpeedUpButton = new wxButton(AudioToolBar, ID_AUITOOLBAR_SPEED_UP,
+                                      _("+"),
+                                      wxDefaultPosition, wxSize(32, -1));
+    _playSpeedUpButton->SetToolTip(_("Faster"));
+    AudioToolBar->AddControl(_playSpeedUpButton);
+
+    AudioToolBar->Realize();
+    MainAuiManager->AddPane(AudioToolBar, wxAuiPaneInfo().Name(_T("Audio Tool Bar")).ToolbarPane().Caption(_("Audio Tool Bar")).CloseButton(false).Layer(10).Row(1).Position(0).Top().Gripper().Show(true));
     WindowMgmtToolbar = new xlAuiToolBar(this, ID_AUIWINDOWTOOLBAR, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE);
     WindowMgmtToolbar->AddTool(ID_AUITOOLBARITEM2, _("Effect Settings"), GetToolbarBitmapBundle("xlART_EFFECTSETTINGS"), wxNullBitmap, wxITEM_CHECK, _("Effect Settings"), wxEmptyString, NULL);
     WindowMgmtToolbar->AddTool(ID_AUITOOLBARITEM5, _("Effect Colors"), GetToolbarBitmapBundle("xlART_COLORS"), wxNullBitmap, wxITEM_CHECK, _("Effect Colors"), wxEmptyString, NULL);
@@ -1301,6 +1348,9 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     Connect(ID_AUITOOLBAR_LAST_FRAME, wxEVT_COMMAND_TOOL_CLICKED, (wxObjectEventFunction)&xLightsFrame::OnAuiToolBarLastFrameClick);
     Connect(ID_AUITOOLBAR_REPLAY_SECTION, wxEVT_COMMAND_TOOL_CLICKED, (wxObjectEventFunction)&xLightsFrame::OnAuiToolBarItemReplaySectionClick);
     Connect(ID_CHECKBOX_LIGHT_OUTPUT, wxEVT_COMMAND_TOOL_CLICKED, (wxObjectEventFunction)&xLightsFrame::OnCheckBoxLightOutputClick);
+    Connect(ID_AUITOOLBAR_VOLUME_SLIDER, wxEVT_SLIDER, (wxObjectEventFunction)&xLightsFrame::OnAuiToolBarVolumeSliderChange);
+    Connect(ID_AUITOOLBAR_SPEED_DOWN, wxEVT_BUTTON, (wxObjectEventFunction)&xLightsFrame::OnAuiToolBarSpeedDownClick);
+    Connect(ID_AUITOOLBAR_SPEED_UP, wxEVT_BUTTON, (wxObjectEventFunction)&xLightsFrame::OnAuiToolBarSpeedUpClick);
     Connect(ID_AUITOOLBARITEM2, wxEVT_COMMAND_TOOL_CLICKED, (wxObjectEventFunction)&xLightsFrame::ShowHideEffectSettingsWindow);
     Connect(ID_AUITOOLBARITEM5, wxEVT_COMMAND_TOOL_CLICKED, (wxObjectEventFunction)&xLightsFrame::ShowHideColorWindow);
     Connect(ID_AUITOOLBARITEM7, wxEVT_COMMAND_TOOL_CLICKED, (wxObjectEventFunction)&xLightsFrame::ShowHideBufferSettingsWindow);
@@ -1696,13 +1746,11 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     spdlog::debug("Disable Key Accelerations: {}.", _disableKeyAcceleration ? "Y": "N");
 
     config->Read("xLightsTimelineZooming", &_timelineZooming, 0);
-    config->Read("xLightsPlayVolume", &playVolume, 100);
-    MenuItem_LoudVol->Check(playVolume == 100);
-    MenuItem_MedVol->Check(playVolume == 66);
-    MenuItem_QuietVol->Check(playVolume == 33);
-    MenuItem_VQuietVol->Check(playVolume == 10);
-    MenuItem_SilentVol->Check(playVolume == 0);
-    AudioManager::GetAudioManager()->SetGlobalVolume(playVolume);
+    int initialVolume = 100;
+    config->Read("xLightsPlayVolume", &initialVolume, 100);
+    // SetPlayVolumeTo applies to AudioManager AND syncs the menu radios
+    // AND the toolbar slider in one place.
+    SetPlayVolumeTo(initialVolume);
 
     wxString randomEffects = "";
     config->Read("xLightsRandomEffects", &randomEffects);
@@ -3949,22 +3997,34 @@ void xLightsFrame::SetPlaySpeedTo(float speed)
         }
     }
 
+    wxString speedLabel;
     if (speed == 1.0) {
         AudioMenu->Check(ID_PLAY_FULL, true);
+        speedLabel = "1.0x";
     } else if (speed == 1.5) {
         AudioMenu->Check(ID_MNU_1POINT5SPEED, true);
+        speedLabel = "1.5x";
     } else if (speed == 2) {
         AudioMenu->Check(ID_MN_2SPEED, true);
+        speedLabel = "2x";
     } else if (speed == 3) {
         AudioMenu->Check(ID_MNU_3SPEED, true);
+        speedLabel = "3x";
     } else if (speed == 4) {
         AudioMenu->Check(ID_MNU_4SPEED, true);
+        speedLabel = "4x";
     } else if (speed == 0.75) {
         AudioMenu->Check(ID_PLAY_3_4, true);
+        speedLabel = "3/4x";
     } else if (speed == 0.5) {
         AudioMenu->Check(ID_PLAY_1_2, true);
+        speedLabel = "1/2x";
     } else if (speed == 0.25) {
         AudioMenu->Check(ID_PLAY_1_4, true);
+        speedLabel = "1/4x";
+    }
+    if (_playSpeedLabel != nullptr && !speedLabel.IsEmpty()) {
+        _playSpeedLabel->SetLabel(speedLabel);
     }
 }
 
@@ -7372,28 +7432,82 @@ void xLightsFrame::OnMenuItem_PurgeVendorCacheSelected(wxCommandEvent& event)
     PurgeDownloadCache();
 }
 
+void xLightsFrame::SetPlayVolumeTo(int vol)
+{
+    if (vol < 0) vol = 0;
+    if (vol > 100) vol = 100;
+    playVolume = vol;
+    AudioManager::GetAudioManager()->SetGlobalVolume(playVolume);
+
+    // Mirror to the toolbar slider (no-op if already at this value).
+    if (_playVolumeSlider != nullptr && _playVolumeSlider->GetValue() != playVolume) {
+        _playVolumeSlider->SetValue(playVolume);
+    }
+    // Mirror to the Audio menu radio group. Uncheck all if the volume
+    // doesn't match a preset; check the matching item if it does.
+    if (MenuItem_LoudVol != nullptr) MenuItem_LoudVol->Check(playVolume == 100);
+    if (MenuItem_MedVol != nullptr) MenuItem_MedVol->Check(playVolume == 66);
+    if (MenuItem_QuietVol != nullptr) MenuItem_QuietVol->Check(playVolume == 33);
+    if (MenuItem_VQuietVol != nullptr) MenuItem_VQuietVol->Check(playVolume == 10);
+    if (MenuItem_SilentVol != nullptr) MenuItem_SilentVol->Check(playVolume == 0);
+}
+
 void xLightsFrame::OnMenuItem_LoudVolSelected(wxCommandEvent& event)
 {
-    playVolume = 100;
-    AudioManager::GetAudioManager()->SetGlobalVolume(playVolume);
+    SetPlayVolumeTo(100);
 }
 
 void xLightsFrame::OnMenuItem_MedVolSelected(wxCommandEvent& event)
 {
-    playVolume = 66;
-    AudioManager::GetAudioManager()->SetGlobalVolume(playVolume);
+    SetPlayVolumeTo(66);
 }
 
 void xLightsFrame::OnMenuItem_QuietVolSelected(wxCommandEvent& event)
 {
-    playVolume = 33;
-    AudioManager::GetAudioManager()->SetGlobalVolume(playVolume);
+    SetPlayVolumeTo(33);
 }
 
 void xLightsFrame::OnMenuItem_VQuietVolSelected(wxCommandEvent& event)
 {
-    playVolume = 10;
-    AudioManager::GetAudioManager()->SetGlobalVolume(playVolume);
+    SetPlayVolumeTo(10);
+}
+
+void xLightsFrame::OnAuiToolBarVolumeSliderChange(wxCommandEvent& event)
+{
+    if (_playVolumeSlider != nullptr) {
+        SetPlayVolumeTo(_playVolumeSlider->GetValue());
+    }
+}
+
+// Single click on +/- steps through the 8 preset speeds. The actual
+// rate change goes through SetPlaySpeedTo → AudioManager::SetPlaybackRate
+// in a single synchronous event, the same path the Audio menu uses — no
+// popup, nothing blocks the playback timer.
+static const float kPresetSpeeds[8] = {
+    0.25f, 0.5f, 0.75f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f
+};
+
+static int CurrentSpeedIndex(double current) {
+    for (int i = 0; i < 8; ++i) {
+        if (current == kPresetSpeeds[i]) return i;
+    }
+    return 3; // default to 1.0x if current isn't a preset
+}
+
+void xLightsFrame::OnAuiToolBarSpeedDownClick(wxCommandEvent& event)
+{
+    int idx = CurrentSpeedIndex(playSpeed);
+    if (idx > 0) {
+        SetPlaySpeedTo(kPresetSpeeds[idx - 1]);
+    }
+}
+
+void xLightsFrame::OnAuiToolBarSpeedUpClick(wxCommandEvent& event)
+{
+    int idx = CurrentSpeedIndex(playSpeed);
+    if (idx < 7) {
+        SetPlaySpeedTo(kPresetSpeeds[idx + 1]);
+    }
 }
 
 void xLightsFrame::ShowPresetsPanel()
@@ -8714,8 +8828,7 @@ void xLightsFrame::OnMenuItemSearchEffectsSelected(wxCommandEvent& event)
 
 void xLightsFrame::OnMenuItem_SilentVolSelected(wxCommandEvent& event)
 {
-    playVolume = 0;
-    AudioManager::GetAudioManager()->SetGlobalVolume(playVolume);
+    SetPlayVolumeTo(0);
 }
 
 void xLightsFrame::OnMenuItem_TODSelected(wxCommandEvent& event)

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -190,7 +190,7 @@ const wxWindowID xLightsFrame::ID_AUITOOLBAR_LAST_FRAME = wxNewId();
 const wxWindowID xLightsFrame::ID_AUITOOLBAR_REPLAY_SECTION = wxNewId();
 const wxWindowID xLightsFrame::ID_CHECKBOX_LIGHT_OUTPUT = wxNewId();
 const wxWindowID xLightsFrame::ID_AUITOOLBAR_VOLUME_SLIDER = wxNewId();
-const wxWindowID xLightsFrame::ID_AUITOOLBAR_SPEED_BUTTON = wxNewId();
+const wxWindowID xLightsFrame::ID_AUITOOLBAR_SPEED_LABEL = wxNewId();
 const wxWindowID xLightsFrame::ID_AUITOOLBAR_SPEED_DOWN = wxNewId();
 const wxWindowID xLightsFrame::ID_AUITOOLBAR_SPEED_UP = wxNewId();
 const wxWindowID xLightsFrame::ID_AUITOOLBAR_PLAY = wxNewId();
@@ -810,12 +810,12 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     // no modal popup is ever shown and macOS doesn't pause the playback
     // timer / restart audio while changing speed.
     _playSpeedDownButton = new wxButton(AudioToolBar, ID_AUITOOLBAR_SPEED_DOWN,
-                                        _("–"),
+                                        _("-"),
                                         wxDefaultPosition, wxSize(32, -1));
     _playSpeedDownButton->SetToolTip(_("Slower"));
     AudioToolBar->AddControl(_playSpeedDownButton);
 
-    _playSpeedLabel = new wxStaticText(AudioToolBar, ID_AUITOOLBAR_SPEED_BUTTON,
+    _playSpeedLabel = new wxStaticText(AudioToolBar, ID_AUITOOLBAR_SPEED_LABEL,
                                        _("1.0x"),
                                        wxDefaultPosition, wxSize(46, -1),
                                        wxALIGN_CENTRE_HORIZONTAL);

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -720,7 +720,7 @@ public:
     static const wxWindowID ID_AUITOOLBAR_REPLAY_SECTION;
     static const wxWindowID ID_CHECKBOX_LIGHT_OUTPUT;
     static const wxWindowID ID_AUITOOLBAR_VOLUME_SLIDER;
-    static const wxWindowID ID_AUITOOLBAR_SPEED_BUTTON;
+    static const wxWindowID ID_AUITOOLBAR_SPEED_LABEL;
     static const wxWindowID ID_AUITOOLBAR_SPEED_DOWN;
     static const wxWindowID ID_AUITOOLBAR_SPEED_UP;
     static const wxWindowID ID_AUITOOLBAR_PLAY;

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -620,6 +620,14 @@ public:
     void OnMenuItem_MedVolSelected(wxCommandEvent& event);
     void OnMenuItem_QuietVolSelected(wxCommandEvent& event);
     void OnMenuItem_VQuietVolSelected(wxCommandEvent& event);
+    void OnAuiToolBarVolumeSliderChange(wxCommandEvent& event);
+    void OnAuiToolBarSpeedDownClick(wxCommandEvent& event);
+    void OnAuiToolBarSpeedUpClick(wxCommandEvent& event);
+    // Single entry point for changing playback volume programmatically
+    // or from the toolbar. Updates playVolume, AudioManager, the matching
+    // Audio menu radio (if vol == one of the preset values), and the
+    // toolbar slider. Volume is 0-100.
+    void SetPlayVolumeTo(int vol);
     void TogglePresetsPanel();
     void ShowPresetsPanel();
     uint64_t BadDriveAccess(const std::list<std::string>& files, std::list<std::pair<std::string, uint64_t>>& slow, uint64_t thresholdUS);
@@ -711,6 +719,10 @@ public:
     static const wxWindowID ID_AUITOOLBAR_LAST_FRAME;
     static const wxWindowID ID_AUITOOLBAR_REPLAY_SECTION;
     static const wxWindowID ID_CHECKBOX_LIGHT_OUTPUT;
+    static const wxWindowID ID_AUITOOLBAR_VOLUME_SLIDER;
+    static const wxWindowID ID_AUITOOLBAR_SPEED_BUTTON;
+    static const wxWindowID ID_AUITOOLBAR_SPEED_DOWN;
+    static const wxWindowID ID_AUITOOLBAR_SPEED_UP;
     static const wxWindowID ID_AUITOOLBAR_PLAY;
     static const wxWindowID ID_AUITOOLBARITEM2;
     static const wxWindowID ID_AUITOOLBARITEM5;
@@ -723,6 +735,7 @@ public:
     static const wxWindowID ID_AUITOOLBARITEM9;
     static const wxWindowID ID_AUITOOLBARITEM10;
     static const wxWindowID ID_AUIWINDOWTOOLBAR;
+    static const wxWindowID ID_AUITOOLBAR_AUDIO;
     static const wxWindowID ID_PASTE_BY_TIME;
     static const wxWindowID ID_PASTE_BY_CELL;
     static const wxWindowID ID_AUITOOLBAR_EDIT;
@@ -1082,6 +1095,7 @@ public:
     xlAuiToolBar* EffectsToolBar;
     xlAuiToolBar* MainToolBar;
     xlAuiToolBar* PlayToolBar;
+    xlAuiToolBar* AudioToolBar;
     xlAuiToolBar* ViewToolBar;
     xlAuiToolBar* WindowMgmtToolbar;
     //*)
@@ -1779,6 +1793,18 @@ private:
     double playSpeed;
     int playVolume;
     bool playAnimation;
+
+    // Toolbar mirrors of the Audio menu's Volume / Speed radio groups.
+    // Created in OnInit alongside PlayToolBar; updated bidirectionally
+    // with the menu via SetPlayVolumeTo / SetPlaySpeedTo. The Speed
+    // button pops up a wxMenu that re-uses the existing Audio menu's
+    // radio IDs so selecting from it goes through the exact same event
+    // path as picking from the menu bar (avoids the wxChoice native
+    // dropdown blocking the playback timer on macOS).
+    wxSlider* _playVolumeSlider = nullptr;
+    wxStaticText* _playSpeedLabel = nullptr;
+    wxButton* _playSpeedDownButton = nullptr;
+    wxButton* _playSpeedUpButton = nullptr;
 
     std::string selectedEffectName;
     std::string selectedEffectString;


### PR DESCRIPTION
## Summary

Adds a new dockable **Audio Tool Bar** (alongside the existing Play / Edit / View / Windows toolbars) giving users always-visible playback **Volume** and **Speed** controls. The existing Audio menu's 5 volume presets and 8 speed presets are buried in a menu drill-down; this surfaces them on the toolbar.

## Why

Volume and speed during playback are common-enough adjustments that the menu round-trip is friction. After this PR, both are one-click on the toolbar, and the layout can be moved / floated / hidden like any other toolbar.

## Controls

| | Widget | Behavior |
|---|---|---|
| **Volume** | `wxSlider` 0-100 with "Vol:" label | Live update on drag |
| **Speed** | `-` / `+` `wxButton`s with a `wxStaticText` showing current preset (1/4x .. 4x) | Each click steps one preset |

Both bidirectionally synced with the existing Audio menu radio items:
- Slider lands on 100/66/33/10/0 → matching menu radio checked; lands elsewhere → all unchecked.
- Menu item picked → slider snaps.
- Toolbar `+`/`-` → walks the preset list, mirrors to menu.
- Menu speed picked → toolbar label updates.

## Why `-`/`+` buttons instead of a dropdown for speed

Tried both `wxChoice` and a button-that-pops-a-`wxMenu`. Both go through wx's modal `PopupMenu` on macOS, which **blocks the wx event loop while the popup is shown**. The playback timer pauses for the duration, and on dismissal the audio engine plays catch-up — perceptible as a "stop/restart" at speed changes. `-`/`+` buttons each fire one direct event with no popup, so the dispatch path matches the menu-bar's native NSMenu handling (which doesn't block timers). Confirmed audibly: toolbar speed change is now indistinguishable from menu-bar speed change.

## Implementation

- New `xlAuiToolBar* AudioToolBar` member; added as its own `wxAuiPaneInfo()` pane on `Row(1)` so it doesn't clip the existing top row.
- All UI changes are wxWidgets primitives (no `#ifdef`, no platform-specific code) — identical on Windows / macOS / Linux.
- `SetPlayVolumeTo(int)` is a new central helper that updates `playVolume`, `AudioManager::SetGlobalVolume`, the toolbar slider, and the matching Audio menu radio. The 5 existing menu volume handlers now just call this.
- Speed step handlers (`OnAuiToolBarSpeedDownClick` / `OnAuiToolBarSpeedUpClick`) walk a static `kPresetSpeeds[8]` array and call the existing `SetPlaySpeedTo(float)` — same path the Audio menu's `SetPlaySpeed(wxCommandEvent&)` ends up at.
- `TOOLBAR_SAVE_VERSION` bumped `"0003"` → `"0005"` so stale cached perspectives don't hide the new pane on existing installs.

## Test plan

- [x] macOS Debug: Audio toolbar appears on its own row at top of window, with Vol slider + `-` 1.0x `+` controls
- [x] Drag volume slider → audio level changes live; menu's Loud/Medium/Quiet/Very Quiet/Silent radio updates
- [x] Pick menu volume preset → slider snaps to matching value
- [x] Click `+` from 1.0x → walks to 1.5x, 2x, 3x, 4x (stops at 4x)
- [x] Click `-` from 1.0x → walks to 3/4x, 1/2x, 1/4x (stops at 1/4x)
- [x] Pick speed from Audio menu → toolbar label updates
- [x] Pane can be dragged, floated, re-docked via gripper
- [x] Volume persists across launches (existing behavior, unchanged)
- [ ] Windows: untouched code paths, pure wxWidgets — should be identical
- [ ] Linux: same

## Known pre-existing issue (out of scope)

Changing playback rate across the 1.0x boundary on macOS produces an audible stop/restart from the `AVAudioEngine`'s `AVAudioUnitTimePitch` node being inserted/removed by `ensureTimePitch()` in `macOS/src-apple-core/media/AVAudioEngineOutputBridge.mm`. This affects both the new toolbar `+`/`-` and the existing Audio menu identically (any 1.0 ↔ non-1.0 transition triggers an `[engine stop]` + `[engine startAndReturnError:]`). Going to be filed as a separate issue / PR against the macOS submodule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
