### PR TITLE
Crashes from the logs

### DIFF
--- a/src-core/utils/VectorMath.cpp
+++ b/src-core/utils/VectorMath.cpp
@@ -349,8 +349,9 @@ glm::mat4 VectorMath::rotMatrixFromXAxisToVector(const glm::vec3 &vector)
 
 glm::mat4 VectorMath::rotationMatrixFromXAxisToVector(const glm::vec3 &a)
 {
-    glm::vec3 v = glm::vec3(0, -a.z, a.y);
     float len = glm::length(a);
+    if (len == 0.0f) return glm::mat4(1.0f);
+    glm::vec3 v = glm::vec3(0, -a.z, a.y);
     float ax = a.x / len;
     float angle = acos(ax);
     if (ax > 0.9999f || angle == 0.0f) {

--- a/src-ui-wx/graphics/opengl/xlOGL3GraphicsContext.cpp
+++ b/src-ui-wx/graphics/opengl/xlOGL3GraphicsContext.cpp
@@ -364,6 +364,8 @@ ShaderProgram normal3Program;
 ShaderProgram meshSolidProgram;
 ShaderProgram meshTextureProgram;
 
+static bool s_shadersInitialized = false;
+
 bool xlOGL3GraphicsContext::InitializeSharedContext() {
 
     bool valid = true;
@@ -701,6 +703,7 @@ bool xlOGL3GraphicsContext::InitializeSharedContext() {
                               );
     }
 
+    s_shadersInitialized = valid;
     return valid;
 }
 
@@ -1261,6 +1264,7 @@ xlGraphicsContext* xlOGL3GraphicsContext::drawPoints(xlVertexAccumulator *vac, c
     return this;
 }
 xlGraphicsContext* xlOGL3GraphicsContext::drawPrimitive(int type, xlVertexAccumulator *vac, const xlColor &color, int start, int count) {
+    if (!s_shadersInitialized) return this;
     xlOGL3VertexAccumulator *v = dynamic_cast<xlOGL3VertexAccumulator*>(vac);
     if (!v || v->getCount() == 0) {
         return this;
@@ -1333,6 +1337,7 @@ xlGraphicsContext* xlOGL3GraphicsContext::drawPoints(xlVertexColorAccumulator *v
 }
 
 xlGraphicsContext* xlOGL3GraphicsContext::drawPrimitive(int type, xlVertexColorAccumulator *vac, int start, int count) {
+    if (!s_shadersInitialized) return this;
     if (vac->getCount() == 0) {
         return this;
     }
@@ -1497,6 +1502,7 @@ xlGraphicsContext* xlOGL3GraphicsContext::drawTexture(xlTexture *texture,
     return drawTexture(&va, texture, brightness, alpha, 0, 6);
 }
 xlGraphicsContext* xlOGL3GraphicsContext::drawTexture(xlVertexTextureAccumulator *vac, xlTexture *texture, int brightness, uint8_t alpha, int start, int count) {
+    if (!s_shadersInitialized) return this;
     xlOGL3VertexTextureAccumulator *va = dynamic_cast<xlOGL3VertexTextureAccumulator*>(vac);
     xlGLTexture *t = (xlGLTexture*)texture;
 
@@ -1878,6 +1884,7 @@ xlGraphicsContext* xlOGL3GraphicsContext::drawMeshTransparents(xlMesh *mesh, int
     return this;
 }
 void xlOGL3GraphicsContext::drawMesh(xlMesh *mesh, int brightness, bool useViewMatrix, bool transparents) {
+    if (!s_shadersInitialized) return;
     xlGLMesh *glm = (xlGLMesh*)mesh;
     if (glm->vbuffer == 0) {
         glm->LoadBuffers();

--- a/src-ui-wx/sequencer/Waveform.cpp
+++ b/src-ui-wx/sequencer/Waveform.cpp
@@ -1087,9 +1087,10 @@ void Waveform::render()
     }
     ctx->SetViewport(0, 0, mWindowWidth, mWindowHeight);
 
-    if (mCurrentWaveView >= 0) {
-		DrawWaveView(ctx, views[mCurrentWaveView]);
-	}
+    int waveView = mCurrentWaveView;
+    if (waveView >= 0 && waveView < (int)views.size()) {
+        DrawWaveView(ctx, views[waveView]);
+    }
 
     FinishDrawing(ctx);
 }


### PR DESCRIPTION
Fix crash on hardware with OpenGL 1.1 (GDI Generic) when shaders fail to initialise 
Fix crash in PolyLine model when two adjacent control points are coincident (zero-length segment) 
Fix crash in Waveform render when media is closed during a pending paint