### PR TITLE
Sequencer: Shift+double-click a model row to expand/collapse strands (#2411)

### DIFF
--- a/src-core/render/Element.h
+++ b/src-core/render/Element.h
@@ -276,6 +276,8 @@ class ModelElement : public Element
 
         bool ShowStrands() const { return mStrandsVisible;}
         void ShowStrands(bool b) { mStrandsVisible = b;}
+        bool ShowSubModels() const { return mSubModelsVisible;}
+        void ShowSubModels(bool b) { mSubModelsVisible = b;}
         virtual NodeLayer* GetNodeEffectLayer(int index) const override;
 
         std::recursive_timed_mutex &GetRenderLock() { return changeLock; }
@@ -292,6 +294,7 @@ class ModelElement : public Element
     protected:
     private:
         bool mStrandsVisible = false;
+        bool mSubModelsVisible = false;
         bool mSelected = false;
         std::vector<SubModelElement*> mSubModels;
         std::vector<StrandElement*> mStrands;

--- a/src-core/render/SequenceElements.cpp
+++ b/src-core/render/SequenceElements.cpp
@@ -1212,10 +1212,12 @@ void addModelElement(ModelElement* elem, std::vector<Row_Information_Struct>& mR
             }
         }
     }
-    else if (elem->ShowStrands()) {
+    else if (elem->ShowSubModels() || elem->ShowStrands()) {
         bool hideUnused = hideUnusedSubmodels && elem->HasEffects();
         for (int s = 0; s < elem->GetSubModelAndStrandCount(); s++) {
             SubModelElement* se = elem->GetSubModel(s);
+            if (se->GetType() == ElementType::ELEMENT_TYPE_STRAND && !elem->ShowStrands()) continue;
+            if (se->GetType() != ElementType::ELEMENT_TYPE_STRAND && !elem->ShowSubModels()) continue;
             if (hideUnused && !se->HasEffects()) continue;
             int m = se->GetEffectLayerCount();
             if (se->GetCollapsed()) {

--- a/src-ui-wx/sequencer/RowHeading.cpp
+++ b/src-ui-wx/sequencer/RowHeading.cpp
@@ -283,16 +283,16 @@ void RowHeading::ProcessTooltip(wxMouseEvent& event)
             wxClientDC dc(this);
             wxSize size = dc.GetTextExtent(e->GetName() + layers);
 
-            // Only set tooltip if the text looks too big to display correctly
+            wxString tip;
             if (size.x > getWidth() - DEFAULT_ROW_HEADING_MARGIN - ICON_SPACE) {
-                auto s1 = GetToolTipText().ToStdString();
-                auto s2 = e->GetName();
-                if (GetToolTipText() != e->GetName() + layers) {
-                    SetToolTip(e->GetName() + layers);
-                }
+                tip = e->GetName() + layers;
             }
-            else {
-                SetToolTip("");
+            if (e->GetType() == ElementType::ELEMENT_TYPE_MODEL) {
+                if (!tip.empty()) tip += "\n";
+                tip += "Double-click: show/hide submodels\nShift+double-click: show/hide submodels and strands";
+            }
+            if (GetToolTipText() != tip) {
+                SetToolTip(tip);
             }
         }
         else {
@@ -535,6 +535,23 @@ void RowHeading::leftDoubleClick(wxMouseEvent& event)
     Row_Information_Struct *ri =  mSequenceElements->GetVisibleRowInformation(mSelectedRow);
     Element* element = ri->element;
 
+    if (element->GetType() == ElementType::ELEMENT_TYPE_MODEL) {
+        ModelElement* me = dynamic_cast<ModelElement*>(element);
+        if (event.ShiftDown()) {
+            bool showAll = !me->ShowSubModels() && !me->ShowStrands();
+            me->ShowSubModels(showAll);
+            me->ShowStrands(showAll);
+        } else if (me->ShowSubModels()) {
+            me->ShowSubModels(false);
+            me->ShowStrands(false);
+        } else {
+            me->ShowSubModels(true);
+        }
+        wxCommandEvent evt(EVT_ROW_HEADINGS_CHANGED);
+        evt.SetString(element->GetModelName());
+        wxPostEvent(GetParent(), evt);
+        return;
+    }
     ToggleExpand(element);
 }
 
@@ -603,7 +620,7 @@ void RowHeading::rightClick( wxMouseEvent& event)
                     if (element->GetType() != ElementType::ELEMENT_TYPE_SUBMODEL) {
                         canPromote = true;
                     }
-                    mnuLayer.Append(ID_ROW_MNU_TOGGLE_STRANDS, "Toggle Strands");
+                    mnuLayer.Append(ID_ROW_MNU_TOGGLE_STRANDS, "Toggle Strands\tShift+DblClick");
                     if (ri->strandIndex >= 0) {
                         mnuLayer.Append(ID_ROW_MNU_TOGGLE_NODES, "Toggle Nodes");
                     }
@@ -2122,7 +2139,9 @@ void RowHeading::OnLayerPopup(wxCommandEvent& event)
             me = se->GetModelElement();
         }
         if (me != nullptr) {
-            me->ShowStrands(!me->ShowStrands());
+            bool show = !me->ShowStrands();
+            me->ShowStrands(show);
+            if (show) me->ShowSubModels(true);
             wxCommandEvent eventRowHeaderChanged(EVT_ROW_HEADINGS_CHANGED);
             eventRowHeaderChanged.SetString(element->GetModelName());
             wxPostEvent(GetParent(), eventRowHeaderChanged);

--- a/src-ui-wx/sequencer/RowHeading.cpp
+++ b/src-ui-wx/sequencer/RowHeading.cpp
@@ -538,7 +538,7 @@ void RowHeading::leftDoubleClick(wxMouseEvent& event)
     if (element->GetType() == ElementType::ELEMENT_TYPE_MODEL) {
         ModelElement* me = dynamic_cast<ModelElement*>(element);
         if (event.ShiftDown()) {
-            bool showAll = !me->ShowSubModels() && !me->ShowStrands();
+            bool showAll = !(me->ShowSubModels() && me->ShowStrands());
             me->ShowSubModels(showAll);
             me->ShowStrands(showAll);
         } else if (me->ShowSubModels()) {
@@ -620,7 +620,7 @@ void RowHeading::rightClick( wxMouseEvent& event)
                     if (element->GetType() != ElementType::ELEMENT_TYPE_SUBMODEL) {
                         canPromote = true;
                     }
-                    mnuLayer.Append(ID_ROW_MNU_TOGGLE_STRANDS, "Toggle Strands\tShift+DblClick");
+                    mnuLayer.Append(ID_ROW_MNU_TOGGLE_STRANDS, "Toggle Strands (Shift+DblClick)");
                     if (ri->strandIndex >= 0) {
                         mnuLayer.Append(ID_ROW_MNU_TOGGLE_NODES, "Toggle Nodes");
                     }
@@ -2154,8 +2154,10 @@ void RowHeading::OnLayerPopup(wxCommandEvent& event)
             if (e->GetType() != ElementType::ELEMENT_TYPE_TIMING) {
                 if (ExpandElementIfEffects(e)) {
                     ModelElement* me = dynamic_cast<ModelElement*>(e);
-                    if (me != nullptr)
+                    if (me != nullptr) {
                         me->ShowStrands(true);
+                        me->ShowSubModels(true);
+                    }
                 }
             }
         }
@@ -2169,6 +2171,7 @@ void RowHeading::OnLayerPopup(wxCommandEvent& event)
                 ModelElement* me = dynamic_cast<ModelElement*>(e);
                 if (me != nullptr) {
                     me->ShowStrands(false);
+                    me->ShowSubModels(false);
                 }
             }
         }
@@ -2288,8 +2291,10 @@ bool RowHeading::ExpandElementIfEffects(Element* e)
                     hasEffects = mm->HasEffects();
                     hasEffects |= ExpandElementIfEffects(mSequenceElements->GetElement(*it));
 
-                    if (hasEffects)
+                    if (hasEffects) {
                         me->ShowStrands(true);
+                        me->ShowSubModels(true);
+                    }
                 }
             }
         } else {
@@ -2300,8 +2305,10 @@ bool RowHeading::ExpandElementIfEffects(Element* e)
                 hasEffects |= ExpandElementIfEffects(me->GetSubModel(i));
             }
 
-            if (hasEffects)
+            if (hasEffects) {
                 me->ShowStrands(true);
+                me->ShowSubModels(true);
+            }
         }
     } else if (e->GetType() == ElementType::ELEMENT_TYPE_STRAND) {
         StrandElement* se = dynamic_cast<StrandElement*>(e);


### PR DESCRIPTION
One possible implementation - thoughts? 

Double Click just shows submodels. Shift+Double Click shows submodels + strands.
Either a second time, collapses things.

The hide unused right click is still there.

Also a tooltip also included to show this feature.