### PR TITLE
Make RenderProgressDialog stay on top of other windows

### DIFF
--- a/src-ui-wx/diagnostics/RenderProgressDialog.cpp
+++ b/src-ui-wx/diagnostics/RenderProgressDialog.cpp
@@ -34,7 +34,7 @@ RenderProgressDialog::RenderProgressDialog(wxWindow* parent)
 	//(*Initialize(RenderProgressDialog)
 	wxFlexGridSizer* FlexGridSizer1;
 
-	Create(parent, wxID_ANY, _("Rendering Progress"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxMAXIMIZE_BOX, _T("wxID_ANY"));
+	Create(parent, wxID_ANY, _("Rendering Progress"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxMAXIMIZE_BOX|wxSTAY_ON_TOP, _T("wxID_ANY"));
 	FlexGridSizer1 = new wxFlexGridSizer(2, 1, 0, 0);
 	FlexGridSizer1->AddGrowableCol(0);
 	FlexGridSizer1->AddGrowableRow(0);
@@ -68,7 +68,6 @@ RenderProgressDialog::RenderProgressDialog(wxWindow* parent)
         Layout();
     }
     EnsureWindowHeaderIsOnScreen(this);
-	SetWindowStyle(GetWindowStyle() | wxSTAY_ON_TOP);
 }
 
 RenderProgressDialog::~RenderProgressDialog()

--- a/src-ui-wx/diagnostics/RenderProgressDialog.cpp
+++ b/src-ui-wx/diagnostics/RenderProgressDialog.cpp
@@ -68,6 +68,7 @@ RenderProgressDialog::RenderProgressDialog(wxWindow* parent)
         Layout();
     }
     EnsureWindowHeaderIsOnScreen(this);
+	SetWindowStyle(GetWindowStyle() | wxSTAY_ON_TOP);
 }
 
 RenderProgressDialog::~RenderProgressDialog()

--- a/src-ui-wx/wxsmith/RenderProgressDialog.wxs
+++ b/src-ui-wx/wxsmith/RenderProgressDialog.wxs
@@ -3,7 +3,7 @@
 	<object class="wxDialog" name="RenderProgressDialog">
 		<title>Rendering Progress</title>
 		<id_arg>0</id_arg>
-		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxMAXIMIZE_BOX</style>
+		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxMAXIMIZE_BOX|wxSTAY_ON_TOP</style>
 		<object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
 			<cols>1</cols>
 			<rows>2</rows>

--- a/src-ui-wx/wxsmith/RenderProgressDialog.wxs
+++ b/src-ui-wx/wxsmith/RenderProgressDialog.wxs
@@ -3,7 +3,7 @@
 	<object class="wxDialog" name="RenderProgressDialog">
 		<title>Rendering Progress</title>
 		<id_arg>0</id_arg>
-		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxMAXIMIZE_BOX|wxSTAY_ON_TOP</style>
+		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxMAXIMIZE_BOX</style>
 		<object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
 			<cols>1</cols>
 			<rows>2</rows>


### PR DESCRIPTION
A very minor enhancement for consistency and to solve "oh, where in the world did that just go?" on the Rendering Progress window.

All window panels typically stay on top of xLights, but the "Rendering Progress" window does not. If you have xLights maximized, and you double click on the render progress bar, it opens "Rendering Progress", but if you accidentally triple click it, it will bring xLights forward over the rendering progress and hide that window, so if you try to double click it again, it does not do anything because the window is open, just hidden behind xLights. This also is an issue if you are trying to diagnose render times with a model and switching back and forth, if you "lose" the window behind other windows, theres no easy way to find it until either you re-render and open the Rendering Progress window again, or manually move everything out of the way until you find it.

To solve this, I've introduced a single line addition that keeps the Rendering Progress window on top of xLights instead of allowing it to fall behind.