### PR TITLE
Guard against the discovery crash (#5844)

### DIFF
--- a/src-core/controllers/ESPixelStick.cpp
+++ b/src-core/controllers/ESPixelStick.cpp
@@ -354,6 +354,9 @@ bool ESPixelStick::SetInputUniverses(Controller* controller, UICallbacks* ui) {
         GetInputConfig(inputConfig);
 
         std::list<Output*> outputs = controller->GetOutputs();
+        if (outputs.empty()) {
+            return false;
+        }
 
         std::string type = "DDP";
         int startUniverse = 0;

--- a/src-core/controllers/PowerDMX.cpp
+++ b/src-core/controllers/PowerDMX.cpp
@@ -183,6 +183,9 @@ int32_t PowerDMX::SetInputUniverses(nlohmann::json& data, Controller* controller
 
     // Get universes based on IP
     std::list<Output*> outputs = controller->GetOutputs();
+    if (outputs.empty()) {
+        return startChannel;
+    }
 
     auto out = outputs.front();
     startChannel = out->GetStartChannel();


### PR DESCRIPTION
If no outputs discovered then dont crash but return false.