### PR TITLE
 Fixed hangs in Face/State Definition dialogs on large models (#6374)

### DIFF
--- a/src-core/models/Model.cpp
+++ b/src-core/models/Model.cpp
@@ -3378,13 +3378,37 @@ std::string Model::GetNodeNear(IModelPreview* preview, xlPoint pt, bool flip)
     if (flip)
         py = h - pt.y;
 
+    // Pre-compute loop-invariant values to avoid O(n) GetMinScreenXY inside the O(n) node loop.
+    const bool centerBased = GetModelScreenLocation().IsCenterBased();
+    const float renderWi = GetModelScreenLocation().RenderWi;
+    const float renderHt = GetModelScreenLocation().RenderHt;
+    const float vScaleFactor = GetModelScreenLocation().GetVScaleFactor();
+    float ml = 0.0f, mb = 0.0f;
+    if (centerBased) {
+        GetMinScreenXY(ml, mb);
+        ml += renderWi / 2.0f;
+        mb += renderHt / 2.0f;
+    }
+
     int i = 1;
     for (const auto& it : Nodes) {
-        auto c = it.get()->Coords;
-        for (const auto& it2 : c) {
-            float sx, sy;
-            GetScreenLocation(sx, sy, it2, w, h, scale);
-
+        for (const auto& it2 : it->Coords) {
+            float sx = it2.screenX;
+            float sy = it2.screenY;
+            if (!centerBased) {
+                sx -= renderWi / 2.0f;
+                sy *= vScaleFactor;
+                if (vScaleFactor < 0.0f) {
+                    sy += renderHt / 2.0f;
+                } else {
+                    sy -= renderHt / 2.0f;
+                }
+                sy = (sy * scale) + (h / 2.0f);
+                sx = (sx * scale) + (w / 2.0f);
+            } else {
+                sx = ((sx - ml) * scale) + (w / 2.0f);
+                sy = ((sy - mb) * scale) + (h / 2.0f);
+            }
             if (sx >= (px - pointScale) && sx <= (px + pointScale) &&
                 sy >= (py - pointScale) && sy <= (py + pointScale)) {
                 return std::to_string(i);
@@ -3400,14 +3424,39 @@ bool Model::GetScreenLocations(IModelPreview* preview, std::map<int, std::pair<f
     int w, h;
     float scale = GetPreviewDimScale(preview, w, h);
 
+    const bool centerBased = GetModelScreenLocation().IsCenterBased();
+    const float renderWi = GetModelScreenLocation().RenderWi;
+    const float renderHt = GetModelScreenLocation().RenderHt;
+    const float vScaleFactor = GetModelScreenLocation().GetVScaleFactor();
+    float ml = 0.0f, mb = 0.0f;
+    if (centerBased) {
+        GetMinScreenXY(ml, mb);
+        ml += renderWi / 2.0f;
+        mb += renderHt / 2.0f;
+    }
+
     int i = 1;
     for (const auto& it : Nodes) {
         auto c = it.get()->Coords;
         if (c.size() != 1)
             return false;
         for (const auto& it2 : c) {
-            float sx, sy;
-            GetScreenLocation(sx, sy, it2, w, h, scale);
+            float sx = it2.screenX;
+            float sy = it2.screenY;
+            if (!centerBased) {
+                sx -= renderWi / 2.0f;
+                sy *= vScaleFactor;
+                if (vScaleFactor < 0.0f) {
+                    sy += renderHt / 2.0f;
+                } else {
+                    sy -= renderHt / 2.0f;
+                }
+                sy = (sy * scale) + (h / 2.0f);
+                sx = (sx * scale) + (w / 2.0f);
+            } else {
+                sx = ((sx - ml) * scale) + (w / 2.0f);
+                sy = ((sy - mb) * scale) + (h / 2.0f);
+            }
             coords[i] = std::make_pair(sx, sy);
         }
         ++i;
@@ -3439,13 +3488,37 @@ std::vector<int> Model::GetNodesInBoundingBox(IModelPreview* preview, xlPoint st
         endpy = tmp;
     }
 
+    const bool centerBased = GetModelScreenLocation().IsCenterBased();
+    const float renderWi = GetModelScreenLocation().RenderWi;
+    const float renderHt = GetModelScreenLocation().RenderHt;
+    const float vScaleFactor = GetModelScreenLocation().GetVScaleFactor();
+    float ml = 0.0f, mb = 0.0f;
+    if (centerBased) {
+        GetMinScreenXY(ml, mb);
+        ml += renderWi / 2.0f;
+        mb += renderHt / 2.0f;
+    }
+
     int i = 1;
     for (const auto& it : Nodes) {
         auto c = it.get()->Coords;
         for (const auto& it2 : c) {
-            float sx, sy;
-            GetScreenLocation(sx, sy, it2, w, h, scale);
-
+            float sx = it2.screenX;
+            float sy = it2.screenY;
+            if (!centerBased) {
+                sx -= renderWi / 2.0f;
+                sy *= vScaleFactor;
+                if (vScaleFactor < 0.0f) {
+                    sy += renderHt / 2.0f;
+                } else {
+                    sy -= renderHt / 2.0f;
+                }
+                sy = (sy * scale) + (h / 2.0f);
+                sx = (sx * scale) + (w / 2.0f);
+            } else {
+                sx = ((sx - ml) * scale) + (w / 2.0f);
+                sy = ((sy - mb) * scale) + (h / 2.0f);
+            }
             if (sx >= startpx && sx <= endpx &&
                 sy >= startpy && sy <= endpy) {
                 nodes.push_back(i);

--- a/src-ui-wx/model/ModelFaceDialog.cpp
+++ b/src-ui-wx/model/ModelFaceDialog.cpp
@@ -386,6 +386,7 @@ ModelFaceDialog::ModelFaceDialog(wxWindow* parent, OutputManager* outputManager,
 
     FlexGridSizer1->Fit(this);
     FlexGridSizer1->SetSizeHints(this);
+    SplitterWindow1->SetSashPosition(Panel3->GetBestSize().GetWidth());
     Center();
     SetEscapeId(wxID_CANCEL);
 
@@ -457,16 +458,33 @@ void ModelFaceDialog::SetFaceInfo(Model *cls, std::map< std::string, std::map<st
         FaceTypeChoice->Disable();
     }
 
-    wxArrayString names;
-    names.push_back("");
-    for (size_t x = 0; x < cls->GetNodeCount(); x++) {
-        wxString nn = cls->GetNodeName(x, true);
-        names.push_back(nn);
-    }
+    size_t nodeCount = cls->GetNodeCount();
+    _nodeNameToIndex.clear();
+    _nodeNameToIndex.reserve(nodeCount);
 
-    NodesGridCellEditor *editor = new NodesGridCellEditor();
-    editor->names = names;
-    SingleNodeGrid->SetDefaultEditor(editor);
+    // For very large models the NodesGridCellEditor wxListBox becomes unusably slow.
+    // Above this threshold skip the dropdown and fall back to plain text entry.
+    static constexpr size_t MAX_NODES_FOR_DROPDOWN = 5000;
+    const bool buildDropdown = (nodeCount <= MAX_NODES_FOR_DROPDOWN);
+
+    if (buildDropdown) {
+        wxArrayString names;
+        names.reserve(nodeCount + 1);
+        names.push_back("");
+        for (size_t x = 0; x < nodeCount; x++) {
+            std::string nn = cls->GetNodeName(x, true);
+            _nodeNameToIndex[nn].push_back(x);
+            names.push_back(wxString(nn));
+        }
+        NodesGridCellEditor *editor = new NodesGridCellEditor();
+        editor->names = names;
+        SingleNodeGrid->SetDefaultEditor(editor);
+    } else {
+        for (size_t x = 0; x < nodeCount; x++) {
+            std::string nn = cls->GetNodeName(x, true);
+            _nodeNameToIndex[nn].push_back(x);
+        }
+    }
     for (int x = 0; x < SingleNodeGrid->GetNumberRows(); x++) {
         SingleNodeGrid->SetReadOnly(x, 1);
     }
@@ -481,7 +499,10 @@ void ModelFaceDialog::SetFaceInfo(Model *cls, std::map< std::string, std::map<st
         NodeRangeGrid->SetReadOnly(x, 1);
     }
 
-    UpdatePreview("", *wxWHITE);
+    // Defer the first preview render so the dialog is shown before the first-time
+    // OpenGL context initialisation in DisplayEffectOnWindow can block the UI thread.
+    CallAfter([this]() { UpdatePreview("", *wxWHITE); });
+
     std::list<std::string> warnings = cls->CheckModelSettings();
     if (!warnings.empty()) {
         std::string warningsStr = Join(warnings, "\n");
@@ -1088,12 +1109,12 @@ void ModelFaceDialog::UpdatePreview(const std::string& channels, wxColor c)
             wxStringTokenizer wtkz(channels, ",");
             while (wtkz.HasMoreTokens())
             {
-                wxString valstr = wtkz.GetNextToken();
-                for (size_t n = 0; n < model->GetNodeCount(); n++) {
-                    wxString ns = model->GetNodeName(n, true);
-                    if (ns == valstr) {
-                        model->SetNodeColor(n, cc);
-                        _selected.push_back(n);
+                std::string valstr = wtkz.GetNextToken().ToStdString();
+                auto it = _nodeNameToIndex.find(valstr);
+                if (it != _nodeNameToIndex.end()) {
+                    for (size_t idx : it->second) {
+                        model->SetNodeColor(idx, cc);
+                        _selected.push_back(idx);
                     }
                 }
             }

--- a/src-ui-wx/model/ModelFaceDialog.h
+++ b/src-ui-wx/model/ModelFaceDialog.h
@@ -33,6 +33,7 @@
 #include <map>
 #include <list>
 #include <string>
+#include <unordered_map>
 
 class Model;
 class ModelPreview;
@@ -178,6 +179,7 @@ private:
     ModelPreview* modelPreview = nullptr;
     Model* model = nullptr;
     std::map<std::string, std::map<std::string, std::string>> faceData;
+    std::unordered_map<std::string, std::vector<size_t>> _nodeNameToIndex;
 
     void SelectFaceModel(const std::string& s);
     void UpdatePreview(const std::string& channels, wxColor c);

--- a/src-ui-wx/model/ModelStateDialog.cpp
+++ b/src-ui-wx/model/ModelStateDialog.cpp
@@ -386,11 +386,27 @@ void ModelStateDialog::SetStateInfo(Model* cls, std::map<std::string, std::map<s
         StateTypeChoice->Disable();
     }
 
+    size_t nodeCount = cls->GetNodeCount();
+    _nodeNameToIndex.clear();
+    _nodeNameToIndex.reserve(nodeCount);
+
+    static constexpr size_t MAX_NODES_FOR_DROPDOWN = 5000;
+    const bool buildDropdown = (nodeCount <= MAX_NODES_FOR_DROPDOWN);
+
     wxArrayString names;
-    names.push_back("");
-    for (size_t x = 0; x < cls->GetNodeCount(); x++) {
-        wxString nn = cls->GetNodeName(x, true);
-        names.push_back(nn);
+    if (buildDropdown) {
+        names.reserve(nodeCount + 1);
+        names.push_back("");
+        for (size_t x = 0; x < nodeCount; x++) {
+            std::string nn = cls->GetNodeName(x, true);
+            _nodeNameToIndex[nn].push_back(x);
+            names.push_back(wxString(nn));
+        }
+    } else {
+        for (size_t x = 0; x < nodeCount; x++) {
+            std::string nn = cls->GetNodeName(x, true);
+            _nodeNameToIndex[nn].push_back(x);
+        }
     }
 
     for (int x = 0; x < SingleNodeGrid->GetNumberRows(); x++) {
@@ -400,12 +416,14 @@ void ModelStateDialog::SetStateInfo(Model* cls, std::map<std::string, std::map<s
         nvalidator.SetCharIncludes(nfilter);
         neditor->SetValidator(nvalidator);
 
-        NodesGridCellEditor* editor = new NodesGridCellEditor();
-        editor->names = names;
-
         SingleNodeGrid->SetCellEditor(x, NAME_COL, neditor);
-        SingleNodeGrid->SetCellEditor(x, CHANNEL_COL, editor);
         SingleNodeGrid->SetReadOnly(x, COLOUR_COL);
+
+        if (buildDropdown) {
+            NodesGridCellEditor* editor = new NodesGridCellEditor();
+            editor->names = names;
+            SingleNodeGrid->SetCellEditor(x, CHANNEL_COL, editor);
+        }
     }
 
     for (int x = 0; x < NodeRangeGrid->GetNumberRows(); x++) {
@@ -695,10 +713,10 @@ void ModelStateDialog::SetSingleNodeColor(wxGrid* grid, const int row, xlColor c
     wxString v = grid->GetCellValue(row, CHANNEL_COL);
     wxStringTokenizer wtkz(v, ",");
     while (wtkz.HasMoreTokens()) {
-        wxString valstr = wtkz.GetNextToken();
-        for (size_t n = 0; n < model->GetNodeCount(); n++) {
-            wxString ns = model->GetNodeName(n, true);
-            if (ns == valstr) {
+        std::string valstr = wtkz.GetNextToken().ToStdString();
+        auto it = _nodeNameToIndex.find(valstr);
+        if (it != _nodeNameToIndex.end()) {
+            for (size_t n : it->second) {
                 model->SetNodeColor(n, c);
                 if (highlight) _selected.push_back(n);
             }

--- a/src-ui-wx/model/ModelStateDialog.h
+++ b/src-ui-wx/model/ModelStateDialog.h
@@ -29,6 +29,9 @@
 #include <glm/glm.hpp>
 
 #include <map>
+#include <unordered_map>
+#include <vector>
+#include <string>
 
 class Model;
 class ModelPreview;
@@ -165,6 +168,7 @@ private:
     bool overRide = false;
     bool showDialog = true;
 
+    std::unordered_map<std::string, std::vector<size_t>> _nodeNameToIndex;
     std::map<std::string, std::map<std::string, std::string>> stateData;
     void SelectStateModel(const std::string& s);
     void UpdateStateType();


### PR DESCRIPTION
For large models the time to build the Node 1, Node 2, Single Node pick list was long. As well there was a recalc everytime the mouse moved going thru the 1000s of nodes.