### PR TITLE
Fix imports for old and new xmodels

### DIFF
--- a/src-core/import_export/VendorCatalog.cpp
+++ b/src-core/import_export/VendorCatalog.cpp
@@ -123,6 +123,11 @@ void ModelWiring::DownloadXModel() {
     if (!d.load_file(_xmodelFile.c_str())) return;
     pugi::xml_node root = d.document_element();
     if (!root) return;
+    // Unwrap new-format <models> container to patch attributes on the actual <model> element
+    if (std::string_view(root.name()) == "models") {
+        root = root.first_child();
+        if (!root) return;
+    }
     bool changed = false;
     if (!root.attribute("PixelType") && !_model->_pixelDescription.empty()) {
         root.append_attribute("PixelType") = _model->_pixelDescription.c_str();

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -4617,18 +4617,24 @@ static Model* GetXlightsModel(Model* model, std::string& last_model, xLightsFram
             std::transform(last_model_lower.begin(), last_model_lower.end(), last_model_lower.begin(), ::tolower);
             if (last_model_lower.ends_with(".xmodel")) {
                 doc.load_file(last_model.c_str());
-                if (doc.document_element() && !doc.document_element().attribute("name").empty()) {
+                {
+                    pugi::xml_node modelElem = doc.document_element();
+                    // Unwrap new-format <models> container to read model attributes
+                    if (modelElem && std::string_view(modelElem.name()) == "models") {
+                        modelElem = modelElem.first_child();
+                    }
+                    if (modelElem && !modelElem.attribute("name").empty()) {
                     docLoaded = true;
-                    std::string modelName = doc.document_element().attribute("name").as_string("");
+                    std::string modelName = modelElem.attribute("name").as_string("");
 
-                    if (!doc.document_element().attribute("widthmm").empty()) {
-                        widthmm = (int)std::strtol(doc.document_element().attribute("widthmm").as_string(""), nullptr, 10);
+                    if (!modelElem.attribute("widthmm").empty()) {
+                        widthmm = (int)std::strtol(modelElem.attribute("widthmm").as_string(""), nullptr, 10);
                     }
-                    if (!doc.document_element().attribute("heightmm").empty()) {
-                        heightmm = (int)std::strtol(doc.document_element().attribute("heightmm").as_string(""), nullptr, 10);
+                    if (!modelElem.attribute("heightmm").empty()) {
+                        heightmm = (int)std::strtol(modelElem.attribute("heightmm").as_string(""), nullptr, 10);
                     }
-                    if (!doc.document_element().attribute("depthmm").empty()) {
-                        depthmm = (int)std::strtol(doc.document_element().attribute("depthmm").as_string(""), nullptr, 10);
+                    if (!modelElem.attribute("depthmm").empty()) {
+                        depthmm = (int)std::strtol(modelElem.attribute("depthmm").as_string(""), nullptr, 10);
                     }
 
 #ifdef __WXMSW__
@@ -4738,6 +4744,7 @@ static Model* GetXlightsModel(Model* model, std::string& last_model, xLightsFram
 #endif
 
                 }
+                } // end modelElem scope
             }
         }
     }

--- a/src-ui-wx/model/NodeSelectGrid.cpp
+++ b/src-ui-wx/model/NodeSelectGrid.cpp
@@ -896,6 +896,10 @@ void NodeSelectGrid::ImportModel(const std::string& filename)
 
     if (result) {
         pugi::xml_node root = doc.document_element();
+        // Unwrap new-format <models> container to get the inner <model> element
+        if (std::string_view(root.name()) == "models") {
+            root = root.first_child();
+        }
         ImportModelXML(root);
     } else {
         DisplayError("Failure loading xModel file.");
@@ -905,7 +909,13 @@ void NodeSelectGrid::ImportModel(const std::string& filename)
 //Load Custom Model As Selection
 void NodeSelectGrid::ImportModelXML(pugi::xml_node xmlData)
 {
-    if (std::string_view(xmlData.name()) != "custommodel") {
+    std::string_view nodeName = xmlData.name();
+    if (nodeName == "model") {
+        if (std::string_view(xmlData.attribute("DisplayAs").as_string()) != "Custom") {
+            DisplayError("xModel file not a Custom Model.");
+            return;
+        }
+    } else if (nodeName != "custommodel") {
         DisplayError("xModel file not a Custom Model.");
         return;
     }

--- a/src-ui-wx/model/SubModelsDialog.cpp
+++ b/src-ui-wx/model/SubModelsDialog.cpp
@@ -3542,6 +3542,9 @@ void SubModelsDialog::ImportSubModel(std::string filename)
     if (result)
     {
         pugi::xml_node root = doc.document_element();
+        if (std::string_view(root.name()) == "models") {
+            root = root.first_child();
+        }
         ImportSubModelXML(root);
     }
     else
@@ -3786,9 +3789,36 @@ void SubModelsDialog::CreateSubmodel(const std::string& name, const std::list<st
 
 void SubModelsDialog::ImportCustomModel(std::string filename)
 {
-    // Load custom model data using XmlSerializer
-    auto customModelOpt = XmlSerialize::LoadCustomModelFromFile(filename);
-    
+    std::optional<XmlSerialize::CustomModelImportData> customModelOpt;
+
+    pugi::xml_document fileDoc;
+    if (!fileDoc.load_file(filename.c_str())) {
+        DisplayError("Failure loading xModel file or model is not a 2D custom model.");
+        return;
+    }
+
+    pugi::xml_node root = fileDoc.document_element();
+    if (std::string_view(root.name()) == "models") {
+        // New-format xmodel: <models><model DisplayAs="Custom" ...>
+        pugi::xml_node modelNode = root.first_child();
+        if (!modelNode || std::string_view(modelNode.attribute("DisplayAs").as_string()) != "Custom") {
+            DisplayError("Failure loading xModel file or model is not a 2D custom model.");
+            return;
+        }
+        // Adapt to <custommodel> element so LoadCustomModelFromXml can parse it
+        pugi::xml_document tempDoc;
+        pugi::xml_node cmNode = tempDoc.append_child("custommodel");
+        for (pugi::xml_attribute attr = modelNode.first_attribute(); attr; attr = attr.next_attribute()) {
+            cmNode.append_attribute(attr.name()) = attr.value();
+        }
+        for (pugi::xml_node child = modelNode.first_child(); child; child = child.next_sibling()) {
+            cmNode.append_copy(child);
+        }
+        customModelOpt = XmlSerialize::LoadCustomModelFromXml(cmNode);
+    } else {
+        customModelOpt = XmlSerialize::LoadCustomModelFromFile(filename);
+    }
+
     if (!customModelOpt.has_value()) {
         DisplayError("Failure loading xModel file or model is not a 2D custom model.");
         return;


### PR DESCRIPTION
The sumodel dialog import didnt handle the new format, nor did the vendor downloads or the vendor recommended models.