### PR TITLE
Fix Song Structure regions hiding the timeline ruler / timing marks (#6500)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -23,6 +23,9 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                 a translucent overlay on timeline + effects grid, and per-region bulk actions —
                                 Copy Effects to Region, Apply Selected Effect Palette to Region, Fill Region from
                                 Timing Marks, Create Regions from Timing Marks, and Export Region(s) as new sequences.
+    -bug (charlie)              Song Structure Regions now render correctly in light mode and on Windows - the
+                                region band no longer paints opaque over the timeline timing marks, and region
+                                names/boundaries use contrasting colors per appearance (#6500)
     -enh (cybercop23)            KulpLights controllers with 2 serial ports now support independent protocols per port (#3926)
     -enh (alex)                  Radial effect wheel popup on empty sequencer grid double-click
     -enh (alex)                  Shift-drag effect edges in sequencer grid to adjust fade-in/fade-out times (#6492)

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -8832,6 +8832,8 @@ void EffectsGrid::DrawSongStructureOverlays(xlGraphicsContext* ctx) {
     }
 
     if (ssm.GetRegionCount() >= 2) {
+        // White boundary lines vanish against the light-mode grid background.
+        xlColor lineColor = IsDarkMode() ? xlColor(255, 255, 255, 40) : xlColor(0, 0, 0, 60);
         for (size_t i = 1; i < ssm.GetRegionCount(); i++) {
             int boundaryTimeMS = ssm.GetRegion(i).startTimeMS;
             int xPos = mTimeline->GetPositionFromTimeMS(boundaryTimeMS);
@@ -8839,7 +8841,6 @@ void EffectsGrid::DrawSongStructureOverlays(xlGraphicsContext* ctx) {
                 xlVertexAccumulator* va = ctx->createVertexAccumulator();
                 va->AddVertex(xPos, 0);
                 va->AddVertex(xPos, mWindowHeight);
-                xlColor lineColor(255, 255, 255, 40);
                 ctx->drawLines(va, lineColor);
                 delete va;
             }

--- a/src-ui-wx/sequencer/TimeLine.cpp
+++ b/src-ui-wx/sequencer/TimeLine.cpp
@@ -1283,6 +1283,10 @@ void TimeLine::render( wxDC& dc ) {
     if (!mIsInitialized)
         return;
 
+    // Region color bands are drawn first, as a background tint, so the ruler
+    // hash marks and time labels painted below remain visible on top of them.
+    DrawSongStructureBands(dc, w, h);
+
     wxFont f = dc.GetFont();
     f.SetPointSize(7.0);
     dc.SetFont(f);
@@ -1515,8 +1519,51 @@ void TimeLine::RecalcEndTime()
     mEndTimeMS = GetMaxViewableTimeMS();
 }
 
+wxColour TimeLine::GetSongStructureBandColor(const SongStructureRegion& region) const
+{
+    // wxDC ignores the alpha channel on some platforms (notably MSW/GDI), so a
+    // wxColour with alpha renders fully opaque. Manually blend the region color
+    // over the timeline background instead - this looks translucent on every
+    // platform and naturally adapts to light/dark mode (the background differs).
+    const wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE);
+    constexpr double bandAlpha = 50.0 / 255.0;
+    uint8_t r = (region.colorARGB >> 16) & 0xFF;
+    uint8_t g = (region.colorARGB >> 8) & 0xFF;
+    uint8_t b = region.colorARGB & 0xFF;
+    return wxColour((uint8_t)(r * bandAlpha + bg.Red() * (1.0 - bandAlpha)),
+                    (uint8_t)(g * bandAlpha + bg.Green() * (1.0 - bandAlpha)),
+                    (uint8_t)(b * bandAlpha + bg.Blue() * (1.0 - bandAlpha)));
+}
+
+void TimeLine::DrawSongStructureBands(wxDC& dc, int w, int h)
+{
+    // Drawn BEHIND the ruler hash marks/time labels (called before they are
+    // painted) so the timing stays visible - the band is just a background tint.
+    if (_sequenceElements == nullptr) return;
+    const SongStructureManager& ssm = _sequenceElements->GetSongStructureManager();
+    if (!ssm.HasRegions()) return;
+
+    for (size_t i = 0; i < ssm.GetRegionCount(); i++) {
+        const SongStructureRegion& region = ssm.GetRegion(i);
+
+        int x1 = GetPositionFromTimeMS(region.startTimeMS);
+        int x2 = GetPositionFromTimeMS(region.endTimeMS);
+
+        if (x2 < 0 || x1 > w) continue;
+        x1 = std::max(0, x1);
+        x2 = std::min(w, x2);
+
+        dc.SetPen(*wxTRANSPARENT_PEN);
+        dc.SetBrush(wxBrush(GetSongStructureBandColor(region)));
+        dc.DrawRectangle(x1, 0, x2 - x1, h);
+    }
+}
+
 void TimeLine::DrawSongStructureRegions(wxDC& dc, int w, int h)
 {
+    // Region name labels only - drawn on top of the ruler so both the name and
+    // the timing marks stay visible. The band tint is painted separately by
+    // DrawSongStructureBands() before the ruler.
     if (_sequenceElements == nullptr) return;
     const SongStructureManager& ssm = _sequenceElements->GetSongStructureManager();
     if (!ssm.HasRegions()) return;
@@ -1535,18 +1582,9 @@ void TimeLine::DrawSongStructureRegions(wxDC& dc, int w, int h)
         x1 = std::max(0, x1);
         x2 = std::min(w, x2);
 
-        uint8_t r = (region.colorARGB >> 16) & 0xFF;
-        uint8_t g = (region.colorARGB >> 8) & 0xFF;
-        uint8_t b = region.colorARGB & 0xFF;
-
-        // Draw transparent colored band spanning full height of timeline
-        wxColour bandColor(r, g, b, 50);
-        dc.SetPen(*wxTRANSPARENT_PEN);
-        dc.SetBrush(wxBrush(bandColor));
-        dc.DrawRectangle(x1, 0, x2 - x1, h);
-
-        // Draw region name centered
+        // Draw region name centered, contrasting against the (light or dark) band
         if (x2 - x1 > 30) {
+            wxColour bandColor = GetSongStructureBandColor(region);
             wxString name = region.name;
             wxSize textSize = dc.GetTextExtent(name);
             while (name.length() > 1 && textSize.GetWidth() > (x2 - x1 - 8)) {
@@ -1556,7 +1594,8 @@ void TimeLine::DrawSongStructureRegions(wxDC& dc, int w, int h)
             if (textSize.GetWidth() <= (x2 - x1 - 8)) {
                 int textX = x1 + ((x2 - x1) - textSize.GetWidth()) / 2;
                 int textY = (h - textSize.GetHeight()) / 2;
-                dc.SetTextForeground(wxColour(200, 200, 200));
+                double luminance = 0.299 * bandColor.Red() + 0.587 * bandColor.Green() + 0.114 * bandColor.Blue();
+                dc.SetTextForeground(luminance > 140.0 ? wxColour(40, 40, 40) : wxColour(220, 220, 220));
                 dc.DrawText(name, textX, textY);
             }
         }
@@ -1569,7 +1608,10 @@ void TimeLine::DrawSongStructureBoundaries(wxDC& dc, int w, int h)
     const SongStructureManager& ssm = _sequenceElements->GetSongStructureManager();
     if (ssm.GetRegionCount() < 2) return;
 
-    dc.SetPen(wxPen(wxColour(255, 255, 255, 120), 1));
+    // White is invisible against the light-mode timeline background; pick a
+    // contrasting boundary color per appearance.
+    const wxColour boundaryColor = IsDarkMode() ? wxColour(235, 235, 235) : wxColour(60, 60, 60);
+    dc.SetPen(wxPen(boundaryColor, 1));
     for (size_t i = 1; i < ssm.GetRegionCount(); i++) {
         int boundaryTimeMS = ssm.GetRegion(i).startTimeMS;
         int xPos = GetPositionFromTimeMS(boundaryTimeMS);
@@ -1582,7 +1624,7 @@ void TimeLine::DrawSongStructureBoundaries(wxDC& dc, int w, int h)
             diamond[1] = wxPoint(xPos + 3, cy);
             diamond[2] = wxPoint(xPos, cy + 4);
             diamond[3] = wxPoint(xPos - 3, cy);
-            dc.SetBrush(*wxWHITE_BRUSH);
+            dc.SetBrush(wxBrush(boundaryColor));
             dc.DrawPolygon(4, diamond);
         }
     }

--- a/src-ui-wx/sequencer/TimeLine.h
+++ b/src-ui-wx/sequencer/TimeLine.h
@@ -14,6 +14,7 @@
 #include "wx/window.h"
 
 class SequenceElements;
+struct SongStructureRegion;
 
 #define HORIZONTAL_PADDING      10
 #define PIXELS_PER_MAJOR_HASH   100
@@ -204,6 +205,8 @@ private:
     void RecalcMarkerPositions();
 
     // Song structure drawing and interaction
+    wxColour GetSongStructureBandColor(const SongStructureRegion& region) const;
+    void DrawSongStructureBands(wxDC& dc, int w, int h);
     void DrawSongStructureRegions(wxDC& dc, int w, int h);
     void DrawSongStructureBoundaries(wxDC& dc, int w, int h);
     void OnSongStructurePopup(wxCommandEvent& event);


### PR DESCRIPTION
## Summary

Fixes #6500 — with Song Structure regions defined, the timeline **ruler was hidden behind the region color band**, so the time labels (`30s`, `1m`, …) and hash marks weren't visible. Most obvious in light mode and on Windows.

## Root cause

The region band was drawn *on top of* the ruler, using `wxColour(r, g, b, 50)` via `wxDC`. `wxDC` honors the alpha channel on macOS (so in dark mode it looked translucent there) but **ignores it on Windows/GDI**, where the band rendered fully opaque and completely covered the ruler. Even on macOS the band sat over the ruler rather than behind it, and the region-name text / boundary markers used hardcoded light colors that washed out in light mode.

## Fix

- **Draw the region band as a background tint *behind* the ruler** — `DrawSongStructureBands()` now paints before the hash marks/time labels, so the timing marks always render on top and stay visible on every platform. This is the core fix for "can't see timing marks."
- **Blend the band color over the timeline background manually** instead of relying on `wxDC` alpha, so it looks translucent everywhere (Windows included) and adapts to light/dark mode automatically.
- **Contrasting colors per appearance** for the region name text and the boundary lines/diamonds (the hardcoded light-gray text and white boundaries were invisible against the light-mode background); the effects-grid boundary line is mode-aware too.

## Testing

Verified on macOS in **both light and dark mode** — the ruler timing marks show through the region bands, and region names/boundaries are clearly visible in both. The Windows-specific opaque-overlay path is moot now that the band is drawn behind the ruler.
