### PR TITLE
Sketch and Effect Assist UI changes (#5871)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,8 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.10  May ??, 2026
 
+    -enh (derwin12)              Sketch effect path management: multi-select, Delete key, Move Up/Down
+                                 buttons, per-path description labels, and a description text editor (#5871).
     -enh (scott)                 FPP discovery now uses mDNS on Windows (native windns.h DNS-SD) in
                                  addition to the existing broadcast/multicast ping.
     -enh (heffneil)              Replace Model: new dialog replaces multiple models at once with a

--- a/src-core/effects/SketchEffectDrawing.cpp
+++ b/src-core/effects/SketchEffectDrawing.cpp
@@ -9,6 +9,42 @@
 
 namespace
 {
+    std::string encodeHex(const std::string& input)
+    {
+        static const char hex[] = "0123456789ABCDEF";
+        std::string output;
+        output.reserve(input.size() * 2);
+        for (unsigned char c : input) {
+            output.push_back(hex[(c >> 4) & 0x0F]);
+            output.push_back(hex[c & 0x0F]);
+        }
+        return output;
+    }
+
+    std::string decodeHex(const std::string& input)
+    {
+        if (input.size() % 2 != 0)
+            return std::string();
+
+        auto hexValue = [](char c) -> int {
+            if (c >= '0' && c <= '9') return c - '0';
+            if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+            if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+            return -1;
+        };
+
+        std::string output;
+        output.reserve(input.size() / 2);
+        for (size_t i = 0; i < input.size(); i += 2) {
+            const int hi = hexValue(input[i]);
+            const int lo = hexValue(input[i + 1]);
+            if (hi < 0 || lo < 0)
+                return std::string();
+            output.push_back(static_cast<char>((hi << 4) | lo));
+        }
+        return output;
+    }
+
     double bezier(double t, double start, double control1, double control2, double end)
     {
         double u = 1 - t;
@@ -589,6 +625,8 @@ SketchEffectSketch SketchEffectSketch::SketchFromString(const std::string& sketc
                     } else {
                         path->closePath(false, SketchCanvasPathState::LineToNewPoint);
                     }
+                } else if (pathComponents_str.at(0) == 'D') {
+                    path->SetDescription(decodeHex(pathComponents_str.substr(1)));
                 }
             }
         } catch (...) {
@@ -617,6 +655,8 @@ std::string SketchEffectSketch::toString() const
 
         auto startPt(segments[0]->StartPoint());
         stream << startPt.x << ',' << startPt.y << ';';
+        if (!path->GetDescription().empty())
+            stream << 'D' << encodeHex(path->GetDescription()) << ';';
         for (size_t ii = 0; ii < segments.size(); ++ii) {
             std::shared_ptr<SketchCubicBezier> cubic;
             std::shared_ptr<SketchQuadraticBezier> quadratic;

--- a/src-core/effects/SketchEffectDrawing.h
+++ b/src-core/effects/SketchEffectDrawing.h
@@ -100,11 +100,14 @@ public:
 
     [[nodiscard]] bool isClosed() const { return m_isClosed; }
     [[nodiscard]] SketchCanvasPathState GetClosedState() const { return m_closedState; }
+    [[nodiscard]] const std::string& GetDescription() const { return m_description; }
+    void SetDescription(const std::string& description) { m_description = description; }
 
 protected:
     std::vector<std::shared_ptr<SketchPathSegment>> m_segments;
     bool m_isClosed {false};
     SketchCanvasPathState  m_closedState {SketchCanvasPathState::Undefined};
+    std::string m_description;
 };
 
 // A sketch is a collection of paths... just a thin std::vector wrapper currently

--- a/src-ui-wx/effectpanels/assist/AssistPanel.cpp
+++ b/src-ui-wx/effectpanels/assist/AssistPanel.cpp
@@ -20,6 +20,8 @@
 #include "render/Element.h"
 
 #include <log.h>
+#include <wx/listbox.h>
+#include <wx/textctrl.h>
 
 //(*IdInit(AssistPanel)
 const long AssistPanel::ID_SCROLLEDWINDOW_Assist = wxNewId();
@@ -246,8 +248,14 @@ void AssistPanel::OnCharHook(wxKeyEvent& event)
             }
         } else if (mEffect->GetEffectIndex() == EffectManager::eff_SKETCH) {
             auto sketchAssistPanel = dynamic_cast<SketchAssistPanel *>(mPanel);
-            if (sketchAssistPanel != nullptr)
+            if (sketchAssistPanel != nullptr) {
+                auto* focus = wxWindow::FindFocus();
+                if (dynamic_cast<wxTextCtrl*>(focus) != nullptr || dynamic_cast<wxListBox*>(focus) != nullptr) {
+                    event.Skip();
+                    return;
+                }
                 sketchAssistPanel->ForwardKeyEvent(event);
+            }
         }
     }
 }

--- a/src-ui-wx/effectpanels/assist/SketchAssistPanel.cpp
+++ b/src-ui-wx/effectpanels/assist/SketchAssistPanel.cpp
@@ -22,6 +22,7 @@
 
 #include "utils/nanosvg_xl.h"
 
+#include <algorithm>
 #include <cmath>
 
 namespace
@@ -44,56 +45,23 @@ long SketchAssistPanel::ID_MENU_Delete = wxNewId();
 long SketchAssistPanel::ID_MENU_Reverse = wxNewId();
 long SketchAssistPanel::ID_MENU_MoveUp = wxNewId();
 long SketchAssistPanel::ID_MENU_MoveDown = wxNewId();
+long SketchAssistPanel::ID_MENU_MoveToTop = wxNewId();
+long SketchAssistPanel::ID_MENU_MoveToBottom = wxNewId();
+long SketchAssistPanel::ID_MENU_SortByDescription = wxNewId();
 
 SketchAssistPanel::SketchAssistPanel(wxWindow* parent, wxWindowID id /*wxID_ANY*/, const wxPoint& pos /*wxDefaultPosition*/, const wxSize& size /*wxDefaultSize*/) :
     wxPanel(parent, id, pos, size)
 {
-    /*
+    auto mainSizer = new wxBoxSizer(wxVERTICAL);
+    auto controlsSizer = new wxBoxSizer(wxVERTICAL);
+    auto primaryActionSizer = new wxBoxSizer(wxHORIZONTAL);
+    auto fileActionSizer = new wxBoxSizer(wxHORIZONTAL);
+    auto pathsSizer = new wxStaticBoxSizer(wxVERTICAL, this, "Paths");
+    auto pathsHeaderSizer = new wxBoxSizer(wxHORIZONTAL);
+    auto pathToolbarSizer = new wxBoxSizer(wxHORIZONTAL);
+    auto pathDescriptionSizer = new wxBoxSizer(wxVERTICAL);
+    auto hotkeysSizer = new wxBoxSizer(wxVERTICAL);
 
-    mainSizer
-     \
-      pathUISizer (canvas, bg-image controls, and path/sketch controls)
-      |\
-      | canvasFrame (m_sketchCanvasPanel)
-      |\
-      | pathSketchCtrlsSizer
-      | |\
-      | | pathCtrlsSizer (m_startPathBtn, m_endPathBtn, m_closePathBtn)
-      | |
-      |  \
-      |   sketchCtrlsSizer ("Clear" sketch button)
-      |
-      sketchUISizer (hotkeys text and paths listbox)
-      |\
-      | pathsSizer (m_pathsListBox)
-      |
-      |\
-      | hotkeysSizer (Canvas hotkeys)
-      |
-
-
-    */
-    auto mainSizer = new wxFlexGridSizer(3, 1, 0, 0);
-    mainSizer->AddGrowableCol(0);
-    mainSizer->AddGrowableRow(0);
-
-    auto pathUISizer = new wxFlexGridSizer(/*3*/2, 1, 5, 0);
-    pathUISizer->AddGrowableRow(0);
-    pathUISizer->AddGrowableCol(0);
-
-    auto pathSketchCtrlsSizer = new wxFlexGridSizer(1, 3, 0, 5);
-    auto pathCtrlsSizer = new wxStaticBoxSizer(wxHORIZONTAL, this, "Path");
-    auto sketchCtrlsSizer = new wxStaticBoxSizer(wxHORIZONTAL, this, "Sketch");
-    auto importCtrlsSizer = new wxStaticBoxSizer(wxHORIZONTAL, this, "Import/Export");
-
-    auto sketchUISizer = new wxFlexGridSizer(2, 1, 5, 0);
-    sketchUISizer->AddGrowableRow(1);
-    sketchUISizer->AddGrowableCol(0);
-
-    auto hotkeysSizer = new wxStaticBoxSizer(wxVERTICAL, this, "Canvas hotkeys");
-    auto pathsSizer = new wxStaticBoxSizer(wxHORIZONTAL, this, "Paths");
-
-    // canvas
     auto canvasFrame = new wxStaticBox(this, wxID_ANY, wxEmptyString);
     auto canvasFrameSizer = new wxFlexGridSizer(1, 1, 0, 0);
     canvasFrameSizer->AddGrowableRow(0);
@@ -102,48 +70,65 @@ SketchAssistPanel::SketchAssistPanel(wxWindow* parent, wxWindowID id /*wxID_ANY*
     canvasFrameSizer->Add(m_sketchCanvasPanel, 1, wxALL | wxEXPAND);
     canvasFrame->SetSizer(canvasFrameSizer);
 
-    // path / sketch controls - use GetStaticBox() as parent for controls inside wxStaticBoxSizer
-    m_startPathBtn = new wxButton(pathCtrlsSizer->GetStaticBox(), wxID_ANY, "Start");
-    m_endPathBtn = new wxButton(pathCtrlsSizer->GetStaticBox(), wxID_ANY, "End");
-    m_closePathBtn = new wxButton(pathCtrlsSizer->GetStaticBox(), wxID_ANY, "Close");
-    m_continuePathBtn = new wxButton(pathCtrlsSizer->GetStaticBox(), wxID_ANY, "Continue");
+    m_startPathBtn = new wxButton(this, wxID_ANY, "Start");
+    m_continuePathBtn = new wxButton(this, wxID_ANY, "Continue");
+    m_endPathBtn = new wxButton(this, wxID_ANY, "End");
+    m_closePathBtn = new wxButton(this, wxID_ANY, "Close");
 
-    m_clearSketchBtn = new wxButton(sketchCtrlsSizer->GetStaticBox(), wxID_ANY, "Clear");
-    m_importSketchBtn = new wxButton(importCtrlsSizer->GetStaticBox(), wxID_ANY, "Import");
-    m_exportSketchBtn = new wxButton(importCtrlsSizer->GetStaticBox(), wxID_ANY, "Export");
-    m_importSVGBtn = new wxButton(importCtrlsSizer->GetStaticBox(), wxID_ANY, "Import SVG");
+    m_importSketchBtn = new wxButton(this, wxID_ANY, "Import Sketch");
+    m_exportSketchBtn = new wxButton(this, wxID_ANY, "Export Sketch");
+    m_importSVGBtn = new wxButton(this, wxID_ANY, "Import SVG");
+    m_clearSketchBtn = new wxButton(this, wxID_ANY, "Clear Sketch");
 
-    pathCtrlsSizer->Add(m_startPathBtn, 1, wxALL | wxEXPAND, 3);
-    pathCtrlsSizer->Add(m_endPathBtn, 1, wxALL | wxEXPAND, 3);
-    pathCtrlsSizer->Add(m_closePathBtn, 1, wxALL | wxEXPAND, 3);
-    pathCtrlsSizer->Add(m_continuePathBtn, 1, wxALL | wxEXPAND, 3);
+    m_movePathUpBtn = new wxButton(pathsSizer->GetStaticBox(), wxID_ANY, L"▲", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+    m_movePathDownBtn = new wxButton(pathsSizer->GetStaticBox(), wxID_ANY, L"▼", wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT);
+    m_movePathUpBtn->SetToolTip("Move path up");
+    m_movePathDownBtn->SetToolTip("Move path down");
 
-    sketchCtrlsSizer->Add(m_clearSketchBtn, 1, wxALL | wxEXPAND, 3);
+    primaryActionSizer->Add(new wxStaticText(this, wxID_ANY, "Path Editing:"), 0, wxALL | wxALIGN_CENTER_VERTICAL, 3);
+    primaryActionSizer->Add(m_startPathBtn, 0, wxALL, 3);
+    primaryActionSizer->Add(m_continuePathBtn, 0, wxALL, 3);
+    primaryActionSizer->Add(m_endPathBtn, 0, wxALL, 3);
+    primaryActionSizer->Add(m_closePathBtn, 0, wxALL, 3);
 
-    importCtrlsSizer->Add(m_importSketchBtn, 1, wxALL | wxEXPAND, 3);
-    importCtrlsSizer->Add(m_exportSketchBtn, 1, wxALL | wxEXPAND, 3);
-    importCtrlsSizer->Add(m_importSVGBtn, 1, wxALL | wxEXPAND, 3);
+    fileActionSizer->Add(new wxStaticText(this, wxID_ANY, "File:"), 0, wxALL | wxALIGN_CENTER_VERTICAL, 3);
+    fileActionSizer->Add(m_importSketchBtn, 0, wxALL, 3);
+    fileActionSizer->Add(m_exportSketchBtn, 0, wxALL, 3);
+    fileActionSizer->Add(m_importSVGBtn, 0, wxALL, 3);
+    fileActionSizer->Add(m_clearSketchBtn, 0, wxALL, 3);
 
-    pathSketchCtrlsSizer->AddGrowableCol(2);
-    pathSketchCtrlsSizer->Add(pathCtrlsSizer, 1, wxALL, 2);
-    pathSketchCtrlsSizer->Add(sketchCtrlsSizer, 1, wxALL, 2);
-    pathSketchCtrlsSizer->Add(importCtrlsSizer, 1, wxALL, 2);
+    m_pathsHeaderLabel = new wxStaticText(pathsSizer->GetStaticBox(), wxID_ANY, "Paths (0)");
+    pathsHeaderSizer->Add(m_pathsHeaderLabel, 0, wxALIGN_CENTER_VERTICAL);
+    pathsHeaderSizer->AddStretchSpacer(1);
+    pathToolbarSizer->Add(m_movePathUpBtn, 0, wxALL, 2);
+    pathToolbarSizer->Add(m_movePathDownBtn, 0, wxALL, 2);
+    pathsHeaderSizer->Add(pathToolbarSizer, 0, wxALIGN_CENTER_VERTICAL);
+    pathsSizer->Add(pathsHeaderSizer, 0, wxLEFT | wxRIGHT | wxTOP | wxEXPAND, 3);
 
-    // Hotkeys text
-    hotkeysSizer->Add(new wxStaticText(hotkeysSizer->GetStaticBox(), wxID_ANY, HotkeysText), 1, wxALL | wxEXPAND, 3);
-
-    // Paths ListBox - use GetStaticBox() as parent for controls inside wxStaticBoxSizer
-    m_pathsListBox = new wxListBox(pathsSizer->GetStaticBox(), wxID_ANY);
+    m_pathsListBox = new wxListBox(pathsSizer->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_EXTENDED);
+    const int pathListHeight = m_pathsListBox->GetCharHeight() * 6 + FromDIP(12);
+    m_pathsListBox->SetMinSize(wxSize(-1, pathListHeight));
     pathsSizer->Add(m_pathsListBox, 1, wxALL | wxEXPAND, 3);
 
-    sketchUISizer->Add(pathsSizer, 1, wxALL | wxEXPAND, 5);
-    sketchUISizer->Add(hotkeysSizer, 1, wxALL | wxEXPAND);
+    m_pathDescriptionLabel = new wxStaticText(this, wxID_ANY, "Path Description");
+    m_pathDescriptionText = new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+    m_pathDescriptionText->SetHint("Enter path description...");
+    pathDescriptionSizer->Add(m_pathDescriptionLabel, 0, wxBOTTOM, 2);
+    pathDescriptionSizer->Add(m_pathDescriptionText, 0, wxEXPAND);
 
-    pathUISizer->Add(canvasFrame, 1, wxALL | wxEXPAND, 5);
-    pathUISizer->Add(pathSketchCtrlsSizer, 1, wxALL | wxEXPAND, 5);
+    hotkeysSizer->Add(new wxStaticText(this, wxID_ANY, "Canvas Hotkeys"), 0, wxBOTTOM, 2);
+    auto hotkeysText = new wxStaticText(this, wxID_ANY, HotkeysText);
+    hotkeysText->Wrap(260);
+    hotkeysSizer->Add(hotkeysText, 0, wxEXPAND);
 
-    mainSizer->Add(pathUISizer, 1, wxALL | wxEXPAND, 5);
-    mainSizer->Add(sketchUISizer, 1, wxALL | wxEXPAND, 5);
+    controlsSizer->Add(primaryActionSizer, 0, wxLEFT | wxRIGHT | wxTOP | wxEXPAND, 5);
+    controlsSizer->Add(fileActionSizer, 0, wxLEFT | wxRIGHT | wxTOP | wxEXPAND, 5);
+    controlsSizer->Add(pathsSizer, 0, wxALL | wxEXPAND, 5);
+    controlsSizer->Add(pathDescriptionSizer, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5);
+    controlsSizer->Add(hotkeysSizer, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5);
+
+    mainSizer->Add(canvasFrame, 1, wxALL | wxEXPAND, 5);
+    mainSizer->Add(controlsSizer, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5);
 
     SetSizer(mainSizer);
 
@@ -157,11 +142,20 @@ SketchAssistPanel::SketchAssistPanel(wxWindow* parent, wxWindowID id /*wxID_ANY*
     Connect(m_importSketchBtn->GetId(), wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchAssistPanel::OnButton_ImportSketch);
     Connect(m_exportSketchBtn->GetId(), wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchAssistPanel::OnButton_ExportSketch);
     Connect(m_importSVGBtn->GetId(), wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchAssistPanel::OnButton_ImportSVG);
+    Connect(m_movePathUpBtn->GetId(), wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchAssistPanel::OnButton_MovePathUp);
+    Connect(m_movePathDownBtn->GetId(), wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&SketchAssistPanel::OnButton_MovePathDown);
 
     m_pathsListBox->Connect(wxEVT_LISTBOX, (wxObjectEventFunction)&SketchAssistPanel::OnListBox_PathSelected, nullptr, this);
+    m_pathsListBox->Connect(wxEVT_KEY_DOWN, (wxObjectEventFunction)&SketchAssistPanel::OnListBox_KeyDown, nullptr, this);
     m_pathsListBox->Connect(wxEVT_CONTEXT_MENU, (wxObjectEventFunction)&SketchAssistPanel::OnListBox_ContextMenu, nullptr, this);
+    m_pathDescriptionText->Connect(wxEVT_TEXT, (wxObjectEventFunction)&SketchAssistPanel::OnTextCtrl_PathDescription, nullptr, this);
+    m_pathDescriptionText->Connect(wxEVT_TEXT_ENTER, (wxObjectEventFunction)&SketchAssistPanel::OnTextCtrl_PathDescriptionEnter, nullptr, this);
+    m_pathDescriptionText->Connect(wxEVT_KILL_FOCUS, (wxObjectEventFunction)&SketchAssistPanel::OnTextCtrl_PathDescriptionKillFocus, nullptr, this);
 
     m_sketchCanvasPanel->UpdatePathState(SketchCanvasPathState::Undefined);
+    UpdatePathLabels();
+    UpdatePathDescriptionEditorFromSelection();
+    UpdatePathActionButtons();
 }
 
 void SketchAssistPanel::SetSketchDef(const std::string& sketchDef)
@@ -170,12 +164,19 @@ void SketchAssistPanel::SetSketchDef(const std::string& sketchDef)
         m_sketchDef = sketchDef;
         m_sketch = SketchEffectSketch::SketchFromString(m_sketchDef);
         populatePathListBoxFromSketch();
+        UpdatePathDescriptionEditorFromSelection();
         Refresh();
     }
 }
 
 void SketchAssistPanel::ForwardKeyEvent(wxKeyEvent& event)
 {
+    if (m_pathDescriptionText != nullptr && m_pathDescriptionText->HasFocus())
+        return;
+
+    if (event.GetKeyCode() == WXK_DELETE && m_pathsListBox != nullptr && m_pathsListBox->HasFocus() && DeleteSelectedPaths())
+        return;
+
     if (m_sketchCanvasPanel != nullptr)
         m_sketchCanvasPanel->OnSketchKeyDown(event);
 }
@@ -189,7 +190,10 @@ int SketchAssistPanel::GetSelectedPathIndex()
 {
     if (m_pathsListBox == nullptr)
         return 0;
-    return m_pathsListBox->GetSelection();
+    auto selections = GetSelectedPathIndices();
+    if (selections.empty())
+        return wxNOT_FOUND;
+    return selections.front();
 }
 
 void SketchAssistPanel::NotifySketchUpdated()
@@ -202,6 +206,8 @@ void SketchAssistPanel::NotifySketchUpdated()
 void SketchAssistPanel::NotifySketchPathsUpdated()
 {
     populatePathListBoxFromSketch();
+    UpdatePathDescriptionEditorFromSelection();
+    UpdatePathActionButtons();
 }
 
 void SketchAssistPanel::NotifyPathStateUpdated(SketchCanvasPathState state)
@@ -239,6 +245,8 @@ void SketchAssistPanel::SelectLastPath()
 
     if ((n = m_pathsListBox->GetCount()) != 0) {
         m_pathsListBox->SetSelection(n - 1);
+        UpdatePathDescriptionEditorFromSelection();
+        UpdatePathActionButtons();
         m_continuePathBtn->Enable(canContinuePath());
     }
 }
@@ -272,6 +280,8 @@ void SketchAssistPanel::OnButton_StartPath(wxCommandEvent& /*event*/)
     m_sketchCanvasPanel->ResetHandlesState(SketchCanvasPathState::DefineStartPoint);
 
     m_pathsListBox->DeselectAll();
+    UpdatePathDescriptionEditorFromSelection();
+    UpdatePathActionButtons();
 }
 
 void SketchAssistPanel::OnButton_EndPath(wxCommandEvent& /*event*/)
@@ -299,6 +309,8 @@ void SketchAssistPanel::OnButton_ClearSketch(wxCommandEvent& /*event*/)
     m_pathsListBox->Clear();
 
     m_sketchCanvasPanel->ResetHandlesState();
+    UpdatePathDescriptionEditorFromSelection();
+    UpdatePathActionButtons();
     NotifySketchUpdated();
 }
 
@@ -400,48 +412,179 @@ void SketchAssistPanel::OnButton_ImportSVG(wxCommandEvent& event)
         //redraw screen
         m_sketchCanvasPanel->ResetHandlesState();
         populatePathListBoxFromSketch();
+        UpdatePathDescriptionEditorFromSelection();
+        UpdatePathActionButtons();
         Refresh();
         NotifySketchUpdated();
     }
 }
 
+void SketchAssistPanel::OnButton_MovePathUp(wxCommandEvent& /*event*/)
+{
+    auto selections = GetSelectedPathIndices();
+    if (selections.size() != 1)
+        return;
+
+    const int index = selections.front();
+    if (index <= 0 || index >= (int)m_sketch.pathCount())
+        return;
+
+    m_sketch.swapPaths(index, index - 1);
+    m_sketchCanvasPanel->ResetHandlesState();
+    populatePathListBoxFromSketch();
+    m_pathsListBox->SetSelection(index - 1);
+    UpdatePathDescriptionEditorFromSelection();
+    UpdatePathActionButtons();
+    NotifySketchUpdated();
+}
+
+void SketchAssistPanel::OnButton_MovePathDown(wxCommandEvent& /*event*/)
+{
+    auto selections = GetSelectedPathIndices();
+    if (selections.size() != 1)
+        return;
+
+    const int index = selections.front();
+    if (index < 0 || index >= (int)m_sketch.pathCount() - 1)
+        return;
+
+    m_sketch.swapPaths(index, index + 1);
+    m_sketchCanvasPanel->ResetHandlesState();
+    populatePathListBoxFromSketch();
+    m_pathsListBox->SetSelection(index + 1);
+    UpdatePathDescriptionEditorFromSelection();
+    UpdatePathActionButtons();
+    NotifySketchUpdated();
+}
+
 void SketchAssistPanel::OnListBox_PathSelected(wxCommandEvent& /*event*/)
 {
-    int index = m_pathsListBox->GetSelection();
-    m_sketchCanvasPanel->UpdateHandlesForPath(index);
+    auto selections = GetSelectedPathIndices();
+    if (selections.size() == 1) {
+        m_sketchCanvasPanel->UpdateHandlesForPath(selections.front());
+    } else {
+        m_sketchCanvasPanel->ResetHandlesState();
+    }
+    UpdatePathDescriptionEditorFromSelection();
+    UpdatePathActionButtons();
     m_continuePathBtn->Enable(canContinuePath());
+}
+
+void SketchAssistPanel::OnListBox_KeyDown(wxKeyEvent& event)
+{
+    if (event.GetKeyCode() == WXK_DELETE && DeleteSelectedPaths())
+        return;
+    event.Skip();
+}
+
+void SketchAssistPanel::OnTextCtrl_PathDescription(wxCommandEvent& /*event*/)
+{
+    if (m_ignoreDescriptionTextEvent)
+        return;
+
+    auto selections = GetSelectedPathIndices();
+    if (selections.size() != 1)
+        return;
+
+    const int index = selections.front();
+    if (index < 0 || index >= (int)m_sketch.pathCount())
+        return;
+
+    auto& path = m_sketch.paths()[index];
+    if (path == nullptr)
+        return;
+
+    path->SetDescription(m_pathDescriptionText->GetValue().ToStdString());
+    wxString text;
+    text.sprintf("Path %d", index + 1);
+    if (!path->GetDescription().empty()) {
+        text += " - ";
+        text += path->GetDescription();
+    }
+    m_pathsListBox->SetString(index, text);
+}
+
+void SketchAssistPanel::OnTextCtrl_PathDescriptionEnter(wxCommandEvent& /*event*/)
+{
+    if (m_ignoreDescriptionTextEvent)
+        return;
+    if (m_lastCommittedPathDescription != m_pathDescriptionText->GetValue().ToStdString()) {
+        m_lastCommittedPathDescription = m_pathDescriptionText->GetValue().ToStdString();
+        NotifySketchUpdated();
+    }
+}
+
+void SketchAssistPanel::OnTextCtrl_PathDescriptionKillFocus(wxFocusEvent& event)
+{
+    if (!m_ignoreDescriptionTextEvent) {
+        const std::string description = m_pathDescriptionText->GetValue().ToStdString();
+        if (m_lastCommittedPathDescription != description) {
+            m_lastCommittedPathDescription = description;
+            NotifySketchUpdated();
+        }
+    }
+    event.Skip();
 }
 
 void SketchAssistPanel::OnListBox_ContextMenu(wxContextMenuEvent& event)
 {
     wxPoint pt(m_pathsListBox->ScreenToClient(event.GetPosition()));
     m_pathIndexToDelete = m_pathsListBox->HitTest(pt);
-    if (m_pathIndexToDelete < 0)
-        return;
 
     wxString str;
-
     wxMenu mnu;
-    str.sprintf("Reverse Path %d", 1 + m_pathIndexToDelete);
-    mnu.Append(ID_MENU_Reverse, str);
-    str.sprintf("Delete Path %d", 1 + m_pathIndexToDelete);
-    mnu.Append(ID_MENU_Delete, str);
-    if (m_pathIndexToDelete != 0) {
-        str.sprintf("Move Path %d Up", 1 + m_pathIndexToDelete);
-        mnu.Append(ID_MENU_MoveUp, str);
-    }
-    if (m_pathIndexToDelete != (int)m_pathsListBox->GetCount() - 1) {
-        str.sprintf("Move Path %d Down", 1 + m_pathIndexToDelete);
-        mnu.Append(ID_MENU_MoveDown, str);
 
+    if (m_pathIndexToDelete >= 0) {
+        str.sprintf("Reverse Path %d", 1 + m_pathIndexToDelete);
+        mnu.Append(ID_MENU_Reverse, str);
+        str.sprintf("Delete Path %d", 1 + m_pathIndexToDelete);
+        mnu.Append(ID_MENU_Delete, str);
+        if (m_pathIndexToDelete != 0) {
+            str.sprintf("Move Path %d Up", 1 + m_pathIndexToDelete);
+            mnu.Append(ID_MENU_MoveUp, str);
+        }
+        if (m_pathIndexToDelete != (int)m_pathsListBox->GetCount() - 1) {
+            str.sprintf("Move Path %d Down", 1 + m_pathIndexToDelete);
+            mnu.Append(ID_MENU_MoveDown, str);
+        }
+        if (m_pathIndexToDelete != 0) {
+            str.sprintf("Move Path %d to Top", 1 + m_pathIndexToDelete);
+            mnu.Append(ID_MENU_MoveToTop, str);
+        }
+        if (m_pathIndexToDelete != (int)m_pathsListBox->GetCount() - 1) {
+            str.sprintf("Move Path %d to Bottom", 1 + m_pathIndexToDelete);
+            mnu.Append(ID_MENU_MoveToBottom, str);
+        }
     }
+
+    if (m_pathsListBox->GetCount() > 1) {
+        if (mnu.GetMenuItemCount() > 0)
+            mnu.AppendSeparator();
+        mnu.Append(ID_MENU_SortByDescription, "Sort All by Description");
+    }
+
+    if (mnu.GetMenuItemCount() == 0)
+        return;
     mnu.Connect(wxEVT_MENU, (wxObjectEventFunction)&SketchAssistPanel::OnPopupCommand, nullptr, this);
     PopupMenu(&mnu);
 }
 
 void SketchAssistPanel::OnPopupCommand(wxCommandEvent& event)
 {
-    if (m_pathIndexToDelete >= (int)m_sketch.pathCount())
+    if (event.GetId() == ID_MENU_SortByDescription) {
+        std::sort(m_sketch.paths().begin(), m_sketch.paths().end(),
+                  [](const auto& a, const auto& b) {
+                      return a->GetDescription() < b->GetDescription();
+                  });
+        m_sketchCanvasPanel->ResetHandlesState();
+        populatePathListBoxFromSketch();
+        UpdatePathDescriptionEditorFromSelection();
+        UpdatePathActionButtons();
+        NotifySketchUpdated();
+        return;
+    }
+
+    if (m_pathIndexToDelete < 0 || m_pathIndexToDelete >= (int)m_sketch.pathCount())
         return;
     bool update = false;
 
@@ -457,12 +600,23 @@ void SketchAssistPanel::OnPopupCommand(wxCommandEvent& event)
     } else if (event.GetId() == ID_MENU_MoveDown) {
         m_sketch.swapPaths(m_pathIndexToDelete, m_pathIndexToDelete + 1);
         update = true;
+    } else if (event.GetId() == ID_MENU_MoveToTop) {
+        for (int i = m_pathIndexToDelete; i > 0; --i)
+            m_sketch.swapPaths(i, i - 1);
+        update = true;
+    } else if (event.GetId() == ID_MENU_MoveToBottom) {
+        const int last = (int)m_sketch.pathCount() - 1;
+        for (int i = m_pathIndexToDelete; i < last; ++i)
+            m_sketch.swapPaths(i, i + 1);
+        update = true;
     }
 
     if (update) {
         m_sketchCanvasPanel->ResetHandlesState();
 
         populatePathListBoxFromSketch();
+        UpdatePathDescriptionEditorFromSelection();
+        UpdatePathActionButtons();
         NotifySketchUpdated();
     }
 }
@@ -490,20 +644,107 @@ void SketchAssistPanel::populatePathListBoxFromSketch()
     for (int i = 0; i < (int)m_sketch.paths().size(); ++i) {
         wxString text;
         text.sprintf("Path %d", i + 1);
+        const auto& description = m_sketch.paths()[i]->GetDescription();
+        if (!description.empty()) {
+            text += " - ";
+            text += description;
+        }
         m_pathsListBox->Insert(text, i);
     }
+    UpdatePathLabels();
+}
+
+bool SketchAssistPanel::DeleteSelectedPaths()
+{
+    auto selections = GetSelectedPathIndices();
+    if (selections.empty())
+        return false;
+
+    std::sort(selections.begin(), selections.end(), std::greater<int>());
+    for (const auto index : selections) {
+        if (index >= 0 && index < (int)m_sketch.pathCount())
+            m_sketch.deletePath(index);
+    }
+
+    m_sketchCanvasPanel->ResetHandlesState();
+    populatePathListBoxFromSketch();
+    UpdatePathDescriptionEditorFromSelection();
+    UpdatePathActionButtons();
+    NotifySketchUpdated();
+    m_continuePathBtn->Enable(canContinuePath());
+    return true;
+}
+
+std::vector<int> SketchAssistPanel::GetSelectedPathIndices() const
+{
+    std::vector<int> selections;
+    if (m_pathsListBox == nullptr)
+        return selections;
+
+    wxArrayInt indices;
+    m_pathsListBox->GetSelections(indices);
+    selections.reserve(indices.GetCount());
+    for (auto i = 0u; i < indices.GetCount(); ++i)
+        selections.push_back(indices[i]);
+    return selections;
+}
+
+void SketchAssistPanel::UpdatePathDescriptionEditorFromSelection()
+{
+    if (m_pathDescriptionText == nullptr)
+        return;
+
+    auto selections = GetSelectedPathIndices();
+    if (selections.size() != 1 || selections.front() < 0 || selections.front() >= (int)m_sketch.pathCount()) {
+        m_ignoreDescriptionTextEvent = true;
+        m_pathDescriptionText->ChangeValue(wxEmptyString);
+        m_ignoreDescriptionTextEvent = false;
+        m_lastCommittedPathDescription.clear();
+        m_pathDescriptionText->Enable(false);
+        if (m_pathDescriptionLabel != nullptr)
+            m_pathDescriptionLabel->SetLabel("Path Description");
+        return;
+    }
+
+    const int index = selections.front();
+    m_ignoreDescriptionTextEvent = true;
+    m_pathDescriptionText->ChangeValue(wxString(m_sketch.paths()[index]->GetDescription()));
+    m_ignoreDescriptionTextEvent = false;
+    m_lastCommittedPathDescription = m_sketch.paths()[index]->GetDescription();
+    m_pathDescriptionText->Enable(true);
+    if (m_pathDescriptionLabel != nullptr)
+        m_pathDescriptionLabel->SetLabel("Path Description");
+}
+
+void SketchAssistPanel::UpdatePathLabels()
+{
+    if (m_pathsHeaderLabel != nullptr)
+        m_pathsHeaderLabel->SetLabel(wxString::Format("Paths (%d)", (int)m_sketch.pathCount()));
+}
+
+void SketchAssistPanel::UpdatePathActionButtons()
+{
+    auto selections = GetSelectedPathIndices();
+    const bool hasSelection = !selections.empty();
+    const bool singleSelection = selections.size() == 1;
+    const int selectedIndex = singleSelection ? selections.front() : -1;
+    const int lastIndex = (int)m_sketch.pathCount() - 1;
+
+    if (m_movePathUpBtn != nullptr)
+        m_movePathUpBtn->Enable(singleSelection && selectedIndex > 0);
+    if (m_movePathDownBtn != nullptr)
+        m_movePathDownBtn->Enable(singleSelection && selectedIndex >= 0 && selectedIndex < lastIndex);
 }
 
 bool SketchAssistPanel::canContinuePath() const
 {
-    int index = m_pathsListBox->GetSelection();
-    if (index < 0)
+    auto selections = GetSelectedPathIndices();
+    if (selections.size() != 1)
         return false;
-
-    if (index >= (int)m_sketch.pathCount())
+    const int index = selections.front();
+    if (index < 0 || index >= (int)m_sketch.pathCount())
         return false;
-    auto paths(m_sketch.paths());
-    return !paths[index]->isClosed();
+    return !m_sketch.paths()[index]->isClosed();
 }
 
 bool SketchAssistPanel::areSame(double a, double b, float eps) const

--- a/src-ui-wx/effectpanels/assist/SketchAssistPanel.h
+++ b/src-ui-wx/effectpanels/assist/SketchAssistPanel.h
@@ -5,12 +5,16 @@
 
 #include <functional>
 #include <string>
+#include <vector>
 
 #include <wx/image.h>
 #include <wx/panel.h>
 
 class wxButton;
 class wxListBox;
+class wxStaticText;
+class wxTextCtrl;
+class wxFocusEvent;
 
 class SketchAssistPanel : public wxPanel,
                           public ISketchCanvasParent
@@ -55,13 +59,24 @@ private:
     void OnButton_ImportSketch(wxCommandEvent& event);
     void OnButton_ExportSketch(wxCommandEvent& event);
     void OnButton_ImportSVG(wxCommandEvent& event);
+    void OnButton_MovePathUp(wxCommandEvent& event);
+    void OnButton_MovePathDown(wxCommandEvent& event);
 
     void OnListBox_PathSelected(wxCommandEvent& event);
+    void OnListBox_KeyDown(wxKeyEvent& event);
+    void OnTextCtrl_PathDescription(wxCommandEvent& event);
+    void OnTextCtrl_PathDescriptionEnter(wxCommandEvent& event);
+    void OnTextCtrl_PathDescriptionKillFocus(wxFocusEvent& event);
     void OnListBox_ContextMenu(wxContextMenuEvent& event);
     void OnPopupCommand(wxCommandEvent& event);
 
     void updateBgImage();
     void populatePathListBoxFromSketch();
+    bool DeleteSelectedPaths();
+    std::vector<int> GetSelectedPathIndices() const;
+    void UpdatePathDescriptionEditorFromSelection();
+    void UpdatePathLabels();
+    void UpdatePathActionButtons();
     bool canContinuePath() const;
 
     bool areSame(double a, double b, float eps) const;
@@ -80,12 +95,22 @@ private:
     wxButton* m_importSketchBtn = nullptr;
     wxButton* m_exportSketchBtn = nullptr;
     wxButton* m_importSVGBtn = nullptr;
+    wxButton* m_movePathUpBtn = nullptr;
+    wxButton* m_movePathDownBtn = nullptr;
 
     wxListBox* m_pathsListBox = nullptr;
+    wxStaticText* m_pathsHeaderLabel = nullptr;
+    wxStaticText* m_pathDescriptionLabel = nullptr;
+    wxTextCtrl* m_pathDescriptionText = nullptr;
+    bool m_ignoreDescriptionTextEvent = false;
+    std::string m_lastCommittedPathDescription;
     static long ID_MENU_Delete;
     static long ID_MENU_Reverse;
     static long ID_MENU_MoveUp;
     static long ID_MENU_MoveDown;
+    static long ID_MENU_MoveToTop;
+    static long ID_MENU_MoveToBottom;
+    static long ID_MENU_SortByDescription;
 
     wxString m_bgImagePath;
     wxImage m_bgImage;


### PR DESCRIPTION
Sketch effect path management: multi-select, Delete key, Move Up/Down  buttons, per-path description labels, and a description text editor (#5871). [skip ci]