### PR TITLE
Property grid: Tab/Shift+Tab traverses to next/prev property (fixes #5697)

### DIFF
--- a/src-ui-wx/shared/utils/xlPropertyGrid.h
+++ b/src-ui-wx/shared/utils/xlPropertyGrid.h
@@ -82,6 +82,7 @@ public:
         wxPropertyGrid::Clear();
     }
 
+private:
     void OnCharHook(wxKeyEvent& event) {
         // Only interested in plain Tab / Shift+Tab; Ctrl/Alt+Tab passes through.
         if (event.GetKeyCode() != WXK_TAB || event.ControlDown() || event.AltDown()) {
@@ -118,7 +119,11 @@ public:
         // and look up the target by name (pointers from before the rebuild
         // are dead).
         const wxString nextName = (*it)->GetName();
-        CommitChangesFromEditor();
+        // If validation rejects the value, stay on the current editor so the
+        // user can fix it rather than silently losing focus to another row.
+        if (!CommitChangesFromEditor()) {
+            return;
+        }
         CallAfter([this, nextName]() {
             if (wxPGProperty* p = GetPropertyByName(nextName)) {
                 SelectProperty(p, true);
@@ -127,6 +132,5 @@ public:
         });
     }
 
-private:
     bool m_hidingComboPopups = false;
 };

--- a/src-ui-wx/shared/utils/xlPropertyGrid.h
+++ b/src-ui-wx/shared/utils/xlPropertyGrid.h
@@ -37,6 +37,10 @@ public:
             // property instead, matching the behavior of every other property
             // editor (Excel, Visual Studio properties pane, etc.).
             Bind(wxEVT_CHAR_HOOK, &xlPropertyGrid::OnCharHook, this);
+            // Spin/combo editors capture the mouse wheel and change their value,
+            // which fires a rebuild that loses the selection. Redirect the wheel
+            // from the active editor to the grid so scrolling only scrolls.
+            Bind(wxEVT_PG_SELECTED, &xlPropertyGrid::OnPropertySelected, this);
     }
     virtual ~xlPropertyGrid() {
     }
@@ -83,34 +87,56 @@ public:
     }
 
 private:
+    void OnPropertySelected(wxPropertyGridEvent& event) {
+        event.Skip();
+        if (wxWindow* ed = GetEditorControl()) {
+            ed->Bind(wxEVT_MOUSEWHEEL, &xlPropertyGrid::OnEditorMouseWheel, this);
+        }
+    }
+    void OnEditorMouseWheel(wxMouseEvent& event) {
+        // Forward to the grid so it scrolls; don't Skip, so the editor never
+        // consumes the wheel to change its value.
+        wxMouseEvent fwd(event);
+        fwd.SetEventObject(this);
+        ProcessWindowEvent(fwd);
+    }
     void OnCharHook(wxKeyEvent& event) {
         // Only interested in plain Tab / Shift+Tab; Ctrl/Alt+Tab passes through.
         if (event.GetKeyCode() != WXK_TAB || event.ControlDown() || event.AltDown()) {
             event.Skip();
             return;
         }
-        // If no editor is open, let wx do its default traversal so Tab can
-        // exit the grid normally when the user is just navigating.
-        if (!IsEditorFocused()) {
-            event.Skip();
-            return;
-        }
+        // Nothing selected -> no active editor; let Tab traverse out of the grid.
         wxPGProperty* sel = GetSelection();
         if (sel == nullptr) {
             event.Skip();
             return;
         }
+        // Gate on selection rather than editor focus so combo/choice editors
+        // advance too (IsEditorFocused() is false for them, which used to drop
+        // focus out of the grid). Skip category headers since they have no editor.
+        auto step = [&event](wxPropertyGridIterator& i) {
+            if (event.ShiftDown()) {
+                --i;
+            } else {
+                ++i;
+            }
+        };
         wxPropertyGridIterator it = GetIterator(wxPG_ITERATE_VISIBLE, sel);
-        if (event.ShiftDown()) {
-            --it;
-        } else {
-            ++it;
-        }
+        do {
+            step(it);
+        } while (!it.AtEnd() && (*it)->IsCategory());
         if (it.AtEnd()) {
-            // Boundary: at the first/last property — fall through to default
-            // traversal so the user can Tab out of the grid entirely.
-            event.Skip();
-            return;
+            // Past the last/first editable property: wrap to the other end so
+            // Tab cycles through the grid instead of leaving it.
+            it = GetIterator(wxPG_ITERATE_VISIBLE, event.ShiftDown() ? wxBOTTOM : wxTOP);
+            while (!it.AtEnd() && (*it)->IsCategory()) {
+                step(it);
+            }
+            if (it.AtEnd()) {
+                event.Skip();
+                return;
+            }
         }
         // Commit the current editor's value, then jump to the next property.
         // The commit fires wxEVT_PG_CHANGED, which queues a model reload that

--- a/src-ui-wx/shared/utils/xlPropertyGrid.h
+++ b/src-ui-wx/shared/utils/xlPropertyGrid.h
@@ -11,6 +11,7 @@
 
 #include <set>
 #include <wx/propgrid/propgrid.h>
+#include <wx/propgrid/propgridiface.h>
 #include <wx/combo.h>
 
 // This is to workaround a crash in wxPropertyGrid where doing
@@ -29,6 +30,13 @@ public:
                    const wxString& name = wxASCII_STR(wxPropertyGridNameStr)) :
         wxPropertyGrid(parent, id, pos, size, style, name) {
             Connect(wxEVT_IDLE,(wxObjectEventFunction)&xlPropertyGrid::OnIdle, 0, this);
+            // Tab traversal: stock wxPropertyGrid sends focus to the next sibling
+            // widget on Tab (via Navigate()), so users have to click their way
+            // back into the grid to edit the next property. Intercept Tab via
+            // CHAR_HOOK on the grid and walk to the next/previous visible
+            // property instead, matching the behavior of every other property
+            // editor (Excel, Visual Studio properties pane, etc.).
+            Bind(wxEVT_CHAR_HOOK, &xlPropertyGrid::OnCharHook, this);
     }
     virtual ~xlPropertyGrid() {
     }
@@ -72,6 +80,51 @@ public:
         HideDeletingComboPopups();
 #endif
         wxPropertyGrid::Clear();
+    }
+
+    void OnCharHook(wxKeyEvent& event) {
+        // Only interested in plain Tab / Shift+Tab; Ctrl/Alt+Tab passes through.
+        if (event.GetKeyCode() != WXK_TAB || event.ControlDown() || event.AltDown()) {
+            event.Skip();
+            return;
+        }
+        // If no editor is open, let wx do its default traversal so Tab can
+        // exit the grid normally when the user is just navigating.
+        if (!IsEditorFocused()) {
+            event.Skip();
+            return;
+        }
+        wxPGProperty* sel = GetSelection();
+        if (sel == nullptr) {
+            event.Skip();
+            return;
+        }
+        wxPropertyGridIterator it = GetIterator(wxPG_ITERATE_VISIBLE, sel);
+        if (event.ShiftDown()) {
+            --it;
+        } else {
+            ++it;
+        }
+        if (it.AtEnd()) {
+            // Boundary: at the first/last property — fall through to default
+            // traversal so the user can Tab out of the grid entirely.
+            event.Skip();
+            return;
+        }
+        // Commit the current editor's value, then jump to the next property.
+        // The commit fires wxEVT_PG_CHANGED, which queues a model reload that
+        // rebuilds the whole grid and invalidates property pointers. Defer the
+        // focus shift via CallAfter so it runs once the rebuild has settled,
+        // and look up the target by name (pointers from before the rebuild
+        // are dead).
+        const wxString nextName = (*it)->GetName();
+        CommitChangesFromEditor();
+        CallAfter([this, nextName]() {
+            if (wxPGProperty* p = GetPropertyByName(nextName)) {
+                SelectProperty(p, true);
+                EnsureVisible(p);
+            }
+        });
     }
 
 private:

--- a/src-ui-wx/shared/utils/xlPropertyGrid.h
+++ b/src-ui-wx/shared/utils/xlPropertyGrid.h
@@ -114,7 +114,9 @@ private:
         }
         // Gate on selection rather than editor focus so combo/choice editors
         // advance too (IsEditorFocused() is false for them, which used to drop
-        // focus out of the grid). Skip category headers since they have no editor.
+        // focus out of the grid). Skip expanded category headers (descend to
+        // their first child) but stop on collapsed ones so the user can expand
+        // them (Right arrow) and Tab again to enter the section.
         auto step = [&event](wxPropertyGridIterator& i) {
             if (event.ShiftDown()) {
                 --i;
@@ -122,15 +124,18 @@ private:
                 ++i;
             }
         };
+        auto skippable = [](wxPropertyGridIterator& i) {
+            return (*i)->IsCategory() && (*i)->IsExpanded();
+        };
         wxPropertyGridIterator it = GetIterator(wxPG_ITERATE_VISIBLE, sel);
         do {
             step(it);
-        } while (!it.AtEnd() && (*it)->IsCategory());
+        } while (!it.AtEnd() && skippable(it));
         if (it.AtEnd()) {
-            // Past the last/first editable property: wrap to the other end so
-            // Tab cycles through the grid instead of leaving it.
+            // Past the last/first stop: wrap to the other end so Tab cycles
+            // through the grid instead of leaving it.
             it = GetIterator(wxPG_ITERATE_VISIBLE, event.ShiftDown() ? wxBOTTOM : wxTOP);
-            while (!it.AtEnd() && (*it)->IsCategory()) {
+            while (!it.AtEnd() && skippable(it)) {
                 step(it);
             }
             if (it.AtEnd()) {


### PR DESCRIPTION
## Summary

Closes #5697.

Stock wxPropertyGrid handles **Tab** in an open editor by calling `Navigate(IsForward)`, which moves keyboard focus to the next sibling widget of the grid rather than to the next property within it. The result on the Layout tab's Model pane: type a value (e.g. # Lights Top), press Tab, and focus jumps out to the 3D preview — the user has to click back into the next field every time.

Despite a long-standing assumption that this isn't fixable in wxWidgets, wxPropertyGrid does expose enough to override the behavior cleanly.

## Fix

Override Tab in our existing `xlPropertyGrid` subclass (`src-ui-wx/shared/utils/xlPropertyGrid.h`) via `wxEVT_CHAR_HOOK`:

- **Plain Tab** — advance to the next visible **editable** property and focus its editor, **skipping category/section headers**.
- **Shift+Tab** — same, backward.
- **Works for every row type** — text, dropdown/choice, Click-to-Edit (Start Channel, Preview, …) and disabled/read-only rows. Traversal is gated on the *selected property*, not on editor focus: the first cut only advanced from focused text editors, so it stalled after ~5-6 fields and couldn't get past dropdowns, Click-to-Edit elements, or down into Controller Connections (per @derwin12's testing).
- **Wrap-around** — Tab at the last visible property cycles back to the first, and Shift+Tab at the first cycles to the last, so Tab walks the whole list. (Changed from the original "fall through to wx default at the boundary" per review feedback — the boundary fall-through only happens now if there is no selection / no editable property at all.)
- **Ctrl+Tab / Alt+Tab**, or Tab with no property selected — falls through to wx default traversal.

### Scroll no longer edits values

Spin/choice editors capture the mouse wheel and change their value, which fires the same grid rebuild (below) and bounced the selection back to the top. The active editor's wheel events are now redirected to scroll the grid, so scrolling never mutates a value or loses your place.

### Survival across grid rebuilds

Committing the current edit fires `wxEVT_PG_CHANGED`, which `LayoutPanel::OnPropertyGridChange` translates into a model reload that rebuilds the entire grid. That rebuild invalidates the `wxPGProperty*` pointers we got from the iterator and (without this fix) leaves focus on the layout canvas, because the editor we just focused is destroyed mid-flight.

To survive that:

1. `CommitChangesFromEditor()` is called explicitly so the value lands before we move on; if it fails (validation rejects the value) we stay put.
2. The focus shift is deferred via `CallAfter`, so it runs after any rebuild queued by the commit has settled.
3. The next property is looked up by **name** (`GetPropertyByName(nextName)`), not the now-stale pointer.

## Test plan

- [x] macOS Release build (Xcode 26.5)
- [ ] Layout tab → select a Window Frame (the model from #5697); type `13` in `# Lights Top` and press Tab → focus lands in the next field, value 13 is saved
- [ ] Tab / Shift+Tab traverse the **entire** list, including dropdowns, Click-to-Edit, and disabled rows, and into sections like Controller Connections
- [ ] Tab at the bottommost property wraps to the top; Shift+Tab at the top wraps to the bottom
- [ ] Scrolling the mouse wheel over a spin/dropdown row scrolls the grid without changing its value or losing the selection
- [ ] Ctrl+Tab / Alt+Tab still trigger their normal behaviors
- [ ] Verify on Windows and Linux (wx-platform-neutral code; same widget, same fork)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
