### PR TITLE
Fix model tree stealing focus after non-import model selections (#6461)

### DIFF
--- a/src-core/models/OutputModelManager.h
+++ b/src-core/models/OutputModelManager.h
@@ -59,6 +59,7 @@ public:
     static const uint32_t WORK_RELOAD_MODELLIST = 0x4000;
     static const uint32_t WORK_REDRAW_LAYOUTPREVIEW = 0x8000;
     static const uint32_t WORK_UPDATE_NETWORK_PROPERTIES = 0x10000;
+    static const uint32_t WORK_FOCUS_MODELTREE = 0x20000;
 
     // Composite work constants for common multi-flag patterns
 

--- a/src-ui-wx/app-shell/TabSetup.cpp
+++ b/src-ui-wx/app-shell/TabSetup.cpp
@@ -1146,7 +1146,8 @@ void xLightsFrame::DoWork(uint32_t work, const std::string& type, BaseObject* m,
         OutputModelManager::WORK_RELOAD_OBJECTLIST |
         OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW |
         OutputModelManager::WORK_RELOAD_PROPERTYGRID |
-        OutputModelManager::WORK_SAVE_NETWORKS
+        OutputModelManager::WORK_SAVE_NETWORKS |
+        OutputModelManager::WORK_FOCUS_MODELTREE
     );
     if (work & OutputModelManager::WORK_NETWORK_CHANNELSCHANGE) {
         logger_work->debug("    WORK_NETWORK_CHANNELSCHANGE.");
@@ -1358,7 +1359,9 @@ void xLightsFrame::DoWork(uint32_t work, const std::string& type, BaseObject* m,
         logger_work->debug("    Selecting model '{}'.", (const char*)selectedModel.c_str());
         //SelectModel(selectModel);
         layoutPanel->SelectBaseObject(selectedModel);
-        layoutPanel->FocusModelTree();
+        if (work & OutputModelManager::WORK_FOCUS_MODELTREE) {
+            layoutPanel->FocusModelTree();
+        }
     }
     if (work & OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW) {
         logger_work->debug("    WORK_REDRAW_LAYOUTPREVIEW.");

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -10064,7 +10064,8 @@ void LayoutPanel::ImportModelsFromRGBEffects()
         }
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE |
                                                       OutputModelManager::WORK_RELOAD_ALLMODELS |
-                                                      OutputModelManager::WORK_RELOAD_MODELLIST, "LayoutPanel::ImportModelsFromRGBEffects",
+                                                      OutputModelManager::WORK_RELOAD_MODELLIST |
+                                                      OutputModelManager::WORK_FOCUS_MODELTREE, "LayoutPanel::ImportModelsFromRGBEffects",
                                                       nullptr, nullptr, firstImported);
     }
 }


### PR DESCRIPTION
Side effect of a prior change where it was setting focus on the models after a model import. This change narrows down the model selection to only that scenario.