### PR TITLE
Add link icon to model card in visualizer (5641)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.11  June ??, 2026
+    -enh (cybercop23)            Controller Visualizer: show a link icon on model boxes that come from the base show folder.
     -enh (AGFazio)               Drag rows in the sequencer row header to reorder models and timing tracks.
     -enh (cybercop23)            Import Effects: stacked mappings — dropping/double-clicking an available model
                                  onto an already-mapped destination shows Replace / Add Additional prompt;

--- a/src-ui-wx/setup/ControllerModelDialog.cpp
+++ b/src-ui-wx/setup/ControllerModelDialog.cpp
@@ -1445,6 +1445,16 @@ public:
         DrawTextLimited(dc, _displayName, pt, sz - wxSize(4, 4));
         pt += wxSize(0, (VERTICAL_SIZE * scale) / 2);
         if (m != nullptr) {
+            if (m->IsFromBase()) {
+                wxString linkChar = wxString::FromUTF8("\xF0\x9F\x94\x97"); // 🔗 U+1F517
+                wxSize charSz = dc.GetTextExtent(linkChar);
+                wxPoint linkPt(location.x + offset.x + sz.x - charSz.x - ScaleWithSystemDPI(GetSystemContentScaleFactor(), 3),
+                               location.y + offset.y + ScaleWithSystemDPI(GetSystemContentScaleFactor(), 3));
+                dc.SetClippingRegion(location + offset, sz);
+                dc.DrawText(linkChar, linkPt);
+                dc.DestroyClippingRegion();
+            }
+
             auto iconType = "xlART_" + DisplayAsTypeToString(m->GetDisplayAs()) + "_ICON";
             int iconSize = MODEL_ICON_SIZE;
             if (iconSize > 24) {


### PR DESCRIPTION
(#5641)  Add a link icon to the model card
<img width="386" height="132" alt="image" src="https://github.com/user-attachments/assets/23988f3a-0262-4a4b-a3dd-25e983f78ca9" />
