### PR TITLE
Fix hidden timing tracks reappearing when another timing track is expanded or collapsed (#6424)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -30,17 +30,14 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -enh (scott)                 Custom color picker: skip duplicate colors in the recent colors list.
     -enh (dkulp)                 macOS: include MetricKit crash diagnostics in packaged log uploads; clean up
                                  older MetricKit data.
+    -bug (derwin12)              Fix hidden timing tracks reappearing when another timing track is expanded or collapsed (#6424)
     -bug (dkulp)                 Fix 3D Objects (Image/Mesh/Gridlines/Terrain/Ruler) handle picking on the
                                  Layout tab — selecting, dragging, and center-handle tool cycling now work
                                  again after the DragSession refactor.
     -bug (derwin12)              Fix pivot point for rotating multiple objects (#6418)
     -bug (dkulp)                 Fix drag-and-drop of Video/Pictures/Glediator/Shader files onto the effect
-                                 grid losing the filename — the deferred effect-page-changed event was
-                                 clearing the panel after the drop, then the settings timer wrote the
-                                 cleared panel state back to the effect.
+                                 grid losing the filename
     -bug (dkulp)                 macOS: Video effect now renders rawvideo MOV files (rgb24/bgr24/rgba/bgra)
-                                 by demuxing through AVAssetReader and converting to BGRA directly, instead
-                                 of routing them through VideoToolbox which has no `raw ` decoder.
     -bug (derwin12)              Fix imports for both old and new xmodel formats (Layout import, Node Select
                                  Grid, SubModels dialog) (#6411).
     -bug (derwin12)              Re-Map Custom Model now handles the new xmodel format (#6397, #6400).

--- a/src-core/render/SequenceElements.cpp
+++ b/src-core/render/SequenceElements.cpp
@@ -972,12 +972,14 @@ void SequenceElements::SetTimingVisibility(const std::string& name)
             }
             else {
                 te->SetVisible(false);
-                auto views = Split(te->GetViews(), ',');
-                for (size_t v = 0; v < views.size(); v++) {
-                    const std::string& viewName = views[v];
-                    if (name == viewName) {
-                        te->SetVisible(true);
-                        break;
+                if (te->GetMasterVisible()) {
+                    auto views = Split(te->GetViews(), ',');
+                    for (size_t v = 0; v < views.size(); v++) {
+                        const std::string& viewName = views[v];
+                        if (name == viewName) {
+                            te->SetVisible(true);
+                            break;
+                        }
                     }
                 }
             }
@@ -1713,7 +1715,6 @@ size_t SequenceElements::GetHiddenTimingCount() const
 
 void SequenceElements::HideAllTimingTracks(bool hide)
 {
-    // This only works on timing tracks in master views because of the way we manage timing tracks in non master views
     for (size_t i = 0; i < mAllViews[MASTER_VIEW].size(); i++) {
         Element* elem = mAllViews[MASTER_VIEW][i];
         TimingElement* te = dynamic_cast<TimingElement*>(elem);

--- a/src-ui-wx/layout/ViewsModelsPanel.cpp
+++ b/src-ui-wx/layout/ViewsModelsPanel.cpp
@@ -1213,7 +1213,7 @@ void ViewsModelsPanel::OnListCtrlItemCheck(wxCommandEvent& event)
     else {
         e->SetVisible(!e->GetVisible());
         TimingElement* te = dynamic_cast<TimingElement*>(e);
-        if (_sequenceViewManager->GetSelectedViewIndex() == MASTER_VIEW && te != nullptr) {
+        if (te != nullptr) {
             te->SetMasterVisible(e->GetVisible());
         }
     }


### PR DESCRIPTION
If you have a timing track hidden, if you expanded another timing track it would make that hidden timing track visible again.