### PR TITLE
Smart Presets and smart Ctrl-V (auto layers)

### DIFF
--- a/src-core/render/UndoManager.cpp
+++ b/src-core/render/UndoManager.cpp
@@ -428,10 +428,11 @@ void UndoManager::ProcessUndoStep(std::vector<UndoStep*> &fromList, std::vector<
                 if (oldIdx >= 0) {
                     int newIdx = el->GetIndex();
                     for (auto* step : fromList) {
-                        if (step->undo_action == UNDO_EFFECT_DELETED &&
-                            !step->deleted_effect_info.empty() &&
-                            step->deleted_effect_info[0]->layer_index == oldIdx) {
-                            step->deleted_effect_info[0]->layer_index = newIdx;
+                        if (step->undo_action == UNDO_EFFECT_DELETED) {
+                            for (auto* dei : step->deleted_effect_info) {
+                                if (dei->layer_index == oldIdx)
+                                    dei->layer_index = newIdx;
+                            }
                         }
                     }
                 }

--- a/src-core/render/UndoManager.cpp
+++ b/src-core/render/UndoManager.cpp
@@ -394,7 +394,8 @@ void UndoManager::ProcessUndoStep(std::vector<UndoStep*> &fromList, std::vector<
                 EffectLayer* el = element->GetEffectLayerFromExclusiveIndex(next_action->layer_info[0]->exclusive_layer_index);
                 if (el != nullptr && element->GetEffectLayerCount() > 1) {
                     int pos = el->GetLayerNumber() - 1;
-                    LayerInfo* li = new LayerInfo(next_action->layer_info[0]->element_name, -1, pos);
+                    LayerInfo* li = new LayerInfo(next_action->layer_info[0]->element_name,
+                                                  next_action->layer_info[0]->exclusive_layer_index, pos);
                     UndoStep* action = new UndoStep(UNDO_LAYER_REMOVED, li);
                     toList.push_back(action);
                     element->RemoveEffectLayer(pos);
@@ -422,6 +423,18 @@ void UndoManager::ProcessUndoStep(std::vector<UndoStep*> &fromList, std::vector<
                 UndoStep* action = new UndoStep(UNDO_LAYER_ADDED, li);
                 toList.push_back(action);
                 mParentSequence->PopulateRowInformation();
+                // Make sure redo recreates the layers needed to support the smart copy/paste
+                int oldIdx = next_action->layer_info[0]->exclusive_layer_index;
+                if (oldIdx >= 0) {
+                    int newIdx = el->GetIndex();
+                    for (auto* step : fromList) {
+                        if (step->undo_action == UNDO_EFFECT_DELETED &&
+                            !step->deleted_effect_info.empty() &&
+                            step->deleted_effect_info[0]->layer_index == oldIdx) {
+                            step->deleted_effect_info[0]->layer_index = newIdx;
+                        }
+                    }
+                }
             }
         }
         break;

--- a/src-ui-wx/app-shell/KeyBindings.cpp
+++ b/src-ui-wx/app-shell/KeyBindings.cpp
@@ -160,7 +160,8 @@ static  std::vector<std::pair<std::string, KBSCOPE>> KeyBindingTypes =
     { "JUKEBOX_BTN_4", KBSCOPE::Sequence },
     { "JUKEBOX_BTN_5", KBSCOPE::Sequence },
     { "FPP_CONNECT", KBSCOPE::All },
-    { "FILTER_SEQUENCER", KBSCOPE::Sequence }
+    { "FILTER_SEQUENCER", KBSCOPE::Sequence },
+    { "ALTERNATE_PASTE", KBSCOPE::Sequence }
 };
 
 static  std::vector<std::pair<std::string, std::string>> keyBindingTips = {
@@ -293,6 +294,7 @@ static  std::vector<std::pair<std::string, std::string>> keyBindingTips = {
     { "JUKEBOX_BTN_4", "Jukebox Button 4." },
     { "JUKEBOX_BTN_5", "Jukebox Button 5." },
     { "FPP_CONNECT", "Run FPP Connect" },
+    { "ALTERNATE_PASTE", "Paste effects using the opposite of the configured 'Paste As' mode (Relative vs As Layers)." },
 };
 
 const std::vector<KeyBinding> DefaultBindings =
@@ -991,7 +993,7 @@ bool KeyBinding::IsDuplicateKey(const KeyBinding& b) const
     if (_id == b.GetId()) return false;
 
     if (b.GetScope() == GetScope() || GetScope() == KBSCOPE::All || b.GetScope() == KBSCOPE::All) {
-        if (b.GetKey() == GetKey() && b.RequiresAlt() == RequiresAlt() && KeyBinding::IsControlEqual(b, RequiresRawControl(), RequiresControl()) && b.RequiresShift() == RequiresShift()) {
+        if (b.GetKey() == GetKey() && b.RequiresAlt() == RequiresAlt() && KeyBinding::IsControlEqual(b, RequiresControl(), RequiresRawControl()) && b.RequiresShift() == RequiresShift()) {
             return true;
         }
     }

--- a/src-ui-wx/app-shell/KeyBindings.h
+++ b/src-ui-wx/app-shell/KeyBindings.h
@@ -106,7 +106,12 @@ public:
     bool RequiresAlt() const noexcept { return _alt; }
     bool RequiresShift() const noexcept { return _shift; }
     bool InScope(const KBSCOPE scope) const noexcept { return scope == _scope; }
-    bool IsKey(wxKeyCode key) const noexcept { return (_key == key); }
+    bool IsKey(wxKeyCode key) const noexcept
+    {
+        wxKeyCode k = key;
+        if (k >= 97 && k <= 122) k = (wxKeyCode)(k - 32);
+        return (_key == k);
+    }
     bool IsDisabled() const noexcept { return _disabled; }
     std::string Description() const noexcept;
     std::string KeyDescription() const noexcept;

--- a/src-ui-wx/app-shell/KeyBindings.h
+++ b/src-ui-wx/app-shell/KeyBindings.h
@@ -109,7 +109,7 @@ public:
     bool IsKey(wxKeyCode key) const noexcept
     {
         wxKeyCode k = key;
-        if (k >= 97 && k <= 122) k = (wxKeyCode)(k - 32);
+        if (k >= 'a' && k <= 'z') k = (wxKeyCode)(k - ('a' - 'A'));
         return (_key == k);
     }
     bool IsDisabled() const noexcept { return _disabled; }

--- a/src-ui-wx/preferences/EffectsGridSettingsPanel.cpp
+++ b/src-ui-wx/preferences/EffectsGridSettingsPanel.cpp
@@ -123,7 +123,7 @@ EffectsGridSettingsPanel::EffectsGridSettingsPanel(wxWindow* parent, xLightsFram
 	GridSizer1->Add(StaticTextPasteAs, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
 	PasteAsChoice = new wxChoice(this, ID_CHOICE_PASTE_AS, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_PASTE_AS"));
 	PasteAsChoice->SetSelection( PasteAsChoice->Append(_("Relative")) );
-	PasteAsChoice->Append(_("As Layers"));
+	PasteAsChoice->Append(_("Layers"));
 	PasteAsChoice->SetToolTip(_("Relative: paste effects at the selected position. As Layers: paste preserving layer structure from copied effects."));
 	GridSizer1->Add(PasteAsChoice, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	GridSizer1->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
@@ -163,7 +163,7 @@ bool EffectsGridSettingsPanel::TransferDataToWindow() {
     GroupEffectIndicator->SetValue(frame->ShowGroupEffectIndicator());
     ShowAlternateTimingFormatCheckBox->SetValue(frame->ShowAlternateTimingFormat());
     BellOnRenderCompletion->SetValue(frame->IsRenderBell());
-    PasteAsChoice->SetSelection(frame->PasteAsLayers() ? 1 : 0);
+    PasteAsChoice->SetSelection(frame->IsPasteAsLayers() ? 1 : 0);
     int gs = frame->GridSpacing();
     switch (gs) {
         case 48:

--- a/src-ui-wx/preferences/EffectsGridSettingsPanel.cpp
+++ b/src-ui-wx/preferences/EffectsGridSettingsPanel.cpp
@@ -35,6 +35,8 @@ const wxWindowID EffectsGridSettingsPanel::ID_CHECKBOX6 = wxNewId();
 const wxWindowID EffectsGridSettingsPanel::ID_CHECKBOX5 = wxNewId();
 const wxWindowID EffectsGridSettingsPanel::ID_CHECKBOX8 = wxNewId();
 const wxWindowID EffectsGridSettingsPanel::ID_CHECKBOX9 = wxNewId();
+const wxWindowID EffectsGridSettingsPanel::ID_STATICTEXT_PASTE_AS = wxNewId();
+const wxWindowID EffectsGridSettingsPanel::ID_CHOICE_PASTE_AS = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(EffectsGridSettingsPanel,wxPanel)
@@ -117,6 +119,14 @@ EffectsGridSettingsPanel::EffectsGridSettingsPanel(wxWindow* parent, xLightsFram
 	GridSizer1->Add(BellOnRenderCompletion, 1, wxALL|wxEXPAND, 5);
 	GridSizer1->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	GridSizer1->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	StaticTextPasteAs = new wxStaticText(this, ID_STATICTEXT_PASTE_AS, _("Paste As"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_PASTE_AS"));
+	GridSizer1->Add(StaticTextPasteAs, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+	PasteAsChoice = new wxChoice(this, ID_CHOICE_PASTE_AS, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_PASTE_AS"));
+	PasteAsChoice->SetSelection( PasteAsChoice->Append(_("Relative")) );
+	PasteAsChoice->Append(_("As Layers"));
+	PasteAsChoice->SetToolTip(_("Relative: paste effects at the selected position. As Layers: paste preserving layer structure from copied effects."));
+	GridSizer1->Add(PasteAsChoice, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	GridSizer1->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	SetSizer(GridSizer1);
 	GridSizer1->SetSizeHints(this);
 
@@ -131,6 +141,7 @@ EffectsGridSettingsPanel::EffectsGridSettingsPanel(wxWindow* parent, xLightsFram
 	Connect(ID_CHECKBOX5, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&EffectsGridSettingsPanel::OnColorUpdateWarnCheckBoxClick);
 	Connect(ID_CHECKBOX8, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&EffectsGridSettingsPanel::OnShowAlternateTimingFormatCheckBoxClick);
 	Connect(ID_CHECKBOX9, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&EffectsGridSettingsPanel::OnBellOnRenderCompletionClick);
+	Connect(ID_CHOICE_PASTE_AS, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&EffectsGridSettingsPanel::OnPasteAsChoiceSelect);
 	//*)
 }
 
@@ -152,6 +163,7 @@ bool EffectsGridSettingsPanel::TransferDataToWindow() {
     GroupEffectIndicator->SetValue(frame->ShowGroupEffectIndicator());
     ShowAlternateTimingFormatCheckBox->SetValue(frame->ShowAlternateTimingFormat());
     BellOnRenderCompletion->SetValue(frame->IsRenderBell());
+    PasteAsChoice->SetSelection(frame->PasteAsLayers() ? 1 : 0);
     int gs = frame->GridSpacing();
     switch (gs) {
         case 48:
@@ -202,6 +214,7 @@ bool EffectsGridSettingsPanel::TransferDataFromWindow() {
     frame->SetShowGroupEffectIndicator(GroupEffectIndicator->IsChecked());
     frame->SetShowAlternateTimingFormat(ShowAlternateTimingFormatCheckBox->IsChecked());
     frame->SetRenderBell(BellOnRenderCompletion->IsChecked());
+    frame->SetPasteAsLayers(PasteAsChoice->GetSelection() == 1);
     return true;
 }
 
@@ -284,6 +297,13 @@ void EffectsGridSettingsPanel::OnShowAlternateTimingFormatCheckBoxClick(wxComman
 }
 
 void EffectsGridSettingsPanel::OnBellOnRenderCompletionClick(wxCommandEvent& event)
+{
+    if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
+        TransferDataFromWindow();
+    }
+}
+
+void EffectsGridSettingsPanel::OnPasteAsChoiceSelect(wxCommandEvent& event)
 {
     if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
         TransferDataFromWindow();

--- a/src-ui-wx/preferences/EffectsGridSettingsPanel.h
+++ b/src-ui-wx/preferences/EffectsGridSettingsPanel.h
@@ -38,7 +38,9 @@ class EffectsGridSettingsPanel: public wxPanel
 		wxCheckBox* TransistionMarksCheckBox;
 		wxChoice* DoubleClickChoice;
 		wxChoice* GridSpacingChoice;
+		wxChoice* PasteAsChoice;
 		wxStaticText* StaticText1;
+		wxStaticText* StaticTextPasteAs;
 		//*)
 
         virtual bool TransferDataFromWindow() override;
@@ -59,6 +61,8 @@ class EffectsGridSettingsPanel: public wxPanel
 		static const wxWindowID ID_CHECKBOX5;
 		static const wxWindowID ID_CHECKBOX8;
 		static const wxWindowID ID_CHECKBOX9;
+		static const wxWindowID ID_STATICTEXT_PASTE_AS;
+		static const wxWindowID ID_CHOICE_PASTE_AS;
 		//*)
 
 	private:
@@ -79,6 +83,7 @@ class EffectsGridSettingsPanel: public wxPanel
 		void OnAlternateTimingFormatCheckBoxClick(wxCommandEvent& event);
 		void OnShowAlternateTimingFormatCheckBoxClick(wxCommandEvent& event);
 		void OnBellOnRenderCompletionClick(wxCommandEvent& event);
+		void OnPasteAsChoiceSelect(wxCommandEvent& event);
 		//*)
 
 		DECLARE_EVENT_TABLE()

--- a/src-ui-wx/sequencer/CopyFormat1.cpp
+++ b/src-ui-wx/sequencer/CopyFormat1.cpp
@@ -52,7 +52,7 @@ CopyFormat1::CopyFormat1(const std::string& data)
     // parse the header line
     wxArrayString cols = wxSplit(lines[0], '\t');
 
-    if (cols.size() != 7) {
+    if (cols.size() < 7) {
         // not the right number of columns in the header
         return;
     }
@@ -261,7 +261,7 @@ CopyFormat1Effect::CopyFormat1Effect(const std::string& data, bool pasteByCell)
     wxArrayString cols = wxSplit(data, '\t');
 
     if (!pasteByCell) {
-        if (cols.size() != 8) {
+        if (cols.size() < 8) {
             // not the right number of columns
             return;
         }

--- a/src-ui-wx/sequencer/EffectTreeDialog.cpp
+++ b/src-ui-wx/sequencer/EffectTreeDialog.cpp
@@ -77,7 +77,6 @@ EffectTreeDialog::EffectTreeDialog(wxWindow* parent, wxWindowID id, const wxPoin
     wxFlexGridSizer* FlexGridSizer2;
     wxFlexGridSizer* FlexGridSizer3;
     wxGridSizer* BoxSizer1;
-    wxStaticText* StaticTextApplyLabel;
 
     Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, style, _T("wxID_ANY"));
     FlexGridSizer1 = new wxFlexGridSizer(0, 1, 0, 0);

--- a/src-ui-wx/sequencer/EffectTreeDialog.cpp
+++ b/src-ui-wx/sequencer/EffectTreeDialog.cpp
@@ -13,22 +13,20 @@
 #include <wx/string.h>
 //*)
 
+#include <wx/artprov.h>
 #include <wx/busyinfo.h>
 #include <wx/utils.h>
-#include <wx/artprov.h>
 
 #include "EffectTreeDialog.h"
+#include "UtilFunctions.h"
 #include "xLightsApp.h"
-#include "shared/utils/wxUtilities.h"
-#include "render/SequenceMedia.h"
-#include <fstream>
 #include "xLightsMain.h"
 #include "xLightsVersion.h"
-#include "UtilFunctions.h"
-#include "shared/utils/wxUtilities.h"
-#include "xLightsVersion.h"
-#include "utils/ExternalHooks.h"
 #include "XmlSerializer/FileSerializingVisitor.h"
+#include "render/SequenceMedia.h"
+#include "shared/utils/wxUtilities.h"
+#include "utils/ExternalHooks.h"
+#include <fstream>
 
 #include <log.h>
 
@@ -56,111 +54,123 @@ const wxWindowID EffectTreeDialog::ID_BUTTON5 = wxNewId();
 const wxWindowID EffectTreeDialog::ID_TEXTCTRL_SEARCH = wxNewId();
 const wxWindowID EffectTreeDialog::ID_BUTTON_SEARCH = wxNewId();
 const wxWindowID EffectTreeDialog::ID_TIMER_GIF = wxNewId();
+const wxWindowID EffectTreeDialog::ID_BTN_POSITION = wxNewId();
+const wxWindowID EffectTreeDialog::ID_BTN_LAYERS = wxNewId();
+const wxWindowID EffectTreeDialog::ID_STATICTEXT_APPLY = wxNewId();
 //*)
 
-BEGIN_EVENT_TABLE(EffectTreeDialog,wxPanel)
-	//(*EventTable(EffectTreeDialog)
-	//*)
-    EVT_COMMAND(wxID_ANY, EVT_EFFTREEDROP, EffectTreeDialog::OnDropEffect)
+BEGIN_EVENT_TABLE(EffectTreeDialog, wxPanel)
+//(*EventTable(EffectTreeDialog)
+//*)
+EVT_COMMAND(wxID_ANY, EVT_EFFTREEDROP, EffectTreeDialog::OnDropEffect)
 END_EVENT_TABLE()
 
 #define MIN_PREVIEW_SIZE 64
 #define MAX_PREVIEW_SIZE 256
 #define GIF_DELAY 50
 
-EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint& pos,const wxSize& size,long style)
-{
-	//(*Initialize(EffectTreeDialog)
-	wxBoxSizer* BoxSizer2;
-	wxBoxSizer* BoxSizer3;
-	wxFlexGridSizer* FlexGridSizer1;
-	wxFlexGridSizer* FlexGridSizer2;
-	wxFlexGridSizer* FlexGridSizer3;
-	wxGridSizer* BoxSizer1;
+EffectTreeDialog::EffectTreeDialog(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style) {
+    //(*Initialize(EffectTreeDialog)
+    wxBoxSizer* BoxSizer2;
+    wxBoxSizer* BoxSizer3;
+    wxFlexGridSizer* FlexGridSizer1;
+    wxFlexGridSizer* FlexGridSizer2;
+    wxFlexGridSizer* FlexGridSizer3;
+    wxGridSizer* BoxSizer1;
+    wxStaticText* StaticTextApplyLabel;
 
-	Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, style, _T("wxID_ANY"));
-	FlexGridSizer1 = new wxFlexGridSizer(0, 1, 0, 0);
-	FlexGridSizer1->AddGrowableCol(0);
-	FlexGridSizer1->AddGrowableRow(0);
-	FlexGridSizer2 = new wxFlexGridSizer(0, 3, 0, 0);
-	FlexGridSizer2->AddGrowableCol(0);
-	FlexGridSizer2->AddGrowableRow(0);
-	TreeCtrl1 = new wxTreeCtrl(this, ID_TREECTRL1, wxDefaultPosition, wxDefaultSize, wxTR_DEFAULT_STYLE, wxDefaultValidator, _T("ID_TREECTRL1"));
-	TreeCtrl1->SetMinSize(wxDLG_UNIT(this,wxSize(80,-1)));
-	FlexGridSizer2->Add(TreeCtrl1, 1, wxALL|wxEXPAND, 5);
-	BoxSizer3 = new wxBoxSizer(wxVERTICAL);
-	Button_Top = new wxButton(this, ID_BUTTON11, _T("^^"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(15,-1)), 0, wxDefaultValidator, _T("ID_BUTTON11"));
-	BoxSizer3->Add(Button_Top, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxFIXED_MINSIZE, 5);
-	Button_MoveUp = new wxButton(this, ID_BUTTON9, _T("^"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(15,-1)), 0, wxDefaultValidator, _T("ID_BUTTON9"));
-	BoxSizer3->Add(Button_MoveUp, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxFIXED_MINSIZE, 5);
-	Button_MoveDown = new wxButton(this, ID_BUTTON10, _("v"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(15,-1)), 0, wxDefaultValidator, _T("ID_BUTTON10"));
-	BoxSizer3->Add(Button_MoveDown, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxFIXED_MINSIZE, 5);
-	Button_Bottom = new wxButton(this, ID_BUTTON12, _("vv"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(15,-1)), 0, wxDefaultValidator, _T("ID_BUTTON12"));
-	BoxSizer3->Add(Button_Bottom, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxFIXED_MINSIZE, 5);
-	FlexGridSizer2->Add(BoxSizer3, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
-	FlexGridSizer3 = new wxFlexGridSizer(3, 1, 0, 0);
-	FlexGridSizer3->AddGrowableCol(0);
-	FlexGridSizer3->AddGrowableRow(0);
-	StaticBitmapGif = new wxStaticBitmap(this, ID_STATICBITMAP_GIF, wxNullBitmap, wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICBITMAP_GIF"));
-	FlexGridSizer3->Add(StaticBitmapGif, 1, wxALL|wxALIGN_CENTER_HORIZONTAL, 5);
-	BoxSizer1 = new wxGridSizer(4, 2, 0, 0);
-	btApply = new wxButton(this, ID_BUTTON6, _("&Apply Preset"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON6"));
-	btApply->SetToolTip(_("Apply the selected effect Preset."));
-	BoxSizer1->Add(btApply, 0, wxALL|wxEXPAND, 5);
-	btAddGroup = new wxButton(this, ID_BUTTON7, _("Add &Group"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON7"));
-	btAddGroup->SetToolTip(_("Add effect preset group."));
-	BoxSizer1->Add(btAddGroup, 0, wxALL|wxEXPAND, 5);
-	btUpdate = new wxButton(this, ID_BUTTON2, _("&Update Preset"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON2"));
-	btUpdate->SetToolTip(_("Update the selected effect preset to reflect current effect settings."));
-	BoxSizer1->Add(btUpdate, 0, wxALL|wxEXPAND, 5);
-	btDelete = new wxButton(this, ID_BUTTON4, _("&Delete"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON4"));
-	btDelete->SetToolTip(_("Delete curently selected effect preset."));
-	BoxSizer1->Add(btDelete, 0, wxALL|wxEXPAND, 5);
-	btNewPreset = new wxButton(this, ID_BUTTON1, _("&New Preset"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON1"));
-	btNewPreset->SetToolTip(_("Create New Effect Preset from current settings."));
-	BoxSizer1->Add(btNewPreset, 0, wxALL|wxEXPAND, 5);
-	btImport = new wxButton(this, ID_BUTTON8, _("&Import"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON8"));
-	btImport->SetToolTip(_("Import presets from another file."));
-	BoxSizer1->Add(btImport, 0, wxALL|wxEXPAND, 5);
-	btRename = new wxButton(this, ID_BUTTON3, _("&Rename"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON3"));
-	btRename->SetToolTip(_("Rename currently selected effect preset."));
-	BoxSizer1->Add(btRename, 0, wxALL|wxEXPAND, 5);
-	btExport = new wxButton(this, ID_BUTTON5, _("Export"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON5"));
-	BoxSizer1->Add(btExport, 0, wxALL|wxEXPAND, 5);
-	FlexGridSizer3->Add(BoxSizer1, 1, wxALL|wxEXPAND, 5);
-	BoxSizer2 = new wxBoxSizer(wxHORIZONTAL);
-	TextCtrl1 = new wxTextCtrl(this, ID_TEXTCTRL_SEARCH, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_TEXTCTRL_SEARCH"));
-	BoxSizer2->Add(TextCtrl1, 1, wxRIGHT|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 3);
-	ETButton1 = new wxButton(this, ID_BUTTON_SEARCH, _("Search"), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT, wxDefaultValidator, _T("ID_BUTTON_SEARCH"));
-	BoxSizer2->Add(ETButton1, 0, wxRIGHT|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxFIXED_MINSIZE, 0);
-	FlexGridSizer3->Add(BoxSizer2, 1, wxALL|wxEXPAND, 5);
-	FlexGridSizer2->Add(FlexGridSizer3, 1, wxALL|wxEXPAND, 5);
-	FlexGridSizer1->Add(FlexGridSizer2, 1, wxALL|wxEXPAND, 5);
-	SetSizer(FlexGridSizer1);
-	TimerGif.SetOwner(this, ID_TIMER_GIF);
+    Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, style, _T("wxID_ANY"));
+    FlexGridSizer1 = new wxFlexGridSizer(0, 1, 0, 0);
+    FlexGridSizer1->AddGrowableCol(0);
+    FlexGridSizer1->AddGrowableRow(0);
+    FlexGridSizer2 = new wxFlexGridSizer(0, 3, 0, 0);
+    FlexGridSizer2->AddGrowableCol(0);
+    FlexGridSizer2->AddGrowableRow(0);
+    TreeCtrl1 = new wxTreeCtrl(this, ID_TREECTRL1, wxDefaultPosition, wxDefaultSize, wxTR_DEFAULT_STYLE, wxDefaultValidator, _T("ID_TREECTRL1"));
+    TreeCtrl1->SetMinSize(wxDLG_UNIT(this, wxSize(80, -1)));
+    FlexGridSizer2->Add(TreeCtrl1, 1, wxALL | wxEXPAND, 5);
+    BoxSizer3 = new wxBoxSizer(wxVERTICAL);
+    Button_Top = new wxButton(this, ID_BUTTON11, _T("^^"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(15, -1)), 0, wxDefaultValidator, _T("ID_BUTTON11"));
+    BoxSizer3->Add(Button_Top, 0, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL | wxFIXED_MINSIZE, 5);
+    Button_MoveUp = new wxButton(this, ID_BUTTON9, _T("^"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(15, -1)), 0, wxDefaultValidator, _T("ID_BUTTON9"));
+    BoxSizer3->Add(Button_MoveUp, 0, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL | wxFIXED_MINSIZE, 5);
+    Button_MoveDown = new wxButton(this, ID_BUTTON10, _("v"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(15, -1)), 0, wxDefaultValidator, _T("ID_BUTTON10"));
+    BoxSizer3->Add(Button_MoveDown, 0, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL | wxFIXED_MINSIZE, 5);
+    Button_Bottom = new wxButton(this, ID_BUTTON12, _("vv"), wxDefaultPosition, wxDLG_UNIT(this, wxSize(15, -1)), 0, wxDefaultValidator, _T("ID_BUTTON12"));
+    BoxSizer3->Add(Button_Bottom, 0, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL | wxFIXED_MINSIZE, 5);
+    FlexGridSizer2->Add(BoxSizer3, 0, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 0);
+    FlexGridSizer3 = new wxFlexGridSizer(4, 1, 0, 0);
+    FlexGridSizer3->AddGrowableCol(0);
+    FlexGridSizer3->AddGrowableRow(0);
+    StaticBitmapGif = new wxStaticBitmap(this, ID_STATICBITMAP_GIF, wxNullBitmap, wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICBITMAP_GIF"));
+    FlexGridSizer3->Add(StaticBitmapGif, 1, wxALL | wxALIGN_CENTER_HORIZONTAL, 5);
+    StaticTextApplyLabel = new wxStaticText(this, ID_STATICTEXT_APPLY, _("Apply preset as:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_APPLY"));
+    FlexGridSizer3->Add(StaticTextApplyLabel, 0, wxALL | wxALIGN_LEFT, 5);
+    BoxSizer1 = new wxGridSizer(5, 2, 0, 0);
+    btPosition = new wxButton(this, ID_BTN_POSITION, _("Relative"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BTN_POSITION"));
+    btPosition->SetToolTip(_("Paste effects at the drop row, ignoring layer structure."));
+    BoxSizer1->Add(btPosition, 0, wxALL | wxEXPAND, 5);
+    btLayers = new wxButton(this, ID_BTN_LAYERS, _("Layers"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BTN_LAYERS"));
+    btLayers->SetToolTip(_("Paste effects preserving layer structure."));
+    BoxSizer1->Add(btLayers, 0, wxALL | wxEXPAND, 5);
+    btApply = new wxButton(this, ID_BUTTON6, _("&Apply Preset"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON6"));
+    btApply->SetToolTip(_("Apply the selected effect Preset."));
+    BoxSizer1->Add(btApply, 0, wxALL | wxEXPAND, 5);
+    btAddGroup = new wxButton(this, ID_BUTTON7, _("Add &Group"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON7"));
+    btAddGroup->SetToolTip(_("Add effect preset group."));
+    BoxSizer1->Add(btAddGroup, 0, wxALL | wxEXPAND, 5);
+    btUpdate = new wxButton(this, ID_BUTTON2, _("&Update Preset"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON2"));
+    btUpdate->SetToolTip(_("Update the selected effect preset to reflect current effect settings."));
+    BoxSizer1->Add(btUpdate, 0, wxALL | wxEXPAND, 5);
+    btDelete = new wxButton(this, ID_BUTTON4, _("&Delete"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON4"));
+    btDelete->SetToolTip(_("Delete curently selected effect preset."));
+    BoxSizer1->Add(btDelete, 0, wxALL | wxEXPAND, 5);
+    btNewPreset = new wxButton(this, ID_BUTTON1, _("&New Preset"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON1"));
+    btNewPreset->SetToolTip(_("Create New Effect Preset from current settings."));
+    BoxSizer1->Add(btNewPreset, 0, wxALL | wxEXPAND, 5);
+    btImport = new wxButton(this, ID_BUTTON8, _("&Import"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON8"));
+    btImport->SetToolTip(_("Import presets from another file."));
+    BoxSizer1->Add(btImport, 0, wxALL | wxEXPAND, 5);
+    btRename = new wxButton(this, ID_BUTTON3, _("&Rename"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON3"));
+    btRename->SetToolTip(_("Rename currently selected effect preset."));
+    BoxSizer1->Add(btRename, 0, wxALL | wxEXPAND, 5);
+    btExport = new wxButton(this, ID_BUTTON5, _("Export"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON5"));
+    BoxSizer1->Add(btExport, 0, wxALL | wxEXPAND, 5);
+    FlexGridSizer3->Add(BoxSizer1, 1, wxALL | wxEXPAND, 5);
+    BoxSizer2 = new wxBoxSizer(wxHORIZONTAL);
+    TextCtrl1 = new wxTextCtrl(this, ID_TEXTCTRL_SEARCH, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_TEXTCTRL_SEARCH"));
+    BoxSizer2->Add(TextCtrl1, 1, wxRIGHT | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 3);
+    ETButton1 = new wxButton(this, ID_BUTTON_SEARCH, _("Search"), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT, wxDefaultValidator, _T("ID_BUTTON_SEARCH"));
+    BoxSizer2->Add(ETButton1, 0, wxRIGHT | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL | wxFIXED_MINSIZE, 0);
+    FlexGridSizer3->Add(BoxSizer2, 1, wxALL | wxEXPAND, 5);
+    FlexGridSizer2->Add(FlexGridSizer3, 1, wxALL | wxEXPAND, 5);
+    FlexGridSizer1->Add(FlexGridSizer2, 1, wxALL | wxEXPAND, 5);
+    SetSizer(FlexGridSizer1);
+    TimerGif.SetOwner(this, ID_TIMER_GIF);
 
-	Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_BEGIN_DRAG, (wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1BeginDrag);
-	Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_ITEM_ACTIVATED, (wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1ItemActivated);
-	Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_ITEM_RIGHT_CLICK, (wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1ItemRightClick);
-	Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_SEL_CHANGED, (wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1SelectionChanged);
-	Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_KEY_DOWN, (wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1KeyDown);
-	Connect(ID_BUTTON11, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnButton_TopClick);
-	Connect(ID_BUTTON9, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnButton_MoveUpClick);
-	Connect(ID_BUTTON10, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnButton_MoveDownClick);
-	Connect(ID_BUTTON12, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnButton_BottomClick);
-	Connect(ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtApplyClick);
-	Connect(ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtAddGroupClick);
-	Connect(ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtUpdateClick);
-	Connect(ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtDeleteClick);
-	Connect(ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtNewPresetClick);
-	Connect(ID_BUTTON8, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtImportClick);
-	Connect(ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtRenameClick);
-	Connect(ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtExportClick);
-	Connect(ID_TEXTCTRL_SEARCH, wxEVT_COMMAND_TEXT_ENTER, (wxObjectEventFunction)&EffectTreeDialog::OnTextCtrl1TextEnter);
-	Connect(ID_BUTTON_SEARCH, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnETButton1Click);
-	Connect(ID_TIMER_GIF, wxEVT_TIMER, (wxObjectEventFunction)&EffectTreeDialog::OnTimerGifTrigger);
-	//*)
-
+    Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_BEGIN_DRAG, (wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1BeginDrag);
+    Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_ITEM_ACTIVATED, (wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1ItemActivated);
+    Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_ITEM_RIGHT_CLICK, (wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1ItemRightClick);
+    Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_SEL_CHANGED, (wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1SelectionChanged);
+    Connect(ID_TREECTRL1, wxEVT_COMMAND_TREE_KEY_DOWN, (wxObjectEventFunction)&EffectTreeDialog::OnTreeCtrl1KeyDown);
+    Connect(ID_BUTTON11, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnButton_TopClick);
+    Connect(ID_BUTTON9, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnButton_MoveUpClick);
+    Connect(ID_BUTTON10, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnButton_MoveDownClick);
+    Connect(ID_BUTTON12, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnButton_BottomClick);
+    Connect(ID_BUTTON6, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtApplyClick);
+    Connect(ID_BUTTON7, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtAddGroupClick);
+    Connect(ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtUpdateClick);
+    Connect(ID_BUTTON4, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtDeleteClick);
+    Connect(ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtNewPresetClick);
+    Connect(ID_BUTTON8, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtImportClick);
+    Connect(ID_BUTTON3, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtRenameClick);
+    Connect(ID_BUTTON5, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnbtExportClick);
+    Connect(ID_TEXTCTRL_SEARCH, wxEVT_COMMAND_TEXT_ENTER, (wxObjectEventFunction)&EffectTreeDialog::OnTextCtrl1TextEnter);
+    Connect(ID_BUTTON_SEARCH, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnETButton1Click);
+    Connect(ID_TIMER_GIF, wxEVT_TIMER, (wxObjectEventFunction)&EffectTreeDialog::OnTimerGifTrigger);
+    Connect(ID_BTN_POSITION, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnBtnPositionClick);
+    Connect(ID_BTN_LAYERS, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnBtnLayersClick);
+    //*)
     Connect(wxEVT_SHOW, (wxObjectEventFunction)&EffectTreeDialog::OnShow);
 
     treeRootID = TreeCtrl1->AddRoot("Effect Presets");
@@ -186,8 +196,7 @@ EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint&
     ValidateWindow();
 }
 
-EffectTreeDialog::~EffectTreeDialog()
-{
+EffectTreeDialog::~EffectTreeDialog() {
     TimerGif.Stop();
     StaticBitmapGif->SetBitmap(wxNullBitmap);
 
@@ -195,8 +204,7 @@ EffectTreeDialog::~EffectTreeDialog()
     //*)
 }
 
-void EffectTreeDialog::OnShow(wxShowEvent& event)
-{
+void EffectTreeDialog::OnShow(wxShowEvent& event) {
     if (IsBeingDeleted())
         return;
     if (event.IsShown()) {
@@ -208,8 +216,7 @@ void EffectTreeDialog::OnShow(wxShowEvent& event)
     event.Skip();
 }
 
-void EffectTreeDialog::InitItems(EffectPresetManager& manager)
-{
+void EffectTreeDialog::InitItems(EffectPresetManager& manager) {
     _presetManager = &manager;
 
     _effectsFixed = _presetManager->FixRgbEffects();
@@ -232,15 +239,15 @@ void EffectTreeDialog::InitItems(EffectPresetManager& manager)
     ValidateWindow();
 }
 
-void EffectTreeDialog::AddTreeElementsRecursive(EffectPresetGroup& group, wxTreeItemId curGroupID)
-{
+void EffectTreeDialog::AddTreeElementsRecursive(EffectPresetGroup& group, wxTreeItemId curGroupID) {
     for (const auto& child : group.GetChildren()) {
         wxString name = child->GetName();
-        if (name.IsEmpty()) continue;
+        if (name.IsEmpty())
+            continue;
 
         if (child->IsGroup()) {
             wxTreeItemId nextGroupID = TreeCtrl1->AppendItem(curGroupID, name, -1, -1,
-                new MyTreeItemData(child.get()));
+                                                             new MyTreeItemData(child.get()));
             TreeCtrl1->SetItemHasChildren(nextGroupID);
             AddTreeElementsRecursive(static_cast<EffectPresetGroup&>(*child), nextGroupID);
         } else {
@@ -251,61 +258,46 @@ void EffectTreeDialog::AddTreeElementsRecursive(EffectPresetGroup& group, wxTree
     }
 }
 
-void EffectTreeDialog::ApplyEffect(bool dblClick)
-{
+void EffectTreeDialog::ApplyEffect(bool dblClick) {
     wxTreeItemId itemID = TreeCtrl1->GetSelection();
-    if (!itemID.IsOk())
-    {
-         DisplayError(_("No effect selected."), this);
-    }
-    else if (TreeCtrl1->HasChildren(itemID))
-    {
-        if (dblClick)
-        {
+    if (!itemID.IsOk()) {
+        DisplayError(_("No effect selected."), this);
+    } else if (TreeCtrl1->HasChildren(itemID)) {
+        if (dblClick) {
             TreeCtrl1->Toggle(itemID);
-        }
-        else
-        {
+        } else {
             DisplayError(_("An effect group can not be applied."), this);
         }
-    }
-    else
-    {
-        MyTreeItemData *item = (MyTreeItemData *)TreeCtrl1->GetItemData(itemID);
-        if ( item != nullptr )
-        {
+    } else {
+        MyTreeItemData* item = (MyTreeItemData*)TreeCtrl1->GetItemData(itemID);
+        if (item != nullptr) {
             EffectPreset* preset = item->AsPreset();
-            if (preset != nullptr && !preset->GetSettings().empty())
-            {
+            if (preset != nullptr && !preset->GetSettings().empty()) {
                 wxString settings = preset->GetSettings();
-                xLightParent->ApplyEffectsPreset(settings, preset->GetXLightsVersion());
+                xLightParent->ApplyEffectsPreset(settings, preset->GetXLightsVersion(), _layerMode);
             }
         }
     }
 }
 
-void EffectTreeDialog::OnbtApplyClick(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnbtApplyClick(wxCommandEvent& event) {
     ApplyEffect();
     ValidateWindow();
 }
 
-bool EffectTreeDialog::PromptForName(wxWindow* parent, wxString& name, bool isNew, bool isGroup)
-{
+bool EffectTreeDialog::PromptForName(wxWindow* parent, wxString& name, bool isNew, bool isGroup) {
     std::string promptType = isGroup ? "Group" : "Effect Preset";
     std::string promptNew = isNew ? " New " : "";
     wxString prompt = wxString::Format("Enter %s%s Name", promptNew, promptType);
 
-    wxTextEntryDialog dialog(/*this*/ parent,prompt,_("Name"));
+    wxTextEntryDialog dialog(/*this*/ parent, prompt, _("Name"));
     int DlgResult;
     bool ok;
-    do
-    {
-        ok=true;
+    do {
+        ok = true;
         dialog.SetValue(name);
-        DlgResult=dialog.ShowModal();
-        if (DlgResult == wxID_OK)
-        {
+        DlgResult = dialog.ShowModal();
+        if (DlgResult == wxID_OK) {
             // validate inputs
             name = dialog.GetValue();
             name.Trim();
@@ -320,7 +312,7 @@ bool EffectTreeDialog::PromptForName(wxWindow* parent, wxString& name, bool isNe
             }
 
             wxTreeItemId selectedItem = TreeCtrl1->GetSelection();
-            MyTreeItemData *selectedItemData = (MyTreeItemData *)TreeCtrl1->GetItemData(selectedItem);
+            MyTreeItemData* selectedItemData = (MyTreeItemData*)TreeCtrl1->GetItemData(selectedItem);
 
             bool nameCollission = false;
             if ((selectedItem == treeRootID || selectedItemData->IsGroup()) && isNew) {
@@ -334,46 +326,41 @@ bool EffectTreeDialog::PromptForName(wxWindow* parent, wxString& name, bool isNe
             if (name.IsEmpty() || hasForbiddenChar || nameCollission) {
                 wxString errorMsg = wxString::Format("%s name may not be empty, must be unique within the current group/root of your 'Effect Presets', and cannot contain any of the following characters '%s'.", promptType, forbiddenChars);
 
-                ok=false;
+                ok = false;
                 DisplayError(errorMsg);
             }
         }
-    }
-    while (DlgResult == wxID_OK && !ok);
-    return (DlgResult == wxID_OK );
+    } while (DlgResult == wxID_OK && !ok);
+    return (DlgResult == wxID_OK);
 }
-void EffectTreeDialog::OnbtNewPresetClick(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnbtNewPresetClick(wxCommandEvent& event) {
     wxTreeItemId itemID = TreeCtrl1->GetSelection();
     wxTreeItemId parentID;
-    MyTreeItemData *parentData;
+    MyTreeItemData* parentData;
 
-    if (!itemID.IsOk())
-    {
+    if (!itemID.IsOk()) {
         DisplayError(_("A preset cannot be added at the currently selected location"), this);
         ValidateWindow();
         return;
     }
 
     wxString name;
-    if (!PromptForName(this, name, true, false)) return;
+    if (!PromptForName(this, name, true, false))
+        return;
 
-    MyTreeItemData *itemData = (MyTreeItemData *)TreeCtrl1->GetItemData(itemID);
-    if (itemData->IsGroup())
-    {
+    MyTreeItemData* itemData = (MyTreeItemData*)TreeCtrl1->GetItemData(itemID);
+    if (itemData->IsGroup()) {
         parentID = itemID;
         parentData = itemData;
-    }
-    else
-    {
+    } else {
         parentID = TreeCtrl1->GetItemParent(itemID);
-        parentData = (MyTreeItemData *)TreeCtrl1->GetItemData(parentID);
+        parentData = (MyTreeItemData*)TreeCtrl1->GetItemData(parentID);
     }
 
     EffectPresetGroup* parentGroup = parentData->AsGroup();
     EffectPreset* newPreset = xLightParent->CreateEffectPreset(parentGroup, name.ToStdString());
     name += " [" + ParseLayers(name, newPreset->GetSettings()) + ", " + ParseDuration(name, newPreset->GetSettings()) + "ms]";
-    wxTreeItemId newitemID = TreeCtrl1->AppendItem(parentID, name, -1,-1, new MyTreeItemData(newPreset));
+    wxTreeItemId newitemID = TreeCtrl1->AppendItem(parentID, name, -1, -1, new MyTreeItemData(newPreset));
     TreeCtrl1->Expand(parentID);
     TreeCtrl1->SelectItem(newitemID, true);
     TreeCtrl1->EnsureVisible(newitemID);
@@ -382,104 +369,84 @@ void EffectTreeDialog::OnbtNewPresetClick(wxCommandEvent& event)
     ValidateWindow();
 }
 
-wxString EffectTreeDialog::ParseLayers(wxString name, wxString settings)
-{
-    if (settings == "") return "0";
+wxString EffectTreeDialog::ParseLayers(wxString name, wxString settings) {
+    if (settings == "")
+        return "0";
 
-    //static 
-    //logger_base.debug("Name: %s", (const char *)name.c_str());
-    //logger_base.debug("Settings: %s", (const char *)settings.c_str());
+    // static
+    // logger_base.debug("Name: %s", (const char *)name.c_str());
+    // logger_base.debug("Settings: %s", (const char *)settings.c_str());
     int res = 0;
     bool ac = false;
 
-    if (settings.Contains("\t"))
-    {
+    if (settings.Contains("\t")) {
         int start = 9999;
         int end = -1;
 
         wxArrayString all_efdata = wxSplit(settings, '\n');
 
         bool cf1 = false;
-        for (size_t i = 0; i < all_efdata.size(); i++)
-        {
-            //logger_base.debug("    %d: %s", i, (const char *)all_efdata[i].c_str());
+        for (size_t i = 0; i < all_efdata.size(); i++) {
+            // logger_base.debug("    %d: %s", i, (const char *)all_efdata[i].c_str());
 
             wxArrayString efdata = wxSplit(all_efdata[i], '\t');
 
-            if (efdata.size() > 0)
-            {
-                if (efdata[0] == "CopyFormat1")
-                {
+            if (efdata.size() > 0) {
+                if (efdata[0] == "CopyFormat1") {
                     cf1 = true;
-                }
-                else if (efdata[0] == "CopyFormatAC")
-                {
+                } else if (efdata[0] == "CopyFormatAC") {
                     ac = true;
                     start = wxAtoi(efdata[7]);
                     end = wxAtoi(efdata[8]);
                     break;
-                }
-                else
-                {
-                    if (cf1 && efdata.size() > 6 && efdata[0] != "CopyFormat1" && efdata[0] != "None" && efdata.back() != "NO_PASTE_BY_CELL")
-                    {
-                        int row = wxAtoi(efdata[efdata.size() - 6]);
-                        if (row < start) start = row;
-                        if (row > end) end = row;
-                        //logger_base.debug("        row: %d start: %d end: %d", row, start, end);
-                    }
-                    else if (!cf1 && efdata.size() > 2 && efdata[0] != "None")
-                    {
+                } else {
+                    if (cf1 && efdata.size() > 5 && efdata[0] != "CopyFormat1" && efdata[0] != "None") {
+                        int row = wxAtoi(efdata[5]);
+                        if (row < start)
+                            start = row;
+                        if (row > end)
+                            end = row;
+                        // logger_base.debug("        row: %d start: %d end: %d", row, start, end);
+                    } else if (!cf1 && efdata.size() > 2 && efdata[0] != "None") {
                         int row = wxAtoi(efdata[efdata.size() - 2]);
-                        if (row < start) start = row;
-                        if (row > end) end = row;
-                        //logger_base.debug("        row: %d start: %d end: %d", row, start, end);
-                    }
-                    else if (efdata.back() == "NO_PASTE_BY_CELL" && efdata.size() > 3 && efdata[0] != "None")
-                    {
-                        int row = wxAtoi(efdata[efdata.size() - 3]);
-                        if (row < start) start = row;
-                        if (row > end) end = row;
-                        //logger_base.debug("        row: %d start: %d end: %d", row, start, end);
+                        if (row < start)
+                            start = row;
+                        if (row > end)
+                            end = row;
+                        // logger_base.debug("        row: %d start: %d end: %d", row, start, end);
                     }
                 }
             }
         }
 
-        if (end != -1)
-        {
+        if (end != -1) {
             res = end - start + 1;
         }
-    }
-    else
-    {
+    } else {
         // effect1,effect2,blend,settings ...
         wxArrayString efdata = wxSplit(settings, ',');
-        if (efdata.size() < 2) return "0";
-        if (efdata[0] != "None") res++;
-        if (efdata[1] != "None") res++;
+        if (efdata.size() < 2)
+            return "0";
+        if (efdata[0] != "None")
+            res++;
+        if (efdata[1] != "None")
+            res++;
     }
 
-    //logger_base.debug("    **** %d", res);
+    // logger_base.debug("    **** %d", res);
 
-    if (ac)
-    {
+    if (ac) {
         return wxString::Format("%d - AC", res);
-    }
-    else
-    {
+    } else {
         return wxString::Format("%d", res);
     }
 }
 
-wxString StripLayers(wxString s)
-{
+wxString StripLayers(wxString s) {
     wxString res = s;
-    if (s.EndsWith("]"))
-    {
+    if (s.EndsWith("]")) {
         res = s.BeforeLast('[');
-        if (res.EndsWith(" "))
-        {
+        if (res.EndsWith(" ")) {
             res = res.BeforeLast(' ');
         }
     }
@@ -487,83 +454,70 @@ wxString StripLayers(wxString s)
     return res;
 }
 
-wxString EffectTreeDialog::ParseDuration(wxString name, wxString settings)
-{
-    if (settings == "") return "0";
+wxString EffectTreeDialog::ParseDuration(wxString name, wxString settings) {
+    if (settings == "")
+        return "0";
 
-    //static 
-    //logger_base.debug("Name: %s", (const char *)name.c_str());
-    //logger_base.debug("Settings: %s", (const char *)settings.c_str());
+    // static
+    // logger_base.debug("Name: %s", (const char *)name.c_str());
+    // logger_base.debug("Settings: %s", (const char *)settings.c_str());
     int minstart = 99999999;
     int maxend = -99999999;
 
-    if (settings.Contains("\t"))
-    {
+    if (settings.Contains("\t")) {
         wxArrayString all_efdata = wxSplit(settings, '\n');
 
-        for (size_t i = 0; i < all_efdata.size(); i++)
-        {
-            //logger_base.debug("    %d: %s", i, (const char *)all_efdata[i].c_str());
+        for (size_t i = 0; i < all_efdata.size(); i++) {
+            // logger_base.debug("    %d: %s", i, (const char *)all_efdata[i].c_str());
 
             wxArrayString efdata = wxSplit(all_efdata[i], '\t');
 
-            if (efdata.size() > 0)
-            {
-                if (efdata[0] == "CopyFormat1")
-                {
+            if (efdata.size() > 0) {
+                if (efdata[0] == "CopyFormat1") {
                     // nothing to do
-                }
-                else if (efdata.size() > 10 && efdata[0] == "CopyFormatAC")
-                {
+                } else if (efdata.size() > 10 && efdata[0] == "CopyFormatAC") {
                     int start = wxAtoi(efdata[9]);
                     int end = wxAtoi(efdata[10]);
                     minstart = std::min(start, minstart);
                     maxend = std::max(end, maxend);
                     break;
-                }
-                else
-                {
-                    if (efdata.size() > 4 && efdata[0] != "CopyFormat1" && efdata[0] != "None")
-                    {
+                } else {
+                    if (efdata.size() > 4 && efdata[0] != "CopyFormat1" && efdata[0] != "None") {
                         int start = wxAtoi(efdata[3]);
                         int end = wxAtoi(efdata[4]);
                         minstart = std::min(start, minstart);
                         maxend = std::max(end, maxend);
-                    }
-                    else if (efdata[0] != "None")
-                    {
+                    } else if (efdata[0] != "None") {
                         wxASSERT(false);
                     }
                 }
             }
         }
-    }
-    else
-    {
+    } else {
         // effect1,effect2,blend,settings ...
         wxArrayString efdata = wxSplit(settings, ',');
-        if (efdata.size() < 5) return "0";
+        if (efdata.size() < 5)
+            return "0";
         minstart = wxAtoi(efdata[3]);
         maxend = wxAtoi(efdata[4]);
     }
 
-    if (minstart == 99999999) return "0";
+    if (minstart == 99999999)
+        return "0";
 
     return wxString::Format("%d", maxend - minstart);
 }
 
-void EffectTreeDialog::OnbtUpdateClick(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnbtUpdateClick(wxCommandEvent& event) {
     wxTreeItemId itemID = TreeCtrl1->GetSelection();
     wxString name(TreeCtrl1->GetItemText(itemID));
 
-    if ( TreeCtrl1->HasChildren(itemID))
-    {
+    if (TreeCtrl1->HasChildren(itemID)) {
         wxMessageBox(_("You cannot store an effect on the selected item."), _("ERROR"));
         ValidateWindow();
         return;
     }
-    MyTreeItemData *selData = (MyTreeItemData *)TreeCtrl1->GetItemData(itemID);
+    MyTreeItemData* selData = (MyTreeItemData*)TreeCtrl1->GetItemData(itemID);
     EffectPreset* preset = selData->AsPreset();
 
     xLightParent->UpdateEffectPreset(preset);
@@ -576,27 +530,25 @@ void EffectTreeDialog::OnbtUpdateClick(wxCommandEvent& event)
     GenerateGifImage(itemID, true);
 }
 
-void EffectTreeDialog::OnbtRenameClick(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnbtRenameClick(wxCommandEvent& event) {
     wxTreeItemId itemID = TreeCtrl1->GetSelection();
-    if (!itemID.IsOk())
-    {
+    if (!itemID.IsOk()) {
         DisplayError(_("You Cannot rename this item"), this);
         ValidateWindow();
         return;
     }
 
-    MyTreeItemData *itemData= (MyTreeItemData *)TreeCtrl1->GetItemData(itemID);
+    MyTreeItemData* itemData = (MyTreeItemData*)TreeCtrl1->GetItemData(itemID);
     EffectPresetItem* item = itemData->GetItem();
 
     wxString newName = item->GetName();
-    if (!PromptForName(this, newName, false, itemData->IsGroup())) return;
+    if (!PromptForName(this, newName, false, itemData->IsGroup()))
+        return;
 
     DeleteGifImage(itemID);
 
     _presetManager->RenameItem(item, newName.ToStdString());
-    if (!itemData->IsGroup())
-    {
+    if (!itemData->IsGroup()) {
         EffectPreset* preset = itemData->AsPreset();
         newName += " [" + ParseLayers(newName, preset->GetSettings()) + ", " + ParseDuration(newName, preset->GetSettings()) + "ms]";
     }
@@ -607,8 +559,7 @@ void EffectTreeDialog::OnbtRenameClick(wxCommandEvent& event)
     ValidateWindow();
 }
 
-void EffectTreeDialog::DeleteSelectedItem()
-{
+void EffectTreeDialog::DeleteSelectedItem() {
     std::lock_guard<std::mutex> lock(preset_mutex);
 
     wxTreeItemId itemID = TreeCtrl1->GetSelection();
@@ -635,43 +586,38 @@ void EffectTreeDialog::DeleteSelectedItem()
     ValidateWindow();
 }
 
-void EffectTreeDialog::OnbtDeleteClick(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnbtDeleteClick(wxCommandEvent& event) {
     DeleteSelectedItem();
 }
 
-void EffectTreeDialog::OnbtAddGroupClick(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnbtAddGroupClick(wxCommandEvent& event) {
     wxTreeItemId itemID = TreeCtrl1->GetSelection();
     wxTreeItemId parentID;
-    MyTreeItemData *parentData;
+    MyTreeItemData* parentData;
 
-	if (!itemID.IsOk())
-    {
+    if (!itemID.IsOk()) {
         DisplayError(_("A group cannot be added at the currently selected location"), this);
         ValidateWindow();
         return;
     }
-	
+
     wxString name;
-    if (!PromptForName(this, name, true, true)) return;
+    if (!PromptForName(this, name, true, true))
+        return;
 
     // update Choice_Presets
-    MyTreeItemData *itemData=(MyTreeItemData *)TreeCtrl1->GetItemData(itemID);
-    if( itemData->IsGroup() )
-    {
+    MyTreeItemData* itemData = (MyTreeItemData*)TreeCtrl1->GetItemData(itemID);
+    if (itemData->IsGroup()) {
         parentID = itemID;
         parentData = itemData;
-    }
-    else
-    {
+    } else {
         parentID = TreeCtrl1->GetItemParent(itemID);
-        parentData=(MyTreeItemData *)TreeCtrl1->GetItemData(parentID);
+        parentData = (MyTreeItemData*)TreeCtrl1->GetItemData(parentID);
     }
 
     EffectPresetGroup* parentGroup = parentData->AsGroup();
     EffectPresetGroup* newGroup = _presetManager->AddGroup(parentGroup, name.ToStdString());
-    itemID = TreeCtrl1->AppendItem(parentID, name, -1,-1, new MyTreeItemData(newGroup));
+    itemID = TreeCtrl1->AppendItem(parentID, name, -1, -1, new MyTreeItemData(newGroup));
     TreeCtrl1->SetItemHasChildren(itemID);
     TreeCtrl1->Expand(parentID);
     TreeCtrl1->SelectItem(itemID);
@@ -680,19 +626,16 @@ void EffectTreeDialog::OnbtAddGroupClick(wxCommandEvent& event)
     ValidateWindow();
 }
 
-void EffectTreeDialog::OnTreeCtrl1ItemActivated(wxTreeEvent& event)
-{
+void EffectTreeDialog::OnTreeCtrl1ItemActivated(wxTreeEvent& event) {
     ApplyEffect(true);
     ValidateWindow();
 }
 
-void EffectTreeDialog::EffectsFileDirty()
-{
+void EffectTreeDialog::EffectsFileDirty() {
     xLightParent->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "EffectsFileDirty");
 }
 
-void EffectTreeDialog::OnTreeCtrl1BeginDrag(wxTreeEvent& event)
-{
+void EffectTreeDialog::OnTreeCtrl1BeginDrag(wxTreeEvent& event) {
     wxTreeItemId draggedItem = TreeCtrl1->GetSelection();
 
     if (draggedItem.IsOk() && draggedItem != treeRootID) {
@@ -704,24 +647,22 @@ void EffectTreeDialog::OnTreeCtrl1BeginDrag(wxTreeEvent& event)
     }
 }
 
-void EffectTreeDialog::AddEffect(pugi::xml_node ele, wxTreeItemId curGroupID)
-{
+void EffectTreeDialog::AddEffect(pugi::xml_node ele, wxTreeItemId curGroupID) {
     wxString name = ele.attribute("name").as_string();
     wxString settings = ele.attribute("settings").as_string();
     wxString version = ele.attribute("version").as_string("0000");
     wxString xlVer = ele.attribute("xLightsVersion").as_string("4.0");
-    if (!name.IsEmpty())
-    {
+    if (!name.IsEmpty()) {
         if (NameCollissionInGroup(curGroupID, name)) {
             DisplayError(wxString::Format("Preset '%s' already exists at '%s'", name, GetFullPathOfGroup(curGroupID)), this);
             return;
         }
-        MyTreeItemData *parentData = (MyTreeItemData *)TreeCtrl1->GetItemData(curGroupID);
+        MyTreeItemData* parentData = (MyTreeItemData*)TreeCtrl1->GetItemData(curGroupID);
         EffectPresetGroup* parentGroup = parentData->AsGroup();
         EffectPreset* newPreset = _presetManager->AddPreset(parentGroup, name.ToStdString(),
-                                                             settings.ToStdString(),
-                                                             version.ToStdString(),
-                                                             xlVer.ToStdString());
+                                                            settings.ToStdString(),
+                                                            version.ToStdString(),
+                                                            xlVer.ToStdString());
         wxString displayName = name + " [" + ParseLayers(name, settings) + ", " + ParseDuration(name, settings) + "ms]";
         auto newItem = TreeCtrl1->AppendItem(curGroupID, displayName, -1, -1, new MyTreeItemData(newPreset));
         TreeCtrl1->Expand(curGroupID);
@@ -730,8 +671,7 @@ void EffectTreeDialog::AddEffect(pugi::xml_node ele, wxTreeItemId curGroupID)
     }
 }
 
-void EffectTreeDialog::AddGroup(pugi::xml_node ele, wxTreeItemId curGroupID)
-{
+void EffectTreeDialog::AddGroup(pugi::xml_node ele, wxTreeItemId curGroupID) {
     wxString name = ele.attribute("name").as_string();
 
     if (NameCollissionInGroup(curGroupID, name)) {
@@ -739,51 +679,41 @@ void EffectTreeDialog::AddGroup(pugi::xml_node ele, wxTreeItemId curGroupID)
         return;
     }
 
-    if (!name.IsEmpty())
-    {
-        MyTreeItemData *parentData = (MyTreeItemData*)TreeCtrl1->GetItemData(curGroupID);
+    if (!name.IsEmpty()) {
+        MyTreeItemData* parentData = (MyTreeItemData*)TreeCtrl1->GetItemData(curGroupID);
         EffectPresetGroup* parentGroup = parentData->AsGroup();
         EffectPresetGroup* newGroup = _presetManager->AddGroup(parentGroup, name.ToStdString());
 
         wxTreeItemId nextGroupID = TreeCtrl1->AppendItem(curGroupID, name, -1, -1, new MyTreeItemData(newGroup));
         TreeCtrl1->SetItemHasChildren(nextGroupID);
 
-        for (pugi::xml_node ele2 = ele.first_child(); ele2; ele2 = ele2.next_sibling())
-        {
-            if (std::string_view(ele2.name()) == "effect")
-            {
+        for (pugi::xml_node ele2 = ele.first_child(); ele2; ele2 = ele2.next_sibling()) {
+            if (std::string_view(ele2.name()) == "effect") {
                 AddEffect(ele2, nextGroupID);
-            }
-            else if (std::string_view(ele2.name()) == "effectGroup")
-            {
+            } else if (std::string_view(ele2.name()) == "effectGroup") {
                 AddGroup(ele2, nextGroupID);
             }
         }
     }
 }
 
-void EffectTreeDialog::OnbtImportClick(wxCommandEvent& event)
-{
-    wxFileDialog* OpenDialog = new wxFileDialog( this, "Choose file to Import", wxEmptyString, wxEmptyString,
+void EffectTreeDialog::OnbtImportClick(wxCommandEvent& event) {
+    wxFileDialog* OpenDialog = new wxFileDialog(this, "Choose file to Import", wxEmptyString, wxEmptyString,
                                                 "Preset files (*.xpreset)|*.xpreset|"
 #ifdef __WXOSX__
-                                                "Show files (*.xml)|*.xml",   //cannot filter by full name, only extension
+                                                "Show files (*.xml)|*.xml", // cannot filter by full name, only extension
 #else
                                                 "Show files (xlights_rgbeffects.xml)|xlights_rgbeffects.xml",
 #endif
                                                 wxFD_OPEN | wxFD_FILE_MUST_EXIST | wxFD_MULTIPLE, wxDefaultPosition);
     OpenDialog->SetDirectory(xLightParent->CurrentDir);
-    if (OpenDialog->ShowModal() == wxID_OK)
-    {
+    if (OpenDialog->ShowModal() == wxID_OK) {
         wxTreeItemId id = TreeCtrl1->GetSelection();
         wxTreeItemId insertPoint = treeRootID;
 
-        if ((id.IsOk() && id == treeRootID) || TreeCtrl1->HasChildren(id))
-        {
+        if ((id.IsOk() && id == treeRootID) || TreeCtrl1->HasChildren(id)) {
             insertPoint = id;
-        }
-        else if (id.IsOk())
-        {
+        } else if (id.IsOk()) {
             // if on an effect then add it to the same parent
             insertPoint = TreeCtrl1->GetItemParent(id);
         }
@@ -792,8 +722,7 @@ void EffectTreeDialog::OnbtImportClick(wxCommandEvent& event)
         wxArrayString files;
         OpenDialog->GetFilenames(files);
 
-        for (auto it = files.begin(); it != files.end(); ++it)
-        {
+        for (auto it = files.begin(); it != files.end(); ++it) {
             wxString filename = *it;
             wxFileName name_and_path(filename);
             name_and_path.SetPath(fDir);
@@ -810,37 +739,24 @@ void EffectTreeDialog::OnbtImportClick(wxCommandEvent& event)
 
             pugi::xml_node input_root = input_xml.document_element();
 
-            if (name_and_path.GetExt().Lower() == "xpreset" || std::string_view(input_root.name()) == "preset")
-            {
-                for (pugi::xml_node ele = input_root.first_child(); ele; ele = ele.next_sibling())
-                {
-                    if (std::string_view(ele.name()) == "effectGroup")
-                    {
+            if (name_and_path.GetExt().Lower() == "xpreset" || std::string_view(input_root.name()) == "preset") {
+                for (pugi::xml_node ele = input_root.first_child(); ele; ele = ele.next_sibling()) {
+                    if (std::string_view(ele.name()) == "effectGroup") {
                         AddGroup(ele, insertPoint);
                         presetFound = true;
-                    }
-                    else
-                    {
+                    } else {
                         AddEffect(ele, insertPoint);
                         presetFound = true;
                     }
                 }
-            }
-            else
-            {
-                for (pugi::xml_node e = input_root.first_child(); e; e = e.next_sibling())
-                {
-                    if (std::string_view(e.name()) == "effects")
-                    {
-                        for (pugi::xml_node ele = e.first_child(); ele; ele = ele.next_sibling())
-                        {
-                            if (std::string_view(ele.name()) == "effectGroup")
-                            {
+            } else {
+                for (pugi::xml_node e = input_root.first_child(); e; e = e.next_sibling()) {
+                    if (std::string_view(e.name()) == "effects") {
+                        for (pugi::xml_node ele = e.first_child(); ele; ele = ele.next_sibling()) {
+                            if (std::string_view(ele.name()) == "effectGroup") {
                                 AddGroup(ele, insertPoint);
                                 presetFound = true;
-                            }
-                            else
-                            {
+                            } else {
                                 AddEffect(ele, insertPoint);
                                 presetFound = true;
                             }
@@ -849,8 +765,7 @@ void EffectTreeDialog::OnbtImportClick(wxCommandEvent& event)
                 }
             }
 
-            if (!presetFound)
-            {
+            if (!presetFound) {
                 DisplayError(wxString::Format("No presets found, Presets file %s is empty.\n", filename).ToStdString(), this);
                 ValidateWindow();
                 return;
@@ -861,17 +776,18 @@ void EffectTreeDialog::OnbtImportClick(wxCommandEvent& event)
     ValidateWindow();
 }
 
-void EffectTreeDialog::OnbtExportClick(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnbtExportClick(wxCommandEvent& event) {
     wxTreeItemId id = TreeCtrl1->GetSelection();
-    if (!id.IsOk()) return;
+    if (!id.IsOk())
+        return;
 
     wxString name = TreeCtrl1->GetItemText(id);
 
-    wxLogNull logNo; //kludge: avoid "error 0" message from wxWidgets after new file is written
+    wxLogNull logNo; // kludge: avoid "error 0" message from wxWidgets after new file is written
 
     wxString filename = wxFileSelector(_("Choose output file"), wxEmptyString, StripLayers(name), wxEmptyString, "Preset files (*.xpreset)|*.xpreset", wxFD_SAVE | wxFD_OVERWRITE_PROMPT);
-    if (filename.IsEmpty()) return;
+    if (filename.IsEmpty())
+        return;
 
     FileSerializingVisitor visitor(filename.ToStdString());
     if (!visitor.IsOpen()) {
@@ -910,88 +826,103 @@ void EffectTreeDialog::OnbtExportClick(wxCommandEvent& event)
 
 // This handles all the enabling and disabling of buttons ... stops lots of dialog boxes popping up when users do something
 // that is not allowed.
-void EffectTreeDialog::ValidateWindow()
-{
+void EffectTreeDialog::ValidateWindow() {
     bool effectselected = false;
     bool effectgroupselected = false;
 
     wxTreeItemId id = TreeCtrl1->GetSelection();
 
-    if (!id.IsOk() || id == treeRootID)
-    {
+    if (!id.IsOk() || id == treeRootID) {
         // nothing selected
-    }
-    else if (TreeCtrl1->HasChildren(id))
-    {
+    } else if (TreeCtrl1->HasChildren(id)) {
         effectgroupselected = true;
-    }
-    else
-    {
+    } else {
         effectselected = true;
     }
 
-    if (effectgroupselected)
-    {
+    if (effectgroupselected) {
         btApply->Disable();
         btExport->Enable();
         btDelete->Enable();
         btUpdate->Disable();
         btRename->Enable();
-    }
-    else if (effectselected)
-    {
+        btPosition->Disable();
+        btLayers->Disable();
+
+    } else if (effectselected) {
         btApply->Enable();
         btExport->Enable();
         btDelete->Enable();
         btUpdate->Enable();
         btRename->Enable();
-    }
-    else
-    {
+        btPosition->Enable();
+        btLayers->Enable();
+    } else {
         btApply->Disable();
-        if (id == treeRootID)
-        {
+        if (id == treeRootID) {
             btExport->Enable();
-        }
-        else
-        {
+        } else {
             btExport->Disable();
         }
         btDelete->Disable();
         btUpdate->Disable();
         btRename->Disable();
+        btPosition->Disable();
+        btLayers->Disable();
     }
 }
 
-
-void EffectTreeDialog::OnTreeCtrl1SelectionChanged(wxTreeEvent& event)
-{
+void EffectTreeDialog::OnTreeCtrl1SelectionChanged(wxTreeEvent& event) {
     ValidateWindow();
 
-    GenerateGifImage(TreeCtrl1->GetSelection());
+    wxTreeItemId sel = TreeCtrl1->GetSelection();
+    if (sel.IsOk() && !TreeCtrl1->HasChildren(sel)) {
+        MyTreeItemData* item = (MyTreeItemData*)TreeCtrl1->GetItemData(sel);
+        EffectPreset* preset = item ? item->AsPreset() : nullptr;
+        _layerMode = preset != nullptr && (preset->GetSettings().find("\tLAYER:") != std::string::npos);
+        UpdateModeButtons();
+    }
+
+    GenerateGifImage(sel);
 }
 
-wxTreeItemId EffectTreeDialog::findTreeItem(wxTreeCtrl* pTreeCtrl, const wxTreeItemId& root, const wxTreeItemId& startID, const wxString& text, bool &startfound)
-{
+void EffectTreeDialog::UpdateModeButtons() {
+    if (btPosition == nullptr || btLayers == nullptr)
+        return;
+    btPosition->SetBackgroundColour(_layerMode ? wxNullColour : wxColour(100, 180, 100));
+    btLayers->SetBackgroundColour(_layerMode ? wxColour(100, 180, 100) : wxNullColour);
+    btPosition->Refresh();
+    btLayers->Refresh();
+}
+
+void EffectTreeDialog::OnBtnPositionClick(wxCommandEvent& event) {
+    _layerMode = false;
+    UpdateModeButtons();
+}
+
+void EffectTreeDialog::OnBtnLayersClick(wxCommandEvent& event) {
+    _layerMode = true;
+    UpdateModeButtons();
+}
+
+wxTreeItemId EffectTreeDialog::findTreeItem(wxTreeCtrl* pTreeCtrl, const wxTreeItemId& root, const wxTreeItemId& startID, const wxString& text, bool& startfound) {
     wxTreeItemId item = root, child;
     wxTreeItemIdValue cookie;
     wxString findtext(text), itemtext;
     bool bFound;
 
-    //make search case insensitive
+    // make search case insensitive
     findtext.MakeLower();
 
-    //Loop through all element and branches, first look for start location, second loop until new element of text found
-    while (item.IsOk())
-    {
-        if (startfound)
-        {   //second state found
+    // Loop through all element and branches, first look for start location, second loop until new element of text found
+    while (item.IsOk()) {
+        if (startfound) { // second state found
             itemtext = pTreeCtrl->GetItemText(item).MakeLower();
             bFound = itemtext.Contains(findtext);
-            if (bFound)//text found
+            if (bFound) // text found
                 return item;
         }
-        //state element found
+        // state element found
         if (item == startID)
             startfound = true;
 
@@ -1007,22 +938,19 @@ wxTreeItemId EffectTreeDialog::findTreeItem(wxTreeCtrl* pTreeCtrl, const wxTreeI
     return item;
 }
 
-void EffectTreeDialog::OnETButton1Click(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnETButton1Click(wxCommandEvent& event) {
     SearchForText();
 }
 
-void EffectTreeDialog::OnTextCtrl1TextEnter(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnTextCtrl1TextEnter(wxCommandEvent& event) {
     SearchForText();
 }
 
-void EffectTreeDialog::SearchForText()
-{
+void EffectTreeDialog::SearchForText() {
     wxArrayTreeItemIds Selections;
     wxTreeItemId item;
 
-    //dont search for blank strings
+    // dont search for blank strings
     if (TextCtrl1->GetValue().IsEmpty())
         return;
 
@@ -1032,22 +960,20 @@ void EffectTreeDialog::SearchForText()
     if (!TreeCtrl1->GetCount())
         return;
 
-    //Get Current selected ID and search from there
+    // Get Current selected ID and search from there
     wxTreeItemId startID = TreeCtrl1->GetSelection();
 
-    bool bStartFound = false; //pass a bool by ref to keep track if staring location was found, too lazy for state machine
+    bool bStartFound = false; // pass a bool by ref to keep track if staring location was found, too lazy for state machine
     item = findTreeItem(TreeCtrl1, TreeCtrl1->GetRootItem(), startID, TextCtrl1->GetValue(), bStartFound);
 
-    //none found, start at the top of tree this time
-    if (!item.IsOk())
-    {
+    // none found, start at the top of tree this time
+    if (!item.IsOk()) {
         bStartFound = false;
         item = findTreeItem(TreeCtrl1, TreeCtrl1->GetRootItem(), TreeCtrl1->GetRootItem(), TextCtrl1->GetValue(), bStartFound);
     }
 
-    //none found anywhere
-    if (!item.IsOk())
-    {
+    // none found anywhere
+    if (!item.IsOk()) {
         DisplayInfo(_("Search Found No Results."), this);
         return;
     }
@@ -1058,8 +984,7 @@ void EffectTreeDialog::SearchForText()
     TreeCtrl1->EnsureVisible(item);
 }
 
-wxString EffectTreeDialog::generatePresetName(wxTreeItemId itemID)
-{
+wxString EffectTreeDialog::generatePresetName(wxTreeItemId itemID) {
     wxString presetName;
     if (itemID.IsOk()) {
         MyTreeItemData* itemData = (MyTreeItemData*)TreeCtrl1->GetItemData(itemID);
@@ -1086,8 +1011,7 @@ wxString EffectTreeDialog::generatePresetName(wxTreeItemId itemID)
     return presetName;
 }
 
-void EffectTreeDialog::GenerateGifImage(wxTreeItemId itemID, bool regenerate)
-{
+void EffectTreeDialog::GenerateGifImage(wxTreeItemId itemID, bool regenerate) {
     StopGifImage();
     wxString const fullName = generatePresetName(itemID);
     if (!fullName.IsEmpty()) {
@@ -1096,9 +1020,9 @@ void EffectTreeDialog::GenerateGifImage(wxTreeItemId itemID, bool regenerate)
         if (!FileExists(filePath) || regenerate) {
             wxWindowDisabler disableAll;
             wxBusyInfo wait(wxBusyInfoFlags()
-                            .Parent(this)
-                            .Text("Generating Effect Preview...")
-                            .Icon(wxArtProvider::GetIcon(wxART_MAKE_ART_ID_FROM_STR(_T("xlART_EFFECTS")),wxART_OTHER, wxSize(64, 64))));
+                                .Parent(this)
+                                .Text("Generating Effect Preview...")
+                                .Icon(wxArtProvider::GetIcon(wxART_MAKE_ART_ID_FROM_STR(_T("xlART_EFFECTS")), wxART_OTHER, wxSize(64, 64))));
 
             xLightParent->WriteGIFForPreset(fullName);
         }
@@ -1106,14 +1030,15 @@ void EffectTreeDialog::GenerateGifImage(wxTreeItemId itemID, bool regenerate)
     }
 }
 
-void EffectTreeDialog::LoadGifImage(wxString const& path)
-{
+void EffectTreeDialog::LoadGifImage(wxString const& path) {
     TimerGif.Stop();
     if (FileExists(path) && AnimatedImage::IsGIF(path) && !xLightParent->HidePresetPreview()) {
         std::ifstream file(path.ToStdString(), std::ios::binary | std::ios::ate);
-        if (!file.is_open()) return;
+        if (!file.is_open())
+            return;
         auto sz = file.tellg();
-        if (sz <= 0) return;
+        if (sz <= 0)
+            return;
         file.seekg(0);
         std::vector<uint8_t> data(static_cast<size_t>(sz));
         file.read(reinterpret_cast<char*>(data.data()), sz);
@@ -1123,8 +1048,7 @@ void EffectTreeDialog::LoadGifImage(wxString const& path)
         if (!gifImage->IsOk()) {
             gifImage = nullptr;
             StaticBitmapGif->SetBitmap(*_blankGIFImage.get());
-        }
-        else {
+        } else {
             frameCount = 0;
             TimerGif.Start(GIF_DELAY);
         }
@@ -1133,9 +1057,8 @@ void EffectTreeDialog::LoadGifImage(wxString const& path)
     }
 }
 
-void EffectTreeDialog::PlayGifImage()
-{
-    if(gifImage) {
+void EffectTreeDialog::PlayGifImage() {
+    if (gifImage) {
         int previewSize = GetOptimalPreviewSize();
         const xlImage& xlFrame = gifImage->GetFrameForTime(frameCount * GIF_DELAY, true);
         xlImage scaled = xlFrame.Copy();
@@ -1147,14 +1070,12 @@ void EffectTreeDialog::PlayGifImage()
     }
 }
 
-void EffectTreeDialog::OnTimerGifTrigger(wxTimerEvent& event)
-{
+void EffectTreeDialog::OnTimerGifTrigger(wxTimerEvent& event) {
     ++frameCount;
     PlayGifImage();
 }
 
-void EffectTreeDialog::OnTreeCtrl1KeyDown(wxTreeEvent& event)
-{
+void EffectTreeDialog::OnTreeCtrl1KeyDown(wxTreeEvent& event) {
     auto ke = event.GetKeyEvent();
     if (!ke.CmdDown() && !ke.ControlDown() && !ke.ShiftDown() && !ke.AltDown() && event.GetKeyCode() == WXK_DELETE) {
         DeleteSelectedItem();
@@ -1162,8 +1083,7 @@ void EffectTreeDialog::OnTreeCtrl1KeyDown(wxTreeEvent& event)
     }
 }
 
-void EffectTreeDialog::StopGifImage()
-{
+void EffectTreeDialog::StopGifImage() {
     // reset blank image to current optimal size so dialog doesn't jump around
     int previewSize = GetOptimalPreviewSize();
     _blankGIFImage.reset(new wxBitmap(previewSize, previewSize, true));
@@ -1173,8 +1093,7 @@ void EffectTreeDialog::StopGifImage()
     gifImage = nullptr;
 }
 
-void EffectTreeDialog::DeleteGifImage(wxTreeItemId itemID)
-{
+void EffectTreeDialog::DeleteGifImage(wxTreeItemId itemID) {
     StopGifImage();
     wxString const fullName = generatePresetName(itemID);
     if (!fullName.IsEmpty()) {
@@ -1188,7 +1107,6 @@ void EffectTreeDialog::DeleteGifImage(wxTreeItemId itemID)
 
 #define PREVIEW_PROPORTION 0.25f
 int EffectTreeDialog::GetOptimalPreviewSize() {
-
     // size based on proportion of current dialog size
     int currDialogWidth = GetSize().GetWidth();
     int size = std::floor(currDialogWidth * PREVIEW_PROPORTION);
@@ -1291,8 +1209,7 @@ void EffectTreeDialog::DeleteGifsRecursive(wxTreeItemId parentId) {
     }
 }
 
-std::vector<std::string> EffectTreeDialog::GetGifFileNamesRecursive(wxTreeItemId itemId)
-{
+std::vector<std::string> EffectTreeDialog::GetGifFileNamesRecursive(wxTreeItemId itemId) {
     std::vector<std::string> gifNames;
 
     if (!TreeCtrl1->ItemHasChildren(itemId)) {
@@ -1318,7 +1235,7 @@ std::vector<std::string> EffectTreeDialog::GetGifFileNamesRecursive(wxTreeItemId
             gifNames.push_back(gifFileName.GetFullPath());
         }
 
-        if ( TreeCtrl1->ItemHasChildren(child)) {
+        if (TreeCtrl1->ItemHasChildren(child)) {
             auto list = GetGifFileNamesRecursive(child);
             if (!list.empty()) {
                 gifNames.insert(gifNames.end(), list.begin(), list.end());
@@ -1363,111 +1280,108 @@ void EffectTreeDialog::OnDropEffect(wxCommandEvent& event) {
     int x = event.GetExtraLong() >> 16;
     int y = event.GetExtraLong() & 0xFFFF;
 
-    switch(event.GetInt()) {
-        case 0: {
+    switch (event.GetInt()) {
+    case 0: {
+        // Effect Dropped
+        int flags = wxTREE_HITTEST_ONITEM;
 
-            // Effect Dropped
-            int flags = wxTREE_HITTEST_ONITEM;
+        wxTreeItemId dstItemId = TreeCtrl1->HitTest(wxPoint(x, y), flags);
 
-            wxTreeItemId dstItemId = TreeCtrl1->HitTest(wxPoint(x, y), flags);
+        if (dstItemId.IsOk()) {
+            bool addingToGroup = false;
+            bool srcIsGroup = false;
+            bool srcIsExpanded = false;
+            bool parentChanged = false;
 
-            if (dstItemId.IsOk()) {
+            TreeCtrl1->SetItemDropHighlight(dstItemId, false);
 
-                bool addingToGroup = false;
-                bool srcIsGroup = false;
-                bool srcIsExpanded = false;
-                bool parentChanged = false;
+            // gather drag source item info
+            wxTreeItemId srcItemId = TreeCtrl1->GetSelection();
+            wxString srcName = TreeCtrl1->GetItemText(srcItemId);
 
-                TreeCtrl1->SetItemDropHighlight(dstItemId, false);
-
-                // gather drag source item info
-                wxTreeItemId srcItemId = TreeCtrl1->GetSelection();
-                wxString srcName = TreeCtrl1->GetItemText(srcItemId);
-
-                if (TreeCtrl1->HasChildren(srcItemId)) {
-                    srcIsGroup = true;
-                    srcIsExpanded = TreeCtrl1->IsExpanded(srcItemId);
-                }
-
-                wxTreeItemId dstParentId = TreeCtrl1->GetItemParent(dstItemId);
-                MyTreeItemData* srcData = (MyTreeItemData*)TreeCtrl1->GetItemData(srcItemId);
-                EffectPresetItem* srcItem = srcData->GetItem();
-
-                // gather drop target info
-                MyTreeItemData* dstData = (MyTreeItemData*)TreeCtrl1->GetItemData(dstItemId);
-                EffectPresetItem* dstItem = dstData->GetItem();
-
-                if (dstData->IsGroup()) {
-                    dstParentId = dstItemId;
-                    addingToGroup = true;
-                }
-
-                MyTreeItemData* dstParentData = (MyTreeItemData*)TreeCtrl1->GetItemData(dstParentId);
-                EffectPresetGroup* dstParentGroup = dstParentData->AsGroup();
-
-                // Now Perform the move / rgbeffects updates
-                std::vector<std::string> priorGifFiles;
-
-                if (TreeCtrl1->GetItemParent(srcItemId) != dstParentId) {
-                    parentChanged = true;
-                    priorGifFiles = GetGifFileNamesRecursive(srcItemId);
-                }
-                TreeCtrl1->Delete(srcItemId);
-
-                if (addingToGroup) {
-                    _presetManager->MoveItem(srcItem, dstParentGroup, nullptr);
-                } else {
-                    // Insert after dstItem: we need to find the item before dstItem in parent
-                    // to get the correct "after" position. MoveItem inserts after the given item.
-                    _presetManager->MoveItem(srcItem, dstParentGroup, dstItem);
-                }
-
-                wxTreeItemId newId;
-                if (addingToGroup) {
-                    newId = TreeCtrl1->AppendItem(dstParentId, srcName, -1, -1, new MyTreeItemData(srcItem));
-                } else {
-                    newId = TreeCtrl1->InsertItem(dstParentId, dstItemId, srcName, -1, -1, new MyTreeItemData(srcItem));
-                }
-
-                if (srcIsGroup) {
-                    AddTreeElementsRecursive(static_cast<EffectPresetGroup&>(*srcItem), newId);
-                    TreeCtrl1->SetItemHasChildren(newId);
-                    if (srcIsExpanded) {
-                        TreeCtrl1->Expand(newId);
-                    }
-                }
-
-                if (parentChanged) {
-                    // get new filenames
-                    auto newGifFiles = GetGifFileNamesRecursive(newId);
-
-                    // rename the gifs to new name if they exist
-                    while (!priorGifFiles.empty()) {
-                        wxFileName priorGifFn(priorGifFiles.front());
-
-                        if (priorGifFn.IsOk() && FileExists(priorGifFn)) {
-                            wxFileName newGifFn(newGifFiles.front());
-                            wxRenameFile(priorGifFn.GetFullPath(), newGifFiles.front());
-                        }
-                        priorGifFiles.erase(priorGifFiles.begin());
-                        newGifFiles.erase(newGifFiles.begin());
-                    }
-                }
-
-                TreeCtrl1->SelectItem(newId);
-                TreeCtrl1->EnsureVisible(newId);
-                EffectsFileDirty();
-                ValidateWindow();
+            if (TreeCtrl1->HasChildren(srcItemId)) {
+                srcIsGroup = true;
+                srcIsExpanded = TreeCtrl1->IsExpanded(srcItemId);
             }
-            break;
+
+            wxTreeItemId dstParentId = TreeCtrl1->GetItemParent(dstItemId);
+            MyTreeItemData* srcData = (MyTreeItemData*)TreeCtrl1->GetItemData(srcItemId);
+            EffectPresetItem* srcItem = srcData->GetItem();
+
+            // gather drop target info
+            MyTreeItemData* dstData = (MyTreeItemData*)TreeCtrl1->GetItemData(dstItemId);
+            EffectPresetItem* dstItem = dstData->GetItem();
+
+            if (dstData->IsGroup()) {
+                dstParentId = dstItemId;
+                addingToGroup = true;
+            }
+
+            MyTreeItemData* dstParentData = (MyTreeItemData*)TreeCtrl1->GetItemData(dstParentId);
+            EffectPresetGroup* dstParentGroup = dstParentData->AsGroup();
+
+            // Now Perform the move / rgbeffects updates
+            std::vector<std::string> priorGifFiles;
+
+            if (TreeCtrl1->GetItemParent(srcItemId) != dstParentId) {
+                parentChanged = true;
+                priorGifFiles = GetGifFileNamesRecursive(srcItemId);
+            }
+            TreeCtrl1->Delete(srcItemId);
+
+            if (addingToGroup) {
+                _presetManager->MoveItem(srcItem, dstParentGroup, nullptr);
+            } else {
+                // Insert after dstItem: we need to find the item before dstItem in parent
+                // to get the correct "after" position. MoveItem inserts after the given item.
+                _presetManager->MoveItem(srcItem, dstParentGroup, dstItem);
+            }
+
+            wxTreeItemId newId;
+            if (addingToGroup) {
+                newId = TreeCtrl1->AppendItem(dstParentId, srcName, -1, -1, new MyTreeItemData(srcItem));
+            } else {
+                newId = TreeCtrl1->InsertItem(dstParentId, dstItemId, srcName, -1, -1, new MyTreeItemData(srcItem));
+            }
+
+            if (srcIsGroup) {
+                AddTreeElementsRecursive(static_cast<EffectPresetGroup&>(*srcItem), newId);
+                TreeCtrl1->SetItemHasChildren(newId);
+                if (srcIsExpanded) {
+                    TreeCtrl1->Expand(newId);
+                }
+            }
+
+            if (parentChanged) {
+                // get new filenames
+                auto newGifFiles = GetGifFileNamesRecursive(newId);
+
+                // rename the gifs to new name if they exist
+                while (!priorGifFiles.empty()) {
+                    wxFileName priorGifFn(priorGifFiles.front());
+
+                    if (priorGifFn.IsOk() && FileExists(priorGifFn)) {
+                        wxFileName newGifFn(newGifFiles.front());
+                        wxRenameFile(priorGifFn.GetFullPath(), newGifFiles.front());
+                    }
+                    priorGifFiles.erase(priorGifFiles.begin());
+                    newGifFiles.erase(newGifFiles.begin());
+                }
+            }
+
+            TreeCtrl1->SelectItem(newId);
+            TreeCtrl1->EnsureVisible(newId);
+            EffectsFileDirty();
+            ValidateWindow();
         }
-        default:
-            break;
+        break;
+    }
+    default:
+        break;
     }
 }
 
 void EffectTreeDialogTextDropTarget::UpdateItemFeedback(wxTreeItemId currItem) {
-
     if (_lastDragOverItem.IsOk()) {
         _tree->SetItemDropHighlight(_lastDragOverItem, false);
     }
@@ -1478,8 +1392,7 @@ void EffectTreeDialogTextDropTarget::UpdateItemFeedback(wxTreeItemId currItem) {
 }
 
 #define EXPAND_DELAY 1000
-wxDragResult EffectTreeDialogTextDropTarget::OnDragOver(wxCoord x, wxCoord y, wxDragResult def)
-{
+wxDragResult EffectTreeDialogTextDropTarget::OnDragOver(wxCoord x, wxCoord y, wxDragResult def) {
     static wxLongLong lastHoverTime = wxGetUTCTimeMillis();
 
     if (_type == "EffectPresetOrGroup") {
@@ -1494,7 +1407,7 @@ wxDragResult EffectTreeDialogTextDropTarget::OnDragOver(wxCoord x, wxCoord y, wx
                 return wxDragNone;
             }
 
-            MyTreeItemData *srcItemData = (MyTreeItemData *)_tree->GetItemData(srcItem);
+            MyTreeItemData* srcItemData = (MyTreeItemData*)_tree->GetItemData(srcItem);
 
             wxTreeItemId parent = targetItem;
 
@@ -1535,21 +1448,20 @@ wxDragResult EffectTreeDialogTextDropTarget::OnDragOver(wxCoord x, wxCoord y, wx
 }
 
 bool EffectTreeDialogTextDropTarget::OnDropText(wxCoord x, wxCoord y, const wxString& data) {
-    if (data == "") return false;
+    if (data == "")
+        return false;
 
     long mousePos = x;
     mousePos = mousePos << 16;
     mousePos += y;
     wxCommandEvent event(EVT_EFFTREEDROP);
-    event.SetString(data); // this is the dropped string
+    event.SetString(data);        // this is the dropped string
     event.SetExtraLong(mousePos); // this is the mouse position packed into a long
 
     wxArrayString parms = wxSplit(data, ',');
 
-    if (parms[0] == "EffectPresetOrGroup")
-    {
-        if (_type == "EffectPresetOrGroup")
-        {
+    if (parms[0] == "EffectPresetOrGroup") {
+        if (_type == "EffectPresetOrGroup") {
             event.SetInt(0);
             wxPostEvent(_owner, event);
             return true;
@@ -1559,8 +1471,7 @@ bool EffectTreeDialogTextDropTarget::OnDropText(wxCoord x, wxCoord y, const wxSt
     return false;
 }
 
-void EffectTreeDialog::OnButton_TopClick(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnButton_TopClick(wxCommandEvent& event) {
     wxTreeItemId movedItem = TreeCtrl1->GetSelection();
     if (!movedItem.IsOk() || movedItem == treeRootID) {
         return;
@@ -1586,22 +1497,20 @@ void EffectTreeDialog::OnButton_TopClick(wxCommandEvent& event)
     MoveNode(firstChild, nextSiblingId, false);
 }
 
-void EffectTreeDialog::OnButton_MoveUpClick(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnButton_MoveUpClick(wxCommandEvent& event) {
     wxTreeItemId movedItem = TreeCtrl1->GetSelection();
     if (!movedItem.IsOk() || movedItem == treeRootID) {
         return;
     }
 
     wxTreeItemId prevSiblingId = TreeCtrl1->GetPrevSibling(movedItem);
-    if (!prevSiblingId.IsOk()) { 
+    if (!prevSiblingId.IsOk()) {
         return;
     }
     MoveNode(prevSiblingId, movedItem, false);
 }
 
-void EffectTreeDialog::OnButton_MoveDownClick(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnButton_MoveDownClick(wxCommandEvent& event) {
     wxTreeItemId movedItem = TreeCtrl1->GetSelection();
     if (!movedItem.IsOk() || movedItem == treeRootID) {
         return;
@@ -1625,8 +1534,7 @@ void EffectTreeDialog::OnButton_MoveDownClick(wxCommandEvent& event)
     MoveNode(movedItem, nextSiblingId, true);
 }
 
-void EffectTreeDialog::OnButton_BottomClick(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnButton_BottomClick(wxCommandEvent& event) {
     wxTreeItemId movedItem = TreeCtrl1->GetSelection();
     if (!movedItem.IsOk() || movedItem == treeRootID) {
         return;
@@ -1650,8 +1558,7 @@ void EffectTreeDialog::OnButton_BottomClick(wxCommandEvent& event)
     MoveNode(movedItem, lastSiblingId, true);
 }
 
-void EffectTreeDialog::MoveNode(wxTreeItemId& srcItemId, wxTreeItemId& dstItemId, bool selSrc)
-{
+void EffectTreeDialog::MoveNode(wxTreeItemId& srcItemId, wxTreeItemId& dstItemId, bool selSrc) {
     if (!dstItemId.IsOk() || !srcItemId.IsOk()) {
         return;
     }
@@ -1700,8 +1607,7 @@ void EffectTreeDialog::MoveNode(wxTreeItemId& srcItemId, wxTreeItemId& dstItemId
     ValidateWindow();
 }
 
-void EffectTreeDialog::OnGridPopup(wxCommandEvent& event)
-{
+void EffectTreeDialog::OnGridPopup(wxCommandEvent& event) {
     int id = event.GetId();
     wxTreeItemId selectedItemId = TreeCtrl1->GetSelection();
 
@@ -1726,8 +1632,7 @@ void EffectTreeDialog::OnGridPopup(wxCommandEvent& event)
     }
 }
 
-void EffectTreeDialog::OnTreeCtrl1ItemRightClick(wxTreeEvent& event)
-{
+void EffectTreeDialog::OnTreeCtrl1ItemRightClick(wxTreeEvent& event) {
     wxTreeItemId selectedItem = TreeCtrl1->GetSelection();
     if (selectedItem == treeRootID && TreeCtrl1->GetChildrenCount(selectedItem) == 0) {
         return;
@@ -1744,8 +1649,7 @@ void EffectTreeDialog::OnTreeCtrl1ItemRightClick(wxTreeEvent& event)
     PopupMenu(&mnuLayer);
 }
 
-void EffectTreeDialog::SortTreeCtrl(wxTreeCtrl* treeCtrl, const wxTreeItemId& itemId)
-{
+void EffectTreeDialog::SortTreeCtrl(wxTreeCtrl* treeCtrl, const wxTreeItemId& itemId) {
     if (!itemId.IsOk())
         return;
 

--- a/src-ui-wx/sequencer/EffectTreeDialog.h
+++ b/src-ui-wx/sequencer/EffectTreeDialog.h
@@ -15,180 +15,193 @@
 #include <wx/panel.h>
 #include <wx/sizer.h>
 #include <wx/statbmp.h>
+#include <wx/stattext.h>
 #include <wx/textctrl.h>
 #include <wx/timer.h>
 #include <wx/treectrl.h>
 //*)
-#include <pugixml.hpp>
-#include <wx/filename.h>
 #include <wx/dnd.h>
+#include <wx/filename.h>
+#include <pugixml.hpp>
 
-#include <mutex>
 #include <memory>
+#include <mutex>
 
-#include "utils/AnimatedImage.h"
 #include "effects/EffectPresetManager.h"
+#include "utils/AnimatedImage.h"
 
 class xLightsFrame;
 
-class EffectTreeDialog : public wxPanel
-{
+class EffectTreeDialog : public wxPanel {
     void ValidateWindow();
 
-	public:
+public:
+    EffectTreeDialog(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxTAB_TRAVERSAL);
+    virtual ~EffectTreeDialog();
 
-		EffectTreeDialog(wxWindow* parent,wxWindowID id=wxID_ANY,const wxPoint& pos=wxDefaultPosition,const wxSize& size=wxDefaultSize,long style=wxTAB_TRAVERSAL);
-		virtual ~EffectTreeDialog();
+    //(*Declarations(EffectTreeDialog)
+    wxButton* Button_Bottom;
+    wxButton* Button_MoveDown;
+    wxButton* Button_MoveUp;
+    wxButton* Button_Top;
+    wxButton* ETButton1;
+    wxButton* btLayers;
+    wxButton* btPosition;
+    wxButton* btAddGroup;
+    wxButton* btApply;
+    wxButton* btDelete;
+    wxButton* btExport;
+    wxButton* btImport;
+    wxButton* btNewPreset;
+    wxButton* btRename;
+    wxButton* btUpdate;
+    wxStaticBitmap* StaticBitmapGif;
+    wxStaticText* StaticTextApplyLabel;
+    wxTextCtrl* TextCtrl1;
+    wxTimer TimerGif;
+    wxTreeCtrl* TreeCtrl1;
+    //*)
+    wxTreeItemId treeRootID;
+    void InitItems(EffectPresetManager& manager);
+    bool NameCollissionInGroup(wxTreeItemId groupId, std::string name);
+    static const long ID_GRID_MNU_SORT_ASC;
+    static const long ID_GRID_MNU_SORT_ALL_ASC;
+    void MoveNode(wxTreeItemId& srcItem, wxTreeItemId& destItem, bool selSrc);
+    void SortTreeCtrl(wxTreeCtrl* treeCtrl, const wxTreeItemId& itemId);
 
-		//(*Declarations(EffectTreeDialog)
-		wxButton* Button_Bottom;
-		wxButton* Button_MoveDown;
-		wxButton* Button_MoveUp;
-		wxButton* Button_Top;
-		wxButton* ETButton1;
-		wxButton* btAddGroup;
-		wxButton* btApply;
-		wxButton* btDelete;
-		wxButton* btExport;
-		wxButton* btImport;
-		wxButton* btNewPreset;
-		wxButton* btRename;
-		wxButton* btUpdate;
-		wxStaticBitmap* StaticBitmapGif;
-		wxTextCtrl* TextCtrl1;
-		wxTimer TimerGif;
-		wxTreeCtrl* TreeCtrl1;
-		//*)
-        wxTreeItemId treeRootID;
-        void InitItems(EffectPresetManager& manager);
-        bool NameCollissionInGroup(wxTreeItemId groupId, std::string name);
-        static const long ID_GRID_MNU_SORT_ASC;
-        static const long ID_GRID_MNU_SORT_ALL_ASC;
-        void MoveNode(wxTreeItemId& srcItem, wxTreeItemId& destItem, bool selSrc);
-        void SortTreeCtrl(wxTreeCtrl* treeCtrl, const wxTreeItemId& itemId);
-  
-	protected:
+protected:
+    //(*Identifiers(EffectTreeDialog)
+    static const wxWindowID ID_TREECTRL1;
+    static const wxWindowID ID_BUTTON11;
+    static const wxWindowID ID_BUTTON9;
+    static const wxWindowID ID_BUTTON10;
+    static const wxWindowID ID_BUTTON12;
+    static const wxWindowID ID_STATICBITMAP_GIF;
+    static const wxWindowID ID_BUTTON6;
+    static const wxWindowID ID_BUTTON7;
+    static const wxWindowID ID_BUTTON2;
+    static const wxWindowID ID_BUTTON4;
+    static const wxWindowID ID_BUTTON1;
+    static const wxWindowID ID_BUTTON8;
+    static const wxWindowID ID_BUTTON3;
+    static const wxWindowID ID_BUTTON5;
+    static const wxWindowID ID_BTN_POSITION;
+    static const wxWindowID ID_BTN_LAYERS;
+    static const wxWindowID ID_TEXTCTRL_SEARCH;
+    static const wxWindowID ID_BUTTON_SEARCH;
+    static const wxWindowID ID_TIMER_GIF;
+    static const wxWindowID ID_STATICTEXT_APPLY;
+    //*)
 
-		//(*Identifiers(EffectTreeDialog)
-		static const wxWindowID ID_TREECTRL1;
-		static const wxWindowID ID_BUTTON11;
-		static const wxWindowID ID_BUTTON9;
-		static const wxWindowID ID_BUTTON10;
-		static const wxWindowID ID_BUTTON12;
-		static const wxWindowID ID_STATICBITMAP_GIF;
-		static const wxWindowID ID_BUTTON6;
-		static const wxWindowID ID_BUTTON7;
-		static const wxWindowID ID_BUTTON2;
-		static const wxWindowID ID_BUTTON4;
-		static const wxWindowID ID_BUTTON1;
-		static const wxWindowID ID_BUTTON8;
-		static const wxWindowID ID_BUTTON3;
-		static const wxWindowID ID_BUTTON5;
-		static const wxWindowID ID_TEXTCTRL_SEARCH;
-		static const wxWindowID ID_BUTTON_SEARCH;
-		static const wxWindowID ID_TIMER_GIF;
-		//*)
+private:
+    //(*Handlers(EffectTreeDialog)
+    void OnbtApplyClick(wxCommandEvent& event);
+    void OnbtNewPresetClick(wxCommandEvent& event);
+    void OnbtUpdateClick(wxCommandEvent& event);
+    void OnbtRenameClick(wxCommandEvent& event);
+    void OnbtDeleteClick(wxCommandEvent& event);
+    void OnbtAddGroupClick(wxCommandEvent& event);
+    void OnTreeCtrl1ItemActivated(wxTreeEvent& event);
+    void OnTreeCtrl1BeginDrag(wxTreeEvent& event);
+    void OnbtImportClick(wxCommandEvent& event);
+    void OnbtExportClick(wxCommandEvent& event);
+    void OnTreeCtrl1SelectionChanged(wxTreeEvent& event);
+    void OnETButton1Click(wxCommandEvent& event);
+    void OnTextCtrl1TextEnter(wxCommandEvent& event);
+    void OnTimerGifTrigger(wxTimerEvent& event);
+    void OnTreeCtrl1KeyDown(wxTreeEvent& event);
+    void OnButton_TopClick(wxCommandEvent& event);
+    void OnButton_MoveUpClick(wxCommandEvent& event);
+    void OnButton_MoveDownClick(wxCommandEvent& event);
+    void OnButton_BottomClick(wxCommandEvent& event);
+    void OnTreeCtrl1ItemRightClick(wxTreeEvent& event);
+    void OnBtnPositionClick(wxCommandEvent& event);
+    void OnBtnLayersClick(wxCommandEvent& event);
+    //*)
 
-	private:
+    void OnShow(wxShowEvent& event);
+    void DeleteSelectedItem();
 
-		//(*Handlers(EffectTreeDialog)
-		void OnbtApplyClick(wxCommandEvent& event);
-		void OnbtNewPresetClick(wxCommandEvent& event);
-		void OnbtUpdateClick(wxCommandEvent& event);
-		void OnbtRenameClick(wxCommandEvent& event);
-		void OnbtDeleteClick(wxCommandEvent& event);
-		void OnbtAddGroupClick(wxCommandEvent& event);
-		void OnTreeCtrl1ItemActivated(wxTreeEvent& event);
-		void OnTreeCtrl1BeginDrag(wxTreeEvent& event);
-		void OnbtImportClick(wxCommandEvent& event);
-		void OnbtExportClick(wxCommandEvent& event);
-		void OnTreeCtrl1SelectionChanged(wxTreeEvent& event);
-		void OnETButton1Click(wxCommandEvent& event);
-		void OnTextCtrl1TextEnter(wxCommandEvent& event);
-		void OnTimerGifTrigger(wxTimerEvent& event);
-		void OnTreeCtrl1KeyDown(wxTreeEvent& event);
-		void OnButton_TopClick(wxCommandEvent& event);
-		void OnButton_MoveUpClick(wxCommandEvent& event);
-		void OnButton_MoveDownClick(wxCommandEvent& event);
-		void OnButton_BottomClick(wxCommandEvent& event);
-		void OnTreeCtrl1ItemRightClick(wxTreeEvent& event);
-		//*)
+    std::unique_ptr<wxBitmap> _blankGIFImage;
+    std::unique_ptr<AnimatedImage> gifImage;
+    int frameCount = 0;
+    xLightsFrame* xLightParent = nullptr;
+    EffectPresetManager* _presetManager = nullptr;
+    wxTreeItemId m_draggedItem;
+    std::mutex preset_mutex;
+    bool _effectsFixed = false;
+    bool _layerMode = false;
+    void OnGridPopup(wxCommandEvent& event);
+    void AddTreeElementsRecursive(EffectPresetGroup& group, wxTreeItemId curGroupID);
+    void ApplyEffect(bool dblClick = false);
+    void AddEffect(pugi::xml_node ele, wxTreeItemId curGroupID);
+    void AddGroup(pugi::xml_node ele, wxTreeItemId curGroupID);
+    void EffectsFileDirty();
+    int GetOptimalPreviewSize();
 
-        void OnShow(wxShowEvent& event);
-        void DeleteSelectedItem();
+    wxTreeItemId findTreeItem(wxTreeCtrl* pTreeCtrl, const wxTreeItemId& root, const wxTreeItemId& startID, const wxString& text, bool& startfound);
 
-		std::unique_ptr<wxBitmap> _blankGIFImage;
-        std::unique_ptr<AnimatedImage> gifImage;
-        int frameCount = 0;
-        xLightsFrame* xLightParent = nullptr;
-		EffectPresetManager* _presetManager = nullptr;
-        wxTreeItemId m_draggedItem;
-        std::mutex preset_mutex;
-        bool _effectsFixed = false;
-        void OnGridPopup(wxCommandEvent& event);
-        void AddTreeElementsRecursive(EffectPresetGroup& group, wxTreeItemId curGroupID);
-        void ApplyEffect(bool dblClick=false);
-        void AddEffect(pugi::xml_node ele, wxTreeItemId curGroupID);
-        void AddGroup(pugi::xml_node ele, wxTreeItemId curGroupID);
-        void EffectsFileDirty();
-        int GetOptimalPreviewSize();
-    
-        wxTreeItemId findTreeItem(wxTreeCtrl* pTreeCtrl, const wxTreeItemId& root, const wxTreeItemId& startID, const wxString& text, bool &startfound);
+    void SearchForText();
 
-        void SearchForText();
+    DECLARE_EVENT_TABLE()
 
-		DECLARE_EVENT_TABLE()
+    wxString ParseLayers(wxString name, wxString settings);
+    wxString ParseDuration(wxString name, wxString settings);
 
-        wxString ParseLayers(wxString name, wxString settings);
-        wxString ParseDuration(wxString name, wxString settings);
-
-		wxString generatePresetName(wxTreeItemId itemID);
-        void GenerateGifImage(wxTreeItemId itemID, bool regenerate = false);
-        void LoadGifImage(wxString const& path);
-        void PlayGifImage();
-        void StopGifImage();
-        void DeleteGifImage(wxTreeItemId itemID);
-        bool FixName(std::string& name);
-        void FixDuplicatesInGroup(wxTreeItemId parent);
-        wxTreeItemId FindGroupItem(wxTreeItemId parent, std::string name);
-        std::string GetFullPathOfGroup(wxTreeItemId itemId);
-        std::vector<std::string> GetGifFileNamesRecursive(wxTreeItemId itemId);
-        void DeleteGifsRecursive(wxTreeItemId parentId);
-        void PurgeDanglingGifs();
-        bool PromptForName(wxWindow* parent, wxString& name, bool isNew, bool isGroup);
-        void OnDropEffect(wxCommandEvent& event);
-
+    wxString generatePresetName(wxTreeItemId itemID);
+    void GenerateGifImage(wxTreeItemId itemID, bool regenerate = false);
+    void LoadGifImage(wxString const& path);
+    void PlayGifImage();
+    void StopGifImage();
+    void DeleteGifImage(wxTreeItemId itemID);
+    bool FixName(std::string& name);
+    void FixDuplicatesInGroup(wxTreeItemId parent);
+    wxTreeItemId FindGroupItem(wxTreeItemId parent, std::string name);
+    std::string GetFullPathOfGroup(wxTreeItemId itemId);
+    std::vector<std::string> GetGifFileNamesRecursive(wxTreeItemId itemId);
+    void DeleteGifsRecursive(wxTreeItemId parentId);
+    void PurgeDanglingGifs();
+    bool PromptForName(wxWindow* parent, wxString& name, bool isNew, bool isGroup);
+    void UpdateModeButtons();
+    void OnDropEffect(wxCommandEvent& event);
 };
 
-class MyTreeItemData : public wxTreeItemData
-{
+class MyTreeItemData : public wxTreeItemData {
 public:
-    MyTreeItemData(EffectPresetItem* item) : _item(item) {}
+    MyTreeItemData(EffectPresetItem* item) : _item(item) {
+    }
 
-    EffectPresetItem* GetItem() { return _item; }
-    bool IsGroup() { return _item != nullptr && _item->IsGroup(); }
-    EffectPreset* AsPreset() { return (!_item || _item->IsGroup()) ? nullptr : static_cast<EffectPreset*>(_item); }
-    EffectPresetGroup* AsGroup() { return (!_item || !_item->IsGroup()) ? nullptr : static_cast<EffectPresetGroup*>(_item); }
+    EffectPresetItem* GetItem() {
+        return _item;
+    }
+    bool IsGroup() {
+        return _item != nullptr && _item->IsGroup();
+    }
+    EffectPreset* AsPreset() {
+        return (!_item || _item->IsGroup()) ? nullptr : static_cast<EffectPreset*>(_item);
+    }
+    EffectPresetGroup* AsGroup() {
+        return (!_item || !_item->IsGroup()) ? nullptr : static_cast<EffectPresetGroup*>(_item);
+    }
+
 private:
     EffectPresetItem* _item = nullptr;
 };
 
-class EffectTreeDialogTextDropTarget : public wxTextDropTarget
-{
-    public:
-        EffectTreeDialogTextDropTarget(EffectTreeDialog* owner, wxTreeCtrl* tree, wxString type) {
-            _owner = owner;
-            _tree = tree;
-            _type = type;
-        };
+class EffectTreeDialogTextDropTarget : public wxTextDropTarget {
+public:
+    EffectTreeDialogTextDropTarget(EffectTreeDialog* owner, wxTreeCtrl* tree, wxString type) {
+        _owner = owner;
+        _tree = tree;
+        _type = type;
+    };
 
-        virtual bool OnDropText(wxCoord x, wxCoord y, const wxString& data) override;
-        virtual wxDragResult OnDragOver(wxCoord x, wxCoord y, wxDragResult def) override;
-        void UpdateItemFeedback(wxTreeItemId currItem);
-        EffectTreeDialog* _owner;
-        wxTreeCtrl* _tree;
-        wxString _type;
-        wxTreeItemId _lastDragOverItem;
-        wxLongLong _dragOverHoldTime;
+    virtual bool OnDropText(wxCoord x, wxCoord y, const wxString& data) override;
+    virtual wxDragResult OnDragOver(wxCoord x, wxCoord y, wxDragResult def) override;
+    void UpdateItemFeedback(wxTreeItemId currItem);
+    EffectTreeDialog* _owner;
+    wxTreeCtrl* _tree;
+    wxString _type;
+    wxTreeItemId _lastDragOverItem;
+    wxLongLong _dragOverHoldTime;
 };
-

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -5604,7 +5604,6 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
             struct LayerTarget {
                 Element* element = nullptr;
                 int layerIdx = 0;
-                // int oldFormatRank = -1; // >= 0 means no LAYER: token (old preset format)
             };
             std::map<int, LayerTarget> layerTargetMap; // keyed by eff_row value
             bool hasLayerTokens = false;

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -20,37 +20,37 @@
 #include <GL/gl.h>
 #endif
 
-#include "color/ColorManager.h"
-#include "render/Effect.h"
 #include "EffectDropTarget.h"
-#include "render/EffectLayer.h"
-#include "sequencer/EffectTimingDialog.h"
 #include "EffectsGrid.h"
-#include "lyrics/LyricBreakdown.h"
 #include "MainSequencer.h"
-#include "render/PixelBuffer.h"
 #include "RowHeading.h"
-#include "render/SequenceElements.h"
 #include "TimeLine.h"
-#include "sequencer/AutoLabelDialog.h"
-#include "shared/utils/BitmapCache.h"
-#include "sequencer/DuplicateDialog.h"
-#include "diagnostics/FindDataPanel.h"
-#include "sequencer/RenderCommandEvent.h"
 #include "UtilFunctions.h"
-#include "shared/utils/wxUtilities.h"
-#include "shared/dialogs/CheckboxSelectDialog.h"
-#include "media/VideoReader.h"
-#include "effects/RenderableEffect.h"
-#include "effectpanels/EffectIconCache.h"
-#include "xLightsMain.h"
 #include "xLightsApp.h"
-#include "render/SequenceFile.h"
+#include "xLightsMain.h"
+#include "color/ColorManager.h"
+#include "diagnostics/FindDataPanel.h"
+#include "effectpanels/EffectIconCache.h"
 #include "effects/GlediatorEffect.h"
 #include "effects/PicturesEffect.h"
+#include "effects/RenderableEffect.h"
 #include "effects/ShaderEffect.h"
 #include "effects/VideoEffect.h"
+#include "lyrics/LyricBreakdown.h"
+#include "media/VideoReader.h"
 #include "models/Model.h"
+#include "render/Effect.h"
+#include "render/EffectLayer.h"
+#include "render/PixelBuffer.h"
+#include "render/SequenceElements.h"
+#include "render/SequenceFile.h"
+#include "sequencer/AutoLabelDialog.h"
+#include "sequencer/DuplicateDialog.h"
+#include "sequencer/EffectTimingDialog.h"
+#include "sequencer/RenderCommandEvent.h"
+#include "shared/dialogs/CheckboxSelectDialog.h"
+#include "shared/utils/BitmapCache.h"
+#include "shared/utils/wxUtilities.h"
 #include "utils/string_utils.h"
 
 #include <cmath>
@@ -341,8 +341,6 @@ void EffectsGrid::mouseLeftDClick(wxMouseEvent& event) {
 }
 
 void EffectsGrid::rightClick(wxMouseEvent& event) {
-    
-
     if (mSequenceElements == nullptr) {
         return;
     }
@@ -810,8 +808,6 @@ void EffectsGrid::Replace() {
 }
 
 void EffectsGrid::FindEffectsForData(uint32_t channel, uint8_t chans, uint32_t _findDataMS) const {
-    
-
     // find all effects at this time
     std::vector<findDataEffect> possible;
     for (size_t i = 0; i < mSequenceElements->GetElementCount(); i++) {
@@ -949,7 +945,6 @@ void EffectsGrid::CreateTimingFromSelectedEffects() {
 }
 
 void EffectsGrid::OnGridPopup(wxCommandEvent& event) {
-    
     int id = event.GetId();
     if (id == ID_GRID_MNU_CUT) {
         spdlog::debug("OnGridPopup - CUT");
@@ -1084,8 +1079,6 @@ void EffectsGrid::OnGridPopup(wxCommandEvent& event) {
                             mSequenceElements->get_undo_mgr().CaptureAddedEffect(el->GetParentElement()->GetName(), el->GetIndex(), newef->GetID());
                             mSequenceElements->get_undo_mgr().CreateUndoStep();
                             mSequenceElements->get_undo_mgr().CaptureModifiedEffect(el->GetParentElement()->GetModelName(), el->GetIndex(), eff);
-
-
                         }
                     }
                 }
@@ -1505,8 +1498,6 @@ bool EffectsGrid::AdjustDropLocations(int x, EffectLayer* el) {
 }
 
 bool EffectsGrid::DragOver(int x, int y) {
-    
-
     if (mSequenceElements == nullptr) {
         return false;
     }
@@ -1701,9 +1692,7 @@ void EffectsGrid::mouseMoved(wxMouseEvent& event) {
                 mDragEndX = event.GetX();
                 mDragEndY = event.GetY();
                 UpdateSelectionRectangle();
-            }
-            else
-            {
+            } else {
                 mDragEndX = event.GetX();
                 UpdateSelectionRectangle();
             }
@@ -1821,7 +1810,6 @@ int MapHitLocationToEffectSelection(HitLocation location) {
 }
 
 Effect* EffectsGrid::GetEffectAtRowAndTime(int row, int ms, int& index, HitLocation& selectionType) {
-    
     EffectLayer* effectLayer = mSequenceElements->GetVisibleEffectLayer(row);
 
     if (effectLayer == nullptr) {
@@ -1895,7 +1883,6 @@ void EffectsGrid::ClearSelection() {
 }
 
 void EffectsGrid::mouseDown(wxMouseEvent& event) {
-
     mPartialCellSelected = false;
     mMouseOperationsCancelled = false;
 
@@ -2326,7 +2313,6 @@ void EffectsGrid::ConvertSelectedEffectsTo(const std::string& effectName) {
 }
 
 Effect* EffectsGrid::ACDraw(ACTYPE type, ACSTYLE style, ACMODE mode, int intensity, int a, int b, int startMS, int endMS, int startRow, int endRow) {
-    
     Effect* res = nullptr;
     bool first = false; // true; - if i change this back to true then first drawn effects will be selected
 
@@ -3805,7 +3791,7 @@ void EffectsGrid::mouseReleased(wxMouseEvent& event) {
 }
 
 void EffectsGrid::CheckForPartialCell(int x_pos) {
-    // 
+    //
 
     mPartialCellSelected = false;
     // make sure a valid row and column is selected
@@ -3936,7 +3922,7 @@ void EffectsGrid::Resize(int position, bool offset, bool control) {
     // If we encounter scenarios where it isnt it would be better to send the render dirty
     // event from the calling functions. I have temporarily added logging for all click and
     // drag events to try to help us identify why we miss rendering when we do
-    // 
+    //
     // spdlog::debug("EffectsGrid::Resize would have sent render dirty event");
     // sendRenderDirtyEvent();
 }
@@ -3945,8 +3931,6 @@ void EffectsGrid::ScrollBy(int by) {
 }
 
 void EffectsGrid::MoveSelectedEffectUp(bool shift) {
-    
-
     if (mSequenceElements == nullptr)
         return;
 
@@ -4057,7 +4041,8 @@ void EffectsGrid::MoveSelectedEffectUp(bool shift) {
             for (int row = first_model_row + 1; row < mSequenceElements->GetRowInformationSize(); row++) {
                 EffectLayer* el2 = mSequenceElements->GetEffectLayer(row);
                 if (mSequenceElements->GetEffectLayer(row)->GetTaggedEffectCount() > 0) {
-                    if (min_source_row == -1) min_source_row = row;
+                    if (min_source_row == -1)
+                        min_source_row = row;
                     EffectLayer* el1 = mSequenceElements->GetEffectLayer(row - move_offset);
                     int num_effects = mSequenceElements->GetEffectLayer(row)->GetEffectCount();
                     for (int i = 0; i < num_effects; ++i) {
@@ -4096,8 +4081,6 @@ void EffectsGrid::MoveSelectedEffectUp(bool shift) {
 }
 
 void EffectsGrid::MoveSelectedEffectDown(bool shift) {
-    
-
     if (mSequenceElements == nullptr)
         return;
 
@@ -4209,7 +4192,8 @@ void EffectsGrid::MoveSelectedEffectDown(bool shift) {
             for (int row = last_row; row > first_model_row; row--) {
                 EffectLayer* el1 = mSequenceElements->GetEffectLayer(row - 1);
                 if (mSequenceElements->GetEffectLayer(row - 1)->GetTaggedEffectCount() > 0) {
-                    if (max_source_row == -1) max_source_row = row - 1;
+                    if (max_source_row == -1)
+                        max_source_row = row - 1;
                     EffectLayer* el2 = mSequenceElements->GetEffectLayer(row - 1 + move_offset);
                     int num_effects = mSequenceElements->GetEffectLayer(row - 1)->GetEffectCount();
                     for (int i = 0; i < num_effects; ++i) {
@@ -4250,8 +4234,6 @@ void EffectsGrid::MoveSelectedEffectDown(bool shift) {
 }
 
 void EffectsGrid::MoveSelectedEffectRight(bool shift, bool control, bool alt) {
-    
-
     if (mSequenceElements == nullptr)
         return; // a sequence must be open
 
@@ -4359,8 +4341,6 @@ void EffectsGrid::MoveSelectedEffectRight(bool shift, bool control, bool alt) {
 }
 
 void EffectsGrid::MoveSelectedEffectLeft(bool shift, bool control, bool alt) {
-    
-
     if (mSequenceElements == nullptr)
         return;
 
@@ -4823,8 +4803,6 @@ void EffectsGrid::DeleteSelectedEffects() {
 }
 
 void EffectsGrid::AlignSelectedEffects(EFF_ALIGN_MODE align_mode) {
-    
-
     // TODO :  Fix so that rendering occurs where effects used to exist and their new location
     if (mSequenceElements == nullptr || mSelectedEffect == nullptr) {
         return;
@@ -5080,7 +5058,7 @@ void EffectsGrid::AlignSelectedEffectsToTimingMark() {
     mSequenceElements->get_undo_mgr().CreateUndoStep();
     for (int i = 0; i < mSequenceElements->GetRowInformationSize(); i++) {
         auto* el = mSequenceElements->GetEffectLayer(i);
-        for (int k = 0; k < 20; k++) {//crappy recursion
+        for (int k = 0; k < 20; k++) { // crappy recursion
             bool moved{ false };
             for (auto* ef : el->GetEffects()) {
                 if (ef->GetSelected() != EFFECT_NOT_SELECTED) {
@@ -5180,8 +5158,6 @@ bool EffectsGrid::OneCellSelected() {
 }
 
 Effect* EffectsGrid::OldPaste(const wxString& data, const wxString& pasteDataVersion) {
-    
-
     Effect* res = nullptr;
 
     if (mSequenceElements == nullptr)
@@ -5449,9 +5425,7 @@ int EffectsGrid::GetMSFromColumn(int col) const {
     return 0;
 }
 
-Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersion, bool row_paste) {
-    
-
+Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersion, bool row_paste, bool layerMode) {
     Effect* res = nullptr;
 
     if (mSequenceElements == nullptr)
@@ -5549,10 +5523,32 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
             }
             int drop_row = mDropRow;
             int start_row = wxAtoi(eff1data[5]);
+            bool anchorRowUsed = false;
             if (xlights->IsACActive()) {
                 start_row = wxAtoi(banner_data[7]);
+            } else {
+                // Store anchor row so empty rows above the first effect are correctly preserved when pasting.
+                for (size_t fi = 6; fi < banner_data.size(); ++fi) {
+                    if (banner_data[fi].StartsWith("ANCHOR_ROW:")) {
+                        int ar = wxAtoi(banner_data[fi].Mid(11));
+                        if (ar >= 0) {
+                            start_row = ar;
+                            anchorRowUsed = true;
+                        }
+                        break;
+                    }
+                }
             }
             int drop_row_offset = drop_row - start_row;
+
+            if (anchorRowUsed && !layerMode && wxAtoi(eff1data[5]) > start_row) {
+                int anchorAbsRow = mDropRow + mSequenceElements->GetFirstVisibleModelRow();
+                Row_Information_Struct* ri = mSequenceElements->GetRowInformationFromRow(anchorAbsRow);
+                if (ri != nullptr && ri->element != nullptr && ri->element->GetCollapsed()) {
+                    ri->element->SetCollapsed(false);
+                    mSequenceElements->PopulateRowInformation();
+                }
+            }
             if (number_of_timings > 0 && number_of_effects > 0) // only allow timing and model effects to be pasted on same rows
             {
                 drop_row = 0;
@@ -5605,6 +5601,228 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
 
             mSequenceElements->get_undo_mgr().CreateUndoStep();
 
+            struct LayerTarget {
+                Element* element = nullptr;
+                int layerIdx = 0;
+                // int oldFormatRank = -1; // >= 0 means no LAYER: token (old preset format)
+            };
+            std::map<int, LayerTarget> layerTargetMap; // keyed by eff_row value
+            bool hasLayerTokens = false;
+
+            if (layerMode && number_of_effects > 0 && !xlights->IsACActive()) {
+                bool singleElementPaste = true; // stays true for old-format; computed below for new-format
+                for (size_t si = 1; si < all_efdata.size() - 1 && !hasLayerTokens; si++) {
+                    wxArrayString ef = wxSplit(all_efdata[si], '\t', wxT('\0'));
+                    if (ef.size() < 8 || ef[7] == "TIMING_EFFECT")
+                        continue;
+                    for (int fi = (int)ef.size() - 1; fi >= 8; --fi) {
+                        if (ef[fi].StartsWith("LAYER:") && wxAtoi(ef[fi].Mid(6)) > 0) {
+                            hasLayerTokens = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (hasLayerTokens) {
+                    std::vector<std::pair<int, int>> erLayerVec;
+                    for (size_t si = 1; si < all_efdata.size() - 1; si++) {
+                        wxArrayString ef = wxSplit(all_efdata[si], '\t', wxT('\0'));
+                        if (ef.size() < 8 || ef[7] == "TIMING_EFFECT")
+                            continue;
+                        int er = wxAtoi(ef[5]);
+                        int layerIdx = 0;
+                        for (int fi = (int)ef.size() - 1; fi >= 8; --fi) {
+                            if (ef[fi].StartsWith("LAYER:")) {
+                                layerIdx = wxAtoi(ef[fi].Mid(6));
+                                break;
+                            }
+                        }
+                        erLayerVec.push_back({ er, layerIdx });
+                    }
+                    std::stable_sort(erLayerVec.begin(), erLayerVec.end(),
+                                     [](const auto& a, const auto& b) { return a.first < b.first; });
+
+                    struct ElemGroup {
+                        int numRows = 0;
+                        int targetRank = 0;
+                    };
+                    std::vector<ElemGroup> groups;
+                    std::map<int, int> erToRank;
+                    int prevLayer2 = INT_MAX;
+                    int startRow0 = -1;
+                    int sumExtraRows = 0;
+
+                    for (auto& [er, layerIdx] : erLayerVec) {
+                        if (erToRank.count(er))
+                            continue;
+                        if (layerIdx <= prevLayer2) {
+                            // New element group
+                            if (!groups.empty())
+                                sumExtraRows += groups.back().numRows - 1;
+                            int targetRank = groups.empty() ? 0 : (er - startRow0 - sumExtraRows);
+                            groups.push_back({ 1, targetRank });
+                            if (startRow0 < 0)
+                                startRow0 = er;
+                        } else {
+                            groups.back().numRows++;
+                        }
+                        prevLayer2 = layerIdx;
+                        erToRank[er] = groups.back().targetRank;
+                    }
+
+                    {
+                        int maxRank = 0;
+                        for (auto& [er2, rank2] : erToRank)
+                            maxRank = std::max(maxRank, rank2);
+                        singleElementPaste = (maxRank == 0);
+                    }
+
+                    int anchorOffset = 0;
+                    if (startRow0 >= 0) {
+                        for (size_t fi = 6; fi < banner_data.size(); ++fi) {
+                            if (banner_data[fi].StartsWith("ANCHOR_ROW:")) {
+                                int ar = wxAtoi(banner_data[fi].Mid(11));
+                                if (ar >= 0 && startRow0 > ar)
+                                    anchorOffset = startRow0 - ar;
+                                break;
+                            }
+                        }
+                    }
+                    // Before expanding and mapping ranks, delete unused layers on the model
+                    {
+                        int absModelRow = mDropRow + mSequenceElements->GetFirstVisibleModelRow();
+                        Row_Information_Struct* ri = mSequenceElements->GetRowInformationFromRow(absModelRow);
+                        ModelElement* me = (ri != nullptr) ? dynamic_cast<ModelElement*>(ri->element) : nullptr;
+                        if (me != nullptr) {
+                            auto& undo_mgr = mSequenceElements->get_undo_mgr();
+                            auto deleteUnused = [&](Element* elem) {
+                                for (int i = 0; i < (int)elem->GetEffectLayerCount(); ++i) {
+                                    if (elem->GetEffectLayer(i)->GetEffectCount() == 0 && elem->GetEffectLayerCount() > 1) {
+                                        undo_mgr.CaptureRemovedLayer(elem->GetFullName(), i);
+                                        elem->RemoveEffectLayer(i);
+                                        --i;
+                                    }
+                                }
+                            };
+                            xLightsApp::GetFrame()->AbortRender();
+                            deleteUnused(me);
+                            for (int si = 0; si < me->GetSubModelCount(); ++si)
+                                deleteUnused(me->GetSubModel(si));
+                            undo_mgr.CreateUndoStep(); // needed for redo
+                            if (!singleElementPaste) {
+                                me->ShowStrands(true);
+                                mSequenceElements->PopulateRowInformation();
+                            }
+                        }
+                    }
+
+                    // Map target rank → element by walking rows from the anchor.
+                    std::map<int, Element*> rankToElem;
+                    if (singleElementPaste) {
+                        int row = mDropRow + mSequenceElements->GetFirstVisibleModelRow();
+                        Row_Information_Struct* ri2 = mSequenceElements->GetRowInformationFromRow(row);
+                        if (ri2 != nullptr && ri2->element != nullptr)
+                            rankToElem[0] = ri2->element;
+                    } else {
+                        std::set<int> ranksNeeded;
+                        int maxRank = -1;
+                        for (auto& [er, rank] : erToRank) {
+                            ranksNeeded.insert(rank);
+                            maxRank = std::max(maxRank, rank);
+                        }
+
+                        int row = mDropRow + anchorOffset + mSequenceElements->GetFirstVisibleModelRow();
+                        Element* prevElem = nullptr;
+                        int elemIdx = -1;
+                        while (elemIdx < maxRank && !ranksNeeded.empty()) {
+                            Row_Information_Struct* ri = mSequenceElements->GetRowInformationFromRow(row);
+                            if (ri == nullptr || ri->element == nullptr)
+                                break;
+                            if (ri->element != prevElem) {
+                                ++elemIdx;
+                                if (ranksNeeded.count(elemIdx)) {
+                                    rankToElem[elemIdx] = ri->element;
+                                    ranksNeeded.erase(elemIdx);
+                                }
+                                prevElem = ri->element;
+                            }
+                            ++row;
+                        }
+                    }
+
+                    for (auto& [er, rank] : erToRank) {
+                        LayerTarget lt;
+                        lt.element = rankToElem.count(rank) ? rankToElem[rank] : nullptr;
+                        lt.layerIdx = 0;
+                        layerTargetMap[er] = lt;
+                    }
+
+                } else {
+                    int trow = mDropRow + mSequenceElements->GetFirstVisibleModelRow();
+                    Row_Information_Struct* ri = mSequenceElements->GetRowInformationFromRow(trow);
+                    if (ri != nullptr && ri->element != nullptr) {
+                        Element* targetElem = ri->element;
+                        std::set<int> uniqueRows;
+                        for (size_t si = 1; si < all_efdata.size() - 1; si++) {
+                            wxArrayString ef = wxSplit(all_efdata[si], '\t', wxT('\0'));
+                            if (ef.size() < 8 || ef[7] == "TIMING_EFFECT")
+                                continue;
+                            uniqueRows.insert(wxAtoi(ef[5]));
+                        }
+                        int layerIdx = 0;
+                        for (int er : uniqueRows) {
+                            LayerTarget lt;
+                            lt.element = targetElem;
+                            lt.layerIdx = layerIdx++;
+                            layerTargetMap[er] = lt;
+                        }
+                    }
+                }
+
+                // Pre-create layers for both new-format and old-format layer-mode paste.
+                if (!layerTargetMap.empty()) {
+                    std::map<Element*, int> elemMaxLayer;
+                    for (auto& [row, lt] : layerTargetMap)
+                        if (lt.element)
+                            elemMaxLayer[lt.element] = std::max(elemMaxLayer[lt.element], lt.layerIdx);
+                    for (size_t si = 1; si < all_efdata.size() - 1; si++) {
+                        wxArrayString ef = wxSplit(all_efdata[si], '\t', wxT('\0'));
+                        if (ef.size() < 8 || ef[7] == "TIMING_EFFECT")
+                            continue;
+                        int er = wxAtoi(ef[5]);
+                        auto it = layerTargetMap.find(er);
+                        if (it == layerTargetMap.end() || it->second.element == nullptr)
+                            continue;
+                        for (int fi = (int)ef.size() - 1; fi >= 8; --fi) {
+                            if (ef[fi].StartsWith("LAYER:")) {
+                                int li2 = wxAtoi(ef[fi].Mid(6));
+                                elemMaxLayer[it->second.element] = std::max(elemMaxLayer[it->second.element], li2);
+                                break;
+                            }
+                        }
+                    }
+                    bool precreateNeedsPopulate = false;
+                    for (auto& [elem, maxLayer] : elemMaxLayer) {
+                        while ((int)elem->GetEffectLayerCount() <= maxLayer) {
+                            EffectLayer* nl = elem->AddEffectLayer();
+                            int pos = (int)elem->GetEffectLayerCount() - 1;
+                            mSequenceElements->get_undo_mgr().CaptureAddedLayer(elem->GetFullName(), nl->GetIndex(), pos);
+                            precreateNeedsPopulate = true;
+                        }
+                    }
+                    if (precreateNeedsPopulate) {
+                        if (!singleElementPaste) {
+                            for (auto& [elem, maxLayer] : elemMaxLayer) {
+                                ModelElement* me2 = dynamic_cast<ModelElement*>(elem);
+                                if (me2 != nullptr)
+                                    me2->ShowStrands(true);
+                            }
+                        }
+                        mSequenceElements->PopulateRowInformation();
+                    }
+                }
+            }
+
             for (int rpts = 0; rpts < timestopaste; ++rpts) {
                 for (size_t i = 1; i < all_efdata.size() - 1; i++) {
                     wxArrayString efdata = wxSplit(all_efdata[i], '\t', wxT('\0'));
@@ -5640,14 +5858,35 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
                         drop_row += mSequenceElements->GetFirstVisibleModelRow();
                     }
                     Row_Information_Struct* row_info = mSequenceElements->GetRowInformationFromRow(drop_row);
-                    if (row_info == nullptr)
-                        break;
-                    Element* elem = row_info->element;
-                    if (elem == nullptr)
-                        break;
-                    EffectLayer* el = mSequenceElements->GetEffectLayer(row_info);
-                    if (el == nullptr)
-                        break;
+                    EffectLayer* el = nullptr;
+                    if (layerMode && !is_timing_effect && !layerTargetMap.empty()) {
+                        int er = wxAtoi(efdata[5]);
+                        auto it = layerTargetMap.find(er);
+                        if (it != layerTargetMap.end() && it->second.element != nullptr) {
+                            int layerIdx = it->second.layerIdx;
+                            if (hasLayerTokens) {
+                                for (int fi = (int)efdata.size() - 1; fi >= 8; --fi) {
+                                    if (efdata[fi].StartsWith("LAYER:")) {
+                                        layerIdx = wxAtoi(efdata[fi].Mid(6));
+                                        break;
+                                    }
+                                }
+                            }
+                            if (layerIdx >= 0 && layerIdx < (int)it->second.element->GetEffectLayerCount())
+                                el = it->second.element->GetEffectLayer(layerIdx);
+                        }
+                        if (el == nullptr)
+                            continue;
+                    } else {
+                        if (row_info == nullptr)
+                            break;
+                        Element* elem = row_info->element;
+                        if (elem == nullptr)
+                            break;
+                        el = mSequenceElements->GetEffectLayer(row_info);
+                        if (el == nullptr)
+                            break;
+                    }
                     if (el->GetRangeIsClearMS(new_start_time, new_end_time)) {
                         int effectIndex = xlights->GetEffectManager().GetEffectIndex(efdata[0].ToStdString());
                         if (effectIndex >= 0 || is_timing_effect) {
@@ -5666,10 +5905,10 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
                             if (ef != nullptr) {
                                 ef->SetLocked(false);
                                 spdlog::info("(1) Created effect {}  {}  {}  {} {} -->  {}",
-                                                 (const char*)efdata[0].c_str(),
-                                                 (const char*)efdata[1].Left(128).c_str(),
-                                                 (const char*)efdata[2].c_str(),
-                                                 new_start_time,
+                                             (const char*)efdata[0].c_str(),
+                                             (const char*)efdata[1].Left(128).c_str(),
+                                             (const char*)efdata[2].c_str(),
+                                             new_start_time,
                                              new_end_time, fmt::ptr(ef));
                                 if (!is_timing_effect && xlights->GetEffectManager().GetEffect(efdata[0].ToStdString()) != nullptr && xlights->GetEffectManager().GetEffect(efdata[0].ToStdString())->needToAdjustSettings(pasteDataVersion.ToStdString())) {
                                     xlights->GetEffectManager().GetEffect(efdata[0].ToStdString())->adjustSettings(pasteDataVersion.ToStdString(), ef, false);
@@ -5681,6 +5920,11 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
                 }
             }
             sendRenderDirtyEvent();
+            if (layerMode && !layerTargetMap.empty()) {
+                xlights->DoForceSequencerRefresh();
+                wxCommandEvent eventRowHeaderChanged(EVT_ROW_HEADINGS_CHANGED);
+                wxPostEvent(GetParent(), eventRowHeaderChanged);
+            }
             mPartialCellSelected = false;
         } else {
             // we refer to all_efdata[1] below so make sure it is there
@@ -5741,11 +5985,11 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
                         if (ef != nullptr) {
                             ef->SetLocked(false);
                             spdlog::info("(2) Created effect {}  {}  {}  {} {} -->  {}",
-                                             (const char*)efdata[0].c_str(),
-                                             (const char*)efdata[1].Left(128).c_str(),
-                                             (const char*)efdata[2].c_str(),
-                                             mDropStartTimeMS,
-                                             end_time, fmt::ptr(ef));
+                                         (const char*)efdata[0].c_str(),
+                                         (const char*)efdata[1].Left(128).c_str(),
+                                         (const char*)efdata[2].c_str(),
+                                         mDropStartTimeMS,
+                                         end_time, fmt::ptr(ef));
                             if (!is_timing_effect && xlights->GetEffectManager().GetEffect(efdata[0].ToStdString()) != nullptr && xlights->GetEffectManager().GetEffect(efdata[0].ToStdString())->needToAdjustSettings(pasteDataVersion.ToStdString())) {
                                 xlights->GetEffectManager().GetEffect(efdata[0].ToStdString())->adjustSettings(pasteDataVersion.ToStdString(), ef, false);
                             }
@@ -5829,11 +6073,11 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
                             if (ef != nullptr) {
                                 ef->SetLocked(false);
                                 spdlog::info("(3) Created effect {}  {}  {}  {} {} -->  {}",
-                                                 (const char*)efdata[0].c_str(),
-                                                 (const char*)efdata[1].Left(128).c_str(),
-                                                 (const char*)efdata[2].c_str(),
-                                                 mDropStartTimeMS,
-                                                 end_time, fmt::ptr(ef));
+                                             (const char*)efdata[0].c_str(),
+                                             (const char*)efdata[1].Left(128).c_str(),
+                                             (const char*)efdata[2].c_str(),
+                                             mDropStartTimeMS,
+                                             end_time, fmt::ptr(ef));
                                 if (xlights->GetEffectManager().GetEffect(efdata[0].ToStdString()) != nullptr && xlights->GetEffectManager().GetEffect(efdata[0].ToStdString())->needToAdjustSettings(pasteDataVersion.ToStdString())) {
                                     xlights->GetEffectManager().GetEffect(efdata[0].ToStdString())->adjustSettings(pasteDataVersion.ToStdString(), ef, false);
                                 }
@@ -5884,17 +6128,20 @@ void EffectsGrid::ResizeMoveMultipleEffectsMS(int time, bool offset) {
     GetRangeOfMovementForSelectedEffects(toLeft, toRight);
     if (mResizingMode == EFFECT_RESIZE_LEFT || mResizingMode == EFFECT_RESIZE_LEFT_EDGE) {
         Effect* eff = mEffectLayer ? mEffectLayer->GetEffect(mResizeEffectIndex) : nullptr;
-        if (eff == nullptr) return;
+        if (eff == nullptr)
+            return;
         deltaTime = time - eff->GetStartTimeMS();
     } else if (mResizingMode == EFFECT_RESIZE_RIGHT || mResizingMode == EFFECT_RESIZE_RIGHT_EDGE) {
         Effect* eff = mEffectLayer ? mEffectLayer->GetEffect(mResizeEffectIndex) : nullptr;
-        if (eff == nullptr) return;
+        if (eff == nullptr)
+            return;
         deltaTime = time - eff->GetEndTimeMS();
     } else if (mResizingMode == EFFECT_RESIZE_MOVE) {
         EFFECT_SCREEN_MODE mode;
         int x1, x2, x3, x4;
         Effect* eff = mEffectLayer ? mEffectLayer->GetEffect(mResizeEffectIndex) : nullptr;
-        if (eff == nullptr) return;
+        if (eff == nullptr)
+            return;
         mTimeline->GetPositionsFromTimeRange(eff->GetStartTimeMS(),
                                              eff->GetEndTimeMS(), mode, x1, x2, x3, x4);
         int midpoint = mTimeline->GetTimeMSfromPosition((x1 + x2) / 2) + mTimeline->GetStartTimeMS();
@@ -5921,8 +6168,6 @@ void EffectsGrid::ResizeMoveMultipleEffectsMS(int time, bool offset) {
 }
 
 void EffectsGrid::ResizeMoveMultipleEffectsByTime(int delta, bool force) {
-    
-
     spdlog::debug("EffectsGrid::ResizeMoveMultipleEffectsByTime.");
 
     int deltaTime = mTimeline->RoundToMultipleOfPeriod(std::abs(delta), mSequenceElements->GetFrequency());
@@ -5953,8 +6198,6 @@ void EffectsGrid::ResizeMoveMultipleEffectsByTime(int delta, bool force) {
 }
 
 void EffectsGrid::ButtUpResizeMoveMultipleEffects(bool right) {
-    
-
     spdlog::debug("EffectsGrid::ButtUpResizeMoveMultipleEffects.");
 
     ((MainSequencer*)mParent)->TagAllSelectedEffects();
@@ -5970,8 +6213,6 @@ void EffectsGrid::ButtUpResizeMoveMultipleEffects(bool right) {
 }
 
 void EffectsGrid::StretchMultipleEffectsByTime(int delta) {
-    
-
     spdlog::debug("EffectsGrid::StretchMultipleEffectsByTime.");
 
     int deltaTime = mTimeline->RoundToMultipleOfPeriod(std::abs(delta), mSequenceElements->GetFrequency());
@@ -5997,8 +6238,6 @@ void EffectsGrid::StretchMultipleEffectsByTime(int delta) {
 }
 
 void EffectsGrid::ButtUpStretchMultipleEffects(bool right) {
-    
-
     spdlog::debug("EffectsGrid::ButtUpStretchMultipleEffects.");
 
     ((MainSequencer*)mParent)->TagAllSelectedEffects();
@@ -6953,8 +7192,6 @@ void EffectsGrid::DrawFadeHints(Effect* e, int x1, int y1, int x2, int y2, xlVer
 }
 
 void EffectsGrid::DrawTimingEffects(int row) {
-    
-
     Row_Information_Struct* ri = mSequenceElements->GetVisibleRowInformation(row);
     TimingElement* element = dynamic_cast<TimingElement*>(ri->element);
     EffectLayer* effectLayer = mSequenceElements->GetVisibleEffectLayer(row);
@@ -7389,8 +7626,6 @@ void EffectsGrid::GetRangeOfMovementForSelectedEffects(int& toLeft, int& toRight
 }
 
 void EffectsGrid::MoveAllSelectedEffects(int deltaMS, bool offset) const {
-    
-
     // Tag all selected effects so we don't move them twice
     ((MainSequencer*)mParent)->TagAllSelectedEffects();
 
@@ -7435,8 +7670,6 @@ void EffectsGrid::MoveAllSelectedEffects(int deltaMS, bool offset) const {
 }
 
 void EffectsGrid::StretchAllSelectedEffects(int deltaMS, bool offset) const {
-    
-
     spdlog::debug("EffectsGrid::StretchAllSelectedEffects.");
 
     // Tag all selected effects so we don't move them twice
@@ -7756,7 +7989,7 @@ void EffectsGrid::PasteModelEffectsWithSubModelLayers(int row_number) {
 
         auto it = element_ranges.find(element_name);
         if (it == element_ranges.end()) {
-            element_ranges[element_name] = {eff_row, eff_row};
+            element_ranges[element_name] = { eff_row, eff_row };
         } else {
             it->second.min_row = std::min(it->second.min_row, eff_row);
             it->second.max_row = std::max(it->second.max_row, eff_row);

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -5616,7 +5616,7 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
                     if (ef.size() < 8 || ef[7] == "TIMING_EFFECT")
                         continue;
                     for (int fi = (int)ef.size() - 1; fi >= 8; --fi) {
-                        if (ef[fi].StartsWith("LAYER:") && wxAtoi(ef[fi].Mid(6)) > 0) {
+                        if (ef[fi].StartsWith("LAYER:")) {
                             hasLayerTokens = true;
                             break;
                         }

--- a/src-ui-wx/sequencer/EffectsGrid.h
+++ b/src-ui-wx/sequencer/EffectsGrid.h
@@ -158,7 +158,7 @@ public:
 
     int GetEffectRow(Effect* ef);
     Effect* OldPaste(const wxString &data, const wxString &pasteDataVer);
-    Effect* Paste(const wxString &data, const wxString &pasteDataVer, bool row_paste = false);
+    Effect* Paste(const wxString &data, const wxString &pasteDataVer, bool row_paste = false, bool layerMode = false);
     int GetStartColumn() { return mRangeStartCol < mRangeEndCol ? mRangeStartCol : mRangeEndCol; }
     int GetStartRow() { return mRangeStartRow < mRangeEndRow ? mRangeStartRow : mRangeEndRow; }
     int GetEndColumn() { return mRangeStartCol < mRangeEndCol ? mRangeEndCol : mRangeStartCol; }

--- a/src-ui-wx/sequencer/MainSequencer.cpp
+++ b/src-ui-wx/sequencer/MainSequencer.cpp
@@ -1654,7 +1654,7 @@ std::list<std::string> MainSequencer::GetAllEffectDescriptions() {
     return mSequenceElements->GetAllEffectDescriptions();
 }
 
-void MainSequencer::Paste(bool row_paste, bool invertLayerMode) {
+void MainSequencer::Paste(bool row_paste, bool invertPasteAsLayers) {
     wxTextDataObject data;
     wxClipboard* cbd = wxClipboard::Get();
     if (cbd && cbd->Open()) {
@@ -1662,7 +1662,7 @@ void MainSequencer::Paste(bool row_paste, bool invertLayerMode) {
             // assume clipboard always has data from same version of xLights
             wxString text = data.GetText();
             bool pasteAsLayers = xLightsApp::GetFrame()->IsPasteAsLayers();
-            if (invertLayerMode)
+            if (invertPasteAsLayers)
                 pasteAsLayers = !pasteAsLayers;
             bool layerMode = pasteAsLayers && text.Contains("\tLAYER:");
             Effect* ef = PanelEffectGrid->Paste(text, xlights_version_string, row_paste, layerMode);

--- a/src-ui-wx/sequencer/MainSequencer.cpp
+++ b/src-ui-wx/sequencer/MainSequencer.cpp
@@ -1661,7 +1661,7 @@ void MainSequencer::Paste(bool row_paste, bool invertLayerMode) {
         if ((cbd->IsSupported(wxDF_TEXT) || cbd->IsSupported(wxDF_UNICODETEXT)) && cbd->GetData(data)) {
             // assume clipboard always has data from same version of xLights
             wxString text = data.GetText();
-            bool pasteAsLayers = xLightsApp::GetFrame()->PasteAsLayers();
+            bool pasteAsLayers = xLightsApp::GetFrame()->IsPasteAsLayers();
             if (invertLayerMode)
                 pasteAsLayers = !pasteAsLayers;
             bool layerMode = pasteAsLayers && text.Contains("\tLAYER:");

--- a/src-ui-wx/sequencer/MainSequencer.cpp
+++ b/src-ui-wx/sequencer/MainSequencer.cpp
@@ -7,31 +7,31 @@
  * Copyright claimed based on commit dates recorded in Github
  * License: https://github.com/xLightsSequencer/xLights/blob/master/License.txt
  **************************************************************/
- 
+
 //(*InternalHeaders(MainSequencer)
 #include <wx/intl.h>
 #include <wx/string.h>
 //*)
 
+#include <wx/artprov.h>
+#include <wx/clipbrd.h>
 #include <wx/dcbuffer.h>
 #include <wx/event.h>
-#include <wx/clipbrd.h>
-#include <wx/artprov.h>
 
 #include "MainSequencer.h"
-#include "render/SequenceElements.h"
-#include "xLightsMain.h"
-#include "xLightsApp.h"
-#include "media/JukeboxPanel.h"
 #include "TimeLine.h"
 #include "UtilFunctions.h"
-#include "shared/utils/wxUtilities.h"
+#include "xLightsApp.h"
+#include "xLightsMain.h"
 #include "xLightsVersion.h"
+#include "../graphics/xlGraphicsBase.h"
+#include "effectpanels/EffectIconCache.h"
+#include "effects/RenderableEffect.h"
+#include "media/JukeboxPanel.h"
+#include "render/SequenceElements.h"
 #include "sequencer/EffectsPanel.h"
 #include "shared/utils/ExternalHooksUI.h"
-#include "effects/RenderableEffect.h"
-#include "effectpanels/EffectIconCache.h"
-#include "../graphics/xlGraphicsBase.h"
+#include "shared/utils/wxUtilities.h"
 
 #include <log.h>
 
@@ -50,56 +50,53 @@ const wxWindowID MainSequencer::ID_TEXTCTRL_SEQ_FILTER = wxNewId();
 wxDEFINE_EVENT(EVT_HORIZ_SCROLL, wxCommandEvent);
 wxDEFINE_EVENT(EVT_SCROLL_RIGHT, wxCommandEvent);
 
-BEGIN_EVENT_TABLE(MainSequencer,wxPanel)
-    EVT_MOUSEWHEEL(MainSequencer::mouseWheelMoved)
+BEGIN_EVENT_TABLE(MainSequencer, wxPanel)
+EVT_MOUSEWHEEL(MainSequencer::mouseWheelMoved)
 
-    EVT_COMMAND(wxID_ANY, EVT_HORIZ_SCROLL, MainSequencer::HorizontalScrollChanged)
-    EVT_COMMAND(wxID_ANY, EVT_SCROLL_RIGHT, MainSequencer::ScrollRight)
-    EVT_COMMAND(wxID_ANY, EVT_TIME_LINE_CHANGED, MainSequencer::TimelineChanged)
-    EVT_COMMAND(wxID_ANY, EVT_SEQUENCE_CHANGED, MainSequencer::SequenceChanged)
-    EVT_COMMAND(wxID_ANY, EVT_WAVE_FORM_HIGHLIGHT, MainSequencer::TimeLineSelectionChanged)
+EVT_COMMAND(wxID_ANY, EVT_HORIZ_SCROLL, MainSequencer::HorizontalScrollChanged)
+EVT_COMMAND(wxID_ANY, EVT_SCROLL_RIGHT, MainSequencer::ScrollRight)
+EVT_COMMAND(wxID_ANY, EVT_TIME_LINE_CHANGED, MainSequencer::TimelineChanged)
+EVT_COMMAND(wxID_ANY, EVT_SEQUENCE_CHANGED, MainSequencer::SequenceChanged)
+EVT_COMMAND(wxID_ANY, EVT_WAVE_FORM_HIGHLIGHT, MainSequencer::TimeLineSelectionChanged)
 
 END_EVENT_TABLE()
 
-void MainSequencer::SetHandlers(wxWindow *window)
-{
+void MainSequencer::SetHandlers(wxWindow* window) {
     if (window) {
         window->Connect(wxID_ANY,
                         wxEVT_CHAR,
                         wxKeyEventHandler(MainSequencer::OnChar),
-                        (wxObject*) nullptr,
+                        (wxObject*)nullptr,
                         this);
         window->Connect(wxID_ANY,
                         wxEVT_CHAR_HOOK,
                         wxKeyEventHandler(MainSequencer::OnCharHook),
-                        (wxObject*) nullptr,
+                        (wxObject*)nullptr,
                         this);
         window->Connect(wxID_ANY,
                         wxEVT_KEY_DOWN,
                         wxKeyEventHandler(MainSequencer::OnKeyDown),
-                        (wxObject*) nullptr,
+                        (wxObject*)nullptr,
                         this);
 
-        wxWindowList &list = window->GetChildren();
+        wxWindowList& list = window->GetChildren();
         for (wxWindowList::iterator it = list.begin(); it != list.end(); ++it) {
             wxWindow* pclChild = *it;
             SetHandlers(pclChild);
         }
 
-        window->Connect(wxID_CUT, wxEVT_MENU, (wxObjectEventFunction)&MainSequencer::DoCut,0,this);
-        window->Connect(wxID_COPY, wxEVT_MENU, (wxObjectEventFunction)&MainSequencer::DoCopy,0,this);
-        window->Connect(wxID_PASTE, wxEVT_MENU, (wxObjectEventFunction)&MainSequencer::DoPaste,0,this);
-        window->Connect(wxID_UNDO, wxEVT_MENU, (wxObjectEventFunction)&MainSequencer::DoUndo,0,this);
-        window->Connect(wxID_REDO, wxEVT_MENU, (wxObjectEventFunction)&MainSequencer::DoRedo,0,this);
+        window->Connect(wxID_CUT, wxEVT_MENU, (wxObjectEventFunction)&MainSequencer::DoCut, 0, this);
+        window->Connect(wxID_COPY, wxEVT_MENU, (wxObjectEventFunction)&MainSequencer::DoCopy, 0, this);
+        window->Connect(wxID_PASTE, wxEVT_MENU, (wxObjectEventFunction)&MainSequencer::DoPaste, 0, this);
+        window->Connect(wxID_UNDO, wxEVT_MENU, (wxObjectEventFunction)&MainSequencer::DoUndo, 0, this);
+        window->Connect(wxID_REDO, wxEVT_MENU, (wxObjectEventFunction)&MainSequencer::DoRedo, 0, this);
     }
 }
 
-class TimeDisplayControl : public GRAPHICS_BASE_CLASS
-{
+class TimeDisplayControl : public GRAPHICS_BASE_CLASS {
 public:
-    TimeDisplayControl(wxPanel* parent, wxWindowID id, const wxPoint &pos=wxDefaultPosition,
-                       const wxSize &size=wxDefaultSize, long style=0)
-    : GRAPHICS_BASE_CLASS(parent, id, pos, size, style, "TimeDisplay") {
+    TimeDisplayControl(wxPanel* parent, wxWindowID id, const wxPoint& pos = wxDefaultPosition,
+                       const wxSize& size = wxDefaultSize, long style = 0) : GRAPHICS_BASE_CLASS(parent, id, pos, size, style, "TimeDisplay") {
         _time = "Time: 00:00:00";
         _selected = "";
         _fps = "";
@@ -107,13 +104,13 @@ public:
         fontSize = 0;
         SetColors();
     }
-    virtual ~TimeDisplayControl(){};
+    virtual ~TimeDisplayControl() {};
 
-    void SetSelected(const wxString &sel) {
+    void SetSelected(const wxString& sel) {
         _selected = sel;
         Refresh();
     }
-    bool SetLabels(const wxString &time, const wxString &fps = wxEmptyString, bool r = true) {
+    bool SetLabels(const wxString& time, const wxString& fps = wxEmptyString, bool r = true) {
         bool changed = _fps != fps || _time != time;
         _fps = fps;
         _time = time;
@@ -123,9 +120,9 @@ public:
         return changed;
     }
 
-    protected:
+protected:
     DECLARE_EVENT_TABLE()
-    void Paint( wxPaintEvent& event ) {
+    void Paint(wxPaintEvent& event) {
         wxPaintDC dc(this);
         render();
     }
@@ -144,18 +141,20 @@ public:
         SetColors();
         Refresh();
     }
+
 public:
     void render() override {
-        if(!IsShownOnScreen()) return;
-        if(!mIsInitialized) {
+        if (!IsShownOnScreen())
+            return;
+        if (!mIsInitialized) {
             PrepareCanvas();
         }
 
-        xlGraphicsContext *ctx = PrepareContextForDrawing();
+        xlGraphicsContext* ctx = PrepareContextForDrawing();
         if (ctx == nullptr) {
             return;
         }
-        
+
         int h = mWindowHeight;
         if (!drawingUsingLogicalSize()) {
             h /= GetContentScaleFactor();
@@ -174,7 +173,7 @@ public:
             newFontSize = 10;
         }
         ctx->SetViewport(0, 0, mWindowWidth, mWindowHeight);
-        
+
         float fs = translateToBacking(fontSize);
         if (newFontSize != fontSize || backedFontSize != fs) {
             if (fontTexture) {
@@ -184,12 +183,12 @@ public:
             fontSize = newFontSize;
             fs = translateToBacking(fontSize);
             backedFontSize = fs;
-            const xlFontInfo &fi = xlFontInfo::FindFont((int)fs);
+            const xlFontInfo& fi = xlFontInfo::FindFont((int)fs);
             fontTexture = ctx->createTextureForFont(fi);
         }
-        const xlFontInfo &fi = xlFontInfo::FindFont(fs);
+        const xlFontInfo& fi = xlFontInfo::FindFont(fs);
 #define LINEGAP 1.2
-        xlVertexTextureAccumulator *vta = ctx->createVertexTextureAccumulator();
+        xlVertexTextureAccumulator* vta = ctx->createVertexTextureAccumulator();
         float x = mapLogicalToAbsolute(5);
         float perLine = fi.getSize() * LINEGAP;
         float y = perLine;
@@ -217,7 +216,7 @@ public:
 private:
     xlColor bgColor;
     xlColor fgColor;
-    xlTexture *fontTexture = nullptr;
+    xlTexture* fontTexture = nullptr;
 
     std::string _time;
     std::string _fps;
@@ -233,9 +232,7 @@ EVT_PAINT(TimeDisplayControl::Paint)
 EVT_SYS_COLOUR_CHANGED(TimeDisplayControl::OnSysColourChanged)
 END_EVENT_TABLE()
 
-MainSequencer::MainSequencer(wxWindow* parent, bool smallWaveform, wxWindowID id, const wxPoint& pos, const wxSize& size)
-{
-    
+MainSequencer::MainSequencer(wxWindow* parent, bool smallWaveform, wxWindowID id, const wxPoint& pos, const wxSize& size) {
     spdlog::debug("                Creating main sequencer");
 
     //(*Initialize(MainSequencer)
@@ -244,7 +241,7 @@ MainSequencer::MainSequencer(wxWindow* parent, bool smallWaveform, wxWindowID id
     wxFlexGridSizer* FlexGridSizer4;
     wxStaticText* StaticText1;
 
-    Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL|wxWANTS_CHARS, _T("wxID_ANY"));
+    Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxWANTS_CHARS, _T("wxID_ANY"));
     FlexGridSizer1 = new wxFlexGridSizer(3, 3, 0, 0);
     FlexGridSizer1->AddGrowableCol(1);
     FlexGridSizer1->AddGrowableRow(1);
@@ -252,42 +249,42 @@ MainSequencer::MainSequencer(wxWindow* parent, bool smallWaveform, wxWindowID id
     FlexGridSizer2->AddGrowableCol(0);
     ViewLabel = new wxStaticText(this, wxID_ANY, _("View:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
     StaticText1 = ViewLabel;
-    FlexGridSizer2->Add(StaticText1, 1, wxTOP|wxLEFT|wxRIGHT|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 3);
+    FlexGridSizer2->Add(StaticText1, 1, wxTOP | wxLEFT | wxRIGHT | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 3);
     ViewChoice = new wxChoice(this, ID_CHOICE_VIEW_CHOICE, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_VIEW_CHOICE"));
-    FlexGridSizer2->Add(ViewChoice, 1, wxBOTTOM|wxLEFT|wxRIGHT|wxEXPAND, 0);
-    FlexGridSizer2->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    FlexGridSizer2->Add(ViewChoice, 1, wxBOTTOM | wxLEFT | wxRIGHT | wxEXPAND, 0);
+    FlexGridSizer2->Add(-1, -1, 1, wxALL | wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL, 5);
     FlexGridSizer1->Add(FlexGridSizer2, 0, wxEXPAND, 0);
     FlexGridSizer4 = new wxFlexGridSizer(2, 0, 0, 0);
     FlexGridSizer4->AddGrowableCol(0);
     FlexGridSizer4->AddGrowableRow(1);
-    PanelTimeLine = new TimeLine(this, ID_PANEL1, wxDefaultPosition, wxDLG_UNIT(this,wxSize(-1,15)), wxTAB_TRAVERSAL, _T("ID_PANEL1"));
-    PanelTimeLine->SetMinSize(wxDLG_UNIT(this,wxSize(-1,15)));
-    PanelTimeLine->SetMaxSize(wxDLG_UNIT(this,wxSize(-1,15)));
-    FlexGridSizer4->Add(PanelTimeLine, 1, wxALL|wxEXPAND, 0);
-    PanelWaveForm = new Waveform(this, ID_PANEL3, wxDefaultPosition, wxDLG_UNIT(this,wxSize(-1,40)), wxTAB_TRAVERSAL, _T("ID_PANEL3"));
-    PanelWaveForm->SetMinSize(wxDLG_UNIT(this,wxSize(-1,40)));
-    PanelWaveForm->SetMaxSize(wxDLG_UNIT(this,wxSize(-1,40)));
-    FlexGridSizer4->Add(PanelWaveForm, 1, wxALL|wxEXPAND, 0);
-    FlexGridSizer1->Add(FlexGridSizer4, 1, wxALL|wxEXPAND, 0);
-    FlexGridSizer1->Add(-1,-1,1, wxALL|wxEXPAND, 5);
-    PanelRowHeadings = new RowHeading(this, ID_PANEL6, wxDefaultPosition, wxDLG_UNIT(this,wxSize(90,-1)), wxTAB_TRAVERSAL, _T("ID_PANEL6"));
-    PanelRowHeadings->SetMinSize(wxDLG_UNIT(this,wxSize(90,-1)));
-    PanelRowHeadings->SetMaxSize(wxDLG_UNIT(this,wxSize(90,-1)));
-    FlexGridSizer1->Add(PanelRowHeadings, 1, wxALL|wxEXPAND, 0);
-    PanelEffectGrid = new EffectsGrid(this, ID_PANEL2, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL|wxFULL_REPAINT_ON_RESIZE, _T("ID_PANEL2"));
-    FlexGridSizer1->Add(PanelEffectGrid, 1, wxALL|wxEXPAND, 0);
-    ScrollBarEffectsVertical = new wxScrollBar(this, ID_SCROLLBAR_EFFECTS_VERTICAL, wxDefaultPosition, wxDefaultSize, wxSB_VERTICAL|wxALWAYS_SHOW_SB, wxDefaultValidator, _T("ID_SCROLLBAR_EFFECTS_VERTICAL"));
+    PanelTimeLine = new TimeLine(this, ID_PANEL1, wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, 15)), wxTAB_TRAVERSAL, _T("ID_PANEL1"));
+    PanelTimeLine->SetMinSize(wxDLG_UNIT(this, wxSize(-1, 15)));
+    PanelTimeLine->SetMaxSize(wxDLG_UNIT(this, wxSize(-1, 15)));
+    FlexGridSizer4->Add(PanelTimeLine, 1, wxALL | wxEXPAND, 0);
+    PanelWaveForm = new Waveform(this, ID_PANEL3, wxDefaultPosition, wxDLG_UNIT(this, wxSize(-1, 40)), wxTAB_TRAVERSAL, _T("ID_PANEL3"));
+    PanelWaveForm->SetMinSize(wxDLG_UNIT(this, wxSize(-1, 40)));
+    PanelWaveForm->SetMaxSize(wxDLG_UNIT(this, wxSize(-1, 40)));
+    FlexGridSizer4->Add(PanelWaveForm, 1, wxALL | wxEXPAND, 0);
+    FlexGridSizer1->Add(FlexGridSizer4, 1, wxALL | wxEXPAND, 0);
+    FlexGridSizer1->Add(-1, -1, 1, wxALL | wxEXPAND, 5);
+    PanelRowHeadings = new RowHeading(this, ID_PANEL6, wxDefaultPosition, wxDLG_UNIT(this, wxSize(90, -1)), wxTAB_TRAVERSAL, _T("ID_PANEL6"));
+    PanelRowHeadings->SetMinSize(wxDLG_UNIT(this, wxSize(90, -1)));
+    PanelRowHeadings->SetMaxSize(wxDLG_UNIT(this, wxSize(90, -1)));
+    FlexGridSizer1->Add(PanelRowHeadings, 1, wxALL | wxEXPAND, 0);
+    PanelEffectGrid = new EffectsGrid(this, ID_PANEL2, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL | wxFULL_REPAINT_ON_RESIZE, _T("ID_PANEL2"));
+    FlexGridSizer1->Add(PanelEffectGrid, 1, wxALL | wxEXPAND, 0);
+    ScrollBarEffectsVertical = new wxScrollBar(this, ID_SCROLLBAR_EFFECTS_VERTICAL, wxDefaultPosition, wxDefaultSize, wxSB_VERTICAL | wxALWAYS_SHOW_SB, wxDefaultValidator, _T("ID_SCROLLBAR_EFFECTS_VERTICAL"));
     ScrollBarEffectsVertical->SetScrollbar(0, 1, 10, 1);
-    FlexGridSizer1->Add(ScrollBarEffectsVertical, 1, wxALL|wxEXPAND, 0);
+    FlexGridSizer1->Add(ScrollBarEffectsVertical, 1, wxALL | wxEXPAND, 0);
     CheckBox_SuspendRender = new wxCheckBox(this, ID_CHECKBOX1, _("Suspend Render"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX1"));
     CheckBox_SuspendRender->SetValue(false);
-    FlexGridSizer1->Add(CheckBox_SuspendRender, 1, wxALL|wxEXPAND, 0);
-    ScrollBarEffectsHorizontal = new wxScrollBar(this, ID_SCROLLBAR_EFFECT_GRID_HORZ, wxDefaultPosition, wxDefaultSize, wxSB_HORIZONTAL|wxALWAYS_SHOW_SB, wxDefaultValidator, _T("ID_SCROLLBAR_EFFECT_GRID_HORZ"));
+    FlexGridSizer1->Add(CheckBox_SuspendRender, 1, wxALL | wxEXPAND, 0);
+    ScrollBarEffectsHorizontal = new wxScrollBar(this, ID_SCROLLBAR_EFFECT_GRID_HORZ, wxDefaultPosition, wxDefaultSize, wxSB_HORIZONTAL | wxALWAYS_SHOW_SB, wxDefaultValidator, _T("ID_SCROLLBAR_EFFECT_GRID_HORZ"));
     ScrollBarEffectsHorizontal->SetScrollbar(0, 1, 100, 1);
-    FlexGridSizer1->Add(ScrollBarEffectsHorizontal, 1, wxALL|wxEXPAND, 0);
+    FlexGridSizer1->Add(ScrollBarEffectsHorizontal, 1, wxALL | wxEXPAND, 0);
     SetSizer(FlexGridSizer1);
 
-    Connect(ID_SCROLLBAR_EFFECTS_VERTICAL, wxEVT_SCROLL_TOP|wxEVT_SCROLL_BOTTOM|wxEVT_SCROLL_LINEUP|wxEVT_SCROLL_LINEDOWN|wxEVT_SCROLL_PAGEUP|wxEVT_SCROLL_PAGEDOWN|wxEVT_SCROLL_THUMBTRACK|wxEVT_SCROLL_THUMBRELEASE|wxEVT_SCROLL_CHANGED, (wxObjectEventFunction)&MainSequencer::OnScrollBarEffectsVerticalScrollChanged);
+    Connect(ID_SCROLLBAR_EFFECTS_VERTICAL, wxEVT_SCROLL_TOP | wxEVT_SCROLL_BOTTOM | wxEVT_SCROLL_LINEUP | wxEVT_SCROLL_LINEDOWN | wxEVT_SCROLL_PAGEUP | wxEVT_SCROLL_PAGEDOWN | wxEVT_SCROLL_THUMBTRACK | wxEVT_SCROLL_THUMBRELEASE | wxEVT_SCROLL_CHANGED, (wxObjectEventFunction)&MainSequencer::OnScrollBarEffectsVerticalScrollChanged);
     Connect(ID_SCROLLBAR_EFFECTS_VERTICAL, wxEVT_SCROLL_TOP, (wxObjectEventFunction)&MainSequencer::OnScrollBarEffectsVerticalScrollChanged);
     Connect(ID_SCROLLBAR_EFFECTS_VERTICAL, wxEVT_SCROLL_BOTTOM, (wxObjectEventFunction)&MainSequencer::OnScrollBarEffectsVerticalScrollChanged);
     Connect(ID_SCROLLBAR_EFFECTS_VERTICAL, wxEVT_SCROLL_LINEUP, (wxObjectEventFunction)&MainSequencer::OnScrollBarEffectsVerticalScrollChanged);
@@ -297,7 +294,7 @@ MainSequencer::MainSequencer(wxWindow* parent, bool smallWaveform, wxWindowID id
     Connect(ID_SCROLLBAR_EFFECTS_VERTICAL, wxEVT_SCROLL_THUMBTRACK, (wxObjectEventFunction)&MainSequencer::OnScrollBarEffectsVerticalScrollChanged);
     Connect(ID_SCROLLBAR_EFFECTS_VERTICAL, wxEVT_SCROLL_CHANGED, (wxObjectEventFunction)&MainSequencer::OnScrollBarEffectsVerticalScrollChanged);
     Connect(ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&MainSequencer::OnCheckBox_SuspendRenderClick);
-    Connect(ID_SCROLLBAR_EFFECT_GRID_HORZ, wxEVT_SCROLL_TOP|wxEVT_SCROLL_BOTTOM|wxEVT_SCROLL_LINEUP|wxEVT_SCROLL_LINEDOWN|wxEVT_SCROLL_PAGEUP|wxEVT_SCROLL_PAGEDOWN|wxEVT_SCROLL_THUMBTRACK|wxEVT_SCROLL_THUMBRELEASE|wxEVT_SCROLL_CHANGED, (wxObjectEventFunction)&MainSequencer::OnScrollBarEffectGridHorzScroll);
+    Connect(ID_SCROLLBAR_EFFECT_GRID_HORZ, wxEVT_SCROLL_TOP | wxEVT_SCROLL_BOTTOM | wxEVT_SCROLL_LINEUP | wxEVT_SCROLL_LINEDOWN | wxEVT_SCROLL_PAGEUP | wxEVT_SCROLL_PAGEDOWN | wxEVT_SCROLL_THUMBTRACK | wxEVT_SCROLL_THUMBRELEASE | wxEVT_SCROLL_CHANGED, (wxObjectEventFunction)&MainSequencer::OnScrollBarEffectGridHorzScroll);
     Connect(ID_SCROLLBAR_EFFECT_GRID_HORZ, wxEVT_SCROLL_TOP, (wxObjectEventFunction)&MainSequencer::OnScrollBarEffectGridHorzScroll);
     Connect(ID_SCROLLBAR_EFFECT_GRID_HORZ, wxEVT_SCROLL_BOTTOM, (wxObjectEventFunction)&MainSequencer::OnScrollBarEffectGridHorzScroll);
     Connect(ID_SCROLLBAR_EFFECT_GRID_HORZ, wxEVT_SCROLL_LINEUP, (wxObjectEventFunction)&MainSequencer::OnScrollBarEffectsHorizontalScrollLineUp);
@@ -316,7 +313,7 @@ MainSequencer::MainSequencer(wxWindow* parent, bool smallWaveform, wxWindowID id
 
     // Sequencer prop filter - hidden by default
     _seqFilterCtrl = new wxSearchCtrl(this, ID_TEXTCTRL_SEQ_FILTER,
-        wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+                                      wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
     _seqFilterCtrl->SetDescriptiveText("Filter props...");
     _seqFilterCtrl->ShowCancelButton(true);
     _seqFilterCtrl->Bind(wxEVT_TEXT, &MainSequencer::OnSeqFilterText, this);
@@ -324,15 +321,18 @@ MainSequencer::MainSequencer(wxWindow* parent, bool smallWaveform, wxWindowID id
     _seqFilterCtrl->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN, &MainSequencer::OnSeqFilterCancel, this);
     _seqFilterCtrl->Bind(wxEVT_SEARCHCTRL_SEARCH_BTN, &MainSequencer::OnSeqFilterEnter, this);
     _seqFilterCtrl->Bind(wxEVT_CHAR_HOOK, [this](wxKeyEvent& e) {
-        if (e.GetKeyCode() == WXK_ESCAPE) { ShowSeqFilterPanel(false); }
-        else { e.Skip(); }
+        if (e.GetKeyCode() == WXK_ESCAPE) {
+            ShowSeqFilterPanel(false);
+        } else {
+            e.Skip();
+        }
     });
     FlexGridSizer2->Add(_seqFilterCtrl, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 2);
     _seqFilterCtrl->Hide();
 
     spdlog::debug("                Create time display control");
     timeDisplay = new TimeDisplayControl(this, wxID_ANY);
-    FlexGridSizer2->Add(timeDisplay, 1, wxALL |wxEXPAND, 0);
+    FlexGridSizer2->Add(timeDisplay, 1, wxALL | wxEXPAND, 0);
     FlexGridSizer2->AddGrowableRow(4);
 
     FlexGridSizer2->Fit(this);
@@ -364,17 +364,15 @@ MainSequencer::MainSequencer(wxWindow* parent, bool smallWaveform, wxWindowID id
 #endif
 }
 
-MainSequencer::~MainSequencer()
-{
+MainSequencer::~MainSequencer() {
     // Tag positions are stored in SequenceElements now; nothing to clean up
     timeDisplay = nullptr; // wxWidgets will delete it
 
-	//(*Destroy(MainSequencer)
-	//*)
+    //(*Destroy(MainSequencer)
+    //*)
 }
 
-void MainSequencer::SetSequenceElements(SequenceElements* elements)
-{
+void MainSequencer::SetSequenceElements(SequenceElements* elements) {
     mSequenceElements = elements;
 }
 
@@ -382,34 +380,32 @@ void MainSequencer::SetShowAlternateTimingMark(bool b) {
     mShowAlternateTimingFormat = b;
 }
 
-void MainSequencer::UpdateEffectGridVerticalScrollBar()
-{
+void MainSequencer::UpdateEffectGridVerticalScrollBar() {
     int position = mSequenceElements->GetFirstVisibleModelRow();
     int range = mSequenceElements->GetTotalNumberOfModelRows();
     int pageSize = mSequenceElements->GetMaxModelsDisplayed();
     int thumbSize = mSequenceElements->GetMaxModelsDisplayed();
-    ScrollBarEffectsVertical->SetScrollbar(position,thumbSize,range,pageSize);
+    ScrollBarEffectsVertical->SetScrollbar(position, thumbSize, range, pageSize);
     ScrollBarEffectsVertical->Refresh();
     PanelEffectGrid->Draw();
     PanelRowHeadings->Refresh();
 }
 
-bool MainSequencer::UpdateTimeDisplay(int time_ms, const std::vector<float> &fps, bool render)
-{
+bool MainSequencer::UpdateTimeDisplay(int time_ms, const std::vector<float>& fps, bool render) {
     int time = time_ms >= 0 ? time_ms : 0;
     int msec = time % 1000;
     int seconds = time / 1000;
     int minutes = seconds / 60;
     seconds = seconds % 60;
     wxString play_time = wxString::Format("Time: %d:%02d.%02d", minutes, seconds, msec);
-    if(mShowAlternateTimingFormat) {
+    if (mShowAlternateTimingFormat) {
         int totalSeconds = (minutes * 60) + seconds;
         play_time = wxString::Format("Time: %d.%02ds", totalSeconds, msec);
     }
     wxString fpsStr;
     if (!fps.empty()) {
         fpsStr = wxString::Format("FPS: ");
-        for (auto &f : fps) {
+        for (auto& f : fps) {
             fpsStr += wxString::Format(" %5.1f", f);
         }
     }
@@ -419,12 +415,11 @@ bool MainSequencer::UpdateTimeDisplay(int time_ms, const std::vector<float> &fps
     return false;
 }
 
-void MainSequencer::UpdateSelectedDisplay(int selected)
-{
+void MainSequencer::UpdateSelectedDisplay(int selected) {
     if (selected == 0) {
         timeDisplay->SetSelected("");
     } else {
-        if(mShowAlternateTimingFormat) {
+        if (mShowAlternateTimingFormat) {
             int seconds = selected / 1000;
             int milliseconds = selected % 1000;
             timeDisplay->SetSelected(wxString::Format("Selected: %d.%02ds", seconds, milliseconds));
@@ -434,26 +429,23 @@ void MainSequencer::UpdateSelectedDisplay(int selected)
     }
 }
 
-void MainSequencer::OnScrollBarEffectGridHorzScroll(wxScrollEvent& event)
-{
+void MainSequencer::OnScrollBarEffectGridHorzScroll(wxScrollEvent& event) {
     int position = ScrollBarEffectsHorizontal->GetThumbPosition();
     int timeLength = PanelTimeLine->GetTimeLength();
 
-    int startTime = (int)(((double)position/(double)timeLength) * (double)timeLength);
+    int startTime = (int)(((double)position / (double)timeLength) * (double)timeLength);
     PanelTimeLine->SetStartTimeMS(startTime);
     UpdateEffectGridHorizontalScrollBar();
 }
 
-void MainSequencer::OnScrollBarEffectsVerticalScrollChanged(wxScrollEvent& event)
-{
+void MainSequencer::OnScrollBarEffectsVerticalScrollChanged(wxScrollEvent& event) {
     int position = ScrollBarEffectsVertical->GetThumbPosition();
     int scroll = mSequenceElements->SetFirstVisibleModelRow(position);
     PanelEffectGrid->ScrollBy(scroll);
     UpdateEffectGridVerticalScrollBar();
 }
 
-void MainSequencer::mouseWheelMoved(wxMouseEvent& event)
-{
+void MainSequencer::mouseWheelMoved(wxMouseEvent& event) {
     bool fromTrackPad = IsMouseEventFromTouchpad();
     int i = event.GetWheelRotation();
     if (event.GetWheelAxis() == wxMOUSE_WHEEL_HORIZONTAL) {
@@ -462,7 +454,7 @@ void MainSequencer::mouseWheelMoved(wxMouseEvent& event)
         if (fromTrackPad) {
             ts = PanelTimeLine->GetTimeMSfromPosition(std::abs(event.GetWheelRotation()));
         }
-        if (ts ==0) {
+        if (ts == 0) {
             ts = 1;
         }
         if (i < 0) {
@@ -519,10 +511,10 @@ void MainSequencer::mouseWheelMoved(wxMouseEvent& event)
                 }
             }
         }
-        
+
         if (positionAdj) {
             if (i < 0) {
-                if (position < ScrollBarEffectsVertical->GetRange()-1) {
+                if (position < ScrollBarEffectsVertical->GetRange() - 1) {
                     position += positionAdj;
                     ScrollBarEffectsVertical->SetThumbPosition(position);
                     int scroll = mSequenceElements->SetFirstVisibleModelRow(position);
@@ -538,22 +530,19 @@ void MainSequencer::mouseWheelMoved(wxMouseEvent& event)
             }
         }
         mSequenceElements->PopulateVisibleRowInformation();
-        PanelEffectGrid->ForceRefresh();  // call this so we can check if we need to update which effects are selected
+        PanelEffectGrid->ForceRefresh(); // call this so we can check if we need to update which effects are selected
         PanelRowHeadings->Refresh();
     }
 }
 
-bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
-{
-    
-
+bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event) {
     if (mSequenceElements != nullptr) {
-
         auto k = event.GetKeyCode();
-        if (k == WXK_SHIFT || k == WXK_CONTROL || k == WXK_ALT || k == WXK_RAW_CONTROL) return false;
+        if (k == WXK_SHIFT || k == WXK_CONTROL || k == WXK_ALT || k == WXK_RAW_CONTROL)
+            return false;
 
         if ((!event.ControlDown() && !event.CmdDown() && !event.AltDown() && !event.RawControlDown()) ||
-            (k == 'A' && (event.ControlDown() || event.CmdDown() || event.RawControlDown()) && !event.AltDown())) {
+            ((k == 'A' || k == 'a') && (event.ControlDown() || event.CmdDown() || event.RawControlDown()) && !event.AltDown())) {
             // Just a regular key ... If current focus is a control then we need to not process this
             if (dynamic_cast<wxControl*>(event.GetEventObject()) != nullptr &&
                 (k < 128 || k == WXK_NUMPAD_END || k == WXK_NUMPAD_HOME || k == WXK_NUMPAD_INSERT || k == WXK_HOME || k == WXK_END || k == WXK_NUMPAD_SUBTRACT || k == WXK_NUMPAD_DECIMAL)) {
@@ -566,29 +555,21 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
             std::string type = binding->GetType();
             if (type == "TIMING_ADD") {
                 InsertTimingMarkFromRange();
-            }
-            else if (type == "TIMING_SPLIT") {
+            } else if (type == "TIMING_SPLIT") {
                 SplitTimingMark();
-            }
-            else if (type == "TIMING_DIVIDE_2") {
+            } else if (type == "TIMING_DIVIDE_2") {
                 DivideTimingTrack(2);
-            }
-            else if (type == "TIMING_DIVIDE_3") {
+            } else if (type == "TIMING_DIVIDE_3") {
                 DivideTimingTrack(3);
-            }
-            else if (type == "TIMING_DIVIDE_4") {
+            } else if (type == "TIMING_DIVIDE_4") {
                 DivideTimingTrack(4);
-            }
-            else if (type == "TIMING_DIVIDE_6") {
+            } else if (type == "TIMING_DIVIDE_6") {
                 DivideTimingTrack(6);
-            }
-            else if (type == "TIMING_DIVIDE_8") {
+            } else if (type == "TIMING_DIVIDE_8") {
                 DivideTimingTrack(8);
-            }
-            else if (type == "TIMING_DIVIDE_12") {
+            } else if (type == "TIMING_DIVIDE_12") {
                 DivideTimingTrack(12);
-            }
-            else if (type == "TIMING_DIVIDE_16") {
+            } else if (type == "TIMING_DIVIDE_16") {
                 DivideTimingTrack(16);
             } else if (type == "EFFECTS_TO_TIMING") {
                 PanelEffectGrid->CreateTimingFromSelectedEffects();
@@ -614,18 +595,14 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
                 PanelRowHeadings->SelectTiming(-1);
             } else if (type == "ZOOM_IN") {
                 PanelTimeLine->ZoomIn();
-            }
-            else if (type == "ZOOM_OUT") {
+            } else if (type == "ZOOM_OUT") {
                 PanelTimeLine->ZoomOut();
-            }
-            else if (type == "ZOOM_SEL") {
+            } else if (type == "ZOOM_SEL") {
                 PanelTimeLine->ZoomSelection();
-            }
-            else if (type == "RANDOM") {
+            } else if (type == "RANDOM") {
                 Effect* ef = PanelEffectGrid->Paste("Random\t\t\n", xlights_version_string);
                 SelectEffect(ef);
-            }
-            else if (type == "EFFECT") {
+            } else if (type == "EFFECT") {
                 if (PanelEffectGrid->GetSelectedEffect() == nullptr) {
                     // reset default settings if appropriate
                     if (binding->GetEffectName() != xLightsApp::GetFrame()->GetEffectsPanel()->EffectChoicebook->GetChoiceCtrl()->GetStringSelection()) {
@@ -645,8 +622,7 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
                         SelectEffect(ef);
                     }
                 }
-            }
-            else if (type == "APPLYSETTING") {
+            } else if (type == "APPLYSETTING") {
                 SettingsMap newSetting = SettingsMap();
                 newSetting.Parse(nullptr, binding->GetEffectString(), "");
 
@@ -657,75 +633,55 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
                 for (const auto& s : newSetting) {
                     ApplyEffectSettingToSelected("", s.first, s.second, nullptr, "");
                 }
-            }
-            else if (type == "PRESET") {
+            } else if (type == "PRESET") {
                 Effect* ef = xLightsApp::GetFrame()->ApplyEffectsPreset(binding->GetEffectName());
                 PanelEffectGrid->SelectEffect(ef);
-            }
-            else if (type == "EFFECT_SETTINGS_TOGGLE") {
+            } else if (type == "EFFECT_SETTINGS_TOGGLE") {
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->ShowHideEffectSettingsWindow(e);
-            }
-            else if (type == "SAVE_SEQUENCE") {
+            } else if (type == "SAVE_SEQUENCE") {
                 xLightsApp::GetFrame()->SaveSequence();
-            }
-            else if (type == "SAVEAS_SEQUENCE") {
+            } else if (type == "SAVEAS_SEQUENCE") {
                 xLightsApp::GetFrame()->SaveAsSequence();
-            }
-            else if (type == "EFFECT_ASSIST_TOGGLE") {
+            } else if (type == "EFFECT_ASSIST_TOGGLE") {
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->ShowHideEffectAssistWindow(e);
-            }
-            else if (type == "COLOR_TOGGLE") {
+            } else if (type == "COLOR_TOGGLE") {
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->ShowHideColorWindow(e);
-            }
-            else if (type == "LAYER_SETTING_TOGGLE") {
+            } else if (type == "LAYER_SETTING_TOGGLE") {
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->ShowHideBufferSettingsWindow(e);
-            }
-            else if (type == "LAYER_BLENDING_TOGGLE") {
+            } else if (type == "LAYER_BLENDING_TOGGLE") {
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->ShowHideLayerBlendingWindow(e);
-            }
-            else if (type == "MODEL_PREVIEW_TOGGLE") {
+            } else if (type == "MODEL_PREVIEW_TOGGLE") {
                 ToggleModelPreview();
-            }
-            else if (type == "HOUSE_PREVIEW_TOGGLE") {
+            } else if (type == "HOUSE_PREVIEW_TOGGLE") {
                 ToggleHousePreview();
-            }
-            else if (type == "EFFECTS_TOGGLE") {
+            } else if (type == "EFFECTS_TOGGLE") {
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->ShowHideEffectDropper(e);
-            }
-            else if (type == "DISPLAY_ELEMENTS_TOGGLE") {
+            } else if (type == "DISPLAY_ELEMENTS_TOGGLE") {
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->ShowHideDisplayElementsWindow(e);
-            }
-            else if (type == "JUKEBOX_TOGGLE") {
+            } else if (type == "JUKEBOX_TOGGLE") {
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->OnMenuItem_JukeboxSelected(e);
-            }
-            else if (type == "LOCK_EFFECT") {
+            } else if (type == "LOCK_EFFECT") {
                 PanelEffectGrid->LockEffects(true);
-            }
-            else if (type == "CANCEL_RENDER") {
+            } else if (type == "CANCEL_RENDER") {
                 CancelRender();
-            }
-            else if (type == "TOGGLE_RENDER") {
+            } else if (type == "TOGGLE_RENDER") {
                 CheckBox_SuspendRender->SetValue(!CheckBox_SuspendRender->GetValue());
                 ToggleRender(CheckBox_SuspendRender->GetValue());
-            }
-            else if (type == "UNLOCK_EFFECT") {
+            } else if (type == "UNLOCK_EFFECT") {
                 PanelEffectGrid->LockEffects(false);
-            }
-            else if (type == "MARK_SPOT") {
+            } else if (type == "MARK_SPOT") {
                 SavePosition();
-            }
-            else if (type == "RETURN_TO_SPOT") {
+            } else if (type == "RETURN_TO_SPOT") {
                 RestorePosition();
-            }
-            else if (type == "PRIOR_TAG") {
+            } else if (type == "PRIOR_TAG") {
                 PanelTimeLine->GoToPriorTag();
             } else if (type == "JUKEBOX_BTN_1") {
                 JukeboxPanel* jukeboxPanel = xLightsApp::GetFrame()->GetJukeboxPanel();
@@ -752,23 +708,17 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
                 if (jukeboxPanel != nullptr) {
                     jukeboxPanel->PlayItem(5);
                 }
-            }
-            else if (type == "NEXT_TAG") {
+            } else if (type == "NEXT_TAG") {
                 PanelTimeLine->GoToNextTag();
-            }
-            else if (type == "EFFECT_DESCRIPTION") {
+            } else if (type == "EFFECT_DESCRIPTION") {
                 PanelEffectGrid->SetEffectsDescription();
-            }
-            else if (type == "EFFECT_ALIGN_START") {
+            } else if (type == "EFFECT_ALIGN_START") {
                 PanelEffectGrid->AlignSelectedEffects(EFF_ALIGN_MODE::ALIGN_START_TIMES);
-            }
-            else if (type == "EFFECT_ALIGN_END") {
+            } else if (type == "EFFECT_ALIGN_END") {
                 PanelEffectGrid->AlignSelectedEffects(EFF_ALIGN_MODE::ALIGN_END_TIMES);
-            }
-            else if (type == "EFFECT_ALIGN_BOTH") {
+            } else if (type == "EFFECT_ALIGN_BOTH") {
                 PanelEffectGrid->AlignSelectedEffects(EFF_ALIGN_MODE::ALIGN_BOTH_TIMES);
-            }
-            else if (type == "INSERT_LAYER_ABOVE") {
+            } else if (type == "INSERT_LAYER_ABOVE") {
                 PanelEffectGrid->InsertEffectLayerAbove();
             } else if (type == "INCREASE_SPEED") {
                 float t = xLightsApp::GetFrame()->GetPlaySpeed();
@@ -788,113 +738,82 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
                 spdlog::debug("play next tag");
                 wxCommandEvent playEvent(EVT_SEQUENCE_NEXT_TAG);
                 wxPostEvent(xLightsApp::GetFrame(), playEvent);
-            }
-            else if (type == "AUDIO_FULL_SPEED") {
+            } else if (type == "AUDIO_FULL_SPEED") {
                 xLightsApp::GetFrame()->SetPlaySpeedTo(1.0);
-            }
-            else if (type == "AUDIO_F_1_5_SPEED") {
+            } else if (type == "AUDIO_F_1_5_SPEED") {
                 xLightsApp::GetFrame()->SetPlaySpeedTo(1.5);
-            }
-            else if (type == "AUDIO_F_2_SPEED") {
+            } else if (type == "AUDIO_F_2_SPEED") {
                 xLightsApp::GetFrame()->SetPlaySpeedTo(2.0);
-            }
-            else if (type == "AUDIO_F_3_SPEED") {
+            } else if (type == "AUDIO_F_3_SPEED") {
                 xLightsApp::GetFrame()->SetPlaySpeedTo(3.0);
-            }
-            else if (type == "AUDIO_F_4_SPEED") {
+            } else if (type == "AUDIO_F_4_SPEED") {
                 xLightsApp::GetFrame()->SetPlaySpeedTo(4.0);
-            }
-            else if (type == "AUDIO_S_3_4_SPEED") {
+            } else if (type == "AUDIO_S_3_4_SPEED") {
                 xLightsApp::GetFrame()->SetPlaySpeedTo(0.75);
-            }
-            else if (type == "AUDIO_S_1_2_SPEED") {
+            } else if (type == "AUDIO_S_1_2_SPEED") {
                 xLightsApp::GetFrame()->SetPlaySpeedTo(0.5);
-            }
-            else if (type == "AUDIO_S_1_4_SPEED") {
+            } else if (type == "AUDIO_S_1_4_SPEED") {
                 xLightsApp::GetFrame()->SetPlaySpeedTo(0.25);
-            }
-            else if (type == "SELECT_ALL") {
+            } else if (type == "SELECT_ALL") {
                 mSequenceElements->SelectAllEffects();
                 PanelEffectGrid->Refresh();
-            }
-            else if (type == "SELECT_ALL_NO_TIMING") {
+            } else if (type == "SELECT_ALL_NO_TIMING") {
                 mSequenceElements->SelectAllEffectsNoTiming();
                 PanelEffectGrid->Refresh();
-            }
-            else if (type == "INSERT_LAYER_BELOW") {
+            } else if (type == "INSERT_LAYER_BELOW") {
                 PanelEffectGrid->InsertEffectLayerBelow();
-            }
-            else if (type == "TOGGLE_ELEMENT_EXPAND") {
+            } else if (type == "TOGGLE_ELEMENT_EXPAND") {
                 PanelEffectGrid->ToggleExpandElement(PanelRowHeadings);
-            }
-            else if (type == "SHOW_PRESETS") {
+            } else if (type == "SHOW_PRESETS") {
                 xLightsApp::GetFrame()->ShowPresetsPanel();
-            }
-            else if (type == "PRESETS_TOGGLE") {
+            } else if (type == "PRESETS_TOGGLE") {
                 xLightsApp::GetFrame()->TogglePresetsPanel();
-            }
-            else if (type == "VALUECURVES_TOGGLE") {
+            } else if (type == "VALUECURVES_TOGGLE") {
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->OnMenuItem_ValueCurvesSelected(e);
-            }
-            else if (type == "COLOR_DROPPER_TOGGLE") {
+            } else if (type == "COLOR_DROPPER_TOGGLE") {
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->OnMenuItem_ColourDropperSelected(e);
-            }
-            else if (type == "SEARCH_TOGGLE") {
+            } else if (type == "SEARCH_TOGGLE") {
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->OnMenuItemSelectEffectSelected(e);
-            }
-            else if (type == "FILTER_SEQUENCER") {
+            } else if (type == "FILTER_SEQUENCER") {
                 ShowSeqFilterPanel(!_seqFilterCtrl->IsShown());
-            }
-            else if (type == "PERSPECTIVES_TOGGLE") {
+            } else if (type == "PERSPECTIVES_TOGGLE") {
                 wxCommandEvent e;
                 xLightsApp::GetFrame()->ShowHidePerspectivesWindow(e);
-            }
-            else if (type == "EFFECT_UPDATE") {
+            } else if (type == "EFFECT_UPDATE") {
                 wxCommandEvent eventEffectUpdated(EVT_EFFECT_UPDATED);
                 wxPostEvent(GetParent(), eventEffectUpdated);
-            }
-            else if (type == "COLOR_UPDATE") {
+            } else if (type == "COLOR_UPDATE") {
                 wxCommandEvent eventEffectUpdated(EVT_EFFECT_PALETTE_UPDATED);
                 wxPostEvent(GetParent(), eventEffectUpdated);
-            }
-            else if (type == "MODEL_TOGGLE") {
-                
+            } else if (type == "MODEL_TOGGLE") {
                 PanelEffectGrid->EnDisableSelectedModelWithRefresh();
-            
+
             } else if (type == "MODEL_DISABLE") {
-                
                 PanelEffectGrid->EnDisableSelectedModelWithRefresh(1);
 
-            }
-            else if (type == "MODEL_ENABLE") {
-                
+            } else if (type == "MODEL_ENABLE") {
                 PanelEffectGrid->EnDisableSelectedModelWithRefresh(0);
 
-            } 
-            else if (type == "EFFECT_TOGGLE") {
+            } else if (type == "EFFECT_TOGGLE") {
+                PanelEffectGrid->EnDisableRenderEffectsWithRefresh();
 
-                PanelEffectGrid->EnDisableRenderEffectsWithRefresh();                
-
-            } 
-            else if (type == "EFFECT_DISABLE") {
-
+            } else if (type == "EFFECT_DISABLE") {
                 PanelEffectGrid->EnDisableRenderEffectsWithRefresh(1);
 
-            } 
-            else if (type == "EFFECT_ENABLE") {
-
+            } else if (type == "EFFECT_ENABLE") {
                 PanelEffectGrid->EnDisableRenderEffectsWithRefresh(0);
 
-            } 
-            else if (type == "MODEL_EFFECT_TOGGLE") {
-
+            } else if (type == "MODEL_EFFECT_TOGGLE") {
                 PanelEffectGrid->EnDisableSelectedModelOrEffectsWithRefresh();
 
-            }
-            else {
+            } else if (type == "ALTERNATE_PASTE") {
+                if (mSequenceElements != nullptr) {
+                    Paste(false, true);
+                }
+            } else {
                 spdlog::warn("Keybinding '{}' not recognised.", (const char*)type.c_str());
                 wxASSERT(false);
                 return false;
@@ -907,154 +826,148 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
     return xLightsApp::GetFrame()->HandleAllKeyBinding(event);
 }
 
-void MainSequencer::OnCharHook(wxKeyEvent& event)
-{
+void MainSequencer::OnCharHook(wxKeyEvent& event) {
     // wxSearchCtrl on Windows contains inner children; walk ancestry to check
     if (_seqFilterCtrl != nullptr && _seqFilterCtrl->IsShown()) {
         wxWindow* evtWin = dynamic_cast<wxWindow*>(event.GetEventObject());
         while (evtWin != nullptr) {
-            if (evtWin == _seqFilterCtrl) { event.Skip(); return; }
+            if (evtWin == _seqFilterCtrl) {
+                event.Skip();
+                return;
+            }
             evtWin = evtWin->GetParent();
         }
     }
 
     wxChar uc = event.GetKeyCode();
 
-    if (mSequenceElements != nullptr && xLightsApp::GetFrame() != nullptr && xLightsApp::GetFrame()->IsACActive())
-    {
-        if (PanelEffectGrid->HandleACKey(uc, event.ShiftDown()))
-        {
+    if (mSequenceElements != nullptr && xLightsApp::GetFrame() != nullptr && xLightsApp::GetFrame()->IsACActive()) {
+        if (PanelEffectGrid->HandleACKey(uc, event.ShiftDown())) {
             event.StopPropagation();
             return;
         }
     }
 
-    if (HandleSequencerKeyBinding(event)) return;
+    if (HandleSequencerKeyBinding(event))
+        return;
 
-    //printf("OnCharHook %d   %c\n", uc, uc);
-    switch(uc)
-    {
-        case WXK_BACK:
-			PanelEffectGrid->DeleteSelectedEffects();
-			event.StopPropagation();
-			break;
-		case WXK_INSERT:
-		case WXK_NUMPAD_INSERT:
+    // printf("OnCharHook %d   %c\n", uc, uc);
+    switch (uc) {
+    case WXK_BACK:
+        PanelEffectGrid->DeleteSelectedEffects();
+        event.StopPropagation();
+        break;
+    case WXK_INSERT:
+    case WXK_NUMPAD_INSERT:
 #ifdef __WXMSW__
-			if (event.ControlDown())
-			{
-                if (mSequenceElements != nullptr) {
-                    Copy();
-                }
-				event.StopPropagation();
-			}
-			else if (event.ShiftDown())
-			{
-                if (mSequenceElements != nullptr) {
-                    Paste();
-                }
-				event.StopPropagation();
-			}
+        if (event.ControlDown()) {
+            if (mSequenceElements != nullptr) {
+                Copy();
+            }
+            event.StopPropagation();
+        } else if (event.ShiftDown()) {
+            if (mSequenceElements != nullptr) {
+                Paste();
+            }
+            event.StopPropagation();
+        }
 #endif
-			break;
-		case WXK_DELETE:
+        break;
+    case WXK_DELETE:
 #ifdef __WXMSW__
-			if (!event.ShiftDown())
+        if (!event.ShiftDown())
 #endif
-			{
-				// Delete
-                if (mSequenceElements != nullptr) {
-                    PanelEffectGrid->DeleteSelectedEffects();
-                }
-				event.StopPropagation();
-			}
-#ifdef __WXMSW__
-			else
-			{
-				// Cut - windows only
-                if (mSequenceElements != nullptr) {
-                    Cut();
-                }
-				event.StopPropagation();
-			}
-#endif
-			break;
-        case WXK_UP:
-            PanelEffectGrid->MoveSelectedEffectUp(event.ShiftDown());
-            event.StopPropagation();
-            break;
-        case WXK_DOWN:
-            PanelEffectGrid->MoveSelectedEffectDown(event.ShiftDown());
-            event.StopPropagation();
-            break;
-        case WXK_LEFT:
-            PanelEffectGrid->MoveSelectedEffectLeft(event.ShiftDown(), event.ControlDown() || event.RawControlDown(), event.AltDown());
-            event.StopPropagation();
-            break;
-        case WXK_RIGHT:
-            PanelEffectGrid->MoveSelectedEffectRight(event.ShiftDown(), event.ControlDown() || event.RawControlDown(), event.AltDown());
-            event.StopPropagation();
-            break;
-        case '0':
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9':
-        case WXK_NUMPAD0:
-        case WXK_NUMPAD1:
-        case WXK_NUMPAD2:
-        case WXK_NUMPAD3:
-        case WXK_NUMPAD4:
-        case WXK_NUMPAD5:
-        case WXK_NUMPAD6:
-        case WXK_NUMPAD7:
-        case WXK_NUMPAD8:
-        case WXK_NUMPAD9:
         {
-            int number = wxAtoi(uc);
+            // Delete
+            if (mSequenceElements != nullptr) {
+                PanelEffectGrid->DeleteSelectedEffects();
+            }
+            event.StopPropagation();
+        }
+#ifdef __WXMSW__
+        else {
+            // Cut - windows only
+            if (mSequenceElements != nullptr) {
+                Cut();
+            }
+            event.StopPropagation();
+        }
+#endif
+        break;
+    case WXK_UP:
+        PanelEffectGrid->MoveSelectedEffectUp(event.ShiftDown());
+        event.StopPropagation();
+        break;
+    case WXK_DOWN:
+        PanelEffectGrid->MoveSelectedEffectDown(event.ShiftDown());
+        event.StopPropagation();
+        break;
+    case WXK_LEFT:
+        PanelEffectGrid->MoveSelectedEffectLeft(event.ShiftDown(), event.ControlDown() || event.RawControlDown(), event.AltDown());
+        event.StopPropagation();
+        break;
+    case WXK_RIGHT:
+        PanelEffectGrid->MoveSelectedEffectRight(event.ShiftDown(), event.ControlDown() || event.RawControlDown(), event.AltDown());
+        event.StopPropagation();
+        break;
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case WXK_NUMPAD0:
+    case WXK_NUMPAD1:
+    case WXK_NUMPAD2:
+    case WXK_NUMPAD3:
+    case WXK_NUMPAD4:
+    case WXK_NUMPAD5:
+    case WXK_NUMPAD6:
+    case WXK_NUMPAD7:
+    case WXK_NUMPAD8:
+    case WXK_NUMPAD9: {
+        int number = wxAtoi(uc);
 
-            if (number > 9) number -= WXK_NUMPAD0;
+        if (number > 9)
+            number -= WXK_NUMPAD0;
 
-            if (event.ControlDown() || event.RawControlDown()) {
-                if (event.ShiftDown()) {
-                    PanelTimeLine->SetStartTimeMS(number * 10 * PanelTimeLine->GetTimeLength() / 100);
-                    UpdateEffectGridHorizontalScrollBar();
-                } else {
-                    PanelTimeLine->GoToTag(number);
-                }
+        if (event.ControlDown() || event.RawControlDown()) {
+            if (event.ShiftDown()) {
+                PanelTimeLine->SetStartTimeMS(number * 10 * PanelTimeLine->GetTimeLength() / 100);
+                UpdateEffectGridHorizontalScrollBar();
+            } else {
+                PanelTimeLine->GoToTag(number);
             }
         }
-            break;
-        case WXK_PAGEUP:
-            if (event.ControlDown() || event.RawControlDown()) {
-                ScrollToRow(0);
-            } else {
-                ScrollToRow(std::max(0, mSequenceElements->GetFirstVisibleModelRow() - mSequenceElements->GetMaxModelsDisplayed()));
-            }
-            break;
-        case WXK_PAGEDOWN:
-            if (event.ControlDown() || event.RawControlDown()) {
-                ScrollToRow(mSequenceElements->GetTotalNumberOfModelRows());
-            } else {
-                ScrollToRow(std::min(mSequenceElements->GetTotalNumberOfModelRows() - mSequenceElements->GetMaxModelsDisplayed(), mSequenceElements->GetFirstVisibleModelRow() + mSequenceElements->GetMaxModelsDisplayed()));
-            }
-            break;
-        case WXK_ESCAPE:
-            CancelRender();
-            break;
-        default:
-            event.Skip();
-            break;
+    } break;
+    case WXK_PAGEUP:
+        if (event.ControlDown() || event.RawControlDown()) {
+            ScrollToRow(0);
+        } else {
+            ScrollToRow(std::max(0, mSequenceElements->GetFirstVisibleModelRow() - mSequenceElements->GetMaxModelsDisplayed()));
+        }
+        break;
+    case WXK_PAGEDOWN:
+        if (event.ControlDown() || event.RawControlDown()) {
+            ScrollToRow(mSequenceElements->GetTotalNumberOfModelRows());
+        } else {
+            ScrollToRow(std::min(mSequenceElements->GetTotalNumberOfModelRows() - mSequenceElements->GetMaxModelsDisplayed(), mSequenceElements->GetFirstVisibleModelRow() + mSequenceElements->GetMaxModelsDisplayed()));
+        }
+        break;
+    case WXK_ESCAPE:
+        CancelRender();
+        break;
+    default:
+        event.Skip();
+        break;
     }
 }
 
-void MainSequencer::CancelRender()
-{
+void MainSequencer::CancelRender() {
     static bool escapeReenter = false;
 
     if (!escapeReenter) {
@@ -1066,111 +979,83 @@ void MainSequencer::CancelRender()
     }
 }
 
-void MainSequencer::ToggleRender(bool off)
-{
-    if (mSequenceElements == nullptr) return;
-    if (off) CancelRender();
+void MainSequencer::ToggleRender(bool off) {
+    if (mSequenceElements == nullptr)
+        return;
+    if (off)
+        CancelRender();
     xLightsApp::GetFrame()->SuspendRender(off);
 }
 
-void MainSequencer::OnKeyDown(wxKeyEvent& event)
-{
-    //wxChar uc = event.GetUnicodeKey();
-    //printf("OnKeyDown %d   %c\n", uc, uc);
+void MainSequencer::OnKeyDown(wxKeyEvent& event) {
+    // wxChar uc = event.GetUnicodeKey();
+    // printf("OnKeyDown %d   %c\n", uc, uc);
     event.Skip();
 }
 
-void MainSequencer::OnChar(wxKeyEvent& event)
-{
+void MainSequencer::OnChar(wxKeyEvent& event) {
     // wxSearchCtrl on Windows contains inner children; walk ancestry to check
     if (_seqFilterCtrl != nullptr && _seqFilterCtrl->IsShown()) {
         wxWindow* evtWin = dynamic_cast<wxWindow*>(event.GetEventObject());
         while (evtWin != nullptr) {
-            if (evtWin == _seqFilterCtrl) { event.Skip(); return; }
+            if (evtWin == _seqFilterCtrl) {
+                event.Skip();
+                return;
+            }
             evtWin = evtWin->GetParent();
         }
     }
 
     wxChar uc = event.GetUnicodeKey();
 
-    if (mSequenceElements != nullptr && xLightsApp::GetFrame() != nullptr && xLightsApp::GetFrame()->IsACActive())
-    {
-        if (PanelEffectGrid->HandleACKey(uc))
-        {
+    if (mSequenceElements != nullptr && xLightsApp::GetFrame() != nullptr && xLightsApp::GetFrame()->IsACActive()) {
+        if (PanelEffectGrid->HandleACKey(uc)) {
             event.StopPropagation();
             return;
         }
     }
 
-    if (HandleSequencerKeyBinding(event)) return;
+    if (HandleSequencerKeyBinding(event))
+        return;
 
-    //printf("OnChar %d   %c\n", uc, uc);
-    switch(uc)
-    {
-        case 'c':
-        case 'C':
-        case WXK_CONTROL_C:
-            if (event.CmdDown() || event.ControlDown()) {
-                if (mSequenceElements != nullptr) {
-                    Copy();
-                    event.StopPropagation();
-                }
-            }
-            break;
-        case 'x':
-        case 'X':
-        case WXK_CONTROL_X:
-            if (event.CmdDown() || event.ControlDown()) {
-                if (mSequenceElements != nullptr) {
-                    Cut();
-                    event.StopPropagation();
-                }
-            }
-            break;
-        case 'v':
-        case 'V':
-        case WXK_CONTROL_V:
-            if (event.CmdDown() || event.ControlDown()) {
-                Paste();
+    // printf("OnChar %d   %c\n", uc, uc);
+    switch (uc) {
+    case 'c':
+    case 'C':
+    case WXK_CONTROL_C:
+        if (event.CmdDown() || event.ControlDown()) {
+            if (mSequenceElements != nullptr) {
+                Copy();
                 event.StopPropagation();
             }
-            break;
-        case 'z':
-        case 'Z':
-        case WXK_CONTROL_Z:
-            if(!event.ShiftDown()) {
-                if ((event.CmdDown() || event.ControlDown())) {
-                    if( mSequenceElements != nullptr &&
-                        mSequenceElements->get_undo_mgr().CanUndo() ) {
-                        mSequenceElements->get_undo_mgr().UndoLastStep();
-                        mSequenceElements->UnSelectAllEffects();
-                        PanelEffectGrid->ClearSelection();
-                        PanelEffectGrid->Draw();
-                        PanelEffectGrid->sendRenderDirtyEvent();
-                    }
-                    event.StopPropagation();
-                }
-            } else {
-                if ((event.CmdDown() || event.ControlDown())) {
-                    if( mSequenceElements != nullptr &&
-                        mSequenceElements->get_undo_mgr().CanRedo() ) {
-                        mSequenceElements->get_undo_mgr().RedoLastStep();
-                        mSequenceElements->UnSelectAllEffects();
-                        PanelEffectGrid->ClearSelection();
-                        PanelEffectGrid->Draw();
-                        PanelEffectGrid->sendRenderDirtyEvent();
-                    }
-                    event.StopPropagation();
-                }
+        }
+        break;
+    case 'x':
+    case 'X':
+    case WXK_CONTROL_X:
+        if (event.CmdDown() || event.ControlDown()) {
+            if (mSequenceElements != nullptr) {
+                Cut();
+                event.StopPropagation();
             }
-            break;
-        case 'y':
-        case 'Y':
-        case WXK_CONTROL_Y:
-            if (event.CmdDown() || event.ControlDown()) {
-                if( mSequenceElements != nullptr &&
-                   mSequenceElements->get_undo_mgr().CanRedo() ) {
-                    mSequenceElements->get_undo_mgr().RedoLastStep();
+        }
+        break;
+    case 'v':
+    case 'V':
+    case WXK_CONTROL_V:
+        if (event.CmdDown() || event.ControlDown()) {
+            Paste();
+            event.StopPropagation();
+        }
+        break;
+    case 'z':
+    case 'Z':
+    case WXK_CONTROL_Z:
+        if (!event.ShiftDown()) {
+            if ((event.CmdDown() || event.ControlDown())) {
+                if (mSequenceElements != nullptr &&
+                    mSequenceElements->get_undo_mgr().CanUndo()) {
+                    mSequenceElements->get_undo_mgr().UndoLastStep();
                     mSequenceElements->UnSelectAllEffects();
                     PanelEffectGrid->ClearSelection();
                     PanelEffectGrid->Draw();
@@ -1178,19 +1063,50 @@ void MainSequencer::OnChar(wxKeyEvent& event)
                 }
                 event.StopPropagation();
             }
-            break;
-        case WXK_ESCAPE: {
-            static bool escapeReenter = false;
-
-            if (!escapeReenter) {
-                escapeReenter = true;
-                if (mSequenceElements != nullptr && xLightsApp::GetFrame() != nullptr) {
-                    xLightsApp::GetFrame()->AbortRender();
+        } else {
+            if ((event.CmdDown() || event.ControlDown())) {
+                if (mSequenceElements != nullptr &&
+                    mSequenceElements->get_undo_mgr().CanRedo()) {
+                    mSequenceElements->get_undo_mgr().RedoLastStep();
+                    mSequenceElements->UnSelectAllEffects();
+                    PanelEffectGrid->ClearSelection();
+                    PanelEffectGrid->Draw();
+                    PanelEffectGrid->sendRenderDirtyEvent();
+                    wxCommandEvent eventRowHeaderChanged(EVT_ROW_HEADINGS_CHANGED);
+                    wxPostEvent(GetParent(), eventRowHeaderChanged);
                 }
-                escapeReenter = false;
+                event.StopPropagation();
             }
         }
         break;
+    case 'y':
+    case 'Y':
+    case WXK_CONTROL_Y:
+        if (event.CmdDown() || event.ControlDown()) {
+            if (mSequenceElements != nullptr &&
+                mSequenceElements->get_undo_mgr().CanRedo()) {
+                mSequenceElements->get_undo_mgr().RedoLastStep();
+                mSequenceElements->UnSelectAllEffects();
+                PanelEffectGrid->ClearSelection();
+                PanelEffectGrid->Draw();
+                PanelEffectGrid->sendRenderDirtyEvent();
+                wxCommandEvent eventRowHeaderChanged(EVT_ROW_HEADINGS_CHANGED);
+                wxPostEvent(GetParent(), eventRowHeaderChanged);
+            }
+            event.StopPropagation();
+        }
+        break;
+    case WXK_ESCAPE: {
+        static bool escapeReenter = false;
+
+        if (!escapeReenter) {
+            escapeReenter = true;
+            if (mSequenceElements != nullptr && xLightsApp::GetFrame() != nullptr) {
+                xLightsApp::GetFrame()->AbortRender();
+            }
+            escapeReenter = false;
+        }
+    } break;
     }
 }
 
@@ -1208,7 +1124,7 @@ void MainSequencer::ToggleModelPreview() {
     }
 }
 
-void MainSequencer::TouchPlayControl(const std::string &evt) {
+void MainSequencer::TouchPlayControl(const std::string& evt) {
     wxCommandEvent e;
     if (evt == "Play") {
         xLightsApp::GetFrame()->OnAuiToolBarItemPlayButtonClick(e);
@@ -1223,7 +1139,7 @@ void MainSequencer::TouchPlayControl(const std::string &evt) {
     }
 }
 
-void MainSequencer::TouchButtonEvent(wxCommandEvent &event) {
+void MainSequencer::TouchButtonEvent(wxCommandEvent& event) {
     if (mSequenceElements != nullptr) {
         wxString effect = ((wxWindow*)event.GetEventObject())->GetName();
         Effect* ef = PanelEffectGrid->Paste(effect + "\t\t\n", xlights_version_string);
@@ -1232,26 +1148,23 @@ void MainSequencer::TouchButtonEvent(wxCommandEvent &event) {
 }
 
 #ifdef __XLIGHTS_HAS_TOUCHBARS__
-void MainSequencer::SetupTouchBar(EffectManager &effectManager, ColorPanelTouchBar *colorBar) {
+void MainSequencer::SetupTouchBar(EffectManager& effectManager, ColorPanelTouchBar* colorBar) {
     if (effectGridTouchbar == nullptr && touchBarSupport.HasTouchBar()) {
         std::vector<TouchBarItem*> items;
         std::vector<ButtonTouchBarItem*> pvitems;
-        
+
         pvitems.push_back(new ButtonTouchBarItem([this]() {
             ToggleHousePreview();
         },
-                                                 "Toggle House Preview",
-                                                 wxArtProvider::GetBitmapBundle("xlART_HOUSE_PREVIEW", wxART_TOOLBAR)));
+                                                 "Toggle House Preview", wxArtProvider::GetBitmapBundle("xlART_HOUSE_PREVIEW", wxART_TOOLBAR)));
         pvitems.push_back(new ButtonTouchBarItem([this]() {
             ToggleModelPreview();
         },
-                                                 "Toggle Model Preview",
-                                                 wxArtProvider::GetBitmapBundle("xlART_MODEL_PREVIEW", wxART_TOOLBAR)));
+                                                 "Toggle Model Preview", wxArtProvider::GetBitmapBundle("xlART_MODEL_PREVIEW", wxART_TOOLBAR)));
         items.push_back(new GroupTouchBarItem("Previews", pvitems));
-        
-        
+
         std::vector<ButtonTouchBarItem*> pbitems;
-        
+
         pbitems.push_back(new ButtonTouchBarItem([this]() { TouchPlayControl("Play"); },
                                                  "Play",
                                                  wxArtProvider::GetBitmapBundle("xlART_PLAY", wxART_TOOLBAR)));
@@ -1267,32 +1180,29 @@ void MainSequencer::SetupTouchBar(EffectManager &effectManager, ColorPanelTouchB
         pbitems.push_back(new ButtonTouchBarItem([this]() { TouchPlayControl("Forward"); },
                                                  "Forward",
                                                  wxArtProvider::GetBitmapBundle("xlART_FORWARD", wxART_TOOLBAR)));
-        
+
         items.push_back(new GroupTouchBarItem("Playback Controls", pbitems));
-        
+
         std::vector<ButtonTouchBarItem*> zitems;
-        
+
         zitems.push_back(new ButtonTouchBarItem([this]() {
             PanelTimeLine->ZoomIn();
         },
-                                                 "Zoom In",
-                                                 wxArtProvider::GetBitmapBundle("xlART_ZOOM_IN", wxART_TOOLBAR)));
+                                                "Zoom In", wxArtProvider::GetBitmapBundle("xlART_ZOOM_IN", wxART_TOOLBAR)));
         zitems.push_back(new ButtonTouchBarItem([this]() {
             PanelTimeLine->ZoomOut();
         },
-                                                 "Zoom Out",
-                                                 wxArtProvider::GetBitmapBundle("xlART_ZOOM_OUT", wxART_TOOLBAR)));
+                                                "Zoom Out", wxArtProvider::GetBitmapBundle("xlART_ZOOM_OUT", wxART_TOOLBAR)));
         items.push_back(new GroupTouchBarItem("Zoom", zitems));
-        
 
-        
-        ButtonTouchBarItem *colorsButton = new ButtonTouchBarItem([colorBar]() {
+        ButtonTouchBarItem* colorsButton = new ButtonTouchBarItem([colorBar]() {
             colorBar->SetActive();
-        }, "NSTouchBarColorPickerFill", "Colors");
+        },
+                                                                  "NSTouchBarColorPickerFill", "Colors");
         items.push_back(colorsButton);
-        
+
         for (auto it = effectManager.begin(); it != effectManager.end(); ++it) {
-            wxButton *b = new wxButton(touchBarSupport.GetControlParent(), wxID_ANY,
+            wxButton* b = new wxButton(touchBarSupport.GetControlParent(), wxID_ANY,
                                        "",
                                        wxDefaultPosition,
                                        wxDefaultSize,
@@ -1301,11 +1211,10 @@ void MainSequencer::SetupTouchBar(EffectManager &effectManager, ColorPanelTouchB
                                        (*it)->Name());
             b->SetBitmap(EffectIconCache::GetEffectIcon(*it));
             b->Connect(wxEVT_BUTTON, (wxObjectEventFunction)&MainSequencer::TouchButtonEvent, nullptr, this);
-            
+
             items.push_back(new wxControlTouchBarItem(b));
         }
-        
-        
+
         effectGridTouchbar = std::unique_ptr<EffectGridTouchBar>(new EffectGridTouchBar(touchBarSupport, items));
         effectGridTouchbar->SetActive();
     }
@@ -1329,10 +1238,10 @@ void MainSequencer::DoPaste(wxCommandEvent& event) {
 }
 
 void MainSequencer::DoUndo(wxCommandEvent& event) {
+    if (PanelEffectGrid == nullptr)
+        return;
 
-    if (PanelEffectGrid == nullptr) return;
-
-    if (mSequenceElements != nullptr && mSequenceElements->get_undo_mgr().CanUndo() ) {
+    if (mSequenceElements != nullptr && mSequenceElements->get_undo_mgr().CanUndo()) {
         mSequenceElements->UnSelectAllEffects();
         mSequenceElements->get_undo_mgr().UndoLastStep();
         PanelEffectGrid->ClearSelection();
@@ -1344,9 +1253,10 @@ void MainSequencer::DoUndo(wxCommandEvent& event) {
 }
 
 void MainSequencer::DoRedo(wxCommandEvent& event) {
-    if (PanelEffectGrid == nullptr) return;
+    if (PanelEffectGrid == nullptr)
+        return;
 
-    if (mSequenceElements != nullptr && mSequenceElements->get_undo_mgr().CanRedo() ) {
+    if (mSequenceElements != nullptr && mSequenceElements->get_undo_mgr().CanRedo()) {
         mSequenceElements->UnSelectAllEffects();
         mSequenceElements->get_undo_mgr().RedoLastStep();
         PanelEffectGrid->ClearSelection();
@@ -1357,24 +1267,21 @@ void MainSequencer::DoRedo(wxCommandEvent& event) {
     }
 }
 
-void MainSequencer::SetLargeWaveform()
-{
+void MainSequencer::SetLargeWaveform() {
     PanelWaveForm->SetWaveFormSize(Waveform::GetLargeSize());
     Layout();
     PanelWaveForm->Refresh();
     timeDisplay->Refresh();
 }
 
-void MainSequencer::SetSmallWaveform()
-{
+void MainSequencer::SetSmallWaveform() {
     PanelWaveForm->SetWaveFormSize(Waveform::GetSmallSize());
     Layout();
     PanelWaveForm->Refresh();
     timeDisplay->Refresh();
 }
- 
-void MainSequencer::GetPresetData(wxString& copy_data)
-{
+
+void MainSequencer::GetPresetData(wxString& copy_data) {
     if (PanelEffectGrid->IsACActive()) {
         GetACEffectsData(copy_data);
     } else {
@@ -1383,8 +1290,6 @@ void MainSequencer::GetPresetData(wxString& copy_data)
 }
 
 bool MainSequencer::GetSelectedEffectsData(wxString& copy_data, bool includeElementInfo) {
-    
-
     bool effectsPresent = false;
 
     int start_column = PanelEffectGrid->GetStartColumn();
@@ -1396,48 +1301,41 @@ bool MainSequencer::GetSelectedEffectsData(wxString& copy_data, bool includeElem
     int last_timing_row = 0;
     wxString effect_data;
     EffectLayer* tel = mSequenceElements->GetVisibleEffectLayer(mSequenceElements->GetSelectedTimingRow());
-    if( tel != nullptr && start_column != -1) {
+    if (tel != nullptr && start_column != -1) {
         Effect* eff = tel->GetEffect(start_column);
-        if( eff != nullptr ) {
+        if (eff != nullptr) {
             column_start_time = eff->GetStartTimeMS();
         }
     }
 
-    for(int i=0;i<mSequenceElements->GetRowInformationSize();i++)
-    {
+    for (int i = 0; i < mSequenceElements->GetRowInformationSize(); i++) {
         int row_number;
-        if( i < number_of_timing_rows )
-        {
+        if (i < number_of_timing_rows) {
             row_number = mSequenceElements->GetRowInformation(i)->Index;
-        }
-        else
-        {
-            row_number = mSequenceElements->GetRowInformation(i)->Index-mSequenceElements->GetFirstVisibleModelRow();
+        } else {
+            row_number = mSequenceElements->GetRowInformation(i)->Index - mSequenceElements->GetFirstVisibleModelRow();
         }
         EffectLayer* el = mSequenceElements->GetEffectLayer(i);
         for (int x = 0; x < el->GetEffectCount(); x++) {
-            Effect *ef = el->GetEffect(x);
-            if( ef == nullptr ) break;
+            Effect* ef = el->GetEffect(x);
+            if (ef == nullptr)
+                break;
             if (ef->GetSelected() != EFFECT_NOT_SELECTED && !ef->GetTagged()) {
                 ef->SetTagged(true);
-                wxString start_time = wxString::Format("%d",ef->GetStartTimeMS());
-                wxString end_time = wxString::Format("%d",ef->GetEndTimeMS());
-                wxString row = wxString::Format("%d",row_number);
-                wxString column_start = wxString::Format("%d",column_start_time);
+                wxString start_time = wxString::Format("%d", ef->GetStartTimeMS());
+                wxString end_time = wxString::Format("%d", ef->GetEndTimeMS());
+                wxString row = wxString::Format("%d", row_number);
+                wxString column_start = wxString::Format("%d", column_start_time);
                 effect_data += ef->GetEffectName() + "\t" + ef->GetSettingsAsString() + "\t" + ef->GetPaletteAsString() +
                                "\t" + start_time + "\t" + end_time + "\t" + row + "\t" + column_start;
-                if( i < number_of_timing_rows )
-                {
+                if (i < number_of_timing_rows) {
                     ++number_of_timings;
                     last_timing_row = row_number;
-                    if( first_timing_row < 0 )
-                    {
+                    if (first_timing_row < 0) {
                         first_timing_row = row_number;
                     }
                     effect_data += "\tTIMING_EFFECT\n";
-                }
-                else
-                {
+                } else {
                     ++number_of_effects;
                     wxString element_suffix;
                     if (includeElementInfo) {
@@ -1447,28 +1345,26 @@ bool MainSequencer::GetSelectedEffectsData(wxString& copy_data, bool includeElem
                             element_suffix = wxString("\tSUBMODEL:") + se->GetName();
                         }
                     }
-                    if( column_start_time == -1000 && mSequenceElements->GetSelectedTimingRow() >= 0 )
-                    {
-                        if (tel == nullptr)
-                        {
+                    if (column_start_time == -1000 && mSequenceElements->GetSelectedTimingRow() >= 0) {
+                        if (tel == nullptr) {
                             spdlog::critical("MainSequencer::GetSelectedEffectsData tel is nullptr ... this is going to crash.");
                         }
 
-                        if( tel->HitTestEffectByTime(ef->GetStartTimeMS()+1,start_column) )
-                        {
+                        if (tel->HitTestEffectByTime(ef->GetStartTimeMS() + 1, start_column)) {
                             column_start_time = tel->GetEffect(start_column)->GetStartTimeMS();
                         }
                     }
-                    if( column_start_time != -1000 )  // add paste by cell info
+                    // wxString layer_suffix = wxString::Format("\tLAYER:%d", mSequenceElements->GetRowInformation(i)->layerIndex);
+                    Row_Information_Struct* ri = mSequenceElements->GetRowInformation(i);
+                    int layerIndex = ri ? ri->layerIndex : 0;
+                    wxString layer_suffix = wxString::Format("\tLAYER:%d", layerIndex);
+                    if (column_start_time != -1000) // add paste by cell info
                     {
-                        if( mSequenceElements->GetSelectedTimingRow() >= 0 )
-                        {
+                        if (mSequenceElements->GetSelectedTimingRow() >= 0) {
                             Effect* te_start = tel->GetEffectByTime(ef->GetStartTimeMS() + 1); // if we don't add 1ms, it picks up the end of the previous timing instead of the start of this one
                             Effect* te_end = tel->GetEffectByTime(ef->GetEndTimeMS());
-                            if( te_start != nullptr && te_end != nullptr )
-                            {
-                                if (tel == nullptr)
-                                {
+                            if (te_start != nullptr && te_end != nullptr) {
+                                if (tel == nullptr) {
                                     spdlog::critical("MainSequencer::GetSelectedEffectsData tel is nullptr ... this is going to crash.");
                                 }
 
@@ -1483,38 +1379,51 @@ bool MainSequencer::GetSelectedEffectsData(wxString& copy_data, bool includeElem
                                 int end_pct = ((ef->GetEndTimeMS() - te_end->GetStartTimeMS()) * 100) / (te_end->GetEndTimeMS() - te_end->GetStartTimeMS());
                                 int start_index;
                                 int end_index;
-                                tel->HitTestEffectByTime(te_start->GetStartTimeMS()+1,start_index);
-                                tel->HitTestEffectByTime(te_end->GetStartTimeMS()+1,end_index);
-                                wxString start_pct_str = wxString::Format("%d",start_pct);
-                                wxString end_pct_str = wxString::Format("%d",end_pct);
-                                wxString start_index_str = wxString::Format("%d",start_index);
-                                wxString end_index_str = wxString::Format("%d",end_index);
-                                effect_data += "\t" + start_index_str + "\t" + end_index_str + "\t" + start_pct_str + "\t" + end_pct_str + element_suffix + "\n";
-                            } else {effect_data += "\tNO_PASTE_BY_CELL" + element_suffix + "\n";}
-                        } else {effect_data += "\tNO_PASTE_BY_CELL" + element_suffix + "\n";}
-                    } else {effect_data += "\tNO_PASTE_BY_CELL" + element_suffix + "\n";}
+                                tel->HitTestEffectByTime(te_start->GetStartTimeMS() + 1, start_index);
+                                tel->HitTestEffectByTime(te_end->GetStartTimeMS() + 1, end_index);
+                                wxString start_pct_str = wxString::Format("%d", start_pct);
+                                wxString end_pct_str = wxString::Format("%d", end_pct);
+                                wxString start_index_str = wxString::Format("%d", start_index);
+                                wxString end_index_str = wxString::Format("%d", end_index);
+                                effect_data += "\t" + start_index_str + "\t" + end_index_str + "\t" + start_pct_str + "\t" + end_pct_str + element_suffix + layer_suffix + "\n";
+                            } else {
+                                effect_data += "\tNO_PASTE_BY_CELL" + element_suffix + layer_suffix + "\n";
+                            }
+                        } else {
+                            effect_data += "\tNO_PASTE_BY_CELL" + element_suffix + layer_suffix + "\n";
+                        }
+                    } else {
+                        effect_data += "\tNO_PASTE_BY_CELL" + element_suffix + layer_suffix + "\n";
+                    }
                 }
             }
         }
     }
-    if( first_timing_row >= 0 )
-    {
-        last_timing_row -= first_timing_row;  // calculate the total number of timing rows
+    if (first_timing_row >= 0) {
+        last_timing_row -= first_timing_row; // calculate the total number of timing rows
     }
 
     effectsPresent = number_of_timings + number_of_effects > 0;
 
-    wxString num_timings = wxString::Format("%d",number_of_timings);
-    wxString num_effects = wxString::Format("%d",number_of_effects);
-    wxString num_timing_rows = wxString::Format("%d",number_of_timing_rows);
-    wxString last_row = wxString::Format("%d",last_timing_row);
-    wxString starting_column = wxString::Format("%d",start_column);
-    copy_data = "CopyFormat1\t" + num_timings + "\t" + num_effects + "\t" + num_timing_rows + "\t" + last_row + "\t" + starting_column;
-    if( column_start_time != -1000 ) {
-        copy_data += "\tPASTE_BY_CELL\n" + effect_data;
+    wxString num_timings = wxString::Format("%d", number_of_timings);
+    wxString num_effects = wxString::Format("%d", number_of_effects);
+    wxString num_timing_rows = wxString::Format("%d", number_of_timing_rows);
+    wxString last_row = wxString::Format("%d", last_timing_row);
+    wxString starting_column = wxString::Format("%d", start_column);
+    // Record the lasso selection's top row as the anchor so that empty rows above the first effect are preserved when pasting (ANCHOR_ROW: token).
+    wxString anchorToken;
+    int selStart = PanelEffectGrid->GetStartRow();
+    if (selStart >= 0 && selStart >= mSequenceElements->GetNumberOfTimingRows()) {
+        int relAnchor = selStart - mSequenceElements->GetFirstVisibleModelRow();
+        if (relAnchor >= 0)
+            anchorToken = wxString::Format("\tANCHOR_ROW:%d", relAnchor);
     }
-    else {
-        copy_data += "\tNO_PASTE_BY_CELL\n" + effect_data;
+
+    copy_data = "CopyFormat1\t" + num_timings + "\t" + num_effects + "\t" + num_timing_rows + "\t" + last_row + "\t" + starting_column;
+    if (column_start_time != -1000) {
+        copy_data += "\tPASTE_BY_CELL" + anchorToken + "\n" + effect_data;
+    } else {
+        copy_data += "\tNO_PASTE_BY_CELL" + anchorToken + "\n" + effect_data;
     }
     UnTagAllEffects();
 
@@ -1522,8 +1431,6 @@ bool MainSequencer::GetSelectedEffectsData(wxString& copy_data, bool includeElem
 }
 
 bool MainSequencer::GetACEffectsData(wxString& copy_data) {
-    
-
     bool effectsPresent = false;
 
     int start_column = PanelEffectGrid->GetStartColumn();
@@ -1544,32 +1451,26 @@ bool MainSequencer::GetACEffectsData(wxString& copy_data) {
         if (eff1 != nullptr && eff2 != nullptr) {
             column_start_time = eff1->GetStartTimeMS();
             column_end_time = eff2->GetEndTimeMS();
-        }
-        else {
+        } else {
             return false;
         }
-    }
-    else {
-        return false;  // there should always be a range selection in AC copy mode
+    } else {
+        return false; // there should always be a range selection in AC copy mode
     }
 
-    for (int i = 0; i < mSequenceElements->GetRowInformationSize(); i++)
-    {
+    for (int i = 0; i < mSequenceElements->GetRowInformationSize(); i++) {
         int row_number;
-        if (i < number_of_timing_rows)
-        {
+        if (i < number_of_timing_rows) {
             row_number = mSequenceElements->GetRowInformation(i)->Index;
+        } else {
+            row_number = mSequenceElements->GetRowInformation(i)->Index; // -mSequenceElements->GetFirstVisibleModelRow();
         }
-        else
-        {
-            row_number = mSequenceElements->GetRowInformation(i)->Index;// -mSequenceElements->GetFirstVisibleModelRow();
-        }
-        if (row_number >= start_row && row_number <= end_row)
-        {
+        if (row_number >= start_row && row_number <= end_row) {
             EffectLayer* el = mSequenceElements->GetEffectLayer(i);
             for (int x = 0; x < el->GetEffectCount(); x++) {
-                Effect *ef = el->GetEffect(x);
-                if (ef == nullptr) break;
+                Effect* ef = el->GetEffect(x);
+                if (ef == nullptr)
+                    break;
                 if (!ef->GetTagged()) {
                     ef->SetTagged(true);
                     if (ef->GetStartTimeMS() < column_end_time && ef->GetEndTimeMS() > column_start_time) {
@@ -1590,14 +1491,12 @@ bool MainSequencer::GetACEffectsData(wxString& copy_data) {
                         std::string settings = PanelEffectGrid->TruncateEffectSettings(ef->GetSettings(), ef->GetEffectName(), ef->GetStartTimeMS(), ef->GetEndTimeMS(), adj_start_time, adj_end_time);
 
                         effect_data += ef->GetEffectName() + "\t" + settings + "\t" + ef->GetPaletteAsString() +
-                            "\t" + start_time + "\t" + end_time + "\t" + row + "\t" + column_start;
+                                       "\t" + start_time + "\t" + end_time + "\t" + row + "\t" + column_start;
                         ++number_of_effects;
                         Effect* te_start = tel->GetEffectByTime(adj_start_time + 1); // if we don't add 1ms, it picks up the end of the previous timing instead of the start of this one
                         Effect* te_end = tel->GetEffectByTime(adj_end_time);
-                        if (te_start != nullptr && te_end != nullptr)
-                        {
-                            if (tel == nullptr)
-                            {
+                        if (te_start != nullptr && te_end != nullptr) {
+                            if (tel == nullptr) {
                                 spdlog::critical("MainSequencer::GetSelectedEffectsData tel is nullptr ... this is going to crash.");
                             }
 
@@ -1643,8 +1542,7 @@ bool MainSequencer::CopySelectedEffects() {
     bool dataPresent = false;
     if (PanelEffectGrid->IsACActive()) {
         dataPresent = GetACEffectsData(copy_data);
-    }
-    else {
+    } else {
         dataPresent = GetSelectedEffectsData(copy_data);
     }
     if (dataPresent && !copy_data.IsEmpty() && wxTheClipboard != nullptr && wxTheClipboard->Open()) {
@@ -1676,39 +1574,31 @@ void MainSequencer::Copy() {
 
 void MainSequencer::Cut() {
     if (CopySelectedEffects()) {
-        if (PanelEffectGrid->IsACActive())
-        {
+        if (PanelEffectGrid->IsACActive()) {
             PanelEffectGrid->DoACDraw(false, ACTYPE::OFF, ACSTYLE::INTENSITY, ACTOOL::TOOLNIL, ACMODE::MODENIL);
-        }
-        else
-        {
+        } else {
             PanelEffectGrid->DeleteSelectedEffects();
         }
     }
 }
 
-Effect* MainSequencer::GetSelectedEffect()
-{
+Effect* MainSequencer::GetSelectedEffect() {
     return PanelEffectGrid->GetSelectedEffect();
 }
 
-int MainSequencer::GetSelectedEffectCount(const std::string effectName) const
-{
+int MainSequencer::GetSelectedEffectCount(const std::string effectName) const {
     return PanelEffectGrid->GetSelectedEffectCount(effectName);
 }
 
-bool MainSequencer::AreAllSelectedEffectsOnTheSameElement() const
-{
+bool MainSequencer::AreAllSelectedEffectsOnTheSameElement() const {
     return PanelEffectGrid->AreAllSelectedEffectsOnTheSameElement();
 }
 
-void MainSequencer::ApplyEffectSettingToSelected(const std::string& effectName, const std::string id, const std::string value, ValueCurve* vc, const std::string& vcid)
-{
+void MainSequencer::ApplyEffectSettingToSelected(const std::string& effectName, const std::string id, const std::string value, ValueCurve* vc, const std::string& vcid) {
     return PanelEffectGrid->ApplyEffectSettingToSelected(effectName, id, value, vc, vcid);
 }
 
-void MainSequencer::ApplyButtonPressToSelected(const std::string& effectName, const std::string id)
-{
+void MainSequencer::ApplyButtonPressToSelected(const std::string& effectName, const std::string id) {
     return PanelEffectGrid->ApplyButtonPressToSelected(effectName, id);
 }
 
@@ -1716,90 +1606,80 @@ void MainSequencer::RemapSelectedDMXEffectValues(const std::vector<std::tuple<in
     return PanelEffectGrid->RemapSelectedDMXEffectValues(dmxmappings);
 }
 
-void MainSequencer::ConvertSelectedEffectsTo(const std::string& effectName)
-{
+void MainSequencer::ConvertSelectedEffectsTo(const std::string& effectName) {
     return PanelEffectGrid->ConvertSelectedEffectsTo(effectName);
 }
 
-void MainSequencer::UnselectAllEffects()
-{
+void MainSequencer::UnselectAllEffects() {
     mSequenceElements->UnSelectAllEffects();
 }
 
-void MainSequencer::SelectEffect(Effect* ef)
-{
-    if (!xLightsApp::GetFrame()->IsACActive())
-    {
+void MainSequencer::SelectEffect(Effect* ef) {
+    if (!xLightsApp::GetFrame()->IsACActive()) {
         PanelEffectGrid->SelectEffect(ef);
     }
 }
 
-Effect* MainSequencer::SelectEffectUsingDescription(std::string description)
-{
+Effect* MainSequencer::SelectEffectUsingDescription(std::string description) {
     mSequenceElements->UnSelectAllEffects();
     return mSequenceElements->SelectEffectUsingDescription(description);
 }
 
-Effect* MainSequencer::SelectEffectUsingElementLayerTime(std::string element, int layer, int time)
-{
+Effect* MainSequencer::SelectEffectUsingElementLayerTime(std::string element, int layer, int time) {
     mSequenceElements->UnSelectAllEffects();
     return mSequenceElements->SelectEffectUsingElementLayerTime(element, layer, time);
 }
 
-void MainSequencer::SetChanged()
-{
+void MainSequencer::SetChanged() {
     mSequenceElements->IncrementChangeCount(nullptr);
 }
 
-std::list<std::string> MainSequencer::GetAllElementNamesWithEffects()
-{
+std::list<std::string> MainSequencer::GetAllElementNamesWithEffects() {
     return mSequenceElements->GetAllElementNamesWithEffects();
 }
 
-int MainSequencer::GetElementLayerCount(std::string elementName, std::list<int>* layers)
-{
+int MainSequencer::GetElementLayerCount(std::string elementName, std::list<int>* layers) {
     return mSequenceElements->GetElementLayerCount(elementName, layers);
 }
 
-std::list<Effect*> MainSequencer::GetElementLayerEffects(std::string elementName, int layer)
-{
+std::list<Effect*> MainSequencer::GetElementLayerEffects(std::string elementName, int layer) {
     return mSequenceElements->GetElementLayerEffects(elementName, layer);
 }
 
-std::list<std::string> MainSequencer::GetUniqueEffectPropertyValues(const std::string& id)
-{
+std::list<std::string> MainSequencer::GetUniqueEffectPropertyValues(const std::string& id) {
     return mSequenceElements->GetUniqueEffectPropertyValues(id);
 }
 
-std::list<std::string> MainSequencer::GetAllEffectDescriptions()
-{
+std::list<std::string> MainSequencer::GetAllEffectDescriptions() {
     return mSequenceElements->GetAllEffectDescriptions();
 }
 
-void MainSequencer::Paste(bool row_paste) {
+void MainSequencer::Paste(bool row_paste, bool invertLayerMode) {
     wxTextDataObject data;
-    wxClipboard *cbd = wxClipboard::Get();
+    wxClipboard* cbd = wxClipboard::Get();
     if (cbd && cbd->Open()) {
-        if ((cbd->IsSupported(wxDF_TEXT) || cbd->IsSupported(wxDF_UNICODETEXT))
-            && cbd->GetData(data)) {
-            //assume clipboard always has data from same version of xLights
-            Effect* ef = PanelEffectGrid->Paste(data.GetText(), xlights_version_string, row_paste);
+        if ((cbd->IsSupported(wxDF_TEXT) || cbd->IsSupported(wxDF_UNICODETEXT)) && cbd->GetData(data)) {
+            // assume clipboard always has data from same version of xLights
+            wxString text = data.GetText();
+            bool pasteAsLayers = xLightsApp::GetFrame()->PasteAsLayers();
+            if (invertLayerMode)
+                pasteAsLayers = !pasteAsLayers;
+            bool layerMode = pasteAsLayers && text.Contains("\tLAYER:");
+            Effect* ef = PanelEffectGrid->Paste(text, xlights_version_string, row_paste, layerMode);
             SelectEffect(ef);
         }
         cbd->Close();
     }
 }
 
-void MainSequencer::InsertTimingMarkFromRange()
-{
+void MainSequencer::InsertTimingMarkFromRange() {
     bool is_range = true;
     int x1;
     int x2;
     if (xLightsApp::GetFrame()->GetPlayStatus() == PLAY_TYPE_MODEL) {
         x1 = PanelTimeLine->GetPlayMarker();
         x2 = x1;
-    }
-    else {
+    } else {
         x1 = PanelTimeLine->GetSelectedPositionStart();
         x2 = PanelTimeLine->GetSelectedPositionEnd();
 
@@ -1809,8 +1689,10 @@ void MainSequencer::InsertTimingMarkFromRange()
             x2 = x1;
         }
     }
-    if (x2 == -1) x2 = x1;
-    if (x1 == x2) is_range = false;
+    if (x2 == -1)
+        x2 = x1;
+    if (x1 == x2)
+        is_range = false;
 
     int selectedTiming = mSequenceElements->GetSelectedTimingRow();
     if (selectedTiming >= 0) {
@@ -1834,16 +1716,12 @@ void MainSequencer::InsertTimingMarkFromRange()
                         std::string name, settings;
                         el->AddEffect(0, name, settings, "", t1, t2, false, false);
                         PanelEffectGrid->ForceRefresh();
-                    }
-                    else
-                    {
+                    } else {
                         DisplayError("Timing placement error: Timing exists already in the selected region", this);
                     }
                 }
             }
-        }
-        else
-        {
+        } else {
             // x1 and x2 are the same. Insert from end time of timing to the left to x2
             Element* e = mSequenceElements->GetVisibleRowInformation(selectedTiming)->element;
             if (e != nullptr) {
@@ -1871,21 +1749,17 @@ void MainSequencer::InsertTimingMarkFromRange()
                             // fill to left and right
                             el->AddEffect(0, name, settings, "", lefteffect->GetEndTimeMS(), t2, false, false);
                             el->AddEffect(0, name, settings, "", t2, righteffect->GetStartTimeMS(), false, false);
-                        }
-                        else if (lefteffect != nullptr) {
+                        } else if (lefteffect != nullptr) {
                             el->AddEffect(0, name, settings, "", lefteffect->GetEndTimeMS(), t2, false, false);
-                        }
-                        else if (righteffect != nullptr) {
+                        } else if (righteffect != nullptr) {
                             el->AddEffect(0, name, settings, "", t2, righteffect->GetStartTimeMS(), false, false);
-                        }
-                        else {
+                        } else {
                             el->AddEffect(0, name, settings, "", 0, t2, false, false);
                         }
 
                         PanelEffectGrid->ForceRefresh();
-                    }
-                    else {
-                        SplitTimingMark();  // inserting a timing mark inside a timing mark same as a split
+                    } else {
+                        SplitTimingMark(); // inserting a timing mark inside a timing mark same as a split
                     }
                 }
             }
@@ -1893,84 +1767,65 @@ void MainSequencer::InsertTimingMarkFromRange()
     }
 }
 
-void MainSequencer::SplitTimingMark()
-{
-    
-
+void MainSequencer::SplitTimingMark() {
     int x1;
     int x2;
-    if (xLightsApp::GetFrame()->GetPlayStatus() == PLAY_TYPE_MODEL)
-    {
+    if (xLightsApp::GetFrame()->GetPlayStatus() == PLAY_TYPE_MODEL) {
         x1 = PanelTimeLine->GetPlayMarker();
         x2 = x1;
-    }
-    else
-    {
+    } else {
         x1 = PanelTimeLine->GetSelectedPositionStart();
         x2 = PanelTimeLine->GetSelectedPositionEnd();
 
         int pm = PanelTimeLine->GetPlayMarker();
-        if ((x1 == -1 || x2 == -1 || x1 == x2) && pm != -1)
-        {
+        if ((x1 == -1 || x2 == -1 || x1 == x2) && pm != -1) {
             x1 = pm;
             x2 = x1;
         }
     }
-    if (x2 == -1) x2 = x1;
+    if (x2 == -1)
+        x2 = x1;
     int selectedTiming = mSequenceElements->GetSelectedTimingRow();
-    if (selectedTiming >= 0)
-    {
+    if (selectedTiming >= 0) {
         Element* e = mSequenceElements->GetVisibleRowInformation(selectedTiming)->element;
         EffectLayer* el = e->GetEffectLayer(mSequenceElements->GetVisibleRowInformation(selectedTiming)->layerIndex);
 
-        if (el == nullptr)
-        {
+        if (el == nullptr) {
             spdlog::critical("MainSequencer::SplitTimingMark el is nullptr ... this is going to crash.");
         }
 
         int index1, index2;
         int t1 = PanelTimeLine->GetAbsoluteTimeMSfromPosition(x1);
         int t2 = PanelTimeLine->GetAbsoluteTimeMSfromPosition(x2);
-        if (el->HitTestEffectByTime(t1, index1) && el->HitTestEffectByTime(t2, index2))
-        {
-            if (index1 == index2)
-            {
+        if (el->HitTestEffectByTime(t1, index1) && el->HitTestEffectByTime(t2, index2)) {
+            if (index1 == index2) {
                 Effect* eff1 = el->GetEffect(index1);
                 int old_end_time = eff1->GetEndTimeMS();
-                if (t1 != t2 || ((t1 == t2) && t1 != eff1->GetStartTimeMS() && t1 != eff1->GetEndTimeMS()))
-                {
+                if (t1 != t2 || ((t1 == t2) && t1 != eff1->GetStartTimeMS() && t1 != eff1->GetEndTimeMS())) {
                     eff1->SetEndTimeMS(t1);
                     std::string name, settings;
                     el->AddEffect(0, name, settings, "", t2, old_end_time, false, false);
                     PanelEffectGrid->ForceRefresh();
                 }
-            }
-            else
-            {
+            } else {
                 DisplayError("Timing placement error: Timing cannot be split across timing marks.");
             }
         }
     }
 }
 
-void MainSequencer::DivideTimingTrack(int divisor)
-{
-    
-
+void MainSequencer::DivideTimingTrack(int divisor) {
     int selectedTiming = mSequenceElements->GetSelectedTimingRow();
-    if (selectedTiming >= 0)
-    {
+    if (selectedTiming >= 0) {
         Element* e = mSequenceElements->GetVisibleRowInformation(selectedTiming)->element;
         EffectLayer* el = e->GetEffectLayer(mSequenceElements->GetVisibleRowInformation(selectedTiming)->layerIndex);
 
-        if (el == nullptr)
-        {
+        if (el == nullptr) {
             spdlog::critical("MainSequencer::DivideTimingTrack el is nullptr ... this is going to crash.");
             return;
         }
 
-        if (el->IsFixedTimingLayer())
-        {
+        if (el->IsFixedTimingLayer()) {
             spdlog::warn("MainSequencer::DivideTimingTrack Cannot divide fixed timing layer.");
             return;
         }
@@ -2013,11 +1868,9 @@ void MainSequencer::DivideTimingTrack(int divisor)
     }
 }
 
-void MainSequencer::OnScrollBarEffectsHorizontalScrollLineUp(wxScrollEvent& event)
-{
+void MainSequencer::OnScrollBarEffectsHorizontalScrollLineUp(wxScrollEvent& event) {
     int position = ScrollBarEffectsHorizontal->GetThumbPosition();
-    if( position > 0 )
-    {
+    if (position > 0) {
         int ts = ScrollBarEffectsHorizontal->GetThumbSize() / 10;
         if (ts == 0) {
             ts = 1;
@@ -2030,12 +1883,10 @@ void MainSequencer::OnScrollBarEffectsHorizontalScrollLineUp(wxScrollEvent& even
     }
 }
 
-void MainSequencer::OnScrollBarEffectsHorizontalScrollLineDown(wxScrollEvent& event)
-{
+void MainSequencer::OnScrollBarEffectsHorizontalScrollLineDown(wxScrollEvent& event) {
     int position = ScrollBarEffectsHorizontal->GetThumbPosition();
     int limit = ScrollBarEffectsHorizontal->GetRange();
-    if( position < limit-1 )
-    {
+    if (position < limit - 1) {
         int ts = ScrollBarEffectsHorizontal->GetThumbSize() / 10;
         if (ts == 0) {
             ts = 1;
@@ -2048,22 +1899,18 @@ void MainSequencer::OnScrollBarEffectsHorizontalScrollLineDown(wxScrollEvent& ev
     }
 }
 
-
-void MainSequencer::HorizontalScrollChanged( wxCommandEvent& event)
-{
+void MainSequencer::HorizontalScrollChanged(wxCommandEvent& event) {
     int position = ScrollBarEffectsHorizontal->IsEnabled() ? ScrollBarEffectsHorizontal->GetThumbPosition() : 0;
     int timeLength = PanelTimeLine->GetTimeLength();
-    int startTime = (int)(((double)position/(double)timeLength) * (double)timeLength);
+    int startTime = (int)(((double)position / (double)timeLength) * (double)timeLength);
     PanelTimeLine->SetStartTimeMS(startTime);
     UpdateEffectGridHorizontalScrollBar();
 }
 
-void MainSequencer::ScrollRight(wxCommandEvent& event)
-{
+void MainSequencer::ScrollRight(wxCommandEvent& event) {
     int position = ScrollBarEffectsHorizontal->GetThumbPosition();
     int limit = ScrollBarEffectsHorizontal->GetRange();
-    if( position < limit-1 )
-    {
+    if (position < limit - 1) {
         int ts = ScrollBarEffectsHorizontal->GetThumbSize();
         if (ts == 0) {
             ts = 1;
@@ -2078,19 +1925,16 @@ void MainSequencer::ScrollRight(wxCommandEvent& event)
     }
 }
 
-void MainSequencer::TimeLineSelectionChanged(wxCommandEvent& event)
-{
+void MainSequencer::TimeLineSelectionChanged(wxCommandEvent& event) {
     UpdateSelectedDisplay(event.GetInt());
 }
 
-void MainSequencer::SequenceChanged(wxCommandEvent& event)
-{
+void MainSequencer::SequenceChanged(wxCommandEvent& event) {
     mSequenceElements->IncrementChangeCount(nullptr);
 }
 
-void MainSequencer::TimelineChanged( wxCommandEvent& event)
-{
-    TimelineChangeArguments *tla = (TimelineChangeArguments*)(event.GetClientData());
+void MainSequencer::TimelineChanged(wxCommandEvent& event) {
+    TimelineChangeArguments* tla = (TimelineChangeArguments*)(event.GetClientData());
     PanelWaveForm->SetZoomLevel(tla->ZoomLevel);
     PanelWaveForm->SetStartPixelOffset(tla->StartPixelOffset);
     UpdateTimeDisplay(tla->CurrentTimeMS, {});
@@ -2103,13 +1947,12 @@ void MainSequencer::TimelineChanged( wxCommandEvent& event)
     delete tla;
 }
 
-void MainSequencer::UpdateEffectGridHorizontalScrollBar()
-{
+void MainSequencer::UpdateEffectGridHorizontalScrollBar() {
     PanelWaveForm->SetZoomLevel(PanelTimeLine->GetZoomLevel());
     PanelWaveForm->SetStartPixelOffset(PanelTimeLine->GetStartPixelOffset());
     UpdateTimeDisplay(PanelTimeLine->GetCurrentPlayMarkerMS(), {});
 
-    //printf("%d\n", PanelTimeLine->GetStartPixelOffset());
+    // printf("%d\n", PanelTimeLine->GetStartPixelOffset());
     PanelTimeLine->Refresh();
     PanelTimeLine->Update();
     PanelWaveForm->render();
@@ -2117,32 +1960,31 @@ void MainSequencer::UpdateEffectGridHorizontalScrollBar()
     PanelEffectGrid->Draw();
 
     int zoomLevel = PanelTimeLine->GetZoomLevel();
-    int maxZoomLevel = PanelTimeLine->GetMaxZoomLevel(); 
+    int maxZoomLevel = PanelTimeLine->GetMaxZoomLevel();
     if (zoomLevel >= maxZoomLevel) {
         // Max Zoom so scrollbar is same size as window.
         int range = PanelTimeLine->GetSize().x;
-        int pageSize =range;
+        int pageSize = range;
         int thumbSize = range;
-        ScrollBarEffectsHorizontal->SetScrollbar(0,thumbSize,range,pageSize);
+        ScrollBarEffectsHorizontal->SetScrollbar(0, thumbSize, range, pageSize);
         ScrollBarEffectsHorizontal->Disable();
     } else {
         int startTime;
         int endTime;
         int range = PanelTimeLine->GetTimeLength();
-        PanelTimeLine->GetViewableTimeRange(startTime,endTime);
+        PanelTimeLine->GetViewableTimeRange(startTime, endTime);
 
         int diff = endTime - startTime;
         int thumbSize = diff;
         int pageSize = thumbSize;
         int position = startTime;
-        ScrollBarEffectsHorizontal->SetScrollbar(position,thumbSize,range,pageSize);
+        ScrollBarEffectsHorizontal->SetScrollbar(position, thumbSize, range, pageSize);
         ScrollBarEffectsHorizontal->Enable();
     }
     ScrollBarEffectsHorizontal->Refresh();
 }
 
-void MainSequencer::SetEffectDuration(const std::string& effectType, const uint32_t durationMS)
-{
+void MainSequencer::SetEffectDuration(const std::string& effectType, const uint32_t durationMS) {
     // find the selected effect
     auto eff = GetSelectedEffect();
     if (eff != nullptr) {
@@ -2168,16 +2010,14 @@ void MainSequencer::SetEffectDuration(const std::string& effectType, const uint3
     }
 }
 
-void MainSequencer::TagAllSelectedEffects()
-{
-    for(int row=0;row<mSequenceElements->GetRowInformationSize();row++) {
+void MainSequencer::TagAllSelectedEffects() {
+    for (int row = 0; row < mSequenceElements->GetRowInformationSize(); row++) {
         EffectLayer* el = mSequenceElements->GetEffectLayer(row);
         el->TagAllSelectedEffects();
     }
 }
 
-void MainSequencer::UnTagAllEffects()
-{
+void MainSequencer::UnTagAllEffects() {
     for (int i = 0; i < mSequenceElements->GetRowInformationSize(); i++) {
         EffectLayer* el = mSequenceElements->GetEffectLayer(i);
         if (el != nullptr) {
@@ -2186,9 +2026,9 @@ void MainSequencer::UnTagAllEffects()
     }
 }
 
-void MainSequencer::RestorePosition()
-{
-    if (mSequenceElements == nullptr) return;
+void MainSequencer::RestorePosition() {
+    if (mSequenceElements == nullptr)
+        return;
 
     if (_savedTopModel != "") {
         PanelTimeLine->RestorePosition();
@@ -2204,36 +2044,31 @@ void MainSequencer::RestorePosition()
     }
 }
 
-void MainSequencer::SavePosition()
-{
-    if (mSequenceElements == nullptr || mSequenceElements->GetVisibleEffectLayer(mSequenceElements->GetNumberOfTimingRows()) == nullptr)
-    {
+void MainSequencer::SavePosition() {
+    if (mSequenceElements == nullptr || mSequenceElements->GetVisibleEffectLayer(mSequenceElements->GetNumberOfTimingRows()) == nullptr) {
         _savedTopModel = "";
-    }
-    else
-    {
+    } else {
         PanelTimeLine->SavePosition();
         Element* elem = mSequenceElements->GetVisibleEffectLayer(mSequenceElements->GetNumberOfTimingRows())->GetParentElement();
         _savedTopModel = elem->GetName();
     }
 }
 
-void MainSequencer::ScrollToRow(int row)
-{
-    if (mSequenceElements == nullptr) return;
+void MainSequencer::ScrollToRow(int row) {
+    if (mSequenceElements == nullptr)
+        return;
 
     mSequenceElements->SetFirstVisibleModelRow(row);
     UpdateEffectGridVerticalScrollBar();
 }
 
-void MainSequencer::OnCheckBox_SuspendRenderClick(wxCommandEvent& event)
-{
+void MainSequencer::OnCheckBox_SuspendRenderClick(wxCommandEvent& event) {
     ToggleRender(CheckBox_SuspendRender->IsChecked());
 }
 
-void MainSequencer::ShowSeqFilterPanel(bool show)
-{
-    if (_seqFilterCtrl == nullptr) return;
+void MainSequencer::ShowSeqFilterPanel(bool show) {
+    if (_seqFilterCtrl == nullptr)
+        return;
     if (show) {
         _seqFilterCtrl->Show();
         GetSizer()->Layout();
@@ -2248,9 +2083,9 @@ void MainSequencer::ShowSeqFilterPanel(bool show)
     }
 }
 
-void MainSequencer::ApplySeqFilter(const wxString& filter)
-{
-    if (mSequenceElements == nullptr) return;
+void MainSequencer::ApplySeqFilter(const wxString& filter) {
+    if (mSequenceElements == nullptr)
+        return;
 
     int view = mSequenceElements->GetCurrentView();
     int count = mSequenceElements->GetElementCount(view);
@@ -2258,8 +2093,10 @@ void MainSequencer::ApplySeqFilter(const wxString& filter)
     if (filter.IsEmpty()) {
         for (int i = 0; i < count; i++) {
             Element* el = mSequenceElements->GetElement(i, view);
-            if (el == nullptr) continue;
-            if (el->GetType() == ElementType::ELEMENT_TYPE_TIMING) continue;
+            if (el == nullptr)
+                continue;
+            if (el->GetType() == ElementType::ELEMENT_TYPE_TIMING)
+                continue;
             el->SetVisible(true);
         }
         spdlog::debug("SeqFilter: cleared");
@@ -2267,8 +2104,10 @@ void MainSequencer::ApplySeqFilter(const wxString& filter)
         wxString lower = filter.Lower();
         for (int i = 0; i < count; i++) {
             Element* el = mSequenceElements->GetElement(i, view);
-            if (el == nullptr) continue;
-            if (el->GetType() == ElementType::ELEMENT_TYPE_TIMING) continue;
+            if (el == nullptr)
+                continue;
+            if (el->GetType() == ElementType::ELEMENT_TYPE_TIMING)
+                continue;
             el->SetVisible(wxString(el->GetName()).Lower().Contains(lower));
         }
         spdlog::debug("SeqFilter: filter='{}'", filter.ToStdString());
@@ -2282,20 +2121,17 @@ void MainSequencer::ApplySeqFilter(const wxString& filter)
     PanelRowHeadings->Refresh();
 }
 
-void MainSequencer::OnSeqFilterText(wxCommandEvent& event)
-{
+void MainSequencer::OnSeqFilterText(wxCommandEvent& event) {
     wxString filter = _seqFilterCtrl->GetValue();
     filter.Trim();
     filter.Trim(false);
     ApplySeqFilter(filter);
 }
 
-void MainSequencer::OnSeqFilterEnter(wxCommandEvent& event)
-{
+void MainSequencer::OnSeqFilterEnter(wxCommandEvent& event) {
     ShowSeqFilterPanel(false);
 }
 
-void MainSequencer::OnSeqFilterCancel(wxCommandEvent& event)
-{
+void MainSequencer::OnSeqFilterCancel(wxCommandEvent& event) {
     ShowSeqFilterPanel(false);
 }

--- a/src-ui-wx/sequencer/MainSequencer.h
+++ b/src-ui-wx/sequencer/MainSequencer.h
@@ -79,7 +79,7 @@ class MainSequencer: public wxPanel
 
         void Cut();
         void Copy();
-        void Paste(bool row_paste = false, bool invertLayerMode = false);
+        void Paste(bool row_paste = false, bool invertPasteAsLayers = false);
 
         void DoCopy(wxCommandEvent& event);
         void DoCut(wxCommandEvent& event);

--- a/src-ui-wx/sequencer/MainSequencer.h
+++ b/src-ui-wx/sequencer/MainSequencer.h
@@ -79,7 +79,7 @@ class MainSequencer: public wxPanel
 
         void Cut();
         void Copy();
-        void Paste(bool row_paste = false);
+        void Paste(bool row_paste = false, bool invertLayerMode = false);
 
         void DoCopy(wxCommandEvent& event);
         void DoCut(wxCommandEvent& event);

--- a/src-ui-wx/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/sequencer/tabSequencer.cpp
@@ -4322,9 +4322,9 @@ Effect* xLightsFrame::ApplyEffectsPreset(const std::string& presetName)
     return res;
 }
 
-void xLightsFrame::ApplyEffectsPreset(wxString& data, const wxString& pasteDataVersion)
+void xLightsFrame::ApplyEffectsPreset(wxString& data, const wxString& pasteDataVersion, bool layerMode)
 {
-    mainSequencer->PanelEffectGrid->Paste(data, pasteDataVersion);
+    mainSequencer->PanelEffectGrid->Paste(data, pasteDataVersion, false, layerMode);
 }
 
 void xLightsFrame::PromoteEffects(wxCommandEvent& command)

--- a/src-ui-wx/wxsmith/EffectTreeDialog.wxs
+++ b/src-ui-wx/wxsmith/EffectTreeDialog.wxs
@@ -77,7 +77,7 @@
 					<object class="sizeritem">
 						<object class="wxFlexGridSizer" variable="FlexGridSizer3" member="no">
 							<cols>1</cols>
-							<rows>3</rows>
+							<rows>4</rows>
 							<growablecols>0</growablecols>
 							<growablerows>0</growablerows>
 							<object class="sizeritem">
@@ -87,9 +87,34 @@
 								<option>1</option>
 							</object>
 							<object class="sizeritem">
+								<object class="wxStaticText" name="ID_STATICTEXT_APPLY" variable="StaticTextApplyLabel" member="yes">
+									<label>Apply preset as:</label>
+								</object>
+								<flag>wxALL|wxALIGN_LEFT</flag>
+								<border>5</border>
+							</object>
+							<object class="sizeritem">
 								<object class="wxGridSizer" variable="BoxSizer1" member="no">
 									<cols>2</cols>
-									<rows>4</rows>
+									<rows>5</rows>
+									<object class="sizeritem">
+										<object class="wxButton" name="ID_BTN_POSITION" variable="btPosition" member="yes">
+											<label>Relative</label>
+											<tooltip>Paste effects at the drop row, ignoring layer structure.</tooltip>
+											<handler function="OnBtnPositionClick" entry="EVT_BUTTON" />
+										</object>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+									</object>
+									<object class="sizeritem">
+										<object class="wxButton" name="ID_BTN_LAYERS" variable="btLayers" member="yes">
+											<label>Layers</label>
+											<tooltip>Paste effects preserving layer structure.</tooltip>
+											<handler function="OnBtnLayersClick" entry="EVT_BUTTON" />
+										</object>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+									</object>
 									<object class="sizeritem">
 										<object class="wxButton" name="ID_BUTTON6" variable="btApply" member="yes">
 											<label>&amp;Apply Preset</label>

--- a/src-ui-wx/wxsmith/EffectsGridSettingsPanel.wxs
+++ b/src-ui-wx/wxsmith/EffectsGridSettingsPanel.wxs
@@ -237,6 +237,33 @@
 				<border>5</border>
 				<option>1</option>
 			</object>
+			<object class="sizeritem">
+				<object class="wxStaticText" name="ID_STATICTEXT_PASTE_AS" variable="StaticTextPasteAs" member="yes">
+					<label>Paste As</label>
+				</object>
+				<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxChoice" name="ID_CHOICE_PASTE_AS" variable="PasteAsChoice" member="yes">
+					<content>
+						<item>Relative</item>
+						<item>Layers</item>
+					</content>
+					<selection>0</selection>
+					<tooltip>Relative: paste effects at the selected position. As Layers: paste preserving layer structure from copied effects.</tooltip>
+					<handler function="OnPasteAsChoiceSelect" entry="EVT_CHOICE" />
+				</object>
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="spacer">
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
 		</object>
 	</object>
 </wxsmith>

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -1683,6 +1683,9 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     config->Read("xLightsRenderBell", &_renderBellEnabled, false);
     spdlog::debug("Render Bell Enabled: {}.", toStr(_renderBellEnabled));
 
+    config->Read("xLightsPasteAsLayers", &_pasteAsLayers, false);
+    spdlog::debug("Paste As Layers: {}.", toStr(_pasteAsLayers));
+
     config->Read("xLightsModelBlendDefaultOff", &_modelBlendDefaultOff, false);
     spdlog::debug("Model Blend Default Off: {}.", toStr(_modelBlendDefaultOff));
 
@@ -2373,6 +2376,7 @@ xLightsFrame::~xLightsFrame()
     config->Write("xLightsHidePresetPreview", _hidePresetPreview);
     config->Write("xLightsSmallWaveform", _smallWaveform);
     config->Write("xLightsRenderBell", _renderBellEnabled);
+    config->Write("xLightsPasteAsLayers", _pasteAsLayers);
     config->Write("xLightsModelBlendDefaultOff", _modelBlendDefaultOff);
     config->Write("xLightsLowDefinitionRender", _lowDefinitionRender);
     config->Write("xLightsTimelineZooming", _timelineZooming);
@@ -3043,6 +3047,10 @@ void xLightsFrame::OnNotebook1PageChanged1(wxAuiNotebookEvent& event)
     } else if (pagenum == NEWSEQUENCER) {
         InitSequencer();
         ShowHideAllSequencerWindows(true);
+        if (!_effectPresetsInitialized && EffectTreeDlg != nullptr && m_mgr->GetPane("EffectPresets").IsShown()) {
+            EffectTreeDlg->InitItems(_effectPresetManager);
+            _effectPresetsInitialized = true;
+        }
         EffectSettingsTimer.Start(50, wxTIMER_ONE_SHOT);
         MenuItem_File_Save->SetItemLabel("Save Sequence\tCTRL-s");
         MenuItem_File_Save->Enable(MenuItem_File_SaveAs_Sequence->IsEnabled());

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -1185,7 +1185,7 @@ public:
 
     [[nodiscard]] bool IsRenderBell() const { return _renderBellEnabled; }
     void SetRenderBell(bool b) { _renderBellEnabled = b; }
-    [[nodiscard]] bool PasteAsLayers() const { return _pasteAsLayers; }
+    [[nodiscard]] bool IsPasteAsLayers() const { return _pasteAsLayers; }
     void SetPasteAsLayers(bool b) { _pasteAsLayers = b; }
 	[[nodiscard]] bool IsIgnoreVendorModelRecommendations() const { return _ignoreVendorModelRecommendations; }
     void StartAutomationListener();

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -1157,6 +1157,7 @@ public:
     bool _snapToTimingMarks = true;
     bool _autoSavePerspecive = true;
     bool _renderBellEnabled = false;
+    bool _pasteAsLayers = false;
     bool _ignoreVendorModelRecommendations = false;
     bool _purgeDownloadCacheOnStart = false;
     bool _enablePositionZones = true;
@@ -1184,6 +1185,8 @@ public:
 
     [[nodiscard]] bool IsRenderBell() const { return _renderBellEnabled; }
     void SetRenderBell(bool b) { _renderBellEnabled = b; }
+    [[nodiscard]] bool PasteAsLayers() const { return _pasteAsLayers; }
+    void SetPasteAsLayers(bool b) { _pasteAsLayers = b; }
 	[[nodiscard]] bool IsIgnoreVendorModelRecommendations() const { return _ignoreVendorModelRecommendations; }
     void StartAutomationListener();
     [[nodiscard]] bool ProcessHttpRequest(HttpConnection& connection, HttpRequest& request);
@@ -1657,7 +1660,7 @@ public:
     void DoPromoteEffects(ModelElement *element);
     EffectPreset* CreateEffectPreset(EffectPresetGroup* parent, const std::string& name);
     void UpdateEffectPreset(EffectPreset* preset);
-    void ApplyEffectsPreset(wxString& data, const wxString &pasteDataVersion);
+    void ApplyEffectsPreset(wxString& data, const wxString &pasteDataVersion, bool layerMode = false);
     Effect* ApplyEffectsPreset(const std::string& presetName);
     std::vector<std::string> GetPresets() const;
     void RenameModelInViews(const std::string old_name, const std::string& new_name);


### PR DESCRIPTION
Add "smarts" to presets and regular grid ctrl-c/ctrl-v
Now presets can also start with "empty" laters; ie: start preset at model level, but effects actually start at a lower submodel

https://github.com/user-attachments/assets/d4e9d92d-72d7-48b2-89a9-83ef7a10cdcf

