### PR TITLE
Add ability to repick missing shaders and other media types

### DIFF
--- a/src-core/render/SequenceMedia.cpp
+++ b/src-core/render/SequenceMedia.cpp
@@ -953,6 +953,16 @@ std::vector<std::string> SequenceMedia::GetImagePaths() const
     return paths;
 }
 
+std::vector<std::string> SequenceMedia::GetShaderPaths() const
+{
+    std::scoped_lock lock(_cacheMutex);
+    std::vector<std::string> paths;
+    for (const auto& pair : _shaderCache) {
+        paths.push_back(pair.first);
+    }
+    return paths;
+}
+
 std::vector<std::pair<std::string, std::string>> SequenceMedia::GetImageRelocations() const
 {
     std::scoped_lock lock(_cacheMutex);
@@ -1765,6 +1775,75 @@ bool SequenceMedia::ReloadMedia(const std::string& filepath) {
         return true;
     }
     return false;
+}
+
+void SequenceMedia::ForceRefreshEntry(const std::string& filepath,
+                                      const std::string& resolvedPath,
+                                      MediaType type) {
+    if (filepath.empty()) return;
+
+    // resolvedPath is the known absolute file path supplied by the caller (e.g. from
+    // the file picker). We use it directly so we bypass FixFile's stale positive/negative
+    // caches, which can misdirect GetXxx() to an old location after a re-select.
+    const std::string& loadPath = resolvedPath.empty() ? ResolvePath(filepath) : resolvedPath;
+
+    std::shared_ptr<MediaCacheEntry> entry;
+    {
+        std::scoped_lock lock(_cacheMutex);
+
+        // Generic helper: erase the exact key plus any other entry whose resolved path
+        // collides with loadPath (these would cause GetXxx(filepath)'s duplicate-path
+        // check to short-circuit and return without inserting the new key).
+        // Then insert a fresh entry at filepath.
+        auto doInsert = [&](auto& cache, auto makeEntry) -> std::shared_ptr<MediaCacheEntry> {
+            cache.erase(filepath);
+            for (auto it = cache.begin(); it != cache.end(); ) {
+                if (it->second->GetFilePath() == loadPath || ResolvePath(it->first) == loadPath)
+                    it = cache.erase(it);
+                else
+                    ++it;
+            }
+            auto np = makeEntry();
+            cache.emplace(filepath, np);
+            return np;
+        };
+
+        switch (type) {
+            case MediaType::Image:
+                entry = doInsert(_imageCache,
+                    [&]{ return std::make_shared<ImageCacheEntry>(loadPath); });
+                break;
+            case MediaType::Shader:
+                entry = doInsert(_shaderCache,
+                    [&]{ return std::make_shared<ShaderMediaCacheEntry>(loadPath); });
+                break;
+            case MediaType::SVG:
+                entry = doInsert(_svgCache,
+                    [&]{ return std::make_shared<SVGMediaCacheEntry>(loadPath); });
+                break;
+            case MediaType::TextFile:
+                entry = doInsert(_textCache,
+                    [&]{ return std::make_shared<TextMediaCacheEntry>(loadPath); });
+                break;
+            case MediaType::BinaryFile: {
+                // Preserve the subtype (e.g. "glediator") from the existing entry if present.
+                std::string subtype;
+                auto existing = _binaryCache.find(filepath);
+                if (existing != _binaryCache.end()) subtype = existing->second->GetSubtype();
+                entry = doInsert(_binaryCache,
+                    [&]{ return std::make_shared<BinaryMediaCacheEntry>(loadPath, subtype); });
+                break;
+            }
+            case MediaType::Video:
+                entry = doInsert(_videoCache,
+                    [&]{ return std::make_shared<VideoMediaCacheEntry>(loadPath); });
+                break;
+            default:
+                return;
+        }
+    }
+
+    if (entry) entry->Load();
 }
 
 size_t SequenceMedia::GetMediaCount() const {

--- a/src-core/render/SequenceMedia.h
+++ b/src-core/render/SequenceMedia.h
@@ -401,6 +401,8 @@ public:
     void RecordRelocation(const std::string& from, const std::string& to);
     void ClearRelocations();
 
+    std::vector<std::string> GetShaderPaths() const;
+
     // === Type-specific retrieval (create-on-first-access, resolve via FileUtils::FixFile) ===
     std::shared_ptr<TextMediaCacheEntry> GetTextFile(const std::string& filepath);
     std::shared_ptr<SVGMediaCacheEntry> GetSVG(const std::string& filepath);
@@ -420,6 +422,13 @@ public:
     bool RenameMedia(const std::string& oldPath, const std::string& newPath);
     // Reload a non-embedded entry from disk (erases and re-creates the cache entry)
     bool ReloadMedia(const std::string& filepath);
+    // Force-insert a fresh entry at `filepath` with `resolvedPath` as its physical
+    // file path. Unlike GetXxx(), this always creates a new entry at `filepath` and
+    // never returns an existing entry that happens to share the same resolved path.
+    // Also removes any other cache entry whose resolved path equals `resolvedPath`
+    // to prevent the duplicate-path check from suppressing future GetXxx() calls.
+    // Use this after a re-select or bulk-find where the exact replacement file is known.
+    void ForceRefreshEntry(const std::string& filepath, const std::string& resolvedPath, MediaType type);
     size_t GetMediaCount() const;
     std::vector<std::pair<std::string, MediaType>> GetAllMediaPaths() const;
     // Returns {isEmbedded, isEmbeddable} for any media path across all caches

--- a/src-ui-wx/media/ManageMediaPanel.cpp
+++ b/src-ui-wx/media/ManageMediaPanel.cpp
@@ -1370,6 +1370,51 @@ void ManageMediaPanel::OnTreeContextMenu(wxDataViewEvent& event)
         }
     }
 
+    // Broken non-image media options (Shader, SVG, TextFile, BinaryFile, Video)
+    MediaType mtype = MediaTypeFromPath(path);
+    if (mtype != MediaType::Image && mtype != MediaType::Audio) {
+        std::shared_ptr<MediaCacheEntry> entry;
+        switch (mtype) {
+            case MediaType::Shader:     entry = _sequenceMedia->GetShader(path); break;
+            case MediaType::SVG:        entry = _sequenceMedia->GetSVG(path); break;
+            case MediaType::TextFile:   entry = _sequenceMedia->GetTextFile(path); break;
+            case MediaType::BinaryFile: entry = _sequenceMedia->GetBinaryFile(path); break;
+            case MediaType::Video:      entry = _sequenceMedia->GetVideo(path); break;
+            default: break;
+        }
+        if (entry && !entry->IsOk()) {
+            wxString typeName = wxString(MediaTypeName(mtype));
+            if (menu.GetMenuItemCount() > 0)
+                menu.AppendSeparator();
+
+            wxMenuItem* reselectItem = menu.Append(wxID_ANY, "Re-select " + typeName + "...");
+            menu.Bind(wxEVT_MENU, [this, path, mtype](wxCommandEvent&) {
+                ReSelectMediaByType(path, mtype);
+            }, reselectItem->GetId());
+
+            int brokenCount = 0;
+            for (const auto& [p, pt] : _sequenceMedia->GetAllMediaPaths()) {
+                if (pt != mtype) continue;
+                std::shared_ptr<MediaCacheEntry> e;
+                switch (mtype) {
+                    case MediaType::Shader:     e = _sequenceMedia->GetShader(p); break;
+                    case MediaType::SVG:        e = _sequenceMedia->GetSVG(p); break;
+                    case MediaType::TextFile:   e = _sequenceMedia->GetTextFile(p); break;
+                    case MediaType::BinaryFile: e = _sequenceMedia->GetBinaryFile(p); break;
+                    case MediaType::Video:      e = _sequenceMedia->GetVideo(p); break;
+                    default: break;
+                }
+                if (e && !e->IsOk()) ++brokenCount;
+            }
+            if (brokenCount > 1) {
+                wxMenuItem* bulkItem = menu.Append(wxID_ANY, "Bulk Find " + typeName + "s...");
+                menu.Bind(wxEVT_MENU, [this, mtype](wxCommandEvent&) {
+                    BulkFindMediaByType(mtype);
+                }, bulkItem->GetId());
+            }
+        }
+    }
+
     if (menu.GetMenuItemCount() > 0)
         PopupMenu(&menu);
 }
@@ -1428,7 +1473,10 @@ void ManageMediaPanel::OnReSelectImage(const std::string& oldPath)
                                    : (!_showDirectory.empty() &&
                                       !wxString(pickedPath).StartsWith(wxString(_showDirectory)));
 
-    std::string finalPath = pickedPath;   // path we will ultimately use in cache/effects
+    // finalAbsPath tracks the absolute file path before relativization.
+    // For the embed case it is cleared (no disk file to reference).
+    std::string finalPath = pickedPath;
+    std::string finalAbsPath = pickedPath;
 
     if (outsideFolders) {
         wxFileName fn(pickedPath);
@@ -1481,6 +1529,7 @@ void ManageMediaPanel::OnReSelectImage(const std::string& oldPath)
             _sequenceMedia->RenameImage(pickedPath, embeddedName);
             _sequenceMedia->EmbedImage(embeddedName);
             finalPath = embeddedName;
+            finalAbsPath = "";  // embedded — no on-disk path to pass to ForceRefreshEntry
         } else if (hasImported && sel == 1) {
             // Copy to ImportedMedia/<seqStem>/Images
             std::string newPath = CopyToDir(pickedPath, importedMediaDir);
@@ -1490,6 +1539,7 @@ void ManageMediaPanel::OnReSelectImage(const std::string& oldPath)
                 return;
             }
             finalPath = newPath;
+            finalAbsPath = newPath;
         } else {
             // Copy to one of the folders
             std::string targetDir = copyTargets[sel - copyOffset];
@@ -1509,6 +1559,7 @@ void ManageMediaPanel::OnReSelectImage(const std::string& oldPath)
                 return;
             }
             finalPath = newPath;
+            finalAbsPath = newPath;
         }
     }
 
@@ -1516,6 +1567,7 @@ void ManageMediaPanel::OnReSelectImage(const std::string& oldPath)
     if (_xlFrame) {
         std::string rel = _xlFrame->MakeRelativePath(finalPath);
         if (!rel.empty()) finalPath = rel;
+        // finalAbsPath deliberately NOT relativized — stays absolute for ForceRefreshEntry
     }
 
     // --- Step 4: rename the broken cache entry to finalPath and update effects ---
@@ -1528,51 +1580,13 @@ void ManageMediaPanel::OnReSelectImage(const std::string& oldPath)
         }
     }
 
-    // Update every effect that referenced oldPath to point to finalPath
-    if (_sequenceElements != nullptr && finalPath != oldPath) {
-        auto scanLayer = [&](EffectLayer* layer) {
-            for (int k = 0; k < layer->GetEffectCount(); ++k) {
-                Effect* eff = layer->GetEffect(k);
-                const SettingsMap& settings = eff->GetSettings();
-                std::vector<std::string> keysToUpdate;
-                for (auto it = settings.begin(); it != settings.end(); ++it) {
-                    if (it->second == oldPath)
-                        keysToUpdate.push_back(it->first);
-                }
-                for (const auto& key : keysToUpdate)
-                    eff->SetSetting(key, finalPath);
-            }
-        };
+    UpdateEffectPaths(oldPath, finalPath);
 
-        for (int i = 0; i < (int)_sequenceElements->GetElementCount(); ++i) {
-            Element* e = _sequenceElements->GetElement(i);
-            if (e->GetType() != ElementType::ELEMENT_TYPE_MODEL) continue;
-            ModelElement* model = dynamic_cast<ModelElement*>(e);
-            if (!model) continue;
-
-            for (int j = 0; j < (int)model->GetEffectLayerCount(); ++j)
-                scanLayer(model->GetEffectLayer(j));
-
-            for (int j = 0; j < (int)model->GetSubModelAndStrandCount(); ++j) {
-                SubModelElement* sub = model->GetSubModel(j);
-                for (int l = 0; l < (int)sub->GetEffectLayerCount(); ++l)
-                    scanLayer(sub->GetEffectLayer(l));
-                if (sub->GetType() == ElementType::ELEMENT_TYPE_STRAND) {
-                    StrandElement* strand = dynamic_cast<StrandElement*>(sub);
-                    if (strand) {
-                        for (int k = 0; k < strand->GetNodeLayerCount(); ++k)
-                            scanLayer(strand->GetNodeLayer(k));
-                    }
-                }
-            }
-        }
-    }
-
-    // For external paths, force a reload from disk (removes stale cached data)
+    // For external (non-embedded) paths, use ForceRefreshEntry to bypass both the
+    // duplicate-path check and FixFile's stale caches.
     auto entry = _sequenceMedia->GetImage(finalPath);
     if (entry && !entry->IsEmbedded()) {
-        _sequenceMedia->RemoveImage(finalPath);
-        _sequenceMedia->GetImage(finalPath);
+        _sequenceMedia->ForceRefreshEntry(finalPath, finalAbsPath, MediaType::Image);
     }
 
     Populate(finalPath);
@@ -1681,6 +1695,7 @@ void ManageMediaPanel::OnBulkFindImages()
 
         std::string pickedPath = ToStdString(foundFile);
         std::string finalPath = pickedPath;
+        std::string finalAbsPath = pickedPath;  // absolute path, cleared for embed case
 
         if (outsideFolders) {
             wxFileName fn(pickedPath);
@@ -1699,11 +1714,13 @@ void ManageMediaPanel::OnBulkFindImages()
                 _sequenceMedia->RenameImage(pickedPath, embeddedName);
                 _sequenceMedia->EmbedImage(embeddedName);
                 finalPath = embeddedName;
+                finalAbsPath = "";  // embedded — no on-disk path
             } else if (outsideAction == 1) {
                 // Copy to ImportedMedia/<seqStem>/Images
                 std::string newPath = CopyToDir(pickedPath, bulkImportedMediaDir);
                 if (newPath.empty()) continue;  // skip this file on failure
                 finalPath = newPath;
+                finalAbsPath = newPath;
             } else {
                 // Copy to one of the target directories
                 std::string targetDir = copyTargets[outsideAction - 2];
@@ -1719,6 +1736,7 @@ void ManageMediaPanel::OnBulkFindImages()
                 }
                 if (newPath.empty()) continue;  // skip this file on failure
                 finalPath = newPath;
+                finalAbsPath = newPath;
             }
         }
 
@@ -1726,6 +1744,7 @@ void ManageMediaPanel::OnBulkFindImages()
         if (_xlFrame) {
             std::string rel = _xlFrame->MakeRelativePath(finalPath);
             if (!rel.empty()) finalPath = rel;
+            // finalAbsPath deliberately NOT relativized — stays absolute for ForceRefreshEntry
         }
 
         // Rename the broken cache entry and update effects
@@ -1735,50 +1754,13 @@ void ManageMediaPanel::OnBulkFindImages()
             }
         }
 
-        if (_sequenceElements != nullptr && finalPath != oldPath) {
-            auto scanLayer = [&](EffectLayer* layer) {
-                for (int k = 0; k < layer->GetEffectCount(); ++k) {
-                    Effect* eff = layer->GetEffect(k);
-                    const SettingsMap& settings = eff->GetSettings();
-                    std::vector<std::string> keysToUpdate;
-                    for (auto it = settings.begin(); it != settings.end(); ++it) {
-                        if (it->second == oldPath)
-                            keysToUpdate.push_back(it->first);
-                    }
-                    for (const auto& key : keysToUpdate)
-                        eff->SetSetting(key, finalPath);
-                }
-            };
+        UpdateEffectPaths(oldPath, finalPath);
 
-            for (int i = 0; i < (int)_sequenceElements->GetElementCount(); ++i) {
-                Element* e = _sequenceElements->GetElement(i);
-                if (e->GetType() != ElementType::ELEMENT_TYPE_MODEL) continue;
-                ModelElement* model = dynamic_cast<ModelElement*>(e);
-                if (!model) continue;
-
-                for (int j = 0; j < (int)model->GetEffectLayerCount(); ++j)
-                    scanLayer(model->GetEffectLayer(j));
-
-                for (int j = 0; j < (int)model->GetSubModelAndStrandCount(); ++j) {
-                    SubModelElement* sub = model->GetSubModel(j);
-                    for (int l = 0; l < (int)sub->GetEffectLayerCount(); ++l)
-                        scanLayer(sub->GetEffectLayer(l));
-                    if (sub->GetType() == ElementType::ELEMENT_TYPE_STRAND) {
-                        StrandElement* strand = dynamic_cast<StrandElement*>(sub);
-                        if (strand) {
-                            for (int k = 0; k < strand->GetNodeLayerCount(); ++k)
-                                scanLayer(strand->GetNodeLayer(k));
-                        }
-                    }
-                }
-            }
-        }
-
-        // Force reload for external paths
+        // For external (non-embedded) paths, use ForceRefreshEntry to bypass both the
+        // duplicate-path check and FixFile's stale caches.
         auto entry = _sequenceMedia->GetImage(finalPath);
         if (entry && !entry->IsEmbedded()) {
-            _sequenceMedia->RemoveImage(finalPath);
-            _sequenceMedia->GetImage(finalPath);
+            _sequenceMedia->ForceRefreshEntry(finalPath, finalAbsPath, MediaType::Image);
         }
 
         lastFixedPath = finalPath;
@@ -1789,6 +1771,222 @@ void ManageMediaPanel::OnBulkFindImages()
                                   "Found and updated: %d image(s)\n"
                                   "Not found: %d image(s)", found, notFound),
                  "Bulk Find Images", wxICON_INFORMATION | wxOK, this);
+
+    Populate(lastFixedPath);
+}
+
+void ManageMediaPanel::UpdateEffectPaths(const std::string& oldPath, const std::string& newPath)
+{
+    if (_sequenceElements == nullptr || oldPath == newPath) return;
+
+    auto scanLayer = [&](EffectLayer* layer) {
+        for (int k = 0; k < layer->GetEffectCount(); ++k) {
+            Effect* eff = layer->GetEffect(k);
+            const SettingsMap& settings = eff->GetSettings();
+            std::vector<std::string> keysToUpdate;
+            for (auto it = settings.begin(); it != settings.end(); ++it) {
+                if (it->second == oldPath)
+                    keysToUpdate.push_back(it->first);
+            }
+            for (const auto& key : keysToUpdate)
+                eff->SetSetting(key, newPath);
+        }
+    };
+
+    for (int i = 0; i < (int)_sequenceElements->GetElementCount(); ++i) {
+        Element* e = _sequenceElements->GetElement(i);
+        if (e->GetType() != ElementType::ELEMENT_TYPE_MODEL) continue;
+        ModelElement* model = dynamic_cast<ModelElement*>(e);
+        if (!model) continue;
+
+        for (int j = 0; j < (int)model->GetEffectLayerCount(); ++j)
+            scanLayer(model->GetEffectLayer(j));
+
+        for (int j = 0; j < (int)model->GetSubModelAndStrandCount(); ++j) {
+            SubModelElement* sub = model->GetSubModel(j);
+            for (int l = 0; l < (int)sub->GetEffectLayerCount(); ++l)
+                scanLayer(sub->GetEffectLayer(l));
+            if (sub->GetType() == ElementType::ELEMENT_TYPE_STRAND) {
+                StrandElement* strand = dynamic_cast<StrandElement*>(sub);
+                if (strand) {
+                    for (int k = 0; k < strand->GetNodeLayerCount(); ++k)
+                        scanLayer(strand->GetNodeLayer(k));
+                }
+            }
+        }
+    }
+}
+
+void ManageMediaPanel::OnReSelectShader(const std::string& oldPath)
+{
+    ReSelectMediaByType(oldPath, MediaType::Shader);
+}
+
+void ManageMediaPanel::OnBulkFindShaders()
+{
+    BulkFindMediaByType(MediaType::Shader);
+}
+
+// Generic re-select for any non-Image media type (no embed/ImportedMedia options).
+void ManageMediaPanel::ReSelectMediaByType(const std::string& oldPath, MediaType type)
+{
+    if (_sequenceMedia == nullptr) return;
+
+    wxString typeName = wxString(MediaTypeName(type));
+    wxString defaultDir;
+    {
+        auto* config = GetXLightsConfig();
+        config->Read(LastDirConfigKey(type), &defaultDir);
+        if (defaultDir.empty()) {
+            wxFileName fn(oldPath);
+            if (fn.IsAbsolute() && fn.DirExists())
+                defaultDir = fn.GetPath();
+            else if (!_showDirectory.empty())
+                defaultDir = _showDirectory;
+        }
+    }
+    wxFileName fnOld(oldPath);
+
+    std::string pickedPath;
+    {
+        wxString wildcard = WildcardForMediaType(type) + "|All files (*.*)|*.*";
+        wxFileDialog dlg(this, "Re-select " + typeName + ": " + wxString(oldPath),
+                         defaultDir, fnOld.GetFullName(), wildcard,
+                         wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+        if (dlg.ShowModal() != wxID_OK) return;
+        pickedPath = ToStdString(dlg.GetPath());
+        GetXLightsConfig()->Write(LastDirConfigKey(type), wxFileName(pickedPath).GetPath());
+    }
+
+    // finalAbsPath is the known absolute path of the replacement file.
+    // We keep it separate from finalPath (which may be relativized) so we can
+    // pass it to ForceRefreshEntry and bypass FixFile's stale caches.
+    std::string finalPath = pickedPath;
+    std::string finalAbsPath = pickedPath;
+
+    bool outsideFolders = _xlFrame ? !_xlFrame->IsInShowOrMediaFolder(pickedPath)
+                                   : (!_showDirectory.empty() &&
+                                      !wxString(pickedPath).StartsWith(wxString(_showDirectory)));
+    if (outsideFolders && !_showDirectory.empty()) {
+        const std::string sep(1, wxFileName::GetPathSeparator());
+        std::string subdir = SubdirForMediaType(type);
+        if (_xlFrame) {
+            std::string moved = _xlFrame->MoveToShowFolder(pickedPath, sep + subdir);
+            if (!moved.empty()) { finalPath = moved; finalAbsPath = moved; }
+        } else {
+            wxString dest = wxString(_showDirectory) + wxString(sep) + wxString(subdir);
+            if (!wxDirExists(dest)) wxMkdir(dest);
+            dest += wxString(sep) + wxFileName(pickedPath).GetFullName();
+            if (wxCopyFile(wxString(pickedPath), dest, false)) {
+                finalPath = ToStdString(dest);
+                finalAbsPath = finalPath;
+            }
+        }
+    }
+
+    if (_xlFrame) {
+        std::string rel = _xlFrame->MakeRelativePath(finalPath);
+        if (!rel.empty()) finalPath = rel;
+    }
+
+    if (finalPath != oldPath) {
+        if (!_sequenceMedia->RenameMedia(oldPath, finalPath))
+            _sequenceMedia->RemoveMedia(oldPath);
+    }
+
+    UpdateEffectPaths(oldPath, finalPath);
+    // Use ForceRefreshEntry instead of RemoveMedia+GetXxx: it bypasses both the
+    // duplicate-path check (which can suppress re-insertion of the key) and
+    // FixFile's stale positive/negative caches (which can resolve to old paths).
+    _sequenceMedia->ForceRefreshEntry(finalPath, finalAbsPath, type);
+    Populate(finalPath);
+}
+
+// Generic bulk find for any non-Image media type.
+void ManageMediaPanel::BulkFindMediaByType(MediaType type)
+{
+    if (_sequenceMedia == nullptr) return;
+
+    wxString typeName = wxString(MediaTypeName(type));
+
+    std::vector<std::string> brokenPaths;
+    for (const auto& [path, mtype] : _sequenceMedia->GetAllMediaPaths()) {
+        if (mtype != type) continue;
+        // Re-use GetAllMediaPaths result: load entry and check IsOk
+        // GetXxx() returns from cache; broken entries have IsOk()==false
+        std::shared_ptr<MediaCacheEntry> entry;
+        switch (type) {
+            case MediaType::Shader:     entry = _sequenceMedia->GetShader(path); break;
+            case MediaType::SVG:        entry = _sequenceMedia->GetSVG(path); break;
+            case MediaType::TextFile:   entry = _sequenceMedia->GetTextFile(path); break;
+            case MediaType::BinaryFile: entry = _sequenceMedia->GetBinaryFile(path); break;
+            case MediaType::Video:      entry = _sequenceMedia->GetVideo(path); break;
+            default: break;
+        }
+        if (entry && !entry->IsOk()) brokenPaths.push_back(path);
+    }
+    if (brokenPaths.empty()) return;
+
+    wxString defaultDir = _showDirectory.empty() ? wxString() : wxString(_showDirectory);
+    wxDirDialog dlg(this,
+                    "Select folder containing missing " + typeName.Lower(),
+                    defaultDir, wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST);
+    if (dlg.ShowModal() != wxID_OK) return;
+
+    std::string searchDir = ToStdString(dlg.GetPath());
+    ObtainAccessToURL(searchDir);
+    const std::string sep(1, wxFileName::GetPathSeparator());
+
+    int found = 0;
+    int notFound = 0;
+    std::string lastFixedPath;
+    for (const auto& oldPath : brokenPaths) {
+        wxFileName fnOld(oldPath);
+        wxString nameToFind = fnOld.GetFullName();
+        if (nameToFind.IsEmpty()) { ++notFound; continue; }
+
+        wxString foundFile;
+        wxDir dir(searchDir);
+        if (dir.IsOpened()) {
+            wxString candidate = searchDir + sep + ToStdString(nameToFind);
+            if (wxFileExists(candidate)) {
+                foundFile = candidate;
+            } else {
+                wxArrayString results;
+                wxDir::GetAllFiles(searchDir, &results, nameToFind, wxDIR_FILES | wxDIR_DIRS);
+                if (!results.IsEmpty())
+                    foundFile = results[0];
+            }
+        }
+
+        if (foundFile.IsEmpty()) { ++notFound; continue; }
+
+        // finalAbsPath is the known absolute path; finalPath may be relativized below.
+        std::string finalAbsPath = ToStdString(foundFile);
+        std::string finalPath = finalAbsPath;
+
+        if (_xlFrame) {
+            std::string rel = _xlFrame->MakeRelativePath(finalPath);
+            if (!rel.empty()) finalPath = rel;
+        }
+
+        if (finalPath != oldPath) {
+            if (!_sequenceMedia->RenameMedia(oldPath, finalPath))
+                _sequenceMedia->RemoveMedia(oldPath);
+        }
+
+        UpdateEffectPaths(oldPath, finalPath);
+        _sequenceMedia->ForceRefreshEntry(finalPath, finalAbsPath, type);
+
+        lastFixedPath = finalPath;
+        ++found;
+    }
+
+    wxMessageBox(wxString::Format("Bulk find complete.\n\n"
+                                  "Found and updated: %d %s(s)\n"
+                                  "Not found: %d %s(s)",
+                                  found, typeName.Lower(), notFound, typeName.Lower()),
+                 "Bulk Find " + typeName, wxICON_INFORMATION | wxOK, this);
 
     Populate(lastFixedPath);
 }

--- a/src-ui-wx/media/ManageMediaPanel.h
+++ b/src-ui-wx/media/ManageMediaPanel.h
@@ -114,6 +114,11 @@ private:
     void OnReloadMedia(const std::string& path);
     void OnReSelectImage(const std::string& oldPath);
     void OnBulkFindImages();
+    void OnReSelectShader(const std::string& oldPath);
+    void OnBulkFindShaders();
+    void ReSelectMediaByType(const std::string& oldPath, MediaType type);
+    void BulkFindMediaByType(MediaType type);
+    void UpdateEffectPaths(const std::string& oldPath, const std::string& newPath);
     void OnAddButtonClick(wxCommandEvent& event);
     void OnAIGenerateButtonClick(wxCommandEvent& event);
     void OnRenameButtonClick(wxCommandEvent& event);


### PR DESCRIPTION
Add right click on missing shaders to reselect them from disk. If multiple effects are selected all of them will get this new setting.
Similar to what images has and also now on other media types.