### PR TITLE
#6493 Drag/Drop Sequencer Models and Groups

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.11  June ??, 2026
+    -enh (AGFazio)               Drag rows in the sequencer row header to reorder models and timing tracks.
     -enh (cybercop23)            Import Effects: stacked mappings — dropping/double-clicking an available model
                                  onto an already-mapped destination shows Replace / Add Additional prompt;
                                  Add the ability to load multiple xmap files with a prompt of what to do if maps exist.

--- a/src-ui-wx/sequencer/RowHeading.cpp
+++ b/src-ui-wx/sequencer/RowHeading.cpp
@@ -392,18 +392,13 @@ void RowHeading::mouseLeftUp(wxMouseEvent& event)
         if (HasCapture()) ReleaseMouse();
         _rowDragging = false;
 
-        if (_rowDragSourceIdx >= 0) {
+        if (_rowDragSourceIdx >= 0 && _rowDragTargetBefore >= 0) {
             int view = mSequenceElements->GetCurrentView();
-            int elemCount = (int)mSequenceElements->GetElementCount(view);
             int dest = _rowDragTargetBefore;
-            bool noOp = (dest == _rowDragSourceIdx) || (dest == _rowDragSourceIdx + 1) ||
-                        (dest >= elemCount && _rowDragSourceIdx == elemCount - 1);
-            if (!noOp) {
-                mSequenceElements->get_undo_mgr().CreateUndoStep();
-                mSequenceElements->MoveSequenceElement(_rowDragSourceIdx, dest, view);
-                wxCommandEvent evt(EVT_ROW_HEADINGS_CHANGED);
-                wxPostEvent(GetParent(), evt);
-            }
+            mSequenceElements->get_undo_mgr().CreateUndoStep();
+            mSequenceElements->MoveSequenceElement(_rowDragSourceIdx, dest, view);
+            wxCommandEvent evt(EVT_ROW_HEADINGS_CHANGED);
+            wxPostEvent(GetParent(), evt);
         }
 
         _rowDragSourceIdx = -1;

--- a/src-ui-wx/sequencer/RowHeading.cpp
+++ b/src-ui-wx/sequencer/RowHeading.cpp
@@ -365,7 +365,6 @@ void RowHeading::mouseMove(wxMouseEvent& event)
         int dy = event.GetY() - _rowDragStart.y;
         if (dy > FromDIP(5) || dy < -FromDIP(5)) {
             _rowDragging = true;
-            spdlog::info("RowHeading::mouseMove drag started srcIdx={} dy={}", _rowDragSourceIdx, dy);
             if (!HasCapture()) CaptureMouse();
             return;
         }
@@ -389,7 +388,6 @@ void RowHeading::mouseMove(wxMouseEvent& event)
 
 void RowHeading::mouseLeftUp(wxMouseEvent& event)
 {
-    spdlog::info("RowHeading::mouseLeftUp rowDragging={} srcIdx={} targetBefore={}", _rowDragging, _rowDragSourceIdx, _rowDragTargetBefore);
     if (_rowDragging) {
         if (HasCapture()) ReleaseMouse();
         _rowDragging = false;
@@ -397,7 +395,6 @@ void RowHeading::mouseLeftUp(wxMouseEvent& event)
         if (_rowDragSourceIdx >= 0 && _rowDragTargetBefore >= 0) {
             int view = mSequenceElements->GetCurrentView();
             int dest = _rowDragTargetBefore;
-            spdlog::info("RowHeading::mouseLeftUp calling MoveSequenceElement src={} dest={} view={}", _rowDragSourceIdx, dest, view);
             mSequenceElements->get_undo_mgr().CreateUndoStep();
             mSequenceElements->MoveSequenceElement(_rowDragSourceIdx, dest, view);
             wxCommandEvent evt(EVT_ROW_HEADINGS_CHANGED);
@@ -465,7 +462,6 @@ void RowHeading::mouseLeftDown(wxMouseEvent& event)
                 int view = mSequenceElements->GetCurrentView();
                 _rowDragSourceIdx = mSequenceElements->GetElementIndex(ri->element->GetFullName(), view);
                 _rowDragStart = event.GetPosition();
-                spdlog::info("RowHeading::mouseLeftDown arm drag element='{}' srcIdx={} view={}", ri->element->GetFullName(), _rowDragSourceIdx, view);
             }
         }
     }

--- a/src-ui-wx/sequencer/RowHeading.cpp
+++ b/src-ui-wx/sequencer/RowHeading.cpp
@@ -365,7 +365,7 @@ void RowHeading::mouseMove(wxMouseEvent& event)
         int dy = event.GetY() - _rowDragStart.y;
         if (dy > FromDIP(5) || dy < -FromDIP(5)) {
             _rowDragging = true;
-            spdlog::debug("RowHeading::mouseMove drag started srcIdx={} dy={}", _rowDragSourceIdx, dy);
+            spdlog::info("RowHeading::mouseMove drag started srcIdx={} dy={}", _rowDragSourceIdx, dy);
             if (!HasCapture()) CaptureMouse();
             return;
         }
@@ -389,7 +389,7 @@ void RowHeading::mouseMove(wxMouseEvent& event)
 
 void RowHeading::mouseLeftUp(wxMouseEvent& event)
 {
-    spdlog::debug("RowHeading::mouseLeftUp rowDragging={} srcIdx={} targetBefore={}", _rowDragging, _rowDragSourceIdx, _rowDragTargetBefore);
+    spdlog::info("RowHeading::mouseLeftUp rowDragging={} srcIdx={} targetBefore={}", _rowDragging, _rowDragSourceIdx, _rowDragTargetBefore);
     if (_rowDragging) {
         if (HasCapture()) ReleaseMouse();
         _rowDragging = false;
@@ -397,7 +397,7 @@ void RowHeading::mouseLeftUp(wxMouseEvent& event)
         if (_rowDragSourceIdx >= 0 && _rowDragTargetBefore >= 0) {
             int view = mSequenceElements->GetCurrentView();
             int dest = _rowDragTargetBefore;
-            spdlog::debug("RowHeading::mouseLeftUp calling MoveSequenceElement src={} dest={} view={}", _rowDragSourceIdx, dest, view);
+            spdlog::info("RowHeading::mouseLeftUp calling MoveSequenceElement src={} dest={} view={}", _rowDragSourceIdx, dest, view);
             mSequenceElements->get_undo_mgr().CreateUndoStep();
             mSequenceElements->MoveSequenceElement(_rowDragSourceIdx, dest, view);
             wxCommandEvent evt(EVT_ROW_HEADINGS_CHANGED);
@@ -465,7 +465,7 @@ void RowHeading::mouseLeftDown(wxMouseEvent& event)
                 int view = mSequenceElements->GetCurrentView();
                 _rowDragSourceIdx = mSequenceElements->GetElementIndex(ri->element->GetFullName(), view);
                 _rowDragStart = event.GetPosition();
-                spdlog::debug("RowHeading::mouseLeftDown arm drag element='{}' srcIdx={} view={}", ri->element->GetFullName(), _rowDragSourceIdx, view);
+                spdlog::info("RowHeading::mouseLeftDown arm drag element='{}' srcIdx={} view={}", ri->element->GetFullName(), _rowDragSourceIdx, view);
             }
         }
     }

--- a/src-ui-wx/sequencer/RowHeading.cpp
+++ b/src-ui-wx/sequencer/RowHeading.cpp
@@ -326,6 +326,50 @@ void RowHeading::SetWidth(int w)
 
 void RowHeading::mouseMove(wxMouseEvent& event)
 {
+    if (_rowDragging) {
+        int cursorY = std::max(0, event.GetY());
+        int view = mSequenceElements->GetCurrentView();
+        int visCount = (int)mSequenceElements->GetVisibleRowInformationSize();
+        int elemCount = (int)mSequenceElements->GetElementCount(view);
+
+        struct TopLevelBlock { int viewIdx; int blockStartY; int blockEndY; };
+        std::vector<TopLevelBlock> blocks;
+        for (int r = 0; r < visCount; ++r) {
+            auto* ri = mSequenceElements->GetVisibleRowInformation(r);
+            if (ri && ri->layerIndex == 0 && ri->strandIndex < 0 && ri->nodeIndex < 0 && !ri->submodel) {
+                if (!blocks.empty()) blocks.back().blockEndY = r * DEFAULT_ROW_HEADING_HEIGHT;
+                int idx = mSequenceElements->GetElementIndex(ri->element->GetFullName(), view);
+                blocks.push_back({idx, r * DEFAULT_ROW_HEADING_HEIGHT, visCount * DEFAULT_ROW_HEADING_HEIGHT});
+            }
+        }
+
+        _rowDragTargetBefore = elemCount;
+        _rowDragIndicatorY = visCount * DEFAULT_ROW_HEADING_HEIGHT;
+        for (const auto& b : blocks) {
+            if (cursorY < (b.blockStartY + b.blockEndY) / 2) {
+                _rowDragTargetBefore = b.viewIdx;
+                _rowDragIndicatorY = b.blockStartY;
+                break;
+            }
+            _rowDragTargetBefore = b.viewIdx + 1;
+            _rowDragIndicatorY = b.blockEndY;
+        }
+
+        static const wxCursor s_hand(wxCURSOR_HAND);
+        SetCursor(s_hand);
+        Refresh(false);
+        return;
+    }
+
+    if (_rowDragSourceIdx >= 0 && !_rowDragging) {
+        int dy = event.GetY() - _rowDragStart.y;
+        if (dy > FromDIP(5) || dy < -FromDIP(5)) {
+            _rowDragging = true;
+            if (!HasCapture()) CaptureMouse();
+            return;
+        }
+    }
+
     ProcessTooltip(event);
 
     if (_dragging) {
@@ -337,14 +381,38 @@ void RowHeading::mouseMove(wxMouseEvent& event)
     auto size = GetSize();
     if (HasCapture() || (event.GetX() > size.GetWidth() - 5 && event.GetX() < size.GetWidth())) {
         SetCursor(s_sizeWE);
-    }
-    else {
+    } else {
         SetCursor(s_arrow);
     }
 }
 
 void RowHeading::mouseLeftUp(wxMouseEvent& event)
 {
+    if (_rowDragging) {
+        if (HasCapture()) ReleaseMouse();
+        _rowDragging = false;
+
+        if (_rowDragSourceIdx >= 0) {
+            int view = mSequenceElements->GetCurrentView();
+            int elemCount = (int)mSequenceElements->GetElementCount(view);
+            int dest = _rowDragTargetBefore;
+            bool noOp = (dest == _rowDragSourceIdx) || (dest == _rowDragSourceIdx + 1) ||
+                        (dest >= elemCount && _rowDragSourceIdx == elemCount - 1);
+            if (!noOp) {
+                mSequenceElements->get_undo_mgr().CreateUndoStep();
+                mSequenceElements->MoveSequenceElement(_rowDragSourceIdx, dest, view);
+                wxCommandEvent evt(EVT_ROW_HEADINGS_CHANGED);
+                wxPostEvent(GetParent(), evt);
+            }
+        }
+
+        _rowDragSourceIdx = -1;
+        _rowDragTargetBefore = -1;
+        _rowDragIndicatorY = -1;
+        Refresh(false);
+        return;
+    }
+
     if (_dragging) {
         auto size = GetSize();
         auto* config = GetXLightsConfig();
@@ -352,11 +420,16 @@ void RowHeading::mouseLeftUp(wxMouseEvent& event)
         ReleaseMouse();
         _dragging = false;
     }
+
+    _rowDragSourceIdx = -1;
 }
 
 void RowHeading::mouseLeftDown(wxMouseEvent& event)
 {
     _dragging = false;
+    _rowDragging = false;
+    _rowDragSourceIdx = -1;
+
     auto size = GetSize();
     if (event.GetX() > size.GetWidth() - 5 && event.GetX() < size.GetWidth()) {
         CaptureMouse();
@@ -384,11 +457,17 @@ void RowHeading::mouseLeftDown(wxMouseEvent& event)
             mSequenceElements->DeactivateAllTimingElements();
             TimingElement* te = dynamic_cast<TimingElement*>(e);
             te->SetActive(!result);
-            // Set the selected timing row.
             int selectedTimingRow = result ? mSelectedRow : -1;
             mSequenceElements->SetSelectedTimingRow(selectedTimingRow);
             wxCommandEvent eventRowHeaderChanged(EVT_ROW_HEADINGS_CHANGED);
             wxPostEvent(GetParent(), eventRowHeaderChanged);
+        } else {
+            Row_Information_Struct* ri = mSequenceElements->GetVisibleRowInformation(mSelectedRow);
+            if (ri && ri->layerIndex == 0 && ri->strandIndex < 0 && ri->nodeIndex < 0 && !ri->submodel) {
+                int view = mSequenceElements->GetCurrentView();
+                _rowDragSourceIdx = mSequenceElements->GetElementIndex(ri->element->GetFullName(), view);
+                _rowDragStart = event.GetPosition();
+            }
         }
     }
 }
@@ -2642,6 +2721,12 @@ void RowHeading::render( wxPaintEvent& event )
     wxBrush b(xlColorToWxColour(ColorManager::instance()->GetColor(ColorManager::COLOR_ROW_HEADER)),wxBRUSHSTYLE_SOLID);
     dc.SetBrush(b);
     dc.DrawRectangle(0,endY,w,h);
+
+    if (_rowDragging && _rowDragIndicatorY >= 0) {
+        wxPen linePen(wxColour(0, 120, 215), 3);
+        dc.SetPen(linePen);
+        dc.DrawLine(0, _rowDragIndicatorY, w, _rowDragIndicatorY);
+    }
 }
 
 xlColor RowHeading::GetHeaderColor(Row_Information_Struct* info, int dragRow) const

--- a/src-ui-wx/sequencer/RowHeading.cpp
+++ b/src-ui-wx/sequencer/RowHeading.cpp
@@ -392,7 +392,9 @@ void RowHeading::mouseLeftUp(wxMouseEvent& event)
         if (HasCapture()) ReleaseMouse();
         _rowDragging = false;
 
-        if (_rowDragSourceIdx >= 0 && _rowDragTargetBefore >= 0) {
+        if (_rowDragSourceIdx >= 0 && _rowDragTargetBefore >= 0
+            && _rowDragTargetBefore != _rowDragSourceIdx
+            && _rowDragTargetBefore != _rowDragSourceIdx + 1) {
             int view = mSequenceElements->GetCurrentView();
             int dest = _rowDragTargetBefore;
             mSequenceElements->get_undo_mgr().CreateUndoStep();
@@ -2718,7 +2720,7 @@ void RowHeading::render( wxPaintEvent& event )
     dc.DrawRectangle(0,endY,w,h);
 
     if (_rowDragging && _rowDragIndicatorY >= 0) {
-        wxPen linePen(wxColour(0, 120, 215), 3);
+        wxPen linePen(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT), FromDIP(3));
         dc.SetPen(linePen);
         dc.DrawLine(0, _rowDragIndicatorY, w, _rowDragIndicatorY);
     }

--- a/src-ui-wx/sequencer/RowHeading.cpp
+++ b/src-ui-wx/sequencer/RowHeading.cpp
@@ -365,6 +365,7 @@ void RowHeading::mouseMove(wxMouseEvent& event)
         int dy = event.GetY() - _rowDragStart.y;
         if (dy > FromDIP(5) || dy < -FromDIP(5)) {
             _rowDragging = true;
+            spdlog::debug("RowHeading::mouseMove drag started srcIdx={} dy={}", _rowDragSourceIdx, dy);
             if (!HasCapture()) CaptureMouse();
             return;
         }
@@ -388,6 +389,7 @@ void RowHeading::mouseMove(wxMouseEvent& event)
 
 void RowHeading::mouseLeftUp(wxMouseEvent& event)
 {
+    spdlog::debug("RowHeading::mouseLeftUp rowDragging={} srcIdx={} targetBefore={}", _rowDragging, _rowDragSourceIdx, _rowDragTargetBefore);
     if (_rowDragging) {
         if (HasCapture()) ReleaseMouse();
         _rowDragging = false;
@@ -395,6 +397,7 @@ void RowHeading::mouseLeftUp(wxMouseEvent& event)
         if (_rowDragSourceIdx >= 0 && _rowDragTargetBefore >= 0) {
             int view = mSequenceElements->GetCurrentView();
             int dest = _rowDragTargetBefore;
+            spdlog::debug("RowHeading::mouseLeftUp calling MoveSequenceElement src={} dest={} view={}", _rowDragSourceIdx, dest, view);
             mSequenceElements->get_undo_mgr().CreateUndoStep();
             mSequenceElements->MoveSequenceElement(_rowDragSourceIdx, dest, view);
             wxCommandEvent evt(EVT_ROW_HEADINGS_CHANGED);
@@ -462,6 +465,7 @@ void RowHeading::mouseLeftDown(wxMouseEvent& event)
                 int view = mSequenceElements->GetCurrentView();
                 _rowDragSourceIdx = mSequenceElements->GetElementIndex(ri->element->GetFullName(), view);
                 _rowDragStart = event.GetPosition();
+                spdlog::debug("RowHeading::mouseLeftDown arm drag element='{}' srcIdx={} view={}", ri->element->GetFullName(), _rowDragSourceIdx, view);
             }
         }
     }

--- a/src-ui-wx/sequencer/RowHeading.h
+++ b/src-ui-wx/sequencer/RowHeading.h
@@ -81,6 +81,11 @@ private:
     bool mCanPaste = false;
     const int _minRowHeadingWidth = 158;
     bool _dragging = false;
+    bool _rowDragging = false;
+    int _rowDragSourceIdx = -1;
+    int _rowDragTargetBefore = -1;
+    int _rowDragIndicatorY = -1;
+    wxPoint _rowDragStart;
     bool groupEffectIndicator = true;
 
     

--- a/src-ui-wx/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/sequencer/tabSequencer.cpp
@@ -1118,6 +1118,7 @@ void xLightsFrame::RowHeadingsChanged( wxCommandEvent& event)
             }
         }
     }
+    displayElementsPanel->UpdateModelsForSelectedView();
     _sequenceElements.PopulateRowInformation();
     displayElementsPanel->Initialize();
     ResizeMainSequencer();


### PR DESCRIPTION
Add ability to reorder models and groups from the sequencer window without opening Edit Display Elements. Drag shows a highlighted line where you would like to drop. Carries layers with it.

## Changes
- Row drag in the sequencer row header: click and drag a model/group row to reorder it; a drop-indicator line shows the target position
- Drop indicator color uses the system highlight color and scales correctly on HiDPI displays
- No-op drops (releasing on the source's own position) are silently ignored — no unnecessary undo step is created
- Timing tracks are excluded from drag-to-reorder (clicking a timing row still toggles its active state as before)