### PR TITLE
Smart Presets with relative and auto layer-mode + Ctrl-V paste with layers

### DIFF
--- a/src-core/render/UndoManager.cpp
+++ b/src-core/render/UndoManager.cpp
@@ -394,7 +394,8 @@ void UndoManager::ProcessUndoStep(std::vector<UndoStep*> &fromList, std::vector<
                 EffectLayer* el = element->GetEffectLayerFromExclusiveIndex(next_action->layer_info[0]->exclusive_layer_index);
                 if (el != nullptr && element->GetEffectLayerCount() > 1) {
                     int pos = el->GetLayerNumber() - 1;
-                    LayerInfo* li = new LayerInfo(next_action->layer_info[0]->element_name, -1, pos);
+                    LayerInfo* li = new LayerInfo(next_action->layer_info[0]->element_name,
+                                                  next_action->layer_info[0]->exclusive_layer_index, pos);
                     UndoStep* action = new UndoStep(UNDO_LAYER_REMOVED, li);
                     toList.push_back(action);
                     element->RemoveEffectLayer(pos);
@@ -422,6 +423,19 @@ void UndoManager::ProcessUndoStep(std::vector<UndoStep*> &fromList, std::vector<
                 UndoStep* action = new UndoStep(UNDO_LAYER_ADDED, li);
                 toList.push_back(action);
                 mParentSequence->PopulateRowInformation();
+                // Make sure redo recreates the layers needed to support the smart copy/paste
+                int oldIdx = next_action->layer_info[0]->exclusive_layer_index;
+                if (oldIdx >= 0) {
+                    int newIdx = el->GetIndex();
+                    for (auto* step : fromList) {
+                        if (step->undo_action == UNDO_EFFECT_DELETED) {
+                            for (auto* dei : step->deleted_effect_info) {
+                                if (dei->layer_index == oldIdx)
+                                    dei->layer_index = newIdx;
+                            }
+                        }
+                    }
+                }
             }
         }
         break;

--- a/src-ui-wx/app-shell/KeyBindings.cpp
+++ b/src-ui-wx/app-shell/KeyBindings.cpp
@@ -160,7 +160,8 @@ static  std::vector<std::pair<std::string, KBSCOPE>> KeyBindingTypes =
     { "JUKEBOX_BTN_4", KBSCOPE::Sequence },
     { "JUKEBOX_BTN_5", KBSCOPE::Sequence },
     { "FPP_CONNECT", KBSCOPE::All },
-    { "FILTER_SEQUENCER", KBSCOPE::Sequence }
+    { "FILTER_SEQUENCER", KBSCOPE::Sequence },
+    { "ALTERNATE_PASTE", KBSCOPE::Sequence }
 };
 
 static  std::vector<std::pair<std::string, std::string>> keyBindingTips = {
@@ -293,6 +294,7 @@ static  std::vector<std::pair<std::string, std::string>> keyBindingTips = {
     { "JUKEBOX_BTN_4", "Jukebox Button 4." },
     { "JUKEBOX_BTN_5", "Jukebox Button 5." },
     { "FPP_CONNECT", "Run FPP Connect" },
+    { "ALTERNATE_PASTE", "Paste effects using the opposite of the configured 'Paste As' mode (Relative vs As Layers)." },
 };
 
 const std::vector<KeyBinding> DefaultBindings =
@@ -991,7 +993,7 @@ bool KeyBinding::IsDuplicateKey(const KeyBinding& b) const
     if (_id == b.GetId()) return false;
 
     if (b.GetScope() == GetScope() || GetScope() == KBSCOPE::All || b.GetScope() == KBSCOPE::All) {
-        if (b.GetKey() == GetKey() && b.RequiresAlt() == RequiresAlt() && KeyBinding::IsControlEqual(b, RequiresRawControl(), RequiresControl()) && b.RequiresShift() == RequiresShift()) {
+        if (b.GetKey() == GetKey() && b.RequiresAlt() == RequiresAlt() && KeyBinding::IsControlEqual(b, RequiresControl(), RequiresRawControl()) && b.RequiresShift() == RequiresShift()) {
             return true;
         }
     }

--- a/src-ui-wx/app-shell/KeyBindings.h
+++ b/src-ui-wx/app-shell/KeyBindings.h
@@ -106,7 +106,12 @@ public:
     bool RequiresAlt() const noexcept { return _alt; }
     bool RequiresShift() const noexcept { return _shift; }
     bool InScope(const KBSCOPE scope) const noexcept { return scope == _scope; }
-    bool IsKey(wxKeyCode key) const noexcept { return (_key == key); }
+    bool IsKey(wxKeyCode key) const noexcept
+    {
+        wxKeyCode k = key;
+        if (k >= 'a' && k <= 'z') k = (wxKeyCode)(k - ('a' - 'A'));
+        return (_key == k);
+    }
     bool IsDisabled() const noexcept { return _disabled; }
     std::string Description() const noexcept;
     std::string KeyDescription() const noexcept;

--- a/src-ui-wx/preferences/EffectsGridSettingsPanel.cpp
+++ b/src-ui-wx/preferences/EffectsGridSettingsPanel.cpp
@@ -35,6 +35,8 @@ const wxWindowID EffectsGridSettingsPanel::ID_CHECKBOX6 = wxNewId();
 const wxWindowID EffectsGridSettingsPanel::ID_CHECKBOX5 = wxNewId();
 const wxWindowID EffectsGridSettingsPanel::ID_CHECKBOX8 = wxNewId();
 const wxWindowID EffectsGridSettingsPanel::ID_CHECKBOX9 = wxNewId();
+const wxWindowID EffectsGridSettingsPanel::ID_STATICTEXT_PASTE_AS = wxNewId();
+const wxWindowID EffectsGridSettingsPanel::ID_CHOICE_PASTE_AS = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(EffectsGridSettingsPanel,wxPanel)
@@ -117,6 +119,14 @@ EffectsGridSettingsPanel::EffectsGridSettingsPanel(wxWindow* parent, xLightsFram
 	GridSizer1->Add(BellOnRenderCompletion, 1, wxALL|wxEXPAND, 5);
 	GridSizer1->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	GridSizer1->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	StaticTextPasteAs = new wxStaticText(this, ID_STATICTEXT_PASTE_AS, _("Paste As"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_PASTE_AS"));
+	GridSizer1->Add(StaticTextPasteAs, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+	PasteAsChoice = new wxChoice(this, ID_CHOICE_PASTE_AS, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_PASTE_AS"));
+	PasteAsChoice->SetSelection( PasteAsChoice->Append(_("Relative")) );
+	PasteAsChoice->Append(_("Layers"));
+	PasteAsChoice->SetToolTip(_("Relative: paste effects at the selected position. As Layers: paste preserving layer structure from copied effects."));
+	GridSizer1->Add(PasteAsChoice, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+	GridSizer1->Add(-1,-1,1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
 	SetSizer(GridSizer1);
 	GridSizer1->SetSizeHints(this);
 
@@ -131,6 +141,7 @@ EffectsGridSettingsPanel::EffectsGridSettingsPanel(wxWindow* parent, xLightsFram
 	Connect(ID_CHECKBOX5, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&EffectsGridSettingsPanel::OnColorUpdateWarnCheckBoxClick);
 	Connect(ID_CHECKBOX8, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&EffectsGridSettingsPanel::OnShowAlternateTimingFormatCheckBoxClick);
 	Connect(ID_CHECKBOX9, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&EffectsGridSettingsPanel::OnBellOnRenderCompletionClick);
+	Connect(ID_CHOICE_PASTE_AS, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&EffectsGridSettingsPanel::OnPasteAsChoiceSelect);
 	//*)
 }
 
@@ -152,6 +163,7 @@ bool EffectsGridSettingsPanel::TransferDataToWindow() {
     GroupEffectIndicator->SetValue(frame->ShowGroupEffectIndicator());
     ShowAlternateTimingFormatCheckBox->SetValue(frame->ShowAlternateTimingFormat());
     BellOnRenderCompletion->SetValue(frame->IsRenderBell());
+    PasteAsChoice->SetSelection(frame->IsPasteAsLayers() ? 1 : 0);
     int gs = frame->GridSpacing();
     switch (gs) {
         case 48:
@@ -202,6 +214,7 @@ bool EffectsGridSettingsPanel::TransferDataFromWindow() {
     frame->SetShowGroupEffectIndicator(GroupEffectIndicator->IsChecked());
     frame->SetShowAlternateTimingFormat(ShowAlternateTimingFormatCheckBox->IsChecked());
     frame->SetRenderBell(BellOnRenderCompletion->IsChecked());
+    frame->SetPasteAsLayers(PasteAsChoice->GetSelection() == 1);
     return true;
 }
 
@@ -284,6 +297,13 @@ void EffectsGridSettingsPanel::OnShowAlternateTimingFormatCheckBoxClick(wxComman
 }
 
 void EffectsGridSettingsPanel::OnBellOnRenderCompletionClick(wxCommandEvent& event)
+{
+    if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
+        TransferDataFromWindow();
+    }
+}
+
+void EffectsGridSettingsPanel::OnPasteAsChoiceSelect(wxCommandEvent& event)
 {
     if (wxPreferencesEditor::ShouldApplyChangesImmediately()) {
         TransferDataFromWindow();

--- a/src-ui-wx/preferences/EffectsGridSettingsPanel.h
+++ b/src-ui-wx/preferences/EffectsGridSettingsPanel.h
@@ -38,7 +38,9 @@ class EffectsGridSettingsPanel: public wxPanel
 		wxCheckBox* TransistionMarksCheckBox;
 		wxChoice* DoubleClickChoice;
 		wxChoice* GridSpacingChoice;
+		wxChoice* PasteAsChoice;
 		wxStaticText* StaticText1;
+		wxStaticText* StaticTextPasteAs;
 		//*)
 
         virtual bool TransferDataFromWindow() override;
@@ -59,6 +61,8 @@ class EffectsGridSettingsPanel: public wxPanel
 		static const wxWindowID ID_CHECKBOX5;
 		static const wxWindowID ID_CHECKBOX8;
 		static const wxWindowID ID_CHECKBOX9;
+		static const wxWindowID ID_STATICTEXT_PASTE_AS;
+		static const wxWindowID ID_CHOICE_PASTE_AS;
 		//*)
 
 	private:
@@ -79,6 +83,7 @@ class EffectsGridSettingsPanel: public wxPanel
 		void OnAlternateTimingFormatCheckBoxClick(wxCommandEvent& event);
 		void OnShowAlternateTimingFormatCheckBoxClick(wxCommandEvent& event);
 		void OnBellOnRenderCompletionClick(wxCommandEvent& event);
+		void OnPasteAsChoiceSelect(wxCommandEvent& event);
 		//*)
 
 		DECLARE_EVENT_TABLE()

--- a/src-ui-wx/sequencer/CopyFormat1.cpp
+++ b/src-ui-wx/sequencer/CopyFormat1.cpp
@@ -52,7 +52,7 @@ CopyFormat1::CopyFormat1(const std::string& data)
     // parse the header line
     wxArrayString cols = wxSplit(lines[0], '\t');
 
-    if (cols.size() != 7) {
+    if (cols.size() < 7) {
         // not the right number of columns in the header
         return;
     }
@@ -261,7 +261,7 @@ CopyFormat1Effect::CopyFormat1Effect(const std::string& data, bool pasteByCell)
     wxArrayString cols = wxSplit(data, '\t');
 
     if (!pasteByCell) {
-        if (cols.size() != 8) {
+        if (cols.size() < 8) {
             // not the right number of columns
             return;
         }

--- a/src-ui-wx/sequencer/EffectTreeDialog.cpp
+++ b/src-ui-wx/sequencer/EffectTreeDialog.cpp
@@ -101,20 +101,23 @@ EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint&
 	Button_Bottom = new wxButton(this, ID_BUTTON12, _("vv"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(15,-1)), 0, wxDefaultValidator, _T("ID_BUTTON12"));
 	BoxSizer3->Add(Button_Bottom, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxFIXED_MINSIZE, 5);
 	FlexGridSizer2->Add(BoxSizer3, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
-	FlexGridSizer3 = new wxFlexGridSizer(4, 1, 0, 0);
+	FlexGridSizer3 = new wxFlexGridSizer(5, 1, 0, 0);
 	FlexGridSizer3->AddGrowableCol(0);
 	FlexGridSizer3->AddGrowableRow(0);
 	StaticBitmapGif = new wxStaticBitmap(this, ID_STATICBITMAP_GIF, wxNullBitmap, wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICBITMAP_GIF"));
 	FlexGridSizer3->Add(StaticBitmapGif, 1, wxALL|wxALIGN_CENTER_HORIZONTAL, 5);
 	StaticTextApplyLabel = new wxStaticText(this, ID_STATICTEXT_APPLY, _("Apply preset as:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_APPLY"));
 	FlexGridSizer3->Add(StaticTextApplyLabel, 0, wxALL|wxALIGN_LEFT, 5);
-	BoxSizer1 = new wxGridSizer(5, 2, 0, 0);
-	btPosition = new wxButton(this, ID_BTN_POSITION, _("Relative"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BTN_POSITION"));
+	wxBoxSizer* BoxSizerRadio = new wxBoxSizer(wxHORIZONTAL);
+	btPosition = new wxRadioButton(this, ID_BTN_POSITION, _("Relative"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP, wxDefaultValidator, _T("ID_BTN_POSITION"));
+	btPosition->SetValue(true);
 	btPosition->SetToolTip(_("Paste effects at the drop row, ignoring layer structure."));
-	BoxSizer1->Add(btPosition, 0, wxALL|wxEXPAND, 5);
-	btLayers = new wxButton(this, ID_BTN_LAYERS, _("Layers"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BTN_LAYERS"));
+	BoxSizerRadio->Add(btPosition, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
+	btLayers = new wxRadioButton(this, ID_BTN_LAYERS, _("Using Layers"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BTN_LAYERS"));
 	btLayers->SetToolTip(_("Paste effects preserving layer structure."));
-	BoxSizer1->Add(btLayers, 0, wxALL|wxEXPAND, 5);
+	BoxSizerRadio->Add(btLayers, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
+	FlexGridSizer3->Add(BoxSizerRadio, 0, wxALL|wxEXPAND, 0);
+	BoxSizer1 = new wxGridSizer(4, 2, 0, 0);
 	btApply = new wxButton(this, ID_BUTTON6, _("&Apply Preset"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON6"));
 	btApply->SetToolTip(_("Apply the selected effect Preset."));
 	BoxSizer1->Add(btApply, 0, wxALL|wxEXPAND, 5);
@@ -170,8 +173,8 @@ EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint&
 	Connect(ID_TEXTCTRL_SEARCH, wxEVT_COMMAND_TEXT_ENTER, (wxObjectEventFunction)&EffectTreeDialog::OnTextCtrl1TextEnter);
 	Connect(ID_BUTTON_SEARCH, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnETButton1Click);
 	Connect(ID_TIMER_GIF, wxEVT_TIMER, (wxObjectEventFunction)&EffectTreeDialog::OnTimerGifTrigger);
-	Connect(ID_BTN_POSITION, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnBtnPositionClick);
-	Connect(ID_BTN_LAYERS, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnBtnLayersClick);
+	Connect(ID_BTN_POSITION, wxEVT_RADIOBUTTON, (wxObjectEventFunction)&EffectTreeDialog::OnBtnPositionClick);
+	Connect(ID_BTN_LAYERS, wxEVT_RADIOBUTTON, (wxObjectEventFunction)&EffectTreeDialog::OnBtnLayersClick);
 	//*)
 
     Connect(wxEVT_SHOW, (wxObjectEventFunction)&EffectTreeDialog::OnShow);
@@ -996,10 +999,8 @@ void EffectTreeDialog::UpdateModeButtons()
 {
     if (btPosition == nullptr || btLayers == nullptr)
         return;
-    btPosition->SetBackgroundColour(_layerMode ? wxNullColour : wxColour(100, 180, 100));
-    btLayers->SetBackgroundColour(_layerMode ? wxColour(100, 180, 100) : wxNullColour);
-    btPosition->Refresh();
-    btLayers->Refresh();
+    btPosition->SetValue(!_layerMode);
+    btLayers->SetValue(_layerMode);
 }
 
 void EffectTreeDialog::OnBtnPositionClick(wxCommandEvent& event)

--- a/src-ui-wx/sequencer/EffectTreeDialog.cpp
+++ b/src-ui-wx/sequencer/EffectTreeDialog.cpp
@@ -56,6 +56,9 @@ const wxWindowID EffectTreeDialog::ID_BUTTON5 = wxNewId();
 const wxWindowID EffectTreeDialog::ID_TEXTCTRL_SEARCH = wxNewId();
 const wxWindowID EffectTreeDialog::ID_BUTTON_SEARCH = wxNewId();
 const wxWindowID EffectTreeDialog::ID_TIMER_GIF = wxNewId();
+const wxWindowID EffectTreeDialog::ID_BTN_POSITION = wxNewId();
+const wxWindowID EffectTreeDialog::ID_BTN_LAYERS = wxNewId();
+const wxWindowID EffectTreeDialog::ID_STATICTEXT_APPLY = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(EffectTreeDialog,wxPanel)
@@ -98,12 +101,20 @@ EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint&
 	Button_Bottom = new wxButton(this, ID_BUTTON12, _("vv"), wxDefaultPosition, wxDLG_UNIT(this,wxSize(15,-1)), 0, wxDefaultValidator, _T("ID_BUTTON12"));
 	BoxSizer3->Add(Button_Bottom, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL|wxFIXED_MINSIZE, 5);
 	FlexGridSizer2->Add(BoxSizer3, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 0);
-	FlexGridSizer3 = new wxFlexGridSizer(3, 1, 0, 0);
+	FlexGridSizer3 = new wxFlexGridSizer(4, 1, 0, 0);
 	FlexGridSizer3->AddGrowableCol(0);
 	FlexGridSizer3->AddGrowableRow(0);
 	StaticBitmapGif = new wxStaticBitmap(this, ID_STATICBITMAP_GIF, wxNullBitmap, wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICBITMAP_GIF"));
 	FlexGridSizer3->Add(StaticBitmapGif, 1, wxALL|wxALIGN_CENTER_HORIZONTAL, 5);
-	BoxSizer1 = new wxGridSizer(4, 2, 0, 0);
+	StaticTextApplyLabel = new wxStaticText(this, ID_STATICTEXT_APPLY, _("Apply preset as:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_APPLY"));
+	FlexGridSizer3->Add(StaticTextApplyLabel, 0, wxALL|wxALIGN_LEFT, 5);
+	BoxSizer1 = new wxGridSizer(5, 2, 0, 0);
+	btPosition = new wxButton(this, ID_BTN_POSITION, _("Relative"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BTN_POSITION"));
+	btPosition->SetToolTip(_("Paste effects at the drop row, ignoring layer structure."));
+	BoxSizer1->Add(btPosition, 0, wxALL|wxEXPAND, 5);
+	btLayers = new wxButton(this, ID_BTN_LAYERS, _("Layers"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BTN_LAYERS"));
+	btLayers->SetToolTip(_("Paste effects preserving layer structure."));
+	BoxSizer1->Add(btLayers, 0, wxALL|wxEXPAND, 5);
 	btApply = new wxButton(this, ID_BUTTON6, _("&Apply Preset"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON6"));
 	btApply->SetToolTip(_("Apply the selected effect Preset."));
 	BoxSizer1->Add(btApply, 0, wxALL|wxEXPAND, 5);
@@ -159,6 +170,8 @@ EffectTreeDialog::EffectTreeDialog(wxWindow* parent,wxWindowID id,const wxPoint&
 	Connect(ID_TEXTCTRL_SEARCH, wxEVT_COMMAND_TEXT_ENTER, (wxObjectEventFunction)&EffectTreeDialog::OnTextCtrl1TextEnter);
 	Connect(ID_BUTTON_SEARCH, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnETButton1Click);
 	Connect(ID_TIMER_GIF, wxEVT_TIMER, (wxObjectEventFunction)&EffectTreeDialog::OnTimerGifTrigger);
+	Connect(ID_BTN_POSITION, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnBtnPositionClick);
+	Connect(ID_BTN_LAYERS, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&EffectTreeDialog::OnBtnLayersClick);
 	//*)
 
     Connect(wxEVT_SHOW, (wxObjectEventFunction)&EffectTreeDialog::OnShow);
@@ -278,7 +291,7 @@ void EffectTreeDialog::ApplyEffect(bool dblClick)
             if (preset != nullptr && !preset->GetSettings().empty())
             {
                 wxString settings = preset->GetSettings();
-                xLightParent->ApplyEffectsPreset(settings, preset->GetXLightsVersion());
+                xLightParent->ApplyEffectsPreset(settings, preset->GetXLightsVersion(), _layerMode);
             }
         }
     }
@@ -421,9 +434,9 @@ wxString EffectTreeDialog::ParseLayers(wxString name, wxString settings)
                 }
                 else
                 {
-                    if (cf1 && efdata.size() > 6 && efdata[0] != "CopyFormat1" && efdata[0] != "None" && efdata.back() != "NO_PASTE_BY_CELL")
+                    if (cf1 && efdata.size() > 5 && efdata[0] != "CopyFormat1" && efdata[0] != "None")
                     {
-                        int row = wxAtoi(efdata[efdata.size() - 6]);
+                        int row = wxAtoi(efdata[5]);
                         if (row < start) start = row;
                         if (row > end) end = row;
                         //logger_base.debug("        row: %d start: %d end: %d", row, start, end);
@@ -431,13 +444,6 @@ wxString EffectTreeDialog::ParseLayers(wxString name, wxString settings)
                     else if (!cf1 && efdata.size() > 2 && efdata[0] != "None")
                     {
                         int row = wxAtoi(efdata[efdata.size() - 2]);
-                        if (row < start) start = row;
-                        if (row > end) end = row;
-                        //logger_base.debug("        row: %d start: %d end: %d", row, start, end);
-                    }
-                    else if (efdata.back() == "NO_PASTE_BY_CELL" && efdata.size() > 3 && efdata[0] != "None")
-                    {
-                        int row = wxAtoi(efdata[efdata.size() - 3]);
                         if (row < start) start = row;
                         if (row > end) end = row;
                         //logger_base.debug("        row: %d start: %d end: %d", row, start, end);
@@ -937,6 +943,8 @@ void EffectTreeDialog::ValidateWindow()
         btDelete->Enable();
         btUpdate->Disable();
         btRename->Enable();
+        btPosition->Disable();
+        btLayers->Disable();
     }
     else if (effectselected)
     {
@@ -945,6 +953,8 @@ void EffectTreeDialog::ValidateWindow()
         btDelete->Enable();
         btUpdate->Enable();
         btRename->Enable();
+        btPosition->Enable();
+        btLayers->Enable();
     }
     else
     {
@@ -960,6 +970,8 @@ void EffectTreeDialog::ValidateWindow()
         btDelete->Disable();
         btUpdate->Disable();
         btRename->Disable();
+        btPosition->Disable();
+        btLayers->Disable();
     }
 }
 
@@ -968,7 +980,38 @@ void EffectTreeDialog::OnTreeCtrl1SelectionChanged(wxTreeEvent& event)
 {
     ValidateWindow();
 
-    GenerateGifImage(TreeCtrl1->GetSelection());
+    wxTreeItemId sel = TreeCtrl1->GetSelection();
+    if (sel.IsOk() && !TreeCtrl1->HasChildren(sel))
+    {
+        MyTreeItemData* item = (MyTreeItemData*)TreeCtrl1->GetItemData(sel);
+        EffectPreset* preset = item ? item->AsPreset() : nullptr;
+        _layerMode = preset != nullptr && (preset->GetSettings().find("\tLAYER:") != std::string::npos);
+        UpdateModeButtons();
+    }
+
+    GenerateGifImage(sel);
+}
+
+void EffectTreeDialog::UpdateModeButtons()
+{
+    if (btPosition == nullptr || btLayers == nullptr)
+        return;
+    btPosition->SetBackgroundColour(_layerMode ? wxNullColour : wxColour(100, 180, 100));
+    btLayers->SetBackgroundColour(_layerMode ? wxColour(100, 180, 100) : wxNullColour);
+    btPosition->Refresh();
+    btLayers->Refresh();
+}
+
+void EffectTreeDialog::OnBtnPositionClick(wxCommandEvent& event)
+{
+    _layerMode = false;
+    UpdateModeButtons();
+}
+
+void EffectTreeDialog::OnBtnLayersClick(wxCommandEvent& event)
+{
+    _layerMode = true;
+    UpdateModeButtons();
 }
 
 wxTreeItemId EffectTreeDialog::findTreeItem(wxTreeCtrl* pTreeCtrl, const wxTreeItemId& root, const wxTreeItemId& startID, const wxString& text, bool &startfound)

--- a/src-ui-wx/sequencer/EffectTreeDialog.h
+++ b/src-ui-wx/sequencer/EffectTreeDialog.h
@@ -15,6 +15,7 @@
 #include <wx/panel.h>
 #include <wx/sizer.h>
 #include <wx/statbmp.h>
+#include <wx/stattext.h>
 #include <wx/textctrl.h>
 #include <wx/timer.h>
 #include <wx/treectrl.h>
@@ -46,6 +47,8 @@ class EffectTreeDialog : public wxPanel
 		wxButton* Button_MoveUp;
 		wxButton* Button_Top;
 		wxButton* ETButton1;
+		wxButton* btLayers;
+		wxButton* btPosition;
 		wxButton* btAddGroup;
 		wxButton* btApply;
 		wxButton* btDelete;
@@ -55,6 +58,7 @@ class EffectTreeDialog : public wxPanel
 		wxButton* btRename;
 		wxButton* btUpdate;
 		wxStaticBitmap* StaticBitmapGif;
+		wxStaticText* StaticTextApplyLabel;
 		wxTextCtrl* TextCtrl1;
 		wxTimer TimerGif;
 		wxTreeCtrl* TreeCtrl1;
@@ -84,9 +88,12 @@ class EffectTreeDialog : public wxPanel
 		static const wxWindowID ID_BUTTON8;
 		static const wxWindowID ID_BUTTON3;
 		static const wxWindowID ID_BUTTON5;
+		static const wxWindowID ID_BTN_POSITION;
+		static const wxWindowID ID_BTN_LAYERS;
 		static const wxWindowID ID_TEXTCTRL_SEARCH;
 		static const wxWindowID ID_BUTTON_SEARCH;
 		static const wxWindowID ID_TIMER_GIF;
+		static const wxWindowID ID_STATICTEXT_APPLY;
 		//*)
 
 	private:
@@ -112,6 +119,8 @@ class EffectTreeDialog : public wxPanel
 		void OnButton_MoveDownClick(wxCommandEvent& event);
 		void OnButton_BottomClick(wxCommandEvent& event);
 		void OnTreeCtrl1ItemRightClick(wxTreeEvent& event);
+		void OnBtnPositionClick(wxCommandEvent& event);
+		void OnBtnLayersClick(wxCommandEvent& event);
 		//*)
 
         void OnShow(wxShowEvent& event);
@@ -125,6 +134,7 @@ class EffectTreeDialog : public wxPanel
         wxTreeItemId m_draggedItem;
         std::mutex preset_mutex;
         bool _effectsFixed = false;
+        bool _layerMode = false;
         void OnGridPopup(wxCommandEvent& event);
         void AddTreeElementsRecursive(EffectPresetGroup& group, wxTreeItemId curGroupID);
         void ApplyEffect(bool dblClick=false);
@@ -156,6 +166,7 @@ class EffectTreeDialog : public wxPanel
         void DeleteGifsRecursive(wxTreeItemId parentId);
         void PurgeDanglingGifs();
         bool PromptForName(wxWindow* parent, wxString& name, bool isNew, bool isGroup);
+        void UpdateModeButtons();
         void OnDropEffect(wxCommandEvent& event);
 
 };

--- a/src-ui-wx/sequencer/EffectTreeDialog.h
+++ b/src-ui-wx/sequencer/EffectTreeDialog.h
@@ -13,6 +13,7 @@
 //(*Headers(EffectTreeDialog)
 #include <wx/button.h>
 #include <wx/panel.h>
+#include <wx/radiobut.h>
 #include <wx/sizer.h>
 #include <wx/statbmp.h>
 #include <wx/stattext.h>
@@ -47,8 +48,8 @@ class EffectTreeDialog : public wxPanel
 		wxButton* Button_MoveUp;
 		wxButton* Button_Top;
 		wxButton* ETButton1;
-		wxButton* btLayers;
-		wxButton* btPosition;
+		wxRadioButton* btLayers;
+		wxRadioButton* btPosition;
 		wxButton* btAddGroup;
 		wxButton* btApply;
 		wxButton* btDelete;

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -5449,7 +5449,7 @@ int EffectsGrid::GetMSFromColumn(int col) const {
     return 0;
 }
 
-Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersion, bool row_paste) {
+Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersion, bool row_paste, bool layerMode) {
     
 
     Effect* res = nullptr;
@@ -5549,10 +5549,32 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
             }
             int drop_row = mDropRow;
             int start_row = wxAtoi(eff1data[5]);
+            bool anchorRowUsed = false;
             if (xlights->IsACActive()) {
                 start_row = wxAtoi(banner_data[7]);
+            } else {
+                // Store anchor row so empty rows above the first effect are correctly preserved when pasting.
+                for (size_t fi = 6; fi < banner_data.size(); ++fi) {
+                    if (banner_data[fi].StartsWith("ANCHOR_ROW:")) {
+                        int ar = wxAtoi(banner_data[fi].Mid(11));
+                        if (ar >= 0) {
+                            start_row = ar;
+                            anchorRowUsed = true;
+                        }
+                        break;
+                    }
+                }
             }
             int drop_row_offset = drop_row - start_row;
+
+            if (anchorRowUsed && !layerMode && wxAtoi(eff1data[5]) > start_row) {
+                int anchorAbsRow = mDropRow + mSequenceElements->GetFirstVisibleModelRow();
+                Row_Information_Struct* ri = mSequenceElements->GetRowInformationFromRow(anchorAbsRow);
+                if (ri != nullptr && ri->element != nullptr && ri->element->GetCollapsed()) {
+                    ri->element->SetCollapsed(false);
+                    mSequenceElements->PopulateRowInformation();
+                }
+            }
             if (number_of_timings > 0 && number_of_effects > 0) // only allow timing and model effects to be pasted on same rows
             {
                 drop_row = 0;
@@ -5605,6 +5627,227 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
 
             mSequenceElements->get_undo_mgr().CreateUndoStep();
 
+            struct LayerTarget {
+                Element* element = nullptr;
+                int layerIdx = 0;
+            };
+            std::map<int, LayerTarget> layerTargetMap; // keyed by eff_row value
+            bool hasLayerTokens = false;
+
+            if (layerMode && number_of_effects > 0 && !xlights->IsACActive()) {
+                bool singleElementPaste = true; // stays true for old-format; computed below for new-format
+                for (size_t si = 1; si < all_efdata.size() - 1 && !hasLayerTokens; si++) {
+                    wxArrayString ef = wxSplit(all_efdata[si], '\t', wxT('\0'));
+                    if (ef.size() < 8 || ef[7] == "TIMING_EFFECT")
+                        continue;
+                    for (int fi = (int)ef.size() - 1; fi >= 8; --fi) {
+                        if (ef[fi].StartsWith("LAYER:")) {
+                            hasLayerTokens = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (hasLayerTokens) {
+                    std::vector<std::pair<int, int>> erLayerVec;
+                    for (size_t si = 1; si < all_efdata.size() - 1; si++) {
+                        wxArrayString ef = wxSplit(all_efdata[si], '\t', wxT('\0'));
+                        if (ef.size() < 8 || ef[7] == "TIMING_EFFECT")
+                            continue;
+                        int er = wxAtoi(ef[5]);
+                        int layerIdx = 0;
+                        for (int fi = (int)ef.size() - 1; fi >= 8; --fi) {
+                            if (ef[fi].StartsWith("LAYER:")) {
+                                layerIdx = wxAtoi(ef[fi].Mid(6));
+                                break;
+                            }
+                        }
+                        erLayerVec.push_back({ er, layerIdx });
+                    }
+                    std::stable_sort(erLayerVec.begin(), erLayerVec.end(),
+                                     [](const auto& a, const auto& b) { return a.first < b.first; });
+
+                    struct ElemGroup {
+                        int numRows = 0;
+                        int targetRank = 0;
+                    };
+                    std::vector<ElemGroup> groups;
+                    std::map<int, int> erToRank;
+                    int prevLayer2 = INT_MAX;
+                    int startRow0 = -1;
+                    int sumExtraRows = 0;
+
+                    for (auto& [er, layerIdx] : erLayerVec) {
+                        if (erToRank.count(er))
+                            continue;
+                        if (layerIdx <= prevLayer2) {
+                            // New element group
+                            if (!groups.empty())
+                                sumExtraRows += groups.back().numRows - 1;
+                            int targetRank = groups.empty() ? 0 : (er - startRow0 - sumExtraRows);
+                            groups.push_back({ 1, targetRank });
+                            if (startRow0 < 0)
+                                startRow0 = er;
+                        } else {
+                            groups.back().numRows++;
+                        }
+                        prevLayer2 = layerIdx;
+                        erToRank[er] = groups.back().targetRank;
+                    }
+
+                    {
+                        int maxRank = 0;
+                        for (auto& [er2, rank2] : erToRank)
+                            maxRank = std::max(maxRank, rank2);
+                        singleElementPaste = (maxRank == 0);
+                    }
+
+                    int anchorOffset = 0;
+                    if (startRow0 >= 0) {
+                        for (size_t fi = 6; fi < banner_data.size(); ++fi) {
+                            if (banner_data[fi].StartsWith("ANCHOR_ROW:")) {
+                                int ar = wxAtoi(banner_data[fi].Mid(11));
+                                if (ar >= 0 && startRow0 > ar)
+                                    anchorOffset = startRow0 - ar;
+                                break;
+                            }
+                        }
+                    }
+                    // Before expanding and mapping ranks, delete unused layers on the model
+                    {
+                        int absModelRow = mDropRow + mSequenceElements->GetFirstVisibleModelRow();
+                        Row_Information_Struct* ri = mSequenceElements->GetRowInformationFromRow(absModelRow);
+                        ModelElement* me = (ri != nullptr) ? dynamic_cast<ModelElement*>(ri->element) : nullptr;
+                        if (me != nullptr) {
+                            auto& undo_mgr = mSequenceElements->get_undo_mgr();
+                            auto deleteUnused = [&](Element* elem) {
+                                for (int i = 0; i < (int)elem->GetEffectLayerCount(); ++i) {
+                                    if (elem->GetEffectLayer(i)->GetEffectCount() == 0 && elem->GetEffectLayerCount() > 1) {
+                                        undo_mgr.CaptureRemovedLayer(elem->GetFullName(), i);
+                                        elem->RemoveEffectLayer(i);
+                                        --i;
+                                    }
+                                }
+                            };
+                            xLightsApp::GetFrame()->AbortRender();
+                            deleteUnused(me);
+                            for (int si = 0; si < me->GetSubModelCount(); ++si)
+                                deleteUnused(me->GetSubModel(si));
+                            undo_mgr.CreateUndoStep(); // needed for redo
+                            if (!singleElementPaste) {
+                                me->ShowStrands(true);
+                                mSequenceElements->PopulateRowInformation();
+                            }
+                        }
+                    }
+
+                    // Map target rank → element by walking rows from the anchor.
+                    std::map<int, Element*> rankToElem;
+                    if (singleElementPaste) {
+                        int row = mDropRow + mSequenceElements->GetFirstVisibleModelRow();
+                        Row_Information_Struct* ri2 = mSequenceElements->GetRowInformationFromRow(row);
+                        if (ri2 != nullptr && ri2->element != nullptr)
+                            rankToElem[0] = ri2->element;
+                    } else {
+                        std::set<int> ranksNeeded;
+                        int maxRank = -1;
+                        for (auto& [er, rank] : erToRank) {
+                            ranksNeeded.insert(rank);
+                            maxRank = std::max(maxRank, rank);
+                        }
+
+                        int row = mDropRow + anchorOffset + mSequenceElements->GetFirstVisibleModelRow();
+                        Element* prevElem = nullptr;
+                        int elemIdx = -1;
+                        while (elemIdx < maxRank && !ranksNeeded.empty()) {
+                            Row_Information_Struct* ri = mSequenceElements->GetRowInformationFromRow(row);
+                            if (ri == nullptr || ri->element == nullptr)
+                                break;
+                            if (ri->element != prevElem) {
+                                ++elemIdx;
+                                if (ranksNeeded.count(elemIdx)) {
+                                    rankToElem[elemIdx] = ri->element;
+                                    ranksNeeded.erase(elemIdx);
+                                }
+                                prevElem = ri->element;
+                            }
+                            ++row;
+                        }
+                    }
+
+                    for (auto& [er, rank] : erToRank) {
+                        LayerTarget lt;
+                        lt.element = rankToElem.count(rank) ? rankToElem[rank] : nullptr;
+                        lt.layerIdx = 0;
+                        layerTargetMap[er] = lt;
+                    }
+
+                } else {
+                    int trow = mDropRow + mSequenceElements->GetFirstVisibleModelRow();
+                    Row_Information_Struct* ri = mSequenceElements->GetRowInformationFromRow(trow);
+                    if (ri != nullptr && ri->element != nullptr) {
+                        Element* targetElem = ri->element;
+                        std::set<int> uniqueRows;
+                        for (size_t si = 1; si < all_efdata.size() - 1; si++) {
+                            wxArrayString ef = wxSplit(all_efdata[si], '\t', wxT('\0'));
+                            if (ef.size() < 8 || ef[7] == "TIMING_EFFECT")
+                                continue;
+                            uniqueRows.insert(wxAtoi(ef[5]));
+                        }
+                        int layerIdx = 0;
+                        for (int er : uniqueRows) {
+                            LayerTarget lt;
+                            lt.element = targetElem;
+                            lt.layerIdx = layerIdx++;
+                            layerTargetMap[er] = lt;
+                        }
+                    }
+                }
+
+                // Pre-create layers for both new-format and old-format layer-mode paste.
+                if (!layerTargetMap.empty()) {
+                    std::map<Element*, int> elemMaxLayer;
+                    for (auto& [row, lt] : layerTargetMap)
+                        if (lt.element)
+                            elemMaxLayer[lt.element] = std::max(elemMaxLayer[lt.element], lt.layerIdx);
+                    for (size_t si = 1; si < all_efdata.size() - 1; si++) {
+                        wxArrayString ef = wxSplit(all_efdata[si], '\t', wxT('\0'));
+                        if (ef.size() < 8 || ef[7] == "TIMING_EFFECT")
+                            continue;
+                        int er = wxAtoi(ef[5]);
+                        auto it = layerTargetMap.find(er);
+                        if (it == layerTargetMap.end() || it->second.element == nullptr)
+                            continue;
+                        for (int fi = (int)ef.size() - 1; fi >= 8; --fi) {
+                            if (ef[fi].StartsWith("LAYER:")) {
+                                int li2 = wxAtoi(ef[fi].Mid(6));
+                                elemMaxLayer[it->second.element] = std::max(elemMaxLayer[it->second.element], li2);
+                                break;
+                            }
+                        }
+                    }
+                    bool precreateNeedsPopulate = false;
+                    for (auto& [elem, maxLayer] : elemMaxLayer) {
+                        while ((int)elem->GetEffectLayerCount() <= maxLayer) {
+                            EffectLayer* nl = elem->AddEffectLayer();
+                            int pos = (int)elem->GetEffectLayerCount() - 1;
+                            mSequenceElements->get_undo_mgr().CaptureAddedLayer(elem->GetFullName(), nl->GetIndex(), pos);
+                            precreateNeedsPopulate = true;
+                        }
+                    }
+                    if (precreateNeedsPopulate) {
+                        if (!singleElementPaste) {
+                            for (auto& [elem, maxLayer] : elemMaxLayer) {
+                                ModelElement* me2 = dynamic_cast<ModelElement*>(elem);
+                                if (me2 != nullptr)
+                                    me2->ShowStrands(true);
+                            }
+                        }
+                        mSequenceElements->PopulateRowInformation();
+                    }
+                }
+            }
+
             for (int rpts = 0; rpts < timestopaste; ++rpts) {
                 for (size_t i = 1; i < all_efdata.size() - 1; i++) {
                     wxArrayString efdata = wxSplit(all_efdata[i], '\t', wxT('\0'));
@@ -5640,14 +5883,35 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
                         drop_row += mSequenceElements->GetFirstVisibleModelRow();
                     }
                     Row_Information_Struct* row_info = mSequenceElements->GetRowInformationFromRow(drop_row);
-                    if (row_info == nullptr)
-                        break;
-                    Element* elem = row_info->element;
-                    if (elem == nullptr)
-                        break;
-                    EffectLayer* el = mSequenceElements->GetEffectLayer(row_info);
-                    if (el == nullptr)
-                        break;
+                    EffectLayer* el = nullptr;
+                    if (layerMode && !is_timing_effect && !layerTargetMap.empty()) {
+                        int er = wxAtoi(efdata[5]);
+                        auto it = layerTargetMap.find(er);
+                        if (it != layerTargetMap.end() && it->second.element != nullptr) {
+                            int layerIdx = it->second.layerIdx;
+                            if (hasLayerTokens) {
+                                for (int fi = (int)efdata.size() - 1; fi >= 8; --fi) {
+                                    if (efdata[fi].StartsWith("LAYER:")) {
+                                        layerIdx = wxAtoi(efdata[fi].Mid(6));
+                                        break;
+                                    }
+                                }
+                            }
+                            if (layerIdx >= 0 && layerIdx < (int)it->second.element->GetEffectLayerCount())
+                                el = it->second.element->GetEffectLayer(layerIdx);
+                        }
+                        if (el == nullptr)
+                            continue;
+                    } else {
+                        if (row_info == nullptr)
+                            break;
+                        Element* elem = row_info->element;
+                        if (elem == nullptr)
+                            break;
+                        el = mSequenceElements->GetEffectLayer(row_info);
+                        if (el == nullptr)
+                            break;
+                    }
                     if (el->GetRangeIsClearMS(new_start_time, new_end_time)) {
                         int effectIndex = xlights->GetEffectManager().GetEffectIndex(efdata[0].ToStdString());
                         if (effectIndex >= 0 || is_timing_effect) {
@@ -5681,6 +5945,11 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
                 }
             }
             sendRenderDirtyEvent();
+            if (layerMode && !layerTargetMap.empty()) {
+                xlights->DoForceSequencerRefresh();
+                wxCommandEvent eventRowHeaderChanged(EVT_ROW_HEADINGS_CHANGED);
+                wxPostEvent(GetParent(), eventRowHeaderChanged);
+            }
             mPartialCellSelected = false;
         } else {
             // we refer to all_efdata[1] below so make sure it is there

--- a/src-ui-wx/sequencer/EffectsGrid.h
+++ b/src-ui-wx/sequencer/EffectsGrid.h
@@ -158,7 +158,7 @@ public:
 
     int GetEffectRow(Effect* ef);
     Effect* OldPaste(const wxString &data, const wxString &pasteDataVer);
-    Effect* Paste(const wxString &data, const wxString &pasteDataVer, bool row_paste = false);
+    Effect* Paste(const wxString &data, const wxString &pasteDataVer, bool row_paste = false, bool layerMode = false);
     int GetStartColumn() { return mRangeStartCol < mRangeEndCol ? mRangeStartCol : mRangeEndCol; }
     int GetStartRow() { return mRangeStartRow < mRangeEndRow ? mRangeStartRow : mRangeEndRow; }
     int GetEndColumn() { return mRangeStartCol < mRangeEndCol ? mRangeEndCol : mRangeStartCol; }

--- a/src-ui-wx/sequencer/MainSequencer.cpp
+++ b/src-ui-wx/sequencer/MainSequencer.cpp
@@ -553,7 +553,7 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
         if (k == WXK_SHIFT || k == WXK_CONTROL || k == WXK_ALT || k == WXK_RAW_CONTROL) return false;
 
         if ((!event.ControlDown() && !event.CmdDown() && !event.AltDown() && !event.RawControlDown()) ||
-            (k == 'A' && (event.ControlDown() || event.CmdDown() || event.RawControlDown()) && !event.AltDown())) {
+            ((k == 'A' || k == 'a') && (event.ControlDown() || event.CmdDown() || event.RawControlDown()) && !event.AltDown())) {
             // Just a regular key ... If current focus is a control then we need to not process this
             if (dynamic_cast<wxControl*>(event.GetEventObject()) != nullptr &&
                 (k < 128 || k == WXK_NUMPAD_END || k == WXK_NUMPAD_HOME || k == WXK_NUMPAD_INSERT || k == WXK_HOME || k == WXK_END || k == WXK_NUMPAD_SUBTRACT || k == WXK_NUMPAD_DECIMAL)) {
@@ -893,6 +893,10 @@ bool MainSequencer::HandleSequencerKeyBinding(wxKeyEvent& event)
 
                 PanelEffectGrid->EnDisableSelectedModelOrEffectsWithRefresh();
 
+            } else if (type == "ALTERNATE_PASTE") {
+                if (mSequenceElements != nullptr) {
+                    Paste(false, true);
+                }
             }
             else {
                 spdlog::warn("Keybinding '{}' not recognised.", (const char*)type.c_str());
@@ -1159,6 +1163,8 @@ void MainSequencer::OnChar(wxKeyEvent& event)
                         PanelEffectGrid->ClearSelection();
                         PanelEffectGrid->Draw();
                         PanelEffectGrid->sendRenderDirtyEvent();
+                        wxCommandEvent eventRowHeaderChanged(EVT_ROW_HEADINGS_CHANGED);
+                        wxPostEvent(GetParent(), eventRowHeaderChanged);
                     }
                     event.StopPropagation();
                 }
@@ -1175,6 +1181,8 @@ void MainSequencer::OnChar(wxKeyEvent& event)
                     PanelEffectGrid->ClearSelection();
                     PanelEffectGrid->Draw();
                     PanelEffectGrid->sendRenderDirtyEvent();
+                    wxCommandEvent eventRowHeaderChanged(EVT_ROW_HEADINGS_CHANGED);
+                    wxPostEvent(GetParent(), eventRowHeaderChanged);
                 }
                 event.StopPropagation();
             }
@@ -1459,6 +1467,9 @@ bool MainSequencer::GetSelectedEffectsData(wxString& copy_data, bool includeElem
                             column_start_time = tel->GetEffect(start_column)->GetStartTimeMS();
                         }
                     }
+                    Row_Information_Struct* ri = mSequenceElements->GetRowInformation(i);
+                    int layerIndex = ri ? ri->layerIndex : 0;
+                    wxString layer_suffix = wxString::Format("\tLAYER:%d", layerIndex);
                     if( column_start_time != -1000 )  // add paste by cell info
                     {
                         if( mSequenceElements->GetSelectedTimingRow() >= 0 )
@@ -1489,10 +1500,10 @@ bool MainSequencer::GetSelectedEffectsData(wxString& copy_data, bool includeElem
                                 wxString end_pct_str = wxString::Format("%d",end_pct);
                                 wxString start_index_str = wxString::Format("%d",start_index);
                                 wxString end_index_str = wxString::Format("%d",end_index);
-                                effect_data += "\t" + start_index_str + "\t" + end_index_str + "\t" + start_pct_str + "\t" + end_pct_str + element_suffix + "\n";
-                            } else {effect_data += "\tNO_PASTE_BY_CELL" + element_suffix + "\n";}
-                        } else {effect_data += "\tNO_PASTE_BY_CELL" + element_suffix + "\n";}
-                    } else {effect_data += "\tNO_PASTE_BY_CELL" + element_suffix + "\n";}
+                                effect_data += "\t" + start_index_str + "\t" + end_index_str + "\t" + start_pct_str + "\t" + end_pct_str + element_suffix + layer_suffix + "\n";
+                            } else {effect_data += "\tNO_PASTE_BY_CELL" + element_suffix + layer_suffix + "\n";}
+                        } else {effect_data += "\tNO_PASTE_BY_CELL" + element_suffix + layer_suffix + "\n";}
+                    } else {effect_data += "\tNO_PASTE_BY_CELL" + element_suffix + layer_suffix + "\n";}
                 }
             }
         }
@@ -1509,12 +1520,21 @@ bool MainSequencer::GetSelectedEffectsData(wxString& copy_data, bool includeElem
     wxString num_timing_rows = wxString::Format("%d",number_of_timing_rows);
     wxString last_row = wxString::Format("%d",last_timing_row);
     wxString starting_column = wxString::Format("%d",start_column);
+    // Record the lasso selection's top row as the anchor so that empty rows above the first effect are preserved when pasting (ANCHOR_ROW: token).
+    wxString anchorToken;
+    int selStart = PanelEffectGrid->GetStartRow();
+    if (selStart >= 0 && selStart >= mSequenceElements->GetNumberOfTimingRows()) {
+        int relAnchor = selStart - mSequenceElements->GetFirstVisibleModelRow();
+        if (relAnchor >= 0)
+            anchorToken = wxString::Format("\tANCHOR_ROW:%d", relAnchor);
+    }
+
     copy_data = "CopyFormat1\t" + num_timings + "\t" + num_effects + "\t" + num_timing_rows + "\t" + last_row + "\t" + starting_column;
     if( column_start_time != -1000 ) {
-        copy_data += "\tPASTE_BY_CELL\n" + effect_data;
+        copy_data += "\tPASTE_BY_CELL" + anchorToken + "\n" + effect_data;
     }
     else {
-        copy_data += "\tNO_PASTE_BY_CELL\n" + effect_data;
+        copy_data += "\tNO_PASTE_BY_CELL" + anchorToken + "\n" + effect_data;
     }
     UnTagAllEffects();
 
@@ -1776,14 +1796,19 @@ std::list<std::string> MainSequencer::GetAllEffectDescriptions()
     return mSequenceElements->GetAllEffectDescriptions();
 }
 
-void MainSequencer::Paste(bool row_paste) {
+void MainSequencer::Paste(bool row_paste, bool invertPasteAsLayers) {
     wxTextDataObject data;
     wxClipboard *cbd = wxClipboard::Get();
     if (cbd && cbd->Open()) {
         if ((cbd->IsSupported(wxDF_TEXT) || cbd->IsSupported(wxDF_UNICODETEXT))
             && cbd->GetData(data)) {
             //assume clipboard always has data from same version of xLights
-            Effect* ef = PanelEffectGrid->Paste(data.GetText(), xlights_version_string, row_paste);
+            wxString text = data.GetText();
+            bool pasteAsLayers = xLightsApp::GetFrame()->IsPasteAsLayers();
+            if (invertPasteAsLayers)
+                pasteAsLayers = !pasteAsLayers;
+            bool layerMode = pasteAsLayers && text.Contains("\tLAYER:");
+            Effect* ef = PanelEffectGrid->Paste(text, xlights_version_string, row_paste, layerMode);
             SelectEffect(ef);
         }
         cbd->Close();

--- a/src-ui-wx/sequencer/MainSequencer.h
+++ b/src-ui-wx/sequencer/MainSequencer.h
@@ -79,7 +79,7 @@ class MainSequencer: public wxPanel
 
         void Cut();
         void Copy();
-        void Paste(bool row_paste = false);
+        void Paste(bool row_paste = false, bool invertPasteAsLayers = false);
 
         void DoCopy(wxCommandEvent& event);
         void DoCut(wxCommandEvent& event);

--- a/src-ui-wx/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/sequencer/tabSequencer.cpp
@@ -4322,9 +4322,9 @@ Effect* xLightsFrame::ApplyEffectsPreset(const std::string& presetName)
     return res;
 }
 
-void xLightsFrame::ApplyEffectsPreset(wxString& data, const wxString& pasteDataVersion)
+void xLightsFrame::ApplyEffectsPreset(wxString& data, const wxString& pasteDataVersion, bool layerMode)
 {
-    mainSequencer->PanelEffectGrid->Paste(data, pasteDataVersion);
+    mainSequencer->PanelEffectGrid->Paste(data, pasteDataVersion, false, layerMode);
 }
 
 void xLightsFrame::PromoteEffects(wxCommandEvent& command)

--- a/src-ui-wx/wxsmith/EffectTreeDialog.wxs
+++ b/src-ui-wx/wxsmith/EffectTreeDialog.wxs
@@ -77,7 +77,7 @@
 					<object class="sizeritem">
 						<object class="wxFlexGridSizer" variable="FlexGridSizer3" member="no">
 							<cols>1</cols>
-							<rows>4</rows>
+							<rows>5</rows>
 							<growablecols>0</growablecols>
 							<growablerows>0</growablerows>
 							<object class="sizeritem">
@@ -94,27 +94,34 @@
 								<border>5</border>
 							</object>
 							<object class="sizeritem">
+								<object class="wxBoxSizer" variable="BoxSizerRadio" member="no">
+									<orient>wxHORIZONTAL</orient>
+									<object class="sizeritem">
+										<object class="wxRadioButton" name="ID_BTN_POSITION" variable="btPosition" member="yes">
+											<label>Relative</label>
+											<style>wxRB_GROUP</style>
+											<tooltip>Paste effects at the drop row, ignoring layer structure.</tooltip>
+											<handler function="OnBtnPositionClick" entry="EVT_RADIOBUTTON" />
+										</object>
+										<flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
+										<border>5</border>
+									</object>
+									<object class="sizeritem">
+										<object class="wxRadioButton" name="ID_BTN_LAYERS" variable="btLayers" member="yes">
+											<label>Using Layers</label>
+											<tooltip>Paste effects preserving layer structure.</tooltip>
+											<handler function="OnBtnLayersClick" entry="EVT_RADIOBUTTON" />
+										</object>
+										<flag>wxALL|wxALIGN_CENTER_VERTICAL</flag>
+										<border>5</border>
+									</object>
+								</object>
+								<flag>wxALL|wxEXPAND</flag>
+							</object>
+							<object class="sizeritem">
 								<object class="wxGridSizer" variable="BoxSizer1" member="no">
 									<cols>2</cols>
-									<rows>5</rows>
-									<object class="sizeritem">
-										<object class="wxButton" name="ID_BTN_POSITION" variable="btPosition" member="yes">
-											<label>Relative</label>
-											<tooltip>Paste effects at the drop row, ignoring layer structure.</tooltip>
-											<handler function="OnBtnPositionClick" entry="EVT_BUTTON" />
-										</object>
-										<flag>wxALL|wxEXPAND</flag>
-										<border>5</border>
-									</object>
-									<object class="sizeritem">
-										<object class="wxButton" name="ID_BTN_LAYERS" variable="btLayers" member="yes">
-											<label>Layers</label>
-											<tooltip>Paste effects preserving layer structure.</tooltip>
-											<handler function="OnBtnLayersClick" entry="EVT_BUTTON" />
-										</object>
-										<flag>wxALL|wxEXPAND</flag>
-										<border>5</border>
-									</object>
+									<rows>4</rows>
 									<object class="sizeritem">
 										<object class="wxButton" name="ID_BUTTON6" variable="btApply" member="yes">
 											<label>&amp;Apply Preset</label>

--- a/src-ui-wx/wxsmith/EffectTreeDialog.wxs
+++ b/src-ui-wx/wxsmith/EffectTreeDialog.wxs
@@ -77,7 +77,7 @@
 					<object class="sizeritem">
 						<object class="wxFlexGridSizer" variable="FlexGridSizer3" member="no">
 							<cols>1</cols>
-							<rows>3</rows>
+							<rows>4</rows>
 							<growablecols>0</growablecols>
 							<growablerows>0</growablerows>
 							<object class="sizeritem">
@@ -87,9 +87,34 @@
 								<option>1</option>
 							</object>
 							<object class="sizeritem">
+								<object class="wxStaticText" name="ID_STATICTEXT_APPLY" variable="StaticTextApplyLabel" member="yes">
+									<label>Apply preset as:</label>
+								</object>
+								<flag>wxALL|wxALIGN_LEFT</flag>
+								<border>5</border>
+							</object>
+							<object class="sizeritem">
 								<object class="wxGridSizer" variable="BoxSizer1" member="no">
 									<cols>2</cols>
-									<rows>4</rows>
+									<rows>5</rows>
+									<object class="sizeritem">
+										<object class="wxButton" name="ID_BTN_POSITION" variable="btPosition" member="yes">
+											<label>Relative</label>
+											<tooltip>Paste effects at the drop row, ignoring layer structure.</tooltip>
+											<handler function="OnBtnPositionClick" entry="EVT_BUTTON" />
+										</object>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+									</object>
+									<object class="sizeritem">
+										<object class="wxButton" name="ID_BTN_LAYERS" variable="btLayers" member="yes">
+											<label>Layers</label>
+											<tooltip>Paste effects preserving layer structure.</tooltip>
+											<handler function="OnBtnLayersClick" entry="EVT_BUTTON" />
+										</object>
+										<flag>wxALL|wxEXPAND</flag>
+										<border>5</border>
+									</object>
 									<object class="sizeritem">
 										<object class="wxButton" name="ID_BUTTON6" variable="btApply" member="yes">
 											<label>&amp;Apply Preset</label>

--- a/src-ui-wx/wxsmith/EffectsGridSettingsPanel.wxs
+++ b/src-ui-wx/wxsmith/EffectsGridSettingsPanel.wxs
@@ -237,6 +237,33 @@
 				<border>5</border>
 				<option>1</option>
 			</object>
+			<object class="sizeritem">
+				<object class="wxStaticText" name="ID_STATICTEXT_PASTE_AS" variable="StaticTextPasteAs" member="yes">
+					<label>Paste As</label>
+				</object>
+				<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
+				<object class="wxChoice" name="ID_CHOICE_PASTE_AS" variable="PasteAsChoice" member="yes">
+					<content>
+						<item>Relative</item>
+						<item>Layers</item>
+					</content>
+					<selection>0</selection>
+					<tooltip>Relative: paste effects at the selected position. As Layers: paste preserving layer structure from copied effects.</tooltip>
+					<handler function="OnPasteAsChoiceSelect" entry="EVT_CHOICE" />
+				</object>
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
+			<object class="spacer">
+				<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+				<border>5</border>
+				<option>1</option>
+			</object>
 		</object>
 	</object>
 </wxsmith>

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -1683,6 +1683,9 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     config->Read("xLightsRenderBell", &_renderBellEnabled, false);
     spdlog::debug("Render Bell Enabled: {}.", toStr(_renderBellEnabled));
 
+    config->Read("xLightsPasteAsLayers", &_pasteAsLayers, false);
+    spdlog::debug("Paste As Layers: {}.", toStr(_pasteAsLayers));
+
     config->Read("xLightsModelBlendDefaultOff", &_modelBlendDefaultOff, false);
     spdlog::debug("Model Blend Default Off: {}.", toStr(_modelBlendDefaultOff));
 
@@ -2373,6 +2376,7 @@ xLightsFrame::~xLightsFrame()
     config->Write("xLightsHidePresetPreview", _hidePresetPreview);
     config->Write("xLightsSmallWaveform", _smallWaveform);
     config->Write("xLightsRenderBell", _renderBellEnabled);
+    config->Write("xLightsPasteAsLayers", _pasteAsLayers);
     config->Write("xLightsModelBlendDefaultOff", _modelBlendDefaultOff);
     config->Write("xLightsLowDefinitionRender", _lowDefinitionRender);
     config->Write("xLightsTimelineZooming", _timelineZooming);
@@ -3043,6 +3047,10 @@ void xLightsFrame::OnNotebook1PageChanged1(wxAuiNotebookEvent& event)
     } else if (pagenum == NEWSEQUENCER) {
         InitSequencer();
         ShowHideAllSequencerWindows(true);
+        if (!_effectPresetsInitialized && EffectTreeDlg != nullptr && m_mgr->GetPane("EffectPresets").IsShown()) {
+            EffectTreeDlg->InitItems(_effectPresetManager);
+            _effectPresetsInitialized = true;
+        }
         EffectSettingsTimer.Start(50, wxTIMER_ONE_SHOT);
         MenuItem_File_Save->SetItemLabel("Save Sequence\tCTRL-s");
         MenuItem_File_Save->Enable(MenuItem_File_SaveAs_Sequence->IsEnabled());

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -1157,6 +1157,7 @@ public:
     bool _snapToTimingMarks = true;
     bool _autoSavePerspecive = true;
     bool _renderBellEnabled = false;
+    bool _pasteAsLayers = false;
     bool _ignoreVendorModelRecommendations = false;
     bool _purgeDownloadCacheOnStart = false;
     bool _enablePositionZones = true;
@@ -1184,6 +1185,8 @@ public:
 
     [[nodiscard]] bool IsRenderBell() const { return _renderBellEnabled; }
     void SetRenderBell(bool b) { _renderBellEnabled = b; }
+    [[nodiscard]] bool IsPasteAsLayers() const { return _pasteAsLayers; }
+    void SetPasteAsLayers(bool b) { _pasteAsLayers = b; }
 	[[nodiscard]] bool IsIgnoreVendorModelRecommendations() const { return _ignoreVendorModelRecommendations; }
     void StartAutomationListener();
     [[nodiscard]] bool ProcessHttpRequest(HttpConnection& connection, HttpRequest& request);
@@ -1657,7 +1660,7 @@ public:
     void DoPromoteEffects(ModelElement *element);
     EffectPreset* CreateEffectPreset(EffectPresetGroup* parent, const std::string& name);
     void UpdateEffectPreset(EffectPreset* preset);
-    void ApplyEffectsPreset(wxString& data, const wxString &pasteDataVersion);
+    void ApplyEffectsPreset(wxString& data, const wxString &pasteDataVersion, bool layerMode = false);
     Effect* ApplyEffectsPreset(const std::string& presetName);
     std::vector<std::string> GetPresets() const;
     void RenameModelInViews(const std::string old_name, const std::string& new_name);


### PR DESCRIPTION
Add "smarts" to presets and regular grid ctrl-c/ctrl-v
Now presets can also start with "empty" laters; ie: start preset at model level, but effects actually start at a lower submodel

https://github.com/user-attachments/assets/14df45d0-d59a-4610-ad20-46225fdc3291

