### PR TITLE
Bulk Edit Rotate: skip models whose type doesn't support that axis

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -2406,19 +2406,68 @@ bool ModelSetHasLockedMember(ModelManager& mgr, ModelSet* s) {
     }
     return false;
 }
+// Which axes a model's screen-location class meaningfully rotates around.
+// BoxedScreenLocation supports all three. ThreePointScreenLocation (Arches,
+// CandyCane, Icicles) only exposes X. Two/Poly/Multi/Terrain point screen
+// locations derive their orientation from their anchor points - calling
+// SetRotateX/Y/Z stores a value but has no visible effect.
+bool ModelSupportsRotationAxis(Model* model, char axis) {
+    if (model == nullptr) {
+        return false;
+    }
+    if (dynamic_cast<ModelWithScreenLocation<BoxedScreenLocation>*>(model) != nullptr) {
+        return true;
+    }
+    if (dynamic_cast<ModelWithScreenLocation<ThreePointScreenLocation>*>(model) != nullptr) {
+        return axis == 'X';
+    }
+    return false;
+}
 } // namespace
 
 void LayoutPanel::BulkEditRotateAxis(char axis) {
     std::vector<Model*> modelsToEdit = GetSelectedModelsForEdit();
 
     std::vector<Model*> editableModels;
+    std::vector<Model*> unsupportedModels;
     editableModels.reserve(modelsToEdit.size());
     for (Model* model : modelsToEdit) {
-        if (model != nullptr && !model->GetBaseObjectScreenLocation().IsLocked()) {
+        if (model == nullptr || model->GetBaseObjectScreenLocation().IsLocked()) {
+            continue;
+        }
+        if (ModelSupportsRotationAxis(model, axis)) {
             editableModels.push_back(model);
+        } else {
+            unsupportedModels.push_back(model);
         }
     }
+    auto formatSkippedNames = [](const std::vector<Model*>& skipped) {
+        // Cap list to keep the dialog from getting absurdly tall on huge
+        // selections. 20 lines is roughly a comfortable max for a message
+        // box on a typical display.
+        constexpr size_t kMaxLines = 20;
+        wxString out;
+        size_t n = std::min(skipped.size(), kMaxLines);
+        for (size_t i = 0; i < n; ++i) {
+            out += "  • " + wxString(skipped[i]->GetName()) + "\n";
+        }
+        if (skipped.size() > kMaxLines) {
+            out += wxString::Format("  … and %zu more\n", skipped.size() - kMaxLines);
+        }
+        return out;
+    };
+
     if (editableModels.empty()) {
+        if (!unsupportedModels.empty()) {
+            wxMessageBox(
+                wxString::Format(
+                    "None of the selected models support rotation on the %c axis.\n\n"
+                    "Skipped:\n%s\n"
+                    "Arches/CandyCane/Icicles only support X; Lines/PolyLines derive orientation from their endpoints.",
+                    axis,
+                    formatSkippedNames(unsupportedModels)),
+                "Bulk Edit Rotate", wxOK | wxICON_INFORMATION, this);
+        }
         return;
     }
 
@@ -2606,6 +2655,18 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
         }
         wxMessageBox(wxString::Format(_("Set %s was not rotated because it contains a locked model."), names),
                      _("Bulk Edit Rotate"), wxOK | wxICON_INFORMATION, this);
+    }
+    if (!unsupportedModels.empty()) {
+        wxMessageBox(
+            wxString::Format(
+                "Rotated %zu of %zu selected models.\n\n"
+                "Skipped because their model type does not support rotation on the %c axis:\n%s\n"
+                "Arches/CandyCane/Icicles only support X; Lines/PolyLines derive orientation from their endpoints.",
+                editableModels.size(),
+                editableModels.size() + unsupportedModels.size(),
+                axis,
+                formatSkippedNames(unsupportedModels)),
+            "Bulk Edit Rotate", wxOK | wxICON_INFORMATION, this);
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #6184. Bulk Edit → Rotate X / Y / Z applied the rotation unconditionally to every unlocked selected model, but several model types don't actually honor every axis:

- **BoxedScreenLocation** (Matrix, Custom, Image, Cube, Sphere, Circle, Star, ModelGroup, etc.) — supports X, Y, Z.
- **ThreePointScreenLocation** (Arches, CandyCane, Icicles) — only X has a visible effect.
- **TwoPoint / PolyPoint / MultiPoint** (SingleLine, PolyLine, ChannelBlock, etc.) — orientation comes from endpoints; calling `SetRotateX/Y/Z` stores a value with no visible effect.

So a user could bulk-rotate a mixed selection and watch some models silently ignore the action.

## Fix

`BulkEditRotateAxis` now classifies each selected (unlocked) model into "supported on this axis" or "unsupported", and:

- If **no** selected model supports the axis, the value-entry dialog is skipped and an info box lists the model names with the reason.
- If **some** models support and some don't, the supported ones are rotated normally and a follow-up info box lists the skipped names, one per line, capped at 20 with "… and N more" for huge selections.
- If **all** selected models support the axis, behavior is unchanged (no extra dialog).

Includes are already pulled in transitively (the same `dynamic_cast<ModelWithScreenLocation<BoxedScreenLocation>*>` pattern is already used at `LayoutPanel.cpp:1384`). wx-platform-neutral — works on macOS, Windows, Linux.

## Test plan

- [x] macOS Release build (Xcode 26.5)
- [ ] Select a mix (e.g. Matrix + Arch + SingleLine), Bulk Edit → Rotate Y — Matrix rotates; follow-up dialog lists Arch and SingleLine as skipped
- [ ] Select only Arches + Lines, Bulk Edit → Rotate Y — no value dialog appears; info box lists all of them as skipped
- [ ] Select Matrix + Arch, Bulk Edit → Rotate X — both rotate; no extra dialog (Arch supports X)
- [ ] Select only Matrix models, Bulk Edit → Rotate Z — unchanged behavior, no extra dialog
- [ ] Lock one model in a mixed selection — locked model is silently skipped as before, no double-count in the "of N" total
- [ ] Select 25 unsupported models — skipped list shows 20 names plus "… and 5 more"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
