### PR TITLE
Preserve relative Start Channel even if Individual Start Channels is not checked

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,7 +12,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.10  May ??, 2026
 
-    -bug (cybercop23)                 Importing a multi-model xmodel file now preserves @Model:N and >Model:N
+    -bug (cybercop23)            Importing a multi-model xmodel file now preserves @Model:N and >Model:N
                                  start-channel references instead of resetting them to absolute channels.
     -enh (scott)                 FPP discovery now uses mDNS on Windows (native windns.h DNS-SD) in
                                  addition to the existing broadcast/multicast ping.

--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,8 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.10  May ??, 2026
 
+    -bug (cybercop23)                 Importing a multi-model xmodel file now preserves @Model:N and >Model:N
+                                 start-channel references instead of resetting them to absolute channels.
     -enh (scott)                 FPP discovery now uses mDNS on Windows (native windns.h DNS-SD) in
                                  addition to the existing broadcast/multicast ping.
     -enh (heffneil)              Replace Model: new dialog replaces multiple models at once with a

--- a/src-core/models/Model.cpp
+++ b/src-core/models/Model.cpp
@@ -4058,9 +4058,9 @@ Model* Model::CreateDefaultModelFromSavedModelNode(Model* model, pugi::xml_node 
     if (model != nullptr) {
         // Preserve individual start channels (@Model:chan references) — ModelStartChannel
         // must survive because ComputeStringStartChannel(0) returns it directly.
-        if (!model->HasIndividualStartChannels()) {
+        const std::string& importedSc = model->GetModelStartChannel();
+        if (!model->HasIndividualStartChannels() && (importedSc.empty() || (importedSc[0] != '@' && importedSc[0] != '>')))
             model->SetStartChannel(sc);
-        }
         model->SetHcenterPos(x);
         model->SetVcenterPos(y);
         model->SetLayoutGroup(lg);

--- a/src-core/models/Model.cpp
+++ b/src-core/models/Model.cpp
@@ -4056,8 +4056,8 @@ Model* Model::CreateDefaultModelFromSavedModelNode(Model* model, pugi::xml_node 
     }
 
     if (model != nullptr) {
-        // Preserve individual start channels (@Model:chan references) — ModelStartChannel
-        // must survive because ComputeStringStartChannel(0) returns it directly.
+        // Preserve model-relative start channels (@Model:chan and >Model:chan references) --
+        // ModelStartChannel must survive because ComputeStringStartChannel(0) returns it directly.
         const std::string& importedSc = model->GetModelStartChannel();
         if (!model->HasIndividualStartChannels() && (importedSc.empty() || (importedSc[0] != '@' && importedSc[0] != '>')))
             model->SetStartChannel(sc);

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -4808,10 +4808,11 @@ static Model* GetXlightsModel(Model* model, std::string& last_model, xLightsFram
             // The deserialized model object has _controllerName="" (C++ default), not
             // NO_CONTROLLER, which causes ReworkStartChannel to treat it as a fixed reference
             // point rather than auto-assigning it, leaving it stuck at channel 1.
-            // Models with individual start channels on import are exempt - ie: moving heads strands
-            if (!model->HasIndividualStartChannels()) {
+            // Models with individual start channels and models using @/> model-relative
+            // references are exempt — those are intentional and must be preserved.
+            const std::string& sc = model->GetModelStartChannel();
+            if (!model->HasIndividualStartChannels() && (sc.empty() || (sc[0] != '@' && sc[0] != '>')))
                 model->SetControllerName(NO_CONTROLLER, true);
-            }
 
             // For multi-model xmodel files (<models> root with multiple children), load
             // each additional sibling into additionalModelObjects so FinalizeModel can
@@ -4826,9 +4827,9 @@ static Model* GetXlightsModel(Model* model, std::string& last_model, xLightsFram
                     extraModel->SetStartChannel("1");
                     extraModel = extraModel->CreateDefaultModelFromSavedModelNode(extraModel, child, xlights->AllModels, extraCancelled);
                     if (extraCancelled || extraModel == nullptr) continue;
-                    if (!extraModel->HasIndividualStartChannels()) {
+                    const std::string& extraSc = extraModel->GetModelStartChannel();
+                    if (!extraModel->HasIndividualStartChannels() && (extraSc.empty() || (extraSc[0] != '@' && extraSc[0] != '>')))
                         extraModel->SetControllerName(NO_CONTROLLER, true);
-                    }
                     additionalModelObjects->push_back(extraModel);
                 }
             }

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -4809,7 +4809,7 @@ static Model* GetXlightsModel(Model* model, std::string& last_model, xLightsFram
             // NO_CONTROLLER, which causes ReworkStartChannel to treat it as a fixed reference
             // point rather than auto-assigning it, leaving it stuck at channel 1.
             // Models with individual start channels and models using @/> model-relative
-            // references are exempt — those are intentional and must be preserved.
+            // references are exempt - those are intentional and must be preserved.
             const std::string& sc = model->GetModelStartChannel();
             if (!model->HasIndividualStartChannels() && (sc.empty() || (sc[0] != '@' && sc[0] != '>')))
                 model->SetControllerName(NO_CONTROLLER, true);


### PR DESCRIPTION
As example, the 10 MH YPS Spider model, the MHs are relative to a 216-node string.