### PR TITLE
Package Log Files: fix duplicate primary log in zip; rolled log now included

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -39,6 +39,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -enh (scott)                 Custom color picker: skip duplicate colors in the recent colors list.
     -enh (dkulp)                 macOS: include MetricKit crash diagnostics in packaged log uploads; clean up
                                  older MetricKit data.
+    -bug (derwin12)              Package Log Files: fix duplicate primary log in zip; rolled log now included.
     -bug (derwin12)              Fix lasso selection corrupting State/Faces effect values (#5783)
     -bug (derwin12)              Better handle multi chord MIDI tracks (#6434)
     -bug (Neil)                  Fix edit display elements eye-icon for HiDPI (#5015)

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -4606,7 +4606,7 @@ std::string xLightsFrame::PackageDebugFiles(bool showDialog)
 
 static void AddLogFile(const wxString& CurrentDir, const wxString& fileName, wxDebugReport& report)
 {
-    wxString const filename = GetLogFilePath().string();
+    wxString const filename = wxString::FromUTF8((GetLogFileFolder() / fileName.ToStdString()).string());
 
     if (FileExists(filename)) {
         report.AddFile(filename, fileName);


### PR DESCRIPTION
Prior package had .log and .1.log included and duplicating..