### PR TITLE
#6438 multi model import keeps relative positions

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -4808,6 +4808,14 @@ static Model* GetXlightsModel(Model* model, std::string& last_model, xLightsFram
             // each additional sibling into additionalModelObjects so FinalizeModel can
             // place them alongside the primary model.
             if (additionalModelObjects != nullptr && strcmp(root.name(), "models") == 0) {
+                pugi::xml_node primaryNode = root.first_child();
+                if (primaryNode) {
+                    float wx = primaryNode.attribute("WorldPosX").as_float(0.0f);
+                    float wy = primaryNode.attribute("WorldPosY").as_float(0.0f);
+                    float wz = primaryNode.attribute("WorldPosZ").as_float(0.0f);
+                    model->GetBaseObjectScreenLocation().SetWorldPosition(glm::vec3(wx, wy, wz));
+                }
+
                 for (pugi::xml_node child = root.first_child().next_sibling(); child; child = child.next_sibling()) {
                     bool extraCancelled = false;
                     xlights->GetOutputModelManager()->DisableASAPWork(true);
@@ -4820,6 +4828,10 @@ static Model* GetXlightsModel(Model* model, std::string& last_model, xLightsFram
                     if (!extraModel->HasIndividualStartChannels()) {
                         extraModel->SetControllerName(NO_CONTROLLER, true);
                     }
+                    float wx = child.attribute("WorldPosX").as_float(0.0f);
+                    float wy = child.attribute("WorldPosY").as_float(0.0f);
+                    float wz = child.attribute("WorldPosZ").as_float(0.0f);
+                    extraModel->GetBaseObjectScreenLocation().SetWorldPosition(glm::vec3(wx, wy, wz));
                     additionalModelObjects->push_back(extraModel);
                 }
             }
@@ -4890,7 +4902,6 @@ void LayoutPanel::FinalizeModel()
         std::vector<Model*> additionalModelObjects;
         glm::vec3 firstModelPos(0.0f);
         glm::vec3 multiModelAnchor(0.0f);
-        bool hasMultiModelRelativePositions = false;
         if (b != nullptr && (b->GetModelType() == "Import Custom" || b->GetModelType() == "Download"))
         {
             xlights->AddTraceMessage("LayoutPanel::FinalizeModel We were downloading or importing.");
@@ -4983,9 +4994,6 @@ void LayoutPanel::FinalizeModel()
                 delete prog;
             }
 
-            // For multi-model xmodel imports, preserve relative WorldPos from the file.
-            // Compute the bounding-box anchor (min X, min Y across all models) so the
-            // entire group lands with its anchor corner at the user's drop point.
             if (!additionalModelObjects.empty()) {
                 glm::vec3 primaryOrigPos = _newModel->GetBaseObjectScreenLocation().GetWorldPosition();
                 float anchorX = primaryOrigPos.x;
@@ -4997,7 +5005,6 @@ void LayoutPanel::FinalizeModel()
                     anchorY = std::min(anchorY, ep.y);
                 }
                 multiModelAnchor = glm::vec3(anchorX, anchorY, 0.0f);
-                hasMultiModelRelativePositions = true;
                 glm::vec3 adjustedPos(pos.x + (primaryOrigPos.x - anchorX),
                                       pos.y + (primaryOrigPos.y - anchorY),
                                       pos.z);
@@ -5083,25 +5090,15 @@ void LayoutPanel::FinalizeModel()
             xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS, "FinalizeModel");
         }
 
-        // Place additional models loaded from a multi-model xmodel file.
-        // When WorldPos values were captured from the file (hasMultiModelRelativePositions),
-        // each model is placed at: dropPoint + (originalWorldPos - anchorWorldPos)
-        // so the entire group keeps its relative arrangement, anchored at the drop point.
         if (!additionalModelObjects.empty()) {
             for (Model* extraModel : additionalModelObjects) {
                 if (extraModel == nullptr) continue;
                 std::string uniqueName = xlights->AllModels.GenerateModelName(extraModel->name);
                 extraModel->name = uniqueName;
-
-                glm::vec3 newPos;
-                if (hasMultiModelRelativePositions) {
-                    glm::vec3 origPos = extraModel->GetBaseObjectScreenLocation().GetWorldPosition();
-                    newPos = glm::vec3(firstModelPos.x + (origPos.x - multiModelAnchor.x),
-                                      firstModelPos.y + (origPos.y - multiModelAnchor.y),
-                                      firstModelPos.z + (origPos.z - multiModelAnchor.z));
-                } else {
-                    newPos = firstModelPos;
-                }
+                glm::vec3 origPos = extraModel->GetBaseObjectScreenLocation().GetWorldPosition();
+                glm::vec3 newPos(firstModelPos.x + (origPos.x - multiModelAnchor.x),
+                                 firstModelPos.y + (origPos.y - multiModelAnchor.y),
+                                 firstModelPos.z + (origPos.z - multiModelAnchor.z));
                 extraModel->GetBaseObjectScreenLocation().SetWorldPosition(newPos);
                 extraModel->SetLayoutGroup(currentLayoutGroup == "All Models" ? "Default" : currentLayoutGroup);
                 xlights->AllModels.AddModel(extraModel);

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -4889,6 +4889,8 @@ void LayoutPanel::FinalizeModel()
         std::vector<DownloadedModelInfo> additionalModels;
         std::vector<Model*> additionalModelObjects;
         glm::vec3 firstModelPos(0.0f);
+        glm::vec3 multiModelAnchor(0.0f);
+        bool hasMultiModelRelativePositions = false;
         if (b != nullptr && (b->GetModelType() == "Import Custom" || b->GetModelType() == "Download"))
         {
             xlights->AddTraceMessage("LayoutPanel::FinalizeModel We were downloading or importing.");
@@ -4981,10 +4983,35 @@ void LayoutPanel::FinalizeModel()
                 delete prog;
             }
 
-            if (_newModel->GetDisplayAs() == DisplayAsType::PolyLine) {
-                _newModel->SetPosition(pos.x, pos.y);
+            // For multi-model xmodel imports, preserve relative WorldPos from the file.
+            // Compute the bounding-box anchor (min X, min Y across all models) so the
+            // entire group lands with its anchor corner at the user's drop point.
+            if (!additionalModelObjects.empty()) {
+                glm::vec3 primaryOrigPos = _newModel->GetBaseObjectScreenLocation().GetWorldPosition();
+                float anchorX = primaryOrigPos.x;
+                float anchorY = primaryOrigPos.y;
+                for (Model* em : additionalModelObjects) {
+                    if (em == nullptr) continue;
+                    glm::vec3 ep = em->GetBaseObjectScreenLocation().GetWorldPosition();
+                    anchorX = std::min(anchorX, ep.x);
+                    anchorY = std::min(anchorY, ep.y);
+                }
+                multiModelAnchor = glm::vec3(anchorX, anchorY, 0.0f);
+                hasMultiModelRelativePositions = true;
+                glm::vec3 adjustedPos(pos.x + (primaryOrigPos.x - anchorX),
+                                      pos.y + (primaryOrigPos.y - anchorY),
+                                      pos.z);
+                if (_newModel->GetDisplayAs() == DisplayAsType::PolyLine) {
+                    _newModel->SetPosition(adjustedPos.x, adjustedPos.y);
+                } else {
+                    _newModel->GetBaseObjectScreenLocation().SetWorldPosition(adjustedPos);
+                }
             } else {
-                _newModel->GetBaseObjectScreenLocation().SetWorldPosition(pos);
+                if (_newModel->GetDisplayAs() == DisplayAsType::PolyLine) {
+                    _newModel->SetPosition(pos.x, pos.y);
+                } else {
+                    _newModel->GetBaseObjectScreenLocation().SetWorldPosition(pos);
+                }
             }
             if (b->GetState() == 1)
             {
@@ -5056,24 +5083,28 @@ void LayoutPanel::FinalizeModel()
             xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS, "FinalizeModel");
         }
 
-        // Place additional models loaded from a multi-model xmodel file
+        // Place additional models loaded from a multi-model xmodel file.
+        // When WorldPos values were captured from the file (hasMultiModelRelativePositions),
+        // each model is placed at: dropPoint + (originalWorldPos - anchorWorldPos)
+        // so the entire group keeps its relative arrangement, anchored at the drop point.
         if (!additionalModelObjects.empty()) {
-            constexpr float BATCH_PLACEMENT_PADDING = 20.0f;
-            constexpr float BATCH_PLACEMENT_MIN_OFFSET = 50.0f;
-
-            float previousWidth = std::max(_newModel->GetRestorableMWidth(), BATCH_PLACEMENT_MIN_OFFSET);
-            float currentX = firstModelPos.x + previousWidth + BATCH_PLACEMENT_PADDING;
-
             for (Model* extraModel : additionalModelObjects) {
                 if (extraModel == nullptr) continue;
                 std::string uniqueName = xlights->AllModels.GenerateModelName(extraModel->name);
                 extraModel->name = uniqueName;
-                extraModel->GetBaseObjectScreenLocation().SetWorldPosition(glm::vec3(currentX, firstModelPos.y, firstModelPos.z));
+
+                glm::vec3 newPos;
+                if (hasMultiModelRelativePositions) {
+                    glm::vec3 origPos = extraModel->GetBaseObjectScreenLocation().GetWorldPosition();
+                    newPos = glm::vec3(firstModelPos.x + (origPos.x - multiModelAnchor.x),
+                                      firstModelPos.y + (origPos.y - multiModelAnchor.y),
+                                      firstModelPos.z + (origPos.z - multiModelAnchor.z));
+                } else {
+                    newPos = firstModelPos;
+                }
+                extraModel->GetBaseObjectScreenLocation().SetWorldPosition(newPos);
                 extraModel->SetLayoutGroup(currentLayoutGroup == "All Models" ? "Default" : currentLayoutGroup);
                 xlights->AllModels.AddModel(extraModel);
-
-                float thisWidth = std::max(extraModel->GetRestorableMWidth(), BATCH_PLACEMENT_MIN_OFFSET);
-                currentX += thisWidth + BATCH_PLACEMENT_PADDING;
             }
             xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_REWORK_STARTCHANNELS, "FinalizeModel");
         }

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -4808,15 +4808,21 @@ static Model* GetXlightsModel(Model* model, std::string& last_model, xLightsFram
             // each additional sibling into additionalModelObjects so FinalizeModel can
             // place them alongside the primary model.
             if (additionalModelObjects != nullptr && strcmp(root.name(), "models") == 0) {
-                pugi::xml_node primaryNode = root.first_child();
-                if (primaryNode) {
-                    float wx = primaryNode.attribute("WorldPosX").as_float(0.0f);
-                    float wy = primaryNode.attribute("WorldPosY").as_float(0.0f);
-                    float wz = primaryNode.attribute("WorldPosZ").as_float(0.0f);
-                    model->GetBaseObjectScreenLocation().SetWorldPosition(glm::vec3(wx, wy, wz));
-                }
+                auto applyWorldPos = [](Model* m, const pugi::xml_node& n) {
+                    m->GetBaseObjectScreenLocation().SetWorldPosition(glm::vec3(
+                        n.attribute("WorldPosX").as_float(0.0f),
+                        n.attribute("WorldPosY").as_float(0.0f),
+                        n.attribute("WorldPosZ").as_float(0.0f)));
+                };
 
-                for (pugi::xml_node child = root.first_child().next_sibling(); child; child = child.next_sibling()) {
+                pugi::xml_node primaryNode = root.first_child();
+                while (primaryNode && primaryNode.type() != pugi::node_element)
+                    primaryNode = primaryNode.next_sibling();
+                if (primaryNode)
+                    applyWorldPos(model, primaryNode);
+
+                for (pugi::xml_node child = primaryNode ? primaryNode.next_sibling() : pugi::xml_node(); child; child = child.next_sibling()) {
+                    if (child.type() != pugi::node_element) continue;
                     bool extraCancelled = false;
                     xlights->GetOutputModelManager()->DisableASAPWork(true);
                     Model* extraModel = xlights->AllModels.CreateDefaultModel("Custom", "1");
@@ -4828,10 +4834,7 @@ static Model* GetXlightsModel(Model* model, std::string& last_model, xLightsFram
                     if (!extraModel->HasIndividualStartChannels()) {
                         extraModel->SetControllerName(NO_CONTROLLER, true);
                     }
-                    float wx = child.attribute("WorldPosX").as_float(0.0f);
-                    float wy = child.attribute("WorldPosY").as_float(0.0f);
-                    float wz = child.attribute("WorldPosZ").as_float(0.0f);
-                    extraModel->GetBaseObjectScreenLocation().SetWorldPosition(glm::vec3(wx, wy, wz));
+                    applyWorldPos(extraModel, child);
                     additionalModelObjects->push_back(extraModel);
                 }
             }
@@ -4998,16 +5001,18 @@ void LayoutPanel::FinalizeModel()
                 glm::vec3 primaryOrigPos = _newModel->GetBaseObjectScreenLocation().GetWorldPosition();
                 float anchorX = primaryOrigPos.x;
                 float anchorY = primaryOrigPos.y;
+                float anchorZ = primaryOrigPos.z;
                 for (Model* em : additionalModelObjects) {
                     if (em == nullptr) continue;
                     glm::vec3 ep = em->GetBaseObjectScreenLocation().GetWorldPosition();
                     anchorX = std::min(anchorX, ep.x);
                     anchorY = std::min(anchorY, ep.y);
+                    anchorZ = std::min(anchorZ, ep.z);
                 }
-                multiModelAnchor = glm::vec3(anchorX, anchorY, 0.0f);
+                multiModelAnchor = glm::vec3(anchorX, anchorY, anchorZ);
                 glm::vec3 adjustedPos(pos.x + (primaryOrigPos.x - anchorX),
                                       pos.y + (primaryOrigPos.y - anchorY),
-                                      pos.z);
+                                      pos.z + (primaryOrigPos.z - anchorZ));
                 if (_newModel->GetDisplayAs() == DisplayAsType::PolyLine) {
                     _newModel->SetPosition(adjustedPos.x, adjustedPos.y);
                 } else {


### PR DESCRIPTION
Example, if you export a tree with it's star on top, then import the star would be next to the tree. This fix keeps the models positions as they were exported. 
