### PR TITLE
Rebuild the media folders when you change show folders

### DIFF
--- a/src-ui-wx/app-shell/TabSetup.cpp
+++ b/src-ui-wx/app-shell/TabSetup.cpp
@@ -354,11 +354,8 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
     }
 
     mediaDirectories.clear();
-    if (!xLightsApp::mediaDir.IsNull()) {
-        std::string mds = xLightsApp::mediaDir.ToStdString();
-        if (std::find(mediaDirectories.begin(), mediaDirectories.end(), mds) == mediaDirectories.end())
-            mediaDirectories.push_back(mds);
-    }
+    if (!xLightsApp::mediaDir.IsNull())
+        mediaDirectories.push_back(xLightsApp::mediaDir.ToStdString());
     {
         wxString mediaDirConfig;
         config->Read("MediaDir", &mediaDirConfig);
@@ -371,7 +368,11 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
             }
         }
     }
-    mediaDirectories.push_back(ToStdString(CurrentDir));
+    {
+        std::string curDir = ToStdString(CurrentDir);
+        if (std::find(mediaDirectories.begin(), mediaDirectories.end(), curDir) == mediaDirectories.end())
+            mediaDirectories.push_back(curDir);
+    }
 
     long fseqLinkFlag = 0;
     config->Read("FSEQLinkFlag", &fseqLinkFlag);

--- a/src-ui-wx/app-shell/TabSetup.cpp
+++ b/src-ui-wx/app-shell/TabSetup.cpp
@@ -25,6 +25,7 @@
 #include <thread>
 
 #include "xLightsMain.h"
+#include "xLightsApp.h"
 #include "layout/LayoutPanel.h"
 #include "render/SequenceFile.h"
 #ifdef __WXOSX__
@@ -351,9 +352,26 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
     } else {
         wxLog::SetActiveTarget(new wxLogStderr()); // write to stderr
     }
-    if (std::find(mediaDirectories.begin(), mediaDirectories.end(), CurrentDir) == mediaDirectories.end()) {
-        mediaDirectories.push_back(CurrentDir);
+
+    mediaDirectories.clear();
+    if (!xLightsApp::mediaDir.IsNull()) {
+        std::string mds = xLightsApp::mediaDir.ToStdString();
+        if (std::find(mediaDirectories.begin(), mediaDirectories.end(), mds) == mediaDirectories.end())
+            mediaDirectories.push_back(mds);
     }
+    {
+        wxString mediaDirConfig;
+        config->Read("MediaDir", &mediaDirConfig);
+        if (!mediaDirConfig.empty()) {
+            wxArrayString entries = wxSplit(mediaDirConfig, '|', '\0');
+            for (auto& d : entries) {
+                std::string dstd = d.ToStdString();
+                if (std::find(mediaDirectories.begin(), mediaDirectories.end(), dstd) == mediaDirectories.end())
+                    mediaDirectories.push_back(dstd);
+            }
+        }
+    }
+    mediaDirectories.push_back(ToStdString(CurrentDir));
 
     long fseqLinkFlag = 0;
     config->Read("FSEQLinkFlag", &fseqLinkFlag);


### PR DESCRIPTION
When you switch to a temp showfolder, the old showfolder is still used as a path for media. With this change if you select media from that original showfolder, it realizes that it needs to be embedded/copied/etc.