### PR TITLE
Fix Falcon V3 controllers receiving DDP channel numbers beyond hardware maximum (#5584)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -28,6 +28,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                  including a model picker in the AI image generation dialog.
     -enh (scott)                 Auto-discover WLED controllers via mDNS (_wled._tcp); discovered devices
                                  are added as DDP with auto-size/auto-layout.
+    -bug (derwin12)              Fix Falcon V3 controllers receiving DDP channel numbers beyond hardware maximum (#5584)
     -bug (cybercop23)            Fix Sequencer Copy Layers/SubModels.
     -bug (derwin12)              Sketch effect: background image not displaying in Effect Assist. (#6476)
     -bug (derwin12)              Fix Text effect xlFont up/down scroll (#6460)

--- a/resources/controllers/falcon.xcontroller
+++ b/resources/controllers/falcon.xcontroller
@@ -58,6 +58,7 @@
         <SupportsSmartRemotes>3</SupportsSmartRemotes>
         <AllSmartRemoteTypesPerPortMustBeSame/>
         <MaxPixelPortChannels>3072</MaxPixelPortChannels>
+        <MaxDDPChannels>42000</MaxDDPChannels>
         <SupportsDefaultGamma/>
         <InputProtocols>
             <Protocol>e131</Protocol>

--- a/src-core/controllers/ControllerCaps.cpp
+++ b/src-core/controllers/ControllerCaps.cpp
@@ -592,6 +592,11 @@ int ControllerCaps::GetMaxSerialPortChannels() const {
     return (int)strtol(GetXmlNodeContent(_config, "MaxSerialPortChannels").c_str(), nullptr, 10);
 }
 
+int ControllerCaps::GetMaxDDPChannels() const {
+
+    return (int)strtol(GetXmlNodeContent(_config, "MaxDDPChannels", "0").c_str(), nullptr, 10);
+}
+
 int ControllerCaps::GetMaxInputUniverseChannels() const {
 
     return (int)strtol(GetXmlNodeContent(_config, "MaxInputUniverseChannels", "512").c_str(), nullptr, 10);

--- a/src-core/controllers/ControllerCaps.h
+++ b/src-core/controllers/ControllerCaps.h
@@ -110,6 +110,7 @@ public:
     int GetMaxLEDPanelMatrixPort() const;
     int GetMaxPixelPortChannels() const;
     int GetMaxSerialPortChannels() const;
+    int GetMaxDDPChannels() const;
     int GetMaxInputUniverseChannels() const;
     int GetMinInputUniverseChannels() const;
     int GetNumberOfBanks() const;

--- a/src-core/controllers/Falcon.cpp
+++ b/src-core/controllers/Falcon.cpp
@@ -2267,7 +2267,7 @@ Falcon::Falcon(const std::string& ip, const std::string& proxy) :
                 if (std::regex_search(_firmwareVersion, mm, majminregex)) {
                     _majorFirmwareVersion = (int)std::strtol(mm[1].str().c_str(), nullptr, 10);
                     _minorFirmwareVersion = (int)std::strtol(mm[2].str().c_str(), nullptr, 10);
-                    spdlog::error("    Parsed firmware version {}.{}.", _majorFirmwareVersion, _minorFirmwareVersion);
+                    spdlog::debug("    Parsed firmware version {}.{}.", _majorFirmwareVersion, _minorFirmwareVersion);
                 }
             }
         }
@@ -3163,12 +3163,19 @@ bool Falcon::SetOutputs(ModelManager* allmodels, OutputManager* outputManager, C
 
                 spdlog::info("Serial Port {} Protocol {} Start Channel {}.", sp, (const char*)port->GetProtocol().c_str(), sc);
 
+                const int maxDDPChannels = caps ? caps->GetMaxDDPChannels() : 0;
+                if (maxDDPChannels > 0 && sc >= maxDDPChannels) {
+                    check += fmt::format("ERROR: Serial port {} start channel {} exceeds the maximum DDP channel number {} supported by this controller. Consider changing the start channel or unchecking Keep Channel Numbers.\n",
+                                         sp, sc, maxDDPChannels - 1);
+                    success = false;
+                }
+
                 uri += "&";
                 uri += GetSerialOutputURI(caps, port->GetPort(), outputManager, DecodeSerialOutputProtocol(port->GetProtocol()), sc, ui);
             }
         }
 
-        if (sendSerial) {
+        if (sendSerial && success) {
             PutURL("/SerialOutputs.htm", uri);
         }
     } else {


### PR DESCRIPTION
The serial ports page in Falcon V3 is limited in how high a value you can enter. So warn and block if the channel is too high and you have a serial port configured.