### PR TITLE
Add transition blur (#816)

### DIFF
--- a/resources/effectmetadata/shared/Blending.json
+++ b/resources/effectmetadata/shared/Blending.json
@@ -92,6 +92,17 @@
             "description": "Reverses the direction / polarity of the in-transition. Ignored by transitions that are inherently non-directional."
         },
         {
+            "id": "In_Transition_Blur",
+            "label": "Blur",
+            "type": "int",
+            "controlType": "slider",
+            "min": 0,
+            "max": 25,
+            "default": 0,
+            "suppressIfDefault": true,
+            "description": "Softens the transition edge. Only active for Wipe, Clock, From Middle, Square Explode, Circle Explode, Blinds, Blend, Slide Checks, Slide Bars and Blobs transitions."
+        },
+        {
             "id": "Out_Transition_Header",
             "label": "",
             "type": "string",
@@ -120,6 +131,17 @@
             "default": false,
             "suppressIfDefault": true,
             "description": "Reverses the direction / polarity of the out-transition."
+        },
+        {
+            "id": "Out_Transition_Blur",
+            "label": "Blur",
+            "type": "int",
+            "controlType": "slider",
+            "min": 0,
+            "max": 25,
+            "default": 0,
+            "suppressIfDefault": true,
+            "description": "Softens the transition edge. Only active for Wipe, Clock, From Middle, Square Explode, Circle Explode, Blinds, Blend, Slide Checks, Slide Bars and Blobs transitions."
         }
     ],
     "groups": [
@@ -132,7 +154,8 @@
                     "properties": [
                         "In_Transition_Header",
                         "In_Transition_Adjust",
-                        "In_Transition_Reverse"
+                        "In_Transition_Reverse",
+                        "In_Transition_Blur"
                     ]
                 },
                 {
@@ -140,7 +163,8 @@
                     "properties": [
                         "Out_Transition_Header",
                         "Out_Transition_Adjust",
-                        "Out_Transition_Reverse"
+                        "Out_Transition_Reverse",
+                        "Out_Transition_Blur"
                     ]
                 }
             ]

--- a/src-core/render/PixelBuffer.cpp
+++ b/src-core/render/PixelBuffer.cpp
@@ -3534,8 +3534,11 @@ void PixelBufferClass::LayerInfo::blurMaskToAlpha(int blurAmount) {
         }
     }
 
-    // Bake the blurred mask into pixel alpha (0=visible, 1=hidden) and clear the mask.
+    // Bake the blurred mask into pixel alpha (0=visible, 1=hidden).
     // Pixels near the wipe boundary get partial alpha, creating a soft edge.
+    // Keep the binary mask for fully-hidden pixels so non-alpha-aware blend
+    // modes still treat them as masked.
+    constexpr float kFullyHiddenEps = 1e-6f;
     for (int x = 0; x < w; x++) {
         for (int y = 0; y < h; y++) {
             float alphaFactor = 1.0f - maskFloat[x * h + y];
@@ -3543,11 +3546,10 @@ void PixelBufferClass::LayerInfo::blurMaskToAlpha(int blurAmount) {
             buffer.GetPixel(x, y, c);
             c.alpha = static_cast<uint8_t>(c.alpha * alphaFactor);
             buffer.SetPixel(x, y, c);
+
+            mask[x * h + y] = (alphaFactor <= kFullyHiddenEps) ? 255 : 0;
         }
     }
-    // Clear the mask to zeros so isMasked() returns false for all pixels.
-    // Alpha now carries the edge softness information.
-    memset(mask, 0, maskSize);
 }
 
 void PixelBufferClass::LayerInfo::renderTransitions(bool isFirstFrame, RenderBuffer* prevRB) {

--- a/src-core/render/PixelBuffer.cpp
+++ b/src-core/render/PixelBuffer.cpp
@@ -598,29 +598,30 @@ namespace {
                (c - a) * u.y * (1.0 - u.x) +
                (d - b) * u.x * u.y;
     }
-    xlColor blobs(const ColorBuffer& cb0, const RenderBuffer* rb1, double s, double t, double progress, double scale) {
+    xlColor blobs(const ColorBuffer& cb0, const RenderBuffer* rb1, double s, double t, double progress, double scale, float smoothness) {
         xlColor fromColor((rb1 == nullptr) ? xlBLACK : tex2D(*rb1, s, t));
         xlColor toColor(tex2D(cb0, s, t));
         float n = blobsNoise(scale * Vec2D(s, t));
 
-        float p = lerp(-blobsSmoothness, 1. - +blobsSmoothness, progress);
-        float lo = p - blobsSmoothness;
-        float hi = p + blobsSmoothness;
+        float p = lerp(-smoothness, 1.f - smoothness, (float)progress);
+        float lo = p - smoothness;
+        float hi = p + smoothness;
 
         float q = SmoothStep(lo, hi, n);
 
         return lerp(fromColor, toColor, 1.f - q);
     }
-    void blobs(RenderBuffer& rb0, const ColorBuffer& cb0, const RenderBuffer* rb1, double progress, int adjust) {
+    void blobs(RenderBuffer& rb0, const ColorBuffer& cb0, const RenderBuffer* rb1, double progress, int adjust, int blur = 0) {
         if (progress < 0. || progress > 1.)
             return;
         double scale = interpolate(double(adjust), 0., 4., 100., 14., LinearInterpolater());
+        float smoothness = blobsSmoothness + (blur / 25.0f) * 0.49f;
         parallel_for(
-            0, rb0.BufferHt, [&rb0, &cb0, &rb1, progress, scale](int y) {
+            0, rb0.BufferHt, [&rb0, &cb0, &rb1, progress, scale, smoothness](int y) {
                 double t = double(y) / (rb0.BufferHt - 1);
                 for (int x = 0; x < rb0.BufferWi; ++x) {
                     double s = double(x) / (rb0.BufferWi - 1);
-                    rb0.SetPixel(x, y, blobs(cb0, rb1, s, t, progress, scale));
+                    rb0.SetPixel(x, y, blobs(cb0, rb1, s, t, progress, scale, smoothness));
                 }
             },
             25);
@@ -1948,6 +1949,8 @@ static const std::string SLIDER_In_Transition_Adjust("SLIDER_In_Transition_Adjus
 static const std::string SLIDER_Out_Transition_Adjust("SLIDER_Out_Transition_Adjust");
 static const std::string CHECKBOX_In_Transition_Reverse("CHECKBOX_In_Transition_Reverse");
 static const std::string CHECKBOX_Out_Transition_Reverse("CHECKBOX_Out_Transition_Reverse");
+static const std::string SLIDER_In_Transition_Blur("SLIDER_In_Transition_Blur");
+static const std::string SLIDER_Out_Transition_Blur("SLIDER_Out_Transition_Blur");
 
 void ComputeValueCurve(const std::string& valueCurve, ValueCurve& theValueCurve, int divisor = 1) {
     if (valueCurve == STR_EMPTY) {
@@ -2109,6 +2112,8 @@ void PixelBufferClass::SetLayerSettings(int layer, const SettingsMap& settingsMa
     inf->OutTransitionAdjustValueCurve = valueCurveFromSettingsMap(settingsMap, "Out_Transition_Adjust");
     inf->inTransitionReverse = settingsMap.GetBool(CHECKBOX_In_Transition_Reverse);
     inf->outTransitionReverse = settingsMap.GetBool(CHECKBOX_Out_Transition_Reverse);
+    inf->inTransitionBlur = settingsMap.GetInt(SLIDER_In_Transition_Blur, 0);
+    inf->outTransitionBlur = settingsMap.GetInt(SLIDER_Out_Transition_Blur, 0);
 
     inf->blur = settingsMap.GetInt(SLIDER_Blur, 1);
     inf->rotation = settingsMap.GetInt(SLIDER_Rotation, 0);
@@ -3479,6 +3484,72 @@ namespace {
     }
 }
 
+void PixelBufferClass::LayerInfo::blurMaskToAlpha(int blurAmount) {
+    if (blurAmount <= 0 || maskSize == 0) return;
+
+    GPURenderUtils::waitForRenderCompletion(&buffer);
+
+    int w = BufferWi;
+    int h = BufferHt;
+    int radius = blurAmount;
+
+    // Convert the binary 0/255 mask to float (mask[x * h + y])
+    std::vector<float> maskFloat(w * h);
+    std::vector<float> tmp(w * h);
+    for (int x = 0; x < w; x++) {
+        for (int y = 0; y < h; y++) {
+            maskFloat[x * h + y] = mask[x * h + y] / 255.0f;
+        }
+    }
+
+    // Horizontal box blur pass
+    for (int y = 0; y < h; y++) {
+        for (int x = 0; x < w; x++) {
+            float sum = 0.0f;
+            int count = 0;
+            for (int dx = -radius; dx <= radius; dx++) {
+                int nx = x + dx;
+                if (nx >= 0 && nx < w) {
+                    sum += maskFloat[nx * h + y];
+                    count++;
+                }
+            }
+            tmp[x * h + y] = count > 0 ? sum / count : 0.0f;
+        }
+    }
+
+    // Vertical box blur pass
+    for (int x = 0; x < w; x++) {
+        for (int y = 0; y < h; y++) {
+            float sum = 0.0f;
+            int count = 0;
+            for (int dy = -radius; dy <= radius; dy++) {
+                int ny = y + dy;
+                if (ny >= 0 && ny < h) {
+                    sum += tmp[x * h + ny];
+                    count++;
+                }
+            }
+            maskFloat[x * h + y] = count > 0 ? sum / count : 0.0f;
+        }
+    }
+
+    // Bake the blurred mask into pixel alpha (0=visible, 1=hidden) and clear the mask.
+    // Pixels near the wipe boundary get partial alpha, creating a soft edge.
+    for (int x = 0; x < w; x++) {
+        for (int y = 0; y < h; y++) {
+            float alphaFactor = 1.0f - maskFloat[x * h + y];
+            xlColor c;
+            buffer.GetPixel(x, y, c);
+            c.alpha = static_cast<uint8_t>(c.alpha * alphaFactor);
+            buffer.SetPixel(x, y, c);
+        }
+    }
+    // Clear the mask to zeros so isMasked() returns false for all pixels.
+    // Alpha now carries the edge softness information.
+    memset(mask, 0, maskSize);
+}
+
 void PixelBufferClass::LayerInfo::renderTransitions(bool isFirstFrame, RenderBuffer* prevRB) {
     bool hasMask = false;
     if (inMaskFactor < 1.0 || outMaskFactor < 1.0) {
@@ -3521,7 +3592,7 @@ void PixelBufferClass::LayerInfo::renderTransitions(bool isFirstFrame, RenderBuf
                 if (InTransitionAdjustValueCurve.IsActive())
                     adjust = static_cast<int>(InTransitionAdjustValueCurve.GetOutputValueAt(inMaskFactor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS()));
                 GPURenderUtils::waitForRenderCompletion(prevRB);
-                blobs(buffer, cb, prevRB, inMaskFactor, adjust);
+                blobs(buffer, cb, prevRB, inMaskFactor, adjust, inTransitionBlur);
             } else if (inTransitionType == STR_PINWHEEL) {
                 int adjust = inTransitionAdjust;
                 if (InTransitionAdjustValueCurve.IsActive())
@@ -3549,6 +3620,9 @@ void PixelBufferClass::LayerInfo::renderTransitions(bool isFirstFrame, RenderBuf
             }
         } else {
             calculateMask(inTransitionType, false, isFirstFrame);
+            if (inTransitionBlur > 0) {
+                blurMaskToAlpha(inTransitionBlur);
+            }
         }
         hasMask = true;
     }
@@ -3582,7 +3656,7 @@ void PixelBufferClass::LayerInfo::renderTransitions(bool isFirstFrame, RenderBuf
                 if (OutTransitionAdjustValueCurve.IsActive())
                     adjust = static_cast<int>(OutTransitionAdjustValueCurve.GetOutputValueAt(outMaskFactor, buffer.GetStartTimeMS(), buffer.GetEndTimeMS()));
                 GPURenderUtils::waitForRenderCompletion(prevRB);
-                blobs(buffer, cb, prevRB, outMaskFactor, adjust);
+                blobs(buffer, cb, prevRB, outMaskFactor, adjust, outTransitionBlur);
             } else if (outTransitionType == STR_PINWHEEL) {
                 int adjust = outTransitionAdjust;
                 if (OutTransitionAdjustValueCurve.IsActive())
@@ -3610,6 +3684,9 @@ void PixelBufferClass::LayerInfo::renderTransitions(bool isFirstFrame, RenderBuf
             }
         } else {
             calculateMask(outTransitionType, true, isFirstFrame);
+            if (outTransitionBlur > 0) {
+                blurMaskToAlpha(outTransitionBlur);
+            }
         }
         hasMask = true;
     }

--- a/src-core/render/PixelBuffer.h
+++ b/src-core/render/PixelBuffer.h
@@ -98,6 +98,7 @@ private:
             fadeInSteps = fadeOutSteps = 0;
             inTransitionAdjust = outTransitionAdjust = 0;
             inTransitionReverse = outTransitionReverse = false;
+            inTransitionBlur = outTransitionBlur = 0;
             stagger = 0;
         }
         RenderBuffer buffer;
@@ -180,6 +181,8 @@ private:
         int outTransitionAdjust;
         bool inTransitionReverse;
         bool outTransitionReverse;
+        int inTransitionBlur;
+        int outTransitionBlur;
         float inMaskFactor = 1.0f;
         float outMaskFactor = 1.0f;
         int stagger;
@@ -216,6 +219,7 @@ private:
         void calculateNodeOutputParams(int effectPeriod);
 
     private:
+        void blurMaskToAlpha(int blurAmount);
         void createSquareExplodeMask(bool end);
         void createCircleExplodeMask(bool end);
         void createWipeMask(bool end);

--- a/src-ui-wx/sequencer/BlendingPanel.cpp
+++ b/src-ui-wx/sequencer/BlendingPanel.cpp
@@ -78,6 +78,12 @@ const std::vector<wxString> TRANSITIONS_NO_REVERSE = {
     "Doorway", "Blobs", "Pinwheel", "Swap", "Shatter", "Circles"
 };
 
+// Transitions that support the Blur slider.
+const std::vector<wxString> TRANSITIONS_WITH_BLUR = {
+    "Wipe", "Blobs", "Clock", "Blinds", "From Middle",
+    "Square Explode", "Circle Explode", "Blend", "Slide Checks", "Slide Bars"
+};
+
 // Layer method options in the legacy display order (the map order is
 // alphabetical which isn't what we want).
 const std::vector<wxString> LAYER_METHODS = {
@@ -455,6 +461,15 @@ void BlendingPanel::SetDefaultControls(const Model* /*model*/, bool optionbased)
     resetVC("ID_VALUECURVE_In_Transition_Adjust");
     resetVC("ID_VALUECURVE_Out_Transition_Adjust");
 
+    // Reset blur sliders to 0.
+    auto resetSlider = [this](const char* name) {
+        if (auto* w = wxWindow::FindWindowByName(name, this)) {
+            if (auto* s = dynamic_cast<wxSlider*>(w)) s->SetValue(0);
+        }
+    };
+    resetSlider("ID_SLIDER_In_Transition_Blur");
+    resetSlider("ID_SLIDER_Out_Transition_Blur");
+
     ValidateWindow();
 }
 
@@ -499,6 +514,8 @@ void BlendingPanel::ValidateWindow() {
     auto* outAdjust = GetPropertyInfo("Out_Transition_Adjust");
     auto* inReverse = GetPropertyInfo("In_Transition_Reverse");
     auto* outReverse = GetPropertyInfo("Out_Transition_Reverse");
+    auto* inBlur = GetPropertyInfo("In_Transition_Blur");
+    auto* outBlur = GetPropertyInfo("Out_Transition_Blur");
 
     auto enableRow = [this](JsonEffectPanel::PropertyInfo* p, bool enabled) {
         if (p == nullptr) return;
@@ -523,11 +540,13 @@ void BlendingPanel::ValidateWindow() {
     wxString inTypeSel = _inTypeChoice ? _inTypeChoice->GetStringSelection() : wxString("Fade");
     enableRow(inAdjust, inEnable && !inList(TRANSITIONS_NO_ADJUST, inTypeSel));
     enableRow(inReverse, inEnable && !inList(TRANSITIONS_NO_REVERSE, inTypeSel));
+    enableRow(inBlur, inEnable && inList(TRANSITIONS_WITH_BLUR, inTypeSel));
 
     bool outEnable = fadeOut != 0.0;
     wxString outTypeSel = _outTypeChoice ? _outTypeChoice->GetStringSelection() : wxString("Fade");
     enableRow(outAdjust, outEnable && !inList(TRANSITIONS_NO_ADJUST, outTypeSel));
     enableRow(outReverse, outEnable && !inList(TRANSITIONS_NO_REVERSE, outTypeSel));
+    enableRow(outBlur, outEnable && inList(TRANSITIONS_WITH_BLUR, outTypeSel));
 }
 
 wxString BlendingPanel::GetBlendingString() {
@@ -597,11 +616,13 @@ wxString BlendingPanel::GetBlendingString() {
         stripSetting("E_SLIDER_In_Transition_Adjust");
         stripSetting("E_VALUECURVE_In_Transition_Adjust");
         stripSetting("E_CHECKBOX_In_Transition_Reverse");
+        stripSetting("E_SLIDER_In_Transition_Blur");
     }
     if (fadeOutZero) {
         stripSetting("E_SLIDER_Out_Transition_Adjust");
         stripSetting("E_VALUECURVE_Out_Transition_Adjust");
         stripSetting("E_CHECKBOX_Out_Transition_Reverse");
+        stripSetting("E_SLIDER_Out_Transition_Blur");
     }
 
     s.Replace(",E_", ",T_");


### PR DESCRIPTION
Add the blur slider to fade in / out for most (but not all) transition types.
<img width="809" height="644" alt="image" src="https://github.com/user-attachments/assets/6d4ee8ba-b99e-4bf8-ae9a-f63716520387" />
● Transitions without blur (slider stays disabled):

  - Fade – no spatial edge, blur wouldn't apply
  - Fold
  - Dissolve
  - Circular Swirl
  - Bow Tie
  - Zoom
  - Doorway
  - Pinwheel
  - Star
  - Swap
  - Shatter
  - Circles