### PR TITLE
Needs Review - Shader compiles and missed frames (#6357)

### DIFF
--- a/src-core/effects/ShaderEffect.cpp
+++ b/src-core/effects/ShaderEffect.cpp
@@ -466,9 +466,9 @@ public:
     ShaderRenderCache() { _shaderConfig = nullptr; }
     virtual ~ShaderRenderCache()
     {
-        if (s_programId != 0 && _shaderConfig != nullptr) {
+        if (s_programId != 0 && s_shaderInfo != nullptr) {
             std::unique_lock<std::mutex> lock(shaderMapMutex);
-            shaderMap[s_code]->programIds.push_back(s_programId);
+            s_shaderInfo->programIds.push_back(s_programId);
             s_programId = 0;
         }
         if (_shaderConfig != nullptr) delete _shaderConfig;
@@ -494,14 +494,21 @@ public:
     }
     unsigned RefreshProgramId() {
         if (s_shaderInfo) {
-            std::unique_lock<std::mutex> lock(shaderMapMutex);
-            if (s_shaderInfo->programIds.empty()) {
-                lock.unlock();
-                s_programId = ShaderEffect::programIdForShaderCode(_shaderConfig, this);
-            } else {
-                s_programId = s_shaderInfo->programIds.back();
-                s_shaderInfo->programIds.pop_back();
+            while (true) {
+                unsigned candidate = 0;
+                {
+                    std::unique_lock<std::mutex> lock(shaderMapMutex);
+                    if (s_shaderInfo->programIds.empty()) break;
+                    candidate = s_shaderInfo->programIds.back();
+                    s_shaderInfo->programIds.pop_back();
+                }
+                if (glIsProgram(candidate)) {
+                    s_programId = candidate;
+                    return s_programId;
+                }
             }
+            // Pool exhausted or all entries were stale: recompile in this context.
+            s_programId = ShaderEffect::programIdForShaderCode(_shaderConfig, this);
         }
         return s_programId;
     }
@@ -573,6 +580,13 @@ bool ShaderEffect::SetGLContext(ShaderRenderCache *cache) {
         if (!cache->contextHandle) return false;
     }
     if (!mgr.MakeCurrent(cache->contextHandle)) {
+        cache->s_shadersInit = false;
+        cache->s_vertexArrayId = 0;
+        cache->s_vertexBufferId = 0;
+        cache->s_fbId = 0;
+        cache->s_rbId = 0;
+        cache->s_rbTex = 0;
+        cache->s_audioTex = 0;
         mgr.ReleaseContext(cache->contextHandle);
         cache->contextHandle = nullptr;
         return false;
@@ -583,15 +597,6 @@ bool ShaderEffect::SetGLContext(ShaderRenderCache *cache) {
 void ShaderEffect::UnsetGLContext(ShaderRenderCache* cache) {
     auto& mgr = GLContextManager::Instance();
     mgr.DoneCurrent(cache->contextHandle);
-#if !defined(_WIN32)
-    // macOS/Linux: return context to pool after each frame so other threads
-    // can acquire it.  The per-thread context cache (contextHandle) is
-    // re-acquired at the start of the next frame; pool contexts share no
-    // state so GL resources (FBOs, textures) owned by the cache remain valid.
-    mgr.ReleaseContext(cache->contextHandle);
-    cache->contextHandle = nullptr;
-#endif
-    // Windows: keep context cached in ShaderRenderCache for reuse (pool grows on demand)
 }
 
 void ShaderEffect::Render(Effect* eff, const SettingsMap& SettingsMap, RenderBuffer& buffer)
@@ -998,16 +1003,17 @@ unsigned ShaderEffect::programIdForShaderCode(ShaderConfig* cfg, ShaderRenderCac
     if (iter != ShaderRenderCache::shaderMap.cend()) {
         shaderInfo = (*iter).second;
         while (!shaderInfo->programIds.empty()) {
-            unsigned programId = shaderInfo->programIds.front();
+            unsigned candidate = shaderInfo->programIds.front();
             shaderInfo->programIds.pop_front();
-            if (!glIsProgram(programId)) {
-                spdlog::error("ShaderEffect::programIdForShaderCode() - program id {} is not a shader program!", programId);
-            } else {
-                //spdlog::debug("ShaderEffect::programIdForShaderCode() - shader program {} unchanged -- id {}", (const char*)cfg->GetFilename().c_str(), programId);
-                cache->SetProgramId(programId, shaderInfo);
-                return programId;
+            lock.unlock();
+            if (glIsProgram(candidate)) {
+                cache->SetProgramId(candidate, shaderInfo);
+                return candidate;
             }
+            spdlog::warn("ShaderEffect::programIdForShaderCode() - program id {} invalid in this context, recompiling", candidate);
+            lock.lock();
         }
+        if (!lock.owns_lock()) lock.lock();
     }
 
     lock.unlock();

--- a/src-core/graphics/GLContextManager.cpp
+++ b/src-core/graphics/GLContextManager.cpp
@@ -34,10 +34,8 @@
 #include <EGL/eglext_angle.h>
 #include <GLES3/gl3.h>
 
-// ANGLE's Metal backend is NOT thread-safe — only one context may be active
-// at a time.  Pool size 1 ensures callers serialize naturally: the second
-// thread blocks on the condition_variable until the first releases.
-static constexpr int kMaxPoolSize = 1;
+// ANGLE's Metal backend serializes rendering internally.  The pool grows on
+// demand so each ShaderRenderCache can hold its own context for its lifetime.
 
 struct GLContextManager::PlatformState {
     EGLDisplay display = EGL_NO_DISPLAY;
@@ -180,8 +178,12 @@ GLContextManager::ContextHandle GLContextManager::AcquireContext() {
         // The shared context's surface is not pooled; it stays with the shared ctx
     }
 
-    // Grow pool if below max
-    if (_platform->pool.empty() && _platform->contextCount < kMaxPoolSize) {
+    // Grow pool on demand — no hard cap.  ShaderRenderCache holds each context
+    // for its lifetime (not released per-frame) so the pool must be able to
+    // grow to match the number of concurrently-rendering shader effects.
+    // Note: ANGLE/Metal serializes rendering internally, so concurrent contexts
+    // will contend on the Metal command queue but will not corrupt each other.
+    if (_platform->pool.empty()) {
         lock.unlock();
         auto entry = createEGLContext(_platform, _platform->sharedContext);
         lock.lock();
@@ -191,10 +193,7 @@ GLContextManager::ContextHandle GLContextManager::AcquireContext() {
         }
     }
 
-    // Wait for a context to become available
-    while (_platform->pool.empty()) {
-        _platform->poolNotifier.wait(lock);
-    }
+    if (_platform->pool.empty()) return nullptr;
 
     auto entry = _platform->pool.front();
     _platform->pool.pop_front();
@@ -271,8 +270,6 @@ void* GLContextManager::GetNativeDisplay() const {
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-
-static constexpr int kMaxPoolSize = 24;
 
 struct GLContextManager::PlatformState {
     CGLContextObj sharedContext = nullptr;       // Master context for resource sharing
@@ -422,8 +419,10 @@ GLContextManager::ContextHandle GLContextManager::AcquireContext() {
         if (!_platform->sharedContext) return nullptr;
     }
 
-    // Grow pool if below max
-    if (_platform->pool.empty() && _platform->contextCount < kMaxPoolSize) {
+    // Grow pool on demand — no hard cap.  ShaderRenderCache holds each context
+    // for its lifetime (not released per-frame) so the pool must be able to
+    // grow to match the number of concurrently-rendering shader effects.
+    if (_platform->pool.empty()) {
         lock.unlock();
         CGLContextObj ctx = createCGLContext(_platform->sharedContext);
         lock.lock();
@@ -433,10 +432,7 @@ GLContextManager::ContextHandle GLContextManager::AcquireContext() {
         }
     }
 
-    // Wait for a context to become available
-    while (_platform->pool.empty()) {
-        _platform->poolNotifier.wait(lock);
-    }
+    if (_platform->pool.empty()) return nullptr;
 
     CGLContextObj ctx = _platform->pool.front();
     _platform->pool.pop_front();
@@ -875,10 +871,6 @@ void* GLContextManager::GetNativeDisplay() const {
 #include <EGL/egl.h>
 #include <GL/gl.h>
 
-// One context per background render thread, plus one for the main thread.
-// Mirrors the macOS CGL pool size.
-static constexpr int kMaxPoolSize = 24;
-
 struct GLContextManager::PlatformState {
     // GLX path (X11 / XWayland)
     Display*     xDisplay  = nullptr;
@@ -1113,7 +1105,10 @@ GLContextManager::ContextHandle GLContextManager::AcquireContext() {
 
     std::unique_lock<std::mutex> lock(_platform->poolMutex);
 
-    if (_platform->pool.empty() && _platform->contextCount < kMaxPoolSize) {
+    // Grow pool on demand — no hard cap.  ShaderRenderCache holds each context
+    // for its lifetime (not released per-frame) so the pool must be able to
+    // grow to match the number of concurrently-rendering shader effects.
+    if (_platform->pool.empty()) {
         lock.unlock();
         PlatformState::PoolEntry entry = _platform->useEGL
             ? createEGLPoolEntry(_platform)
@@ -1128,9 +1123,7 @@ GLContextManager::ContextHandle GLContextManager::AcquireContext() {
         }
     }
 
-    while (_platform->pool.empty()) {
-        _platform->poolNotifier.wait(lock);
-    }
+    if (_platform->pool.empty()) return nullptr;
 
     auto entry = _platform->pool.front();
     _platform->pool.pop_front();


### PR DESCRIPTION
@dkulp Dan, you did a big change a few weeks back "Remove all the main thread effect rendering plumbing." that introduced a crash on windows .. I put a change in to "fix" that but that made the shader crash/drop frames. 
"0000 another attemt to render"

This is what the intern came up with - it handles the shaders and no crashes but I dont know if it reverses what you were trying to accomplish in the initial change.