### PR TITLE
Fix PolyLine division-by-zero producing NaN coords that crash macOS depth-sort (#6407)

### DIFF
--- a/src-core/models/Model.cpp
+++ b/src-core/models/Model.cpp
@@ -3127,10 +3127,6 @@ void Model::DisplayModelOnWindow(IModelPreview* preview, xlGraphicsContext* ctx,
                 }
                 const auto& c = Nodes[n]->Coords[0];
                 float z = axis.x * c.screenX + axis.y * c.screenY + axis.z * c.screenZ;
-                // xl::isfinite: std::isfinite folds to `true` under
-                // -ffinite-math-only (Release -ffast-math) — without this,
-                // NaN keys reach std::sort below and break strict weak
-                // ordering (UB; observed crashes). See FloatChecks.h.
                 if (!xl::isfinite(z)) {
                     z = 0.0f;
                 }
@@ -3140,6 +3136,11 @@ void Model::DisplayModelOnWindow(IModelPreview* preview, xlGraphicsContext* ctx,
             // OpenGL convention) renders first — i.e. back-to-front.
             std::sort(keys.begin(), keys.end(),
                       [](const std::pair<float, int>& a, const std::pair<float, int>& b) {
+                          const bool af = xl::isfinite(a.first);
+                          const bool bf = xl::isfinite(b.first);
+                          if (!af && !bf) return false;
+                          if (!af) return false;
+                          if (!bf) return true;
                           return a.first < b.first;
                       });
             for (const auto& kv : keys) {

--- a/src-core/models/PolyLineModel.cpp
+++ b/src-core/models/PolyLineModel.cpp
@@ -583,7 +583,7 @@ void PolyLineModel::DistributeLightsEvenly(       std::vector<xlPolyPoint>& pPos
             }
         }
         glm::vec3 v;
-        float pos = (current_pos - seg_start) / segment_length;
+        float pos = (segment_length > 0.0f) ? (current_pos - seg_start) / segment_length : 0.0f;
         if (pPos[segment].has_curve) {
             v = glm::vec3(*pPos[segment].curve->GetMatrix(sub_segment) * glm::vec4(pos, 0, 0, 1));
         }
@@ -702,7 +702,7 @@ void PolyLineModel::DistributeLightsAcrossSegment( const int                    
     } else {
         num_gaps = _polyLeadOffset[segment] + _polyTrailOffset[segment] + float(lights_to_distribute) - 1.0f;
     }
-    float offset = total_length / num_gaps;
+    float offset = (num_gaps > 0.0f) ? total_length / num_gaps : 0.0f;
     float current_pos = _polyLeadOffset[segment] * offset;
     size_t c = 0;
     int sub_segment = 0;
@@ -722,9 +722,11 @@ void PolyLineModel::DistributeLightsAcrossSegment( const int                    
         }
         glm::vec3 v;
         if (isCurve) {
-            v = glm::vec3(*pPos[segment].curve->GetMatrix(sub_segment) * glm::vec4((current_pos - seg_start) / segment_length, 0, 0, 1));
+            float t = (segment_length > 0.0f) ? (current_pos - seg_start) / segment_length : 0.0f;
+            v = glm::vec3(*pPos[segment].curve->GetMatrix(sub_segment) * glm::vec4(t, 0, 0, 1));
         } else {
-            v = glm::vec3(*pPos[segment].matrix * glm::vec4(current_pos / _polyLineSizes[segment], 0, 0, 1));
+            float t = (_polyLineSizes[segment] > 0.0f) ? current_pos / _polyLineSizes[segment] : 0.0f;
+            v = glm::vec3(*pPos[segment].matrix * glm::vec4(t, 0, 0, 1));
         }
         if (SingleNode) {
             for (size_t z = 0; z < drops_this_node; z++) {


### PR DESCRIPTION
 Why macOS-only:
  - macOS/iPad Release builds compile with -ffast-math → -ffinite-math-only
It wasn't catching the div by zero.