### PR TITLE
Restore moving a model with the arrow keys

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -7504,7 +7504,6 @@ void LayoutPanel::SelectModelInTree(Model* modelToSelect, bool preserveFilter) {
 
                 PlatformHandleSelectionChanged();
                 TreeListViewModels->EnsureVisible(item);
-                TreeListViewModels->GetView()->SetFocus();
                 break;
             }
         }
@@ -11142,11 +11141,8 @@ bool LayoutPanel::HandleLayoutKeyBinding(wxKeyEvent& event) {
     if ((!event.ControlDown() && !event.CmdDown() && !event.AltDown()) ||
         (k == 'A' && (event.ControlDown() || event.CmdDown()) && !event.AltDown())) {
         // Let Control + A through
-        // Just a regular key ... If current focus is an input control then we need to not process this.
-        // Exclude the model tree view: it is not a text input, so layout bindings should still fire
-        // when a model was selected from the layout canvas (which programmatically moves focus there).
+        // Just a regular key ... If current focus is a control then we need to not process this
         if (dynamic_cast<wxControl*>(event.GetEventObject()) != nullptr &&
-            event.GetEventObject() != TreeListViewModels->GetView() &&
             (k < 128 || k == WXK_NUMPAD_END || k == WXK_NUMPAD_HOME || k == WXK_NUMPAD_INSERT || k == WXK_HOME || k == WXK_END || k == WXK_NUMPAD_SUBTRACT || k == WXK_NUMPAD_DECIMAL)) {
             return false;
         }


### PR DESCRIPTION
#6456 Backed out the change that caused the model not to be able to move in the layout using the arrow keys.