### PR TITLE
Fix Faces/States/SubModels count badges not updating after editing

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -6806,6 +6806,7 @@ void LayoutPanel::EditSubmodels()
         dlg.Save();
         md->IncrementChangeCount();
         md->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::EditSubmodels");
+        updatePropertyGrid();
     }
     if (dlg.ReloadLayout) { //force grid to reload
         wxCommandEvent eventForceRefresh(EVT_FORCE_SEQUENCER_REFRESH);
@@ -6830,6 +6831,7 @@ void LayoutPanel::EditFaces()
             md->SetFaceInfo(newFaceInfo);
             md->IncrementChangeCount();
             md->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::EditFaces");
+            updatePropertyGrid();
         }
     }
 }
@@ -6846,6 +6848,7 @@ void LayoutPanel::EditStates()
         md->SetStateInfo(dlg.GetStateInfo());
         md->IncrementChangeCount();
         md->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::EditStates");
+        updatePropertyGrid();
     }
 }
 

--- a/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
+++ b/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
@@ -256,6 +256,9 @@ wxString FormatStatesLabel(const Model& m) {
 wxString FormatSubModelsLabel(const Model& m) {
     return wxString::Format("SubModels (%d)", m.GetNumSubModels());
 }
+wxString FormatAliasesLabel(const Model& m) {
+    return wxString::Format("Aliases (%zu)", m.GetAliases().size());
+}
 } // namespace
 
 class StartChannelProperty : public wxStringProperty {
@@ -428,7 +431,10 @@ void ModelPropertyAdapter::AddProperties(wxPropertyGridInterface* grid, OutputMa
         FormatSubModelsLabel(_model),
         "SubModels", CLICK_TO_EDIT, 5));
     grid->LimitPropertyEditing(p);
-    p = grid->Append(new PopupDialogProperty(&_model, outputManager, "Aliases", "Aliases", CLICK_TO_EDIT, 6));
+    p = grid->Append(new PopupDialogProperty(
+        &_model, outputManager,
+        FormatAliasesLabel(_model),
+        "Aliases", CLICK_TO_EDIT, 6));
     grid->LimitPropertyEditing(p);
     p->SetHelpString("Aliases are used in mapping to provide alternate names for this model which might match a model in a sequence you are importing from. To use it use the Auto Map button.");
 
@@ -537,15 +543,23 @@ void ModelPropertyAdapter::UpdateProperties(wxPropertyGridInterface* grid, Outpu
 
     if (auto* pp = grid->GetPropertyByName("ModelStrandNodeNames")) {
         pp->SetLabel(FormatStrandNodeNamesLabel(_model));
+        grid->RefreshProperty(pp);
     }
     if (auto* pp = grid->GetPropertyByName("ModelFaces")) {
         pp->SetLabel(FormatFacesLabel(_model));
+        grid->RefreshProperty(pp);
     }
     if (auto* pp = grid->GetPropertyByName("ModelStates")) {
         pp->SetLabel(FormatStatesLabel(_model));
+        grid->RefreshProperty(pp);
     }
     if (auto* pp = grid->GetPropertyByName("SubModels")) {
         pp->SetLabel(FormatSubModelsLabel(_model));
+        grid->RefreshProperty(pp);
+    }
+    if (auto* pp = grid->GetPropertyByName("Aliases")) {
+        pp->SetLabel(FormatAliasesLabel(_model));
+        grid->RefreshProperty(pp);
     }
 
     if (grid->GetPropertyByName("Controller") != nullptr) {
@@ -1526,7 +1540,10 @@ int ModelPropertyAdapter::OnPropertyGridChange(wxPropertyGridInterface* grid, wx
         _model.AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS |
                     OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER |
                     OutputModelManager::WORK_RGBEFFECTS_CHANGE, "Model::OnPropertyGridChange::SubModels");
-
+        if (auto* pp = grid->GetPropertyByName("SubModels")) {
+            pp->SetLabel(FormatSubModelsLabel(_model));
+            grid->RefreshProperty(pp);
+        }
         return 0;
     } else if (event.GetPropertyName() == "Description") {
         _model.description = event.GetValue().GetString();
@@ -1537,14 +1554,26 @@ int ModelPropertyAdapter::OnPropertyGridChange(wxPropertyGridInterface* grid, wx
     } else if (event.GetPropertyName() == "ModelFaces") {
         _model.IncrementChangeCount();
         _model.AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "Model::OnPropertyGridChange::ModelFaces");
+        if (auto* pp = grid->GetPropertyByName("ModelFaces")) {
+            pp->SetLabel(FormatFacesLabel(_model));
+            grid->RefreshProperty(pp);
+        }
         return 0;
     } else if (event.GetPropertyName() == "ModelStates") {
         _model.IncrementChangeCount();
         _model.AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "Model::OnPropertyGridChange::ModelStates");
+        if (auto* pp = grid->GetPropertyByName("ModelStates")) {
+            pp->SetLabel(FormatStatesLabel(_model));
+            grid->RefreshProperty(pp);
+        }
         return 0;
     } else if (event.GetPropertyName() == "Aliases") {
         _model.IncrementChangeCount();
         _model.AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "Model::OnPropertyGridChange::Aliases");
+        if (auto* pp = grid->GetPropertyByName("Aliases")) {
+            pp->SetLabel(FormatAliasesLabel(_model));
+            grid->RefreshProperty(pp);
+        }
         return 0;
     } else if (event.GetPropertyName().StartsWith("SuperStringColours")) {
         _model.IncrementChangeCount();


### PR DESCRIPTION
## Summary

Follow-up to #6202 — the `(N)` count badges next to **Faces**, **States**, **SubModels**, and **Strand/Node Names** on the Model pane stayed at their pre-edit value until the model was reselected. Adding a face/state/submodel updated the underlying data but the badge text did not refresh.

Also adds a matching **Aliases (N)** badge so Aliases is consistent with the other popup-dialog rows.

## Bug

The count labels are written by `ModelPropertyAdapter::AddProperties()` when the model is first selected, and re-written by `UpdateProperties()`. Two issues prevented them from refreshing after an edit:

1. **`OnPropertyGridChange` (popup-button path).** When you click the popup button on the property grid and edit Faces/States/SubModels, the dialog returns into `ModelPropertyAdapter::OnPropertyGridChange()`. Those branches incremented the change count and queued `WORK_RGBEFFECTS_CHANGE` but never touched the row label.
2. **`EditFaces` / `EditStates` / `EditSubmodels` (right-click-menu path).** These handlers in `LayoutPanel` modified the model but never called `updatePropertyGrid()`, so `UpdateProperties()` was never invoked.

Additionally, `wxPGProperty::SetLabel()` updates the stored string but does not invalidate the cached row render — a `wxPropertyGridInterface::RefreshProperty()` call is needed for the new text to actually appear.

## Fix

- `ModelPropertyAdapter::OnPropertyGridChange`: in the `ModelFaces`, `ModelStates`, `SubModels`, and `Aliases` branches, re-format the label and call `RefreshProperty()` after the existing change-count / ASAP-work bookkeeping.
- `LayoutPanel::EditFaces` / `EditStates` / `EditSubmodels`: call `updatePropertyGrid()` when the dialog returned OK (and, for faces, when the info actually changed).
- `ModelPropertyAdapter::UpdateProperties`: pair every `SetLabel()` with `RefreshProperty()` so the existing label-refresh code actually repaints.
- `ModelPropertyAdapter::AddProperties`: Aliases row now uses `FormatAliasesLabel(_model)` to show `Aliases (N)`.

All changes are in wx-platform-neutral source — works identically on macOS, Windows, and Linux.

## Test plan

- [x] macOS Release build (Xcode 26.5)
- [ ] Open a model; add a new face via the property-grid popup button — Faces (N) badge updates immediately
- [ ] Add a new state via the popup button — States (N) updates
- [ ] Add a new submodel via the popup button — SubModels (N) updates
- [ ] Add an alias via the popup button — Aliases (N) updates
- [ ] Right-click a model on the layout tree, Edit Faces, add a face — badge updates
- [ ] Same via right-click Edit States and Edit SubModels
- [ ] Cancel out of a dialog — badge stays the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)
