### PR TITLE
Fix issue with marking as "dirty" when switching base and show folders

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -77,6 +77,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                  per-segment sizes ran the light distribution past the point array).
     -bug (dan)                   Fix Windows crash drawing color-vertex primitives when the accumulator
                                  type doesn't match (null-check the dynamic_cast, matching the other overload).
+    -bug (cybercop23)            Fix layout/rgbeffects file spuriously marked dirty on every show folder open.
 
 2026.10  May 31, 2026
     -enh (cybercop23)            Add State effect on SubModels. Ensure only nodes that are part of the SubModel are lit.

--- a/src-core/models/BaseObject.cpp
+++ b/src-core/models/BaseObject.cpp
@@ -300,8 +300,8 @@ bool BaseObject::IsContained(IModelPreview* preview, int x1, int y1, int x2, int
 }
 
 void BaseObject::SetActive(bool active) {
-	_active = active; 
-
+    if (active == _active) return;
+    _active = active;
     AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "BaseObject::SetActive");
     AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "BaseObject::SetActive");
     AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BaseObject::SetActive"); // because the names are displayed differently

--- a/src-core/models/Model.cpp
+++ b/src-core/models/Model.cpp
@@ -4401,7 +4401,10 @@ std::string Model::GetShadowModelFor() const
 void Model::AddASAPWork(uint32_t work, const std::string& from)
 {
     if (auto* omm = modelManager.GetOutputModelManager()) {
-        omm->AddASAPWork(work, from, this, nullptr, GetName());
+        if (modelManager.IsModelsLoading())
+            work &= ~OutputModelManager::WORK_RGBEFFECTS_CHANGE;
+        if (work)
+            omm->AddASAPWork(work, from, this, nullptr, GetName());
     }
 }
 

--- a/src-core/models/ModelManager.h
+++ b/src-core/models/ModelManager.h
@@ -115,6 +115,8 @@ class ModelManager : public ObjectManager
         // parallel.
         unsigned int GetModelGeneration() const { return _modelGeneration.load(); }
 
+        bool IsModelsLoading() const { return _modelsLoading; }
+
     private:
 
     OutputManager* _outputManager = nullptr;


### PR DESCRIPTION
When switching folders without making any changes in either folder, it still marked them as dirty.

* Model::AddASAPWork masks out WORK_RGBEFFECTS_CHANGE while _modelsLoading is true (the existing parallel-load flag in ModelManager). This single gate covers every model setter that would otherwise fire dirty during XML deserialization — SetProtocol, SetCtrlPort, SetActive, and anything else in ControllerConnection or Model itself.
* SetActive keeps the if (active == _active) return; no-op guard (still useful for user-triggered calls that don't change the value).