### PR TITLE
Add the ability to move image in Model Data (#5506)

### DIFF
--- a/src-ui-wx/model/CustomModelDialog.cpp
+++ b/src-ui-wx/model/CustomModelDialog.cpp
@@ -75,6 +75,9 @@ const long CustomModelDialog::ID_BUTTON_BKG_LEFT = wxNewId();
 const long CustomModelDialog::ID_BUTTON_BKG_RIGHT = wxNewId();
 const long CustomModelDialog::ID_BUTTON_BKG_UP = wxNewId();
 const long CustomModelDialog::ID_BUTTON_BKG_DOWN = wxNewId();
+const long CustomModelDialog::ID_BUTTON_BKG_RESET = wxNewId();
+
+static constexpr float kBkgOffsetStep = 0.25f;
 const long CustomModelDialog::ID_CHECKBOX_AUTO_NUMBER = wxNewId();
 const long CustomModelDialog::ID_CHECKBOX_AUTO_INCREMENT = wxNewId();
 const long CustomModelDialog::ID_SPINCTRL_NEXT_CHANNEL = wxNewId();
@@ -447,7 +450,7 @@ CustomModelDialog::CustomModelDialog(wxWindow* parent, OutputManager* om) :
 	BitmapButtonCustomBkgrd->SetDefault();
 	BitmapButtonCustomBkgrd->SetMinSize(wxSize(24,-1));
 	FlexGridSizer1->Add(BitmapButtonCustomBkgrd, 1, wxTOP|wxBOTTOM|wxRIGHT, 5);
-	StaticTextBkgLabel = new wxStaticText(this, wxID_ANY, _T("Image offset (cells):"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+	StaticTextBkgLabel = new wxStaticText(this, wxID_ANY, _("Image offset (cells):"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
 	FlexGridSizer1->Add(StaticTextBkgLabel, 0, wxLEFT|wxTOP, 5);
 	FlexGridSizer1->Add(-1,-1,1, wxALL, 5);
 	wxBoxSizer* BkgOffsetSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -463,8 +466,15 @@ CustomModelDialog::CustomModelDialog(wxWindow* parent, OutputManager* om) :
 	BtnBkgRight = new wxButton(this, ID_BUTTON_BKG_RIGHT, _T("→"), wxDefaultPosition, wxSize(28,-1), 0, wxDefaultValidator, _T("ID_BUTTON_BKG_RIGHT"));
 	BtnBkgRight->SetToolTip(_("Move image right"));
 	BkgOffsetSizer->Add(BtnBkgRight, 0, wxRIGHT, 5);
-	StaticTextBkgOffset = new wxStaticText(this, wxID_ANY, _T("Horiz: 0.00  Vert: 0.00"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
-	BkgOffsetSizer->Add(StaticTextBkgOffset, 0, wxALIGN_CENTER_VERTICAL, 0);
+	wxBoxSizer* OffsetDisplaySizer = new wxBoxSizer(wxVERTICAL);
+	StaticTextBkgOffset = new wxStaticText(this, wxID_ANY, _T("Horiz: 0.00"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+	OffsetDisplaySizer->Add(StaticTextBkgOffset, 0, 0, 0);
+	StaticTextBkgVert = new wxStaticText(this, wxID_ANY, _T("Vert:  0.00"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+	OffsetDisplaySizer->Add(StaticTextBkgVert, 0, 0, 0);
+	BkgOffsetSizer->Add(OffsetDisplaySizer, 0, wxALIGN_CENTER_VERTICAL|wxRIGHT, 5);
+	BtnBkgReset = new wxButton(this, ID_BUTTON_BKG_RESET, _("Reset"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_BUTTON_BKG_RESET"));
+	BtnBkgReset->SetToolTip(_("Reset image offset to zero"));
+	BkgOffsetSizer->Add(BtnBkgReset, 0, wxALIGN_CENTER_VERTICAL, 0);
 	FlexGridSizer1->Add(BkgOffsetSizer, 0, wxBOTTOM|wxLEFT, 5);
 	FlexGridSizer1->Add(-1,-1,1, wxALL, 5);
 	StaticBoxSizer2->Add(FlexGridSizer1, 1, wxEXPAND, 5);
@@ -550,6 +560,7 @@ CustomModelDialog::CustomModelDialog(wxWindow* parent, OutputManager* om) :
 	Connect(ID_BUTTON_BKG_RIGHT, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CustomModelDialog::OnBtnBkgRight);
 	Connect(ID_BUTTON_BKG_UP, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CustomModelDialog::OnBtnBkgUp);
 	Connect(ID_BUTTON_BKG_DOWN, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CustomModelDialog::OnBtnBkgDown);
+	Connect(ID_BUTTON_BKG_RESET, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CustomModelDialog::OnBtnBkgReset);
 	//*)
 
     UpdateBkgOffsetVisibility();
@@ -1123,7 +1134,8 @@ void CustomModelDialog::UpdateBackground()
 
 void CustomModelDialog::UpdateBkgOffsetLabel()
 {
-    StaticTextBkgOffset->SetLabel(wxString::Format("Horiz: %.2f  Vert: %.2f", _bkg_offset_x, _bkg_offset_y));
+    StaticTextBkgOffset->SetLabel(wxString::Format(_("Horiz: %.2f"), _bkg_offset_x));
+    StaticTextBkgVert->SetLabel(wxString::Format(_("Vert:  %.2f"), _bkg_offset_y));
 }
 
 void CustomModelDialog::UpdateBkgOffsetVisibility()
@@ -1135,36 +1147,30 @@ void CustomModelDialog::UpdateBkgOffsetVisibility()
     BtnBkgDown->Show(show);
     BtnBkgRight->Show(show);
     StaticTextBkgOffset->Show(show);
+    StaticTextBkgVert->Show(show);
+    BtnBkgReset->Show(show);
     Layout();
 }
 
-void CustomModelDialog::OnBtnBkgLeft(wxCommandEvent& event)
+void CustomModelDialog::ApplyBkgOffsetDelta(float dx, float dy)
 {
-    _bkg_offset_x -= 0.25f;
+    // Offsets are intentionally transient — not saved with the model
+    _bkg_offset_x += dx;
+    _bkg_offset_y += dy;
     UpdateBkgOffsetLabel();
     UpdateBackground();
     GetActiveGrid()->Refresh();
 }
 
-void CustomModelDialog::OnBtnBkgRight(wxCommandEvent& event)
-{
-    _bkg_offset_x += 0.25f;
-    UpdateBkgOffsetLabel();
-    UpdateBackground();
-    GetActiveGrid()->Refresh();
-}
+void CustomModelDialog::OnBtnBkgLeft(wxCommandEvent& event)  { ApplyBkgOffsetDelta(-kBkgOffsetStep, 0.0f); }
+void CustomModelDialog::OnBtnBkgRight(wxCommandEvent& event) { ApplyBkgOffsetDelta( kBkgOffsetStep, 0.0f); }
+void CustomModelDialog::OnBtnBkgUp(wxCommandEvent& event)    { ApplyBkgOffsetDelta(0.0f, -kBkgOffsetStep); }
+void CustomModelDialog::OnBtnBkgDown(wxCommandEvent& event)  { ApplyBkgOffsetDelta(0.0f,  kBkgOffsetStep); }
 
-void CustomModelDialog::OnBtnBkgUp(wxCommandEvent& event)
+void CustomModelDialog::OnBtnBkgReset(wxCommandEvent& event)
 {
-    _bkg_offset_y -= 0.25f;
-    UpdateBkgOffsetLabel();
-    UpdateBackground();
-    GetActiveGrid()->Refresh();
-}
-
-void CustomModelDialog::OnBtnBkgDown(wxCommandEvent& event)
-{
-    _bkg_offset_y += 0.25f;
+    _bkg_offset_x = 0.0f;
+    _bkg_offset_y = 0.0f;
     UpdateBkgOffsetLabel();
     UpdateBackground();
     GetActiveGrid()->Refresh();

--- a/src-ui-wx/model/CustomModelDialog.cpp
+++ b/src-ui-wx/model/CustomModelDialog.cpp
@@ -71,6 +71,10 @@ const long CustomModelDialog::ID_BUTTON_CustomModelZoomOut = wxNewId();
 const long CustomModelDialog::ID_FILEPICKERCTRL1 = wxNewId();
 const long CustomModelDialog::ID_SLIDER_CUSTOM_LIGHTNESS = wxNewId();
 const long CustomModelDialog::ID_BITMAPBUTTON_CUSTOM_BKGRD = wxNewId();
+const long CustomModelDialog::ID_BUTTON_BKG_LEFT = wxNewId();
+const long CustomModelDialog::ID_BUTTON_BKG_RIGHT = wxNewId();
+const long CustomModelDialog::ID_BUTTON_BKG_UP = wxNewId();
+const long CustomModelDialog::ID_BUTTON_BKG_DOWN = wxNewId();
 const long CustomModelDialog::ID_CHECKBOX_AUTO_NUMBER = wxNewId();
 const long CustomModelDialog::ID_CHECKBOX_AUTO_INCREMENT = wxNewId();
 const long CustomModelDialog::ID_SPINCTRL_NEXT_CHANNEL = wxNewId();
@@ -443,6 +447,26 @@ CustomModelDialog::CustomModelDialog(wxWindow* parent, OutputManager* om) :
 	BitmapButtonCustomBkgrd->SetDefault();
 	BitmapButtonCustomBkgrd->SetMinSize(wxSize(24,-1));
 	FlexGridSizer1->Add(BitmapButtonCustomBkgrd, 1, wxTOP|wxBOTTOM|wxRIGHT, 5);
+	StaticTextBkgLabel = new wxStaticText(this, wxID_ANY, _T("Image offset (cells):"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+	FlexGridSizer1->Add(StaticTextBkgLabel, 0, wxLEFT|wxTOP, 5);
+	FlexGridSizer1->Add(-1,-1,1, wxALL, 5);
+	wxBoxSizer* BkgOffsetSizer = new wxBoxSizer(wxHORIZONTAL);
+	BtnBkgLeft = new wxButton(this, ID_BUTTON_BKG_LEFT, _T("←"), wxDefaultPosition, wxSize(28,-1), 0, wxDefaultValidator, _T("ID_BUTTON_BKG_LEFT"));
+	BtnBkgLeft->SetToolTip(_("Move image left"));
+	BkgOffsetSizer->Add(BtnBkgLeft, 0, wxRIGHT, 2);
+	BtnBkgUp = new wxButton(this, ID_BUTTON_BKG_UP, _T("↑"), wxDefaultPosition, wxSize(28,-1), 0, wxDefaultValidator, _T("ID_BUTTON_BKG_UP"));
+	BtnBkgUp->SetToolTip(_("Move image up"));
+	BkgOffsetSizer->Add(BtnBkgUp, 0, wxRIGHT, 2);
+	BtnBkgDown = new wxButton(this, ID_BUTTON_BKG_DOWN, _T("↓"), wxDefaultPosition, wxSize(28,-1), 0, wxDefaultValidator, _T("ID_BUTTON_BKG_DOWN"));
+	BtnBkgDown->SetToolTip(_("Move image down"));
+	BkgOffsetSizer->Add(BtnBkgDown, 0, wxRIGHT, 2);
+	BtnBkgRight = new wxButton(this, ID_BUTTON_BKG_RIGHT, _T("→"), wxDefaultPosition, wxSize(28,-1), 0, wxDefaultValidator, _T("ID_BUTTON_BKG_RIGHT"));
+	BtnBkgRight->SetToolTip(_("Move image right"));
+	BkgOffsetSizer->Add(BtnBkgRight, 0, wxRIGHT, 5);
+	StaticTextBkgOffset = new wxStaticText(this, wxID_ANY, _T("Horiz: 0.00  Vert: 0.00"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
+	BkgOffsetSizer->Add(StaticTextBkgOffset, 0, wxALIGN_CENTER_VERTICAL, 0);
+	FlexGridSizer1->Add(BkgOffsetSizer, 0, wxBOTTOM|wxLEFT, 5);
+	FlexGridSizer1->Add(-1,-1,1, wxALL, 5);
 	StaticBoxSizer2->Add(FlexGridSizer1, 1, wxEXPAND, 5);
 	Sizer2->Add(StaticBoxSizer2, 1, wxEXPAND, 5);
 	StaticBoxSizer1 = new wxStaticBoxSizer(wxVERTICAL, this, _("Auto Numbering"));
@@ -522,7 +546,13 @@ CustomModelDialog::CustomModelDialog(wxWindow* parent, OutputManager* om) :
 	Connect(ID_BUTTON1, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CustomModelDialog::OnButtonOkClick);
 	Connect(ID_BUTTON2, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CustomModelDialog::OnButtonCancelClick);
 	Connect(ID_NOTEBOOK1, wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED, (wxObjectEventFunction)&CustomModelDialog::OnNotebook1PageChanged);
+	Connect(ID_BUTTON_BKG_LEFT, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CustomModelDialog::OnBtnBkgLeft);
+	Connect(ID_BUTTON_BKG_RIGHT, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CustomModelDialog::OnBtnBkgRight);
+	Connect(ID_BUTTON_BKG_UP, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CustomModelDialog::OnBtnBkgUp);
+	Connect(ID_BUTTON_BKG_DOWN, wxEVT_COMMAND_BUTTON_CLICKED, (wxObjectEventFunction)&CustomModelDialog::OnBtnBkgDown);
 	//*)
+
+    UpdateBkgOffsetVisibility();
 
     name = "";
 
@@ -699,6 +729,7 @@ void CustomModelDialog::Setup(CustomModel* m)
     //}
     UpdatePreview();
     ValidateWindow();
+    UpdateBkgOffsetVisibility();
 }
 
 // make grid the size specified by the spin controls
@@ -1084,10 +1115,59 @@ void CustomModelDialog::UpdateBackground()
     {
         if (*r != nullptr)
         {
-            (*r)->UpdateSize(*grid, bkgrd_active, lightness);
+            (*r)->UpdateSize(*grid, bkgrd_active, lightness, _bkg_offset_x, _bkg_offset_y);
         }
         ++r;
     }
+}
+
+void CustomModelDialog::UpdateBkgOffsetLabel()
+{
+    StaticTextBkgOffset->SetLabel(wxString::Format("Horiz: %.2f  Vert: %.2f", _bkg_offset_x, _bkg_offset_y));
+}
+
+void CustomModelDialog::UpdateBkgOffsetVisibility()
+{
+    bool show = (bkg_image != nullptr);
+    StaticTextBkgLabel->Show(show);
+    BtnBkgLeft->Show(show);
+    BtnBkgUp->Show(show);
+    BtnBkgDown->Show(show);
+    BtnBkgRight->Show(show);
+    StaticTextBkgOffset->Show(show);
+    Layout();
+}
+
+void CustomModelDialog::OnBtnBkgLeft(wxCommandEvent& event)
+{
+    _bkg_offset_x -= 0.25f;
+    UpdateBkgOffsetLabel();
+    UpdateBackground();
+    GetActiveGrid()->Refresh();
+}
+
+void CustomModelDialog::OnBtnBkgRight(wxCommandEvent& event)
+{
+    _bkg_offset_x += 0.25f;
+    UpdateBkgOffsetLabel();
+    UpdateBackground();
+    GetActiveGrid()->Refresh();
+}
+
+void CustomModelDialog::OnBtnBkgUp(wxCommandEvent& event)
+{
+    _bkg_offset_y -= 0.25f;
+    UpdateBkgOffsetLabel();
+    UpdateBackground();
+    GetActiveGrid()->Refresh();
+}
+
+void CustomModelDialog::OnBtnBkgDown(wxCommandEvent& event)
+{
+    _bkg_offset_y += 0.25f;
+    UpdateBkgOffsetLabel();
+    UpdateBackground();
+    GetActiveGrid()->Refresh();
 }
 
 void CustomModelDialog::OnBitmapButtonCustomBkgrdClick(wxCommandEvent& event)
@@ -2707,6 +2787,7 @@ void CustomModelDialog::OnFilePickerCtrl1FileChanged(wxFileDirPickerEvent& event
         UpdateBackground();
         GetActiveGrid()->Refresh();
     }
+    UpdateBkgOffsetVisibility();
 }
 
 void CustomModelDialog::OnGridLabelRightClick(wxGridEvent& event)

--- a/src-ui-wx/model/CustomModelDialog.h
+++ b/src-ui-wx/model/CustomModelDialog.h
@@ -72,6 +72,8 @@ class CustomModelDialog: public wxDialog
     void UpdatePreview(int width, int height, int depth, const std::vector<std::vector<std::vector<int>>>& modelData);
     void UpdatePreview();
     void ValidateWindow();
+    void UpdateBkgOffsetLabel();
+    void UpdateBkgOffsetVisibility();
 	void CreateSubmodelFromLayer(int layer);
 	void CreateMinimalSubmodelFromLayer(int layer);
 	void CreateSubmodelFromColumn(int column);
@@ -141,6 +143,11 @@ class CustomModelDialog: public wxDialog
 		ImageFilePickerCtrl* FilePickerCtrl1;
 		wxBitmapButton* BitmapButtonCustomBkgrd;
 		wxBitmapButton* BitmapButtonCustomCopy;
+		wxButton* BtnBkgDown;
+		wxButton* BtnBkgLeft;
+		wxButton* BtnBkgRight;
+		wxButton* BtnBkgUp;
+		wxStaticText* StaticTextBkgOffset;
 		wxBitmapButton* BitmapButtonCustomCut;
 		wxBitmapButton* BitmapButtonCustomPaste;
 		wxButton* ButtonCancel;
@@ -195,6 +202,10 @@ class CustomModelDialog: public wxDialog
 		static const long ID_FILEPICKERCTRL1;
 		static const long ID_SLIDER_CUSTOM_LIGHTNESS;
 		static const long ID_BITMAPBUTTON_CUSTOM_BKGRD;
+		static const long ID_BUTTON_BKG_LEFT;
+		static const long ID_BUTTON_BKG_RIGHT;
+		static const long ID_BUTTON_BKG_UP;
+		static const long ID_BUTTON_BKG_DOWN;
 		static const long ID_CHECKBOX_AUTO_NUMBER;
 		static const long ID_CHECKBOX_AUTO_INCREMENT;
 		static const long ID_SPINCTRL_NEXT_CHANNEL;
@@ -211,6 +222,9 @@ class CustomModelDialog: public wxDialog
 		wxImage* bkg_image;
         bool bkgrd_active;
         int lightness;
+        float _bkg_offset_x = 0.0f;
+        float _bkg_offset_y = 0.0f;
+        wxStaticText* StaticTextBkgLabel = nullptr;
         bool autonumber = false;
         bool autoincrement = false;
         int next_channel = 1;
@@ -251,6 +265,10 @@ class CustomModelDialog: public wxDialog
 		void OnButton_ImportFromControllerClick(wxCommandEvent& event);
 		void OnCheckBox_Show_DuplicatesClick(wxCommandEvent& event);
 		void OnCheckBox_OutputToLightsClick(wxCommandEvent& event);
+		void OnBtnBkgLeft(wxCommandEvent& event);
+		void OnBtnBkgRight(wxCommandEvent& event);
+		void OnBtnBkgUp(wxCommandEvent& event);
+		void OnBtnBkgDown(wxCommandEvent& event);
 		//*)
 
 	    void OnTimer1Trigger(wxTimerEvent& event);

--- a/src-ui-wx/model/CustomModelDialog.h
+++ b/src-ui-wx/model/CustomModelDialog.h
@@ -74,6 +74,7 @@ class CustomModelDialog: public wxDialog
     void ValidateWindow();
     void UpdateBkgOffsetLabel();
     void UpdateBkgOffsetVisibility();
+    void ApplyBkgOffsetDelta(float dx, float dy);
 	void CreateSubmodelFromLayer(int layer);
 	void CreateMinimalSubmodelFromLayer(int layer);
 	void CreateSubmodelFromColumn(int column);
@@ -145,9 +146,11 @@ class CustomModelDialog: public wxDialog
 		wxBitmapButton* BitmapButtonCustomCopy;
 		wxButton* BtnBkgDown;
 		wxButton* BtnBkgLeft;
+		wxButton* BtnBkgReset;
 		wxButton* BtnBkgRight;
 		wxButton* BtnBkgUp;
 		wxStaticText* StaticTextBkgOffset;
+		wxStaticText* StaticTextBkgVert;
 		wxBitmapButton* BitmapButtonCustomCut;
 		wxBitmapButton* BitmapButtonCustomPaste;
 		wxButton* ButtonCancel;
@@ -206,6 +209,7 @@ class CustomModelDialog: public wxDialog
 		static const long ID_BUTTON_BKG_RIGHT;
 		static const long ID_BUTTON_BKG_UP;
 		static const long ID_BUTTON_BKG_DOWN;
+		static const long ID_BUTTON_BKG_RESET;
 		static const long ID_CHECKBOX_AUTO_NUMBER;
 		static const long ID_CHECKBOX_AUTO_INCREMENT;
 		static const long ID_SPINCTRL_NEXT_CHANNEL;
@@ -219,7 +223,7 @@ class CustomModelDialog: public wxDialog
 		//*)
 
 		std::string background_image;
-		wxImage* bkg_image;
+		wxImage* bkg_image = nullptr;
         bool bkgrd_active;
         int lightness;
         float _bkg_offset_x = 0.0f;
@@ -269,6 +273,7 @@ class CustomModelDialog: public wxDialog
 		void OnBtnBkgRight(wxCommandEvent& event);
 		void OnBtnBkgUp(wxCommandEvent& event);
 		void OnBtnBkgDown(wxCommandEvent& event);
+		void OnBtnBkgReset(wxCommandEvent& event);
 		//*)
 
 	    void OnTimer1Trigger(wxTimerEvent& event);

--- a/src-ui-wx/shared/utils/wxModelGridCellRenderer.cpp
+++ b/src-ui-wx/shared/utils/wxModelGridCellRenderer.cpp
@@ -46,10 +46,12 @@ void wxModelGridCellRenderer::Draw(wxGrid &grid, wxGridCellAttr &attr, wxDC &dc,
     grid.DrawTextRectangle(dc, grid.GetCellValue(row, col), rect,  wxALIGN_CENTRE,  wxALIGN_CENTRE);
 }
 
-void wxModelGridCellRenderer::UpdateSize(wxGrid& grid, bool draw_picture_, int lightness_)
+void wxModelGridCellRenderer::UpdateSize(wxGrid& grid, bool draw_picture_, int lightness_, float offset_x_, float offset_y_)
 {
     draw_picture = draw_picture_;
     lightness = lightness_;
+    offset_x = offset_x_;
+    offset_y = offset_y_;
     DetermineGridSize(grid);
     CreateImage();
 }
@@ -81,7 +83,9 @@ void wxModelGridCellRenderer::CreateImage()
                 bmpDC.SetBackground(b);
                 bmpDC.SetPen(p);
                 bmpDC.DrawRectangle(0, 0, width, height);
-                bmpDC.DrawBitmap(bmp, 0, 0);
+                int ox = (int)(offset_x * cell_w);
+                int oy = (int)(offset_y * cell_h);
+                bmpDC.DrawBitmap(bmp, ox, oy);
             } else {
                 bmpDC.SelectObjectAsSource(wxNullBitmap);
             }
@@ -98,12 +102,14 @@ void wxModelGridCellRenderer::SetImage(wxImage* image_)
 void wxModelGridCellRenderer::DetermineGridSize(wxGrid& grid)
 {
     wxFont font = grid.GetDefaultCellFont();
+    cell_w = 2 * font.GetPixelSize().y;
+    cell_h = int(1.5f * (float)font.GetPixelSize().y);
     width = 0;
     height = 0;
     for (int c = 0; c < grid.GetNumberCols(); ++c) {
-        width += 2 * font.GetPixelSize().y;
+        width += cell_w;
     }
     for (int r = 0; r < grid.GetNumberRows(); ++r) {
-        height += int(1.5 * (float)font.GetPixelSize().y);
+        height += cell_h;
     }
 }

--- a/src-ui-wx/shared/utils/wxModelGridCellRenderer.h
+++ b/src-ui-wx/shared/utils/wxModelGridCellRenderer.h
@@ -23,7 +23,7 @@ public:
 
     virtual void Draw(wxGrid &grid, wxGridCellAttr &attr, wxDC &dc, const wxRect &rect, int row, int col, bool isSelected) wxOVERRIDE;
 
-    void UpdateSize(wxGrid& grid, bool draw_picture_, int lightness_);
+    void UpdateSize(wxGrid& grid, bool draw_picture_, int lightness_, float offset_x_ = 0.0f, float offset_y_ = 0.0f);
     void CreateImage();
     void SetImage(wxImage* image);
     void DetermineGridSize(wxGrid& grid);
@@ -34,6 +34,10 @@ private:
     wxMemoryDC bmpDC;
     int width;
     int height;
+    int cell_w = 1;
+    int cell_h = 1;
     bool draw_picture;
     int lightness;
+    float offset_x = 0.0f;
+    float offset_y = 0.0f;
 };

--- a/src-ui-wx/wxsmith/CustomModelDialog.wxs
+++ b/src-ui-wx/wxsmith/CustomModelDialog.wxs
@@ -228,6 +228,77 @@
 										<border>5</border>
 										<option>1</option>
 									</object>
+									<object class="sizeritem">
+										<object class="wxStaticText" name="wxID_ANY" variable="StaticTextBkgLabel" member="no">
+											<label>Image offset (cells):</label>
+										</object>
+										<flag>wxLEFT|wxTOP</flag>
+										<border>5</border>
+									</object>
+									<object class="spacer">
+										<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
+									<object class="sizeritem">
+										<object class="wxBoxSizer" variable="BkgOffsetSizer" member="no">
+											<orient>wxHORIZONTAL</orient>
+											<object class="sizeritem">
+												<object class="wxButton" name="ID_BUTTON_BKG_LEFT" variable="BtnBkgLeft" member="yes">
+													<label>←</label>
+													<tooltip>Move image left</tooltip>
+													<minsize>28,-1</minsize>
+													<handler function="OnBtnBkgLeft" entry="EVT_BUTTON" />
+												</object>
+												<flag>wxRIGHT</flag>
+												<border>2</border>
+											</object>
+											<object class="sizeritem">
+												<object class="wxButton" name="ID_BUTTON_BKG_UP" variable="BtnBkgUp" member="yes">
+													<label>↑</label>
+													<tooltip>Move image up</tooltip>
+													<minsize>28,-1</minsize>
+													<handler function="OnBtnBkgUp" entry="EVT_BUTTON" />
+												</object>
+												<flag>wxRIGHT</flag>
+												<border>2</border>
+											</object>
+											<object class="sizeritem">
+												<object class="wxButton" name="ID_BUTTON_BKG_DOWN" variable="BtnBkgDown" member="yes">
+													<label>↓</label>
+													<tooltip>Move image down</tooltip>
+													<minsize>28,-1</minsize>
+													<handler function="OnBtnBkgDown" entry="EVT_BUTTON" />
+												</object>
+												<flag>wxRIGHT</flag>
+												<border>2</border>
+											</object>
+											<object class="sizeritem">
+												<object class="wxButton" name="ID_BUTTON_BKG_RIGHT" variable="BtnBkgRight" member="yes">
+													<label>→</label>
+													<tooltip>Move image right</tooltip>
+													<minsize>28,-1</minsize>
+													<handler function="OnBtnBkgRight" entry="EVT_BUTTON" />
+												</object>
+												<flag>wxRIGHT</flag>
+												<border>5</border>
+											</object>
+											<object class="sizeritem">
+												<object class="wxStaticText" name="wxID_ANY" variable="StaticTextBkgOffset" member="yes">
+													<label>Horiz: 0.00  Vert: 0.00</label>
+												</object>
+												<flag>wxALIGN_CENTER_VERTICAL</flag>
+												<border>0</border>
+											</object>
+										</object>
+										<flag>wxBOTTOM|wxLEFT</flag>
+										<border>5</border>
+									</object>
+									<object class="spacer">
+										<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+										<border>5</border>
+										<option>1</option>
+									</object>
 								</object>
 								<flag>wxEXPAND</flag>
 								<border>5</border>

--- a/src-ui-wx/wxsmith/CustomModelDialog.wxs
+++ b/src-ui-wx/wxsmith/CustomModelDialog.wxs
@@ -284,8 +284,31 @@
 												<border>5</border>
 											</object>
 											<object class="sizeritem">
-												<object class="wxStaticText" name="wxID_ANY" variable="StaticTextBkgOffset" member="yes">
-													<label>Horiz: 0.00  Vert: 0.00</label>
+												<object class="wxBoxSizer" variable="OffsetDisplaySizer" member="no">
+													<orient>wxVERTICAL</orient>
+													<object class="sizeritem">
+														<object class="wxStaticText" name="wxID_ANY" variable="StaticTextBkgOffset" member="yes">
+															<label>Horiz: 0.00</label>
+														</object>
+														<flag>0</flag>
+														<border>0</border>
+													</object>
+													<object class="sizeritem">
+														<object class="wxStaticText" name="wxID_ANY" variable="StaticTextBkgVert" member="yes">
+															<label>Vert:  0.00</label>
+														</object>
+														<flag>0</flag>
+														<border>0</border>
+													</object>
+												</object>
+												<flag>wxALIGN_CENTER_VERTICAL|wxRIGHT</flag>
+												<border>5</border>
+											</object>
+											<object class="sizeritem">
+												<object class="wxButton" name="ID_BUTTON_BKG_RESET" variable="BtnBkgReset" member="yes">
+													<label>Reset</label>
+													<tooltip>Reset image offset to zero</tooltip>
+													<handler function="OnBtnBkgReset" entry="EVT_BUTTON" />
 												</object>
 												<flag>wxALIGN_CENTER_VERTICAL</flag>
 												<border>0</border>


### PR DESCRIPTION
Once a background image is loaded, you can move it by 0.5 cells using the arrows:
<img width="326" height="162" alt="image" src="https://github.com/user-attachments/assets/5478e397-d21e-4842-9b93-ab491c44ba48" />
