### PR TITLE
Add option to sort submodel by name

### DIFF
--- a/src-ui-wx/import_export/xLightsImportChannelMapDialog.cpp
+++ b/src-ui-wx/import_export/xLightsImportChannelMapDialog.cpp
@@ -3947,9 +3947,8 @@ wxBitmap xLightsImportChannelMapDialog::GenerateTimelineBitmap(int width, int he
     dc.SetBackground(wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX)));
     dc.Clear();
     if (durationMS > 0 && !intervals.empty()) {
-        wxBrush hatchBrush(wxColour(70, 130, 180), wxBRUSHSTYLE_CROSSDIAG_HATCH);
         dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.SetBrush(hatchBrush);
+        dc.SetBrush(wxBrush(wxColour(70, 130, 180), wxBRUSHSTYLE_SOLID));
         for (const auto& [start, end] : intervals) {
             int x1 = static_cast<int>(static_cast<double>(start) / durationMS * width);
             int x2 = static_cast<int>(static_cast<double>(end) / durationMS * width);

--- a/src-ui-wx/import_export/xLightsImportChannelMapDialog.cpp
+++ b/src-ui-wx/import_export/xLightsImportChannelMapDialog.cpp
@@ -242,7 +242,14 @@ int xLightsImportTreeModel::Compare(const wxDataViewItem& item1, const wxDataVie
             } else {
                 return NumberAwareStringCompareRev(node1->_node, node2->_node);
             }
-        } else if (node1->_strand != "" && node2->_strand != "") { // dont sort the submodels
+        } else if (node1->_strand != "" && node2->_strand != "") {
+            if (_sortSubmodelsByName) {
+                if (ascending) {
+                    return NumberAwareStringCompare(node1->_strand, node2->_strand);
+                } else {
+                    return NumberAwareStringCompareRev(node1->_strand, node2->_strand);
+                }
+            }
             int idx1 = findChildIndex(node1->GetParent(), node1->_strand);
             int idx2 = findChildIndex(node2->GetParent(), node2->_strand);
             return idx1 - idx2;
@@ -519,6 +526,7 @@ const wxWindowID xLightsImportChannelMapDialog::ID_MNU_CLEARSELECTED = wxNewId()
 const wxWindowID xLightsImportChannelMapDialog::ID_MNU_CLEARALL = wxNewId();
 const long xLightsImportChannelMapDialog::ID_MNU_AUTOMAPSELECTED = wxNewId();
 const wxWindowID xLightsImportChannelMapDialog::ID_MNU_ADD_EMPTY_GROUP = wxNewId();
+const long xLightsImportChannelMapDialog::ID_MNU_SORT_SUBMODELS_BY_NAME = wxNewId();
 
 
 BEGIN_EVENT_TABLE(xLightsImportChannelMapDialog,wxDialog)
@@ -748,6 +756,12 @@ void xLightsImportChannelMapDialog::RightClickModels(wxDataViewEvent& event)
         mnuLayer.Append(ID_MNU_SHOWALLMAPPED, "Show All Mapped Models");
         mnuLayer.Append(ID_MNU_AUTOMAPSELECTED, "Auto Map Selected");
         mnuLayer.AppendSeparator();
+        if (_dataModel->_sortSubmodelsByName) {
+            mnuLayer.Append(ID_MNU_SORT_SUBMODELS_BY_NAME, "Reset Submodel Sort");
+        } else {
+            mnuLayer.Append(ID_MNU_SORT_SUBMODELS_BY_NAME, "Sort Submodels By Name");
+        }
+        mnuLayer.AppendSeparator();
         mnuLayer.Append(ID_MNU_CLEARALL, "Clear All");
         mnuLayer.Append(ID_MNU_CLEARSELECTED, "Clear Selected");
         mnuLayer.AppendSeparator();
@@ -781,6 +795,9 @@ void xLightsImportChannelMapDialog::OnPopupModels(wxCommandEvent& event)
         ClearAll();
     } else if (id == ID_MNU_ADD_EMPTY_GROUP) {
         AddEmptyGroup();
+    } else if (id == ID_MNU_SORT_SUBMODELS_BY_NAME) {
+        _dataModel->_sortSubmodelsByName = !_dataModel->_sortSubmodelsByName;
+        _dataModel->Resort();
     }
 }
 

--- a/src-ui-wx/import_export/xLightsImportChannelMapDialog.cpp
+++ b/src-ui-wx/import_export/xLightsImportChannelMapDialog.cpp
@@ -526,7 +526,7 @@ const wxWindowID xLightsImportChannelMapDialog::ID_MNU_CLEARSELECTED = wxNewId()
 const wxWindowID xLightsImportChannelMapDialog::ID_MNU_CLEARALL = wxNewId();
 const long xLightsImportChannelMapDialog::ID_MNU_AUTOMAPSELECTED = wxNewId();
 const wxWindowID xLightsImportChannelMapDialog::ID_MNU_ADD_EMPTY_GROUP = wxNewId();
-const long xLightsImportChannelMapDialog::ID_MNU_SORT_SUBMODELS_BY_NAME = wxNewId();
+const wxWindowID xLightsImportChannelMapDialog::ID_MNU_SORT_SUBMODELS_BY_NAME = wxNewId();
 
 
 BEGIN_EVENT_TABLE(xLightsImportChannelMapDialog,wxDialog)
@@ -756,7 +756,7 @@ void xLightsImportChannelMapDialog::RightClickModels(wxDataViewEvent& event)
         mnuLayer.Append(ID_MNU_SHOWALLMAPPED, "Show All Mapped Models");
         mnuLayer.Append(ID_MNU_AUTOMAPSELECTED, "Auto Map Selected");
         mnuLayer.AppendSeparator();
-        if (_dataModel->_sortSubmodelsByName) {
+        if (_dataModel->GetSortSubmodelsByName()) {
             mnuLayer.Append(ID_MNU_SORT_SUBMODELS_BY_NAME, "Reset Submodel Sort");
         } else {
             mnuLayer.Append(ID_MNU_SORT_SUBMODELS_BY_NAME, "Sort Submodels By Name");
@@ -796,8 +796,7 @@ void xLightsImportChannelMapDialog::OnPopupModels(wxCommandEvent& event)
     } else if (id == ID_MNU_ADD_EMPTY_GROUP) {
         AddEmptyGroup();
     } else if (id == ID_MNU_SORT_SUBMODELS_BY_NAME) {
-        _dataModel->_sortSubmodelsByName = !_dataModel->_sortSubmodelsByName;
-        _dataModel->Resort();
+        _dataModel->SetSortSubmodelsByName(!_dataModel->GetSortSubmodelsByName());
     }
 }
 

--- a/src-ui-wx/import_export/xLightsImportChannelMapDialog.h
+++ b/src-ui-wx/import_export/xLightsImportChannelMapDialog.h
@@ -396,6 +396,8 @@ public:
     bool _hideUnmapped = false;
     void SetHideUnmapped(bool h) { _hideUnmapped = h; }
 
+    bool _sortSubmodelsByName = false;
+
     void SetCtrl(wxDataViewCtrl* ctrl) { _ctrl = ctrl; }
 
 private:
@@ -618,6 +620,7 @@ protected:
         static const wxWindowID ID_MNU_CLEARALL;
         static const long ID_MNU_AUTOMAPSELECTED_AVAIL;
         static const wxWindowID ID_MNU_ADD_EMPTY_GROUP;
+        static const long ID_MNU_SORT_SUBMODELS_BY_NAME;
 
 	private:
         wxString FindTab(wxString &line);

--- a/src-ui-wx/import_export/xLightsImportChannelMapDialog.h
+++ b/src-ui-wx/import_export/xLightsImportChannelMapDialog.h
@@ -396,7 +396,8 @@ public:
     bool _hideUnmapped = false;
     void SetHideUnmapped(bool h) { _hideUnmapped = h; }
 
-    bool _sortSubmodelsByName = false;
+    bool GetSortSubmodelsByName() const { return _sortSubmodelsByName; }
+    void SetSortSubmodelsByName(bool sort) { _sortSubmodelsByName = sort; Resort(); }
 
     void SetCtrl(wxDataViewCtrl* ctrl) { _ctrl = ctrl; }
 
@@ -404,6 +405,7 @@ private:
     xLightsImportModelNodePtrArray   m_children;
     wxDataViewItemArray _pendingAdditions;
     wxDataViewCtrl* _ctrl = nullptr;
+    bool _sortSubmodelsByName = false;
 };
 
 class StashedMapping
@@ -620,7 +622,7 @@ protected:
         static const wxWindowID ID_MNU_CLEARALL;
         static const long ID_MNU_AUTOMAPSELECTED_AVAIL;
         static const wxWindowID ID_MNU_ADD_EMPTY_GROUP;
-        static const long ID_MNU_SORT_SUBMODELS_BY_NAME;
+        static const wxWindowID ID_MNU_SORT_SUBMODELS_BY_NAME;
 
 	private:
         wxString FindTab(wxString &line);


### PR DESCRIPTION
#4636 Right-click option to sort submodels by name. When the option is selected, the right-click changes to Reset Submodel sort.