### PR TITLE
#6534 Add Copy on Drag to sequencer

### DIFF
--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -2205,7 +2205,6 @@ void EffectsGrid::mouseDown(wxMouseEvent& event) {
             mEffectMoveDragging = true;
             mEffectMoveDragThresholdExceeded = false;
             mEffectMoveDragGroup = wasSelectedForGroupDrag;
-            mEffectMoveCopyMode = event.AltDown();
             mEffectMoveDragStartX = event.GetX();
             mEffectMoveDragStartY = event.GetY();
             mEffectMoveAnchorRow = row;
@@ -8159,6 +8158,7 @@ void EffectsGrid::ApplyEffectMoveDrag() {
     // For cross-row move, same-row copy, and cross-row copy:
     // Add new effects at target positions (unselected so delete pass only removes originals).
     Effect* newAnchorEff = nullptr;
+    std::vector<Effect*> newEffects;
     for (auto& snap : mEffectMoveSnapshots) {
         int targetVisibleRow = snap.origVisibleRow + rowDelta;
         if (targetVisibleRow < 0 || targetVisibleRow >= (int)mSequenceElements->GetVisibleRowInformationSize()) continue;
@@ -8182,6 +8182,8 @@ void EffectsGrid::ApplyEffectMoveDrag() {
                 targetLayer->GetIndex(), newEff->GetID());
             if (snap.effect == mEffectMoveAnchorEffect)
                 newAnchorEff = newEff;
+            if (mEffectMoveCopyMode)
+                newEffects.push_back(newEff);
         }
     }
 
@@ -8192,6 +8194,12 @@ void EffectsGrid::ApplyEffectMoveDrag() {
             EffectLayer* el = mSequenceElements->GetEffectLayer(row);
             if (el) el->DeleteSelectedEffects(mSequenceElements->get_undo_mgr());
         }
+    } else {
+        // Copy: deselect originals, select all new copies
+        for (auto& snap : mEffectMoveSnapshots)
+            snap.effect->SetSelected(EFFECT_NOT_SELECTED);
+        for (Effect* e : newEffects)
+            e->SetSelected(EFFECT_SELECTED);
     }
 
     // Update selected effect pointer so it doesn't dangle

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -1778,7 +1778,7 @@ void EffectsGrid::mouseMoved(wxMouseEvent& event) {
             }
         }
         if (mEffectMoveDragThresholdExceeded) {
-            UpdateEffectMoveDragState(event.GetX(), event.GetY(), event.ControlDown());
+            UpdateEffectMoveDragState(event.GetX(), event.GetY(), event.ControlDown(), event.AltDown());
             Draw();
         }
     } else if (mDragging) {
@@ -2112,7 +2112,7 @@ void EffectsGrid::mouseDown(wxMouseEvent& event) {
                                     selectionType == HitLocation::CENTER &&
                                     mResizingMode == EFFECT_RESIZE_MOVE &&
                                     MultipleEffectsSelected() &&
-                                    !(event.ShiftDown() || event.ControlDown() || event.AltDown()));
+                                    !(event.ShiftDown() || event.ControlDown()));
     if (selectedEffect != nullptr) {
         spdlog::debug("EffectsGrid::mouseDown effect selected {}.", (const char*)selectedEffect->GetEffectName().c_str());
         switch (selectionType) {
@@ -2199,10 +2199,13 @@ void EffectsGrid::mouseDown(wxMouseEvent& event) {
 
     if (!mMouseOperationsCancelled) {
         if (mResizingMode == EFFECT_RESIZE_MOVE && selectedEffect != nullptr) {
-            // Ghost drag-to-move: non-destructive drag with dim originals and ghost at target
+            // Ghost drag-to-move/copy: non-destructive drag with dim originals and ghost at target
+            if (selectedEffect->GetSelected() == EFFECT_NOT_SELECTED)
+                selectedEffect->SetSelected(EFFECT_SELECTED);
             mEffectMoveDragging = true;
             mEffectMoveDragThresholdExceeded = false;
             mEffectMoveDragGroup = wasSelectedForGroupDrag;
+            mEffectMoveCopyMode = event.AltDown();
             mEffectMoveDragStartX = event.GetX();
             mEffectMoveDragStartY = event.GetY();
             mEffectMoveAnchorRow = row;
@@ -8030,6 +8033,7 @@ void EffectsGrid::ResetEffectMoveDragState() {
     mEffectMoveDragThresholdExceeded = false;
     mEffectMoveDragGroup = false;
     mEffectMoveHasCollision = false;
+    mEffectMoveCopyMode = false;
     mEffectMoveSnapshots.clear();
     mEffectMoveAnchorEffect = nullptr;
 }
@@ -8059,9 +8063,11 @@ int EffectsGrid::SnapCursorToTimingMark(int timeMS, int x) const {
     return timeMS;
 }
 
-void EffectsGrid::UpdateEffectMoveDragState(int x, int y, bool snapToTiming) {
+void EffectsGrid::UpdateEffectMoveDragState(int x, int y, bool snapToTiming, bool altDown) {
     static const wxCursor s_noEntry(wxCURSOR_NO_ENTRY);
     static const wxCursor s_sizing(wxCURSOR_SIZING);
+
+    mEffectMoveCopyMode = altDown;
 
     if (mEffectMoveSnapshots.empty()) return;
 
@@ -8128,7 +8134,7 @@ void EffectsGrid::UpdateEffectMoveDragState(int x, int y, bool snapToTiming) {
         }
         int ts = snap.origStartTimeMS + rawDelta;
         int te = snap.origEndTimeMS + rawDelta;
-        bool sameLayer = (snapTargetRow == snap.origVisibleRow);
+        bool sameLayer = !mEffectMoveCopyMode && (snapTargetRow == snap.origVisibleRow);
         if (!tl->GetRangeIsClearMS(ts, te, sameLayer)) {
             collision = true;
             break;
@@ -8144,56 +8150,60 @@ void EffectsGrid::ApplyEffectMoveDrag() {
     int rowDelta = mEffectMoveTargetRow - mEffectMoveAnchorRow;
     int deltaMS = mEffectMoveTargetDeltaMS;
 
-    if (rowDelta == 0) {
+    if (rowDelta == 0 && !mEffectMoveCopyMode) {
         MoveAllSelectedEffects(deltaMS, false);
         sendRenderDirtyEvent();
-    } else {
-        // Cross-row: add unselected copies to target layers, then delete selected originals.
-        // New effects must be EFFECT_NOT_SELECTED so DeleteSelectedEffects only removes originals.
-        Effect* newAnchorEff = nullptr;
-        for (auto& snap : mEffectMoveSnapshots) {
-            int targetVisibleRow = snap.origVisibleRow + rowDelta;
-            if (targetVisibleRow < 0 || targetVisibleRow >= (int)mSequenceElements->GetVisibleRowInformationSize()) continue;
-            Row_Information_Struct* targetRI = mSequenceElements->GetVisibleRowInformation(targetVisibleRow);
-            if (targetRI == nullptr || targetRI->element->GetType() == ElementType::ELEMENT_TYPE_TIMING) continue;
-            EffectLayer* targetLayer = mSequenceElements->GetVisibleEffectLayer(targetVisibleRow);
-            if (targetLayer == nullptr) continue;
+        return;
+    }
 
-            int newStart = snap.origStartTimeMS + deltaMS;
-            int newEnd = snap.origEndTimeMS + deltaMS;
+    // For cross-row move, same-row copy, and cross-row copy:
+    // Add new effects at target positions (unselected so delete pass only removes originals).
+    Effect* newAnchorEff = nullptr;
+    for (auto& snap : mEffectMoveSnapshots) {
+        int targetVisibleRow = snap.origVisibleRow + rowDelta;
+        if (targetVisibleRow < 0 || targetVisibleRow >= (int)mSequenceElements->GetVisibleRowInformationSize()) continue;
+        Row_Information_Struct* targetRI = mSequenceElements->GetVisibleRowInformation(targetVisibleRow);
+        if (targetRI == nullptr || targetRI->element->GetType() == ElementType::ELEMENT_TYPE_TIMING) continue;
+        EffectLayer* targetLayer = mSequenceElements->GetVisibleEffectLayer(targetVisibleRow);
+        if (targetLayer == nullptr) continue;
 
-            Effect* newEff = targetLayer->AddEffect(0,
-                snap.effect->GetEffectName(),
-                snap.effect->GetSettingsAsString(),
-                snap.effect->GetPaletteAsString(),
-                newStart, newEnd,
-                EFFECT_NOT_SELECTED, false);
-            if (newEff) {
-                mSequenceElements->get_undo_mgr().CaptureAddedEffect(
-                    targetLayer->GetParentElement()->GetModelName(),
-                    targetLayer->GetIndex(), newEff->GetID());
-                if (snap.effect == mEffectMoveAnchorEffect) {
-                    newAnchorEff = newEff;
-                }
-            }
+        int newStart = snap.origStartTimeMS + deltaMS;
+        int newEnd = snap.origEndTimeMS + deltaMS;
+
+        Effect* newEff = targetLayer->AddEffect(0,
+            snap.effect->GetEffectName(),
+            snap.effect->GetSettingsAsString(),
+            snap.effect->GetPaletteAsString(),
+            newStart, newEnd,
+            EFFECT_NOT_SELECTED, false);
+        if (newEff) {
+            mSequenceElements->get_undo_mgr().CaptureAddedEffect(
+                targetLayer->GetParentElement()->GetModelName(),
+                targetLayer->GetIndex(), newEff->GetID());
+            if (snap.effect == mEffectMoveAnchorEffect)
+                newAnchorEff = newEff;
         }
-        // Delete originals from their source layers
+    }
+
+    if (!mEffectMoveCopyMode) {
+        // Move: delete originals from their source layers
         ((MainSequencer*)mParent)->TagAllSelectedEffects();
         for (int row = 0; row < mSequenceElements->GetRowInformationSize(); row++) {
             EffectLayer* el = mSequenceElements->GetEffectLayer(row);
             if (el) el->DeleteSelectedEffects(mSequenceElements->get_undo_mgr());
         }
-        // Update selected effect pointer so it doesn't dangle
-        if (newAnchorEff) {
-            newAnchorEff->SetSelected(EFFECT_SELECTED);
-            mSelectedEffect = newAnchorEff;
-            mSelectedRow = mEffectMoveTargetRow + mSequenceElements->GetFirstVisibleModelRow();
-        } else {
-            mSelectedEffect = nullptr;
-            mSelectedRow = -1;
-        }
-        sendRenderDirtyEvent();
     }
+
+    // Update selected effect pointer so it doesn't dangle
+    if (newAnchorEff) {
+        newAnchorEff->SetSelected(EFFECT_SELECTED);
+        mSelectedEffect = newAnchorEff;
+        mSelectedRow = mEffectMoveTargetRow + mSequenceElements->GetFirstVisibleModelRow();
+    } else if (!mEffectMoveCopyMode) {
+        mSelectedEffect = nullptr;
+        mSelectedRow = -1;
+    }
+    sendRenderDirtyEvent();
 }
 
 void EffectsGrid::DrawEffectMoveDragOverlay(xlGraphicsContext* ctx) {
@@ -8203,19 +8213,30 @@ void EffectsGrid::DrawEffectMoveDragOverlay(xlGraphicsContext* ctx) {
     int rowDelta = mEffectMoveTargetRow - mEffectMoveAnchorRow;
 
     xlColor dimColor(0, 0, 0, 80);
-    xlColor ghostFill = mEffectMoveHasCollision ? xlColor(200, 40, 40, 100) : xlColor(220, 220, 220, 80);
-    xlColor ghostBorder = mEffectMoveHasCollision ? xlColor(220, 0, 0, 230) : xlColor(160, 160, 255, 230);
+    xlColor ghostFill, ghostBorder;
+    if (mEffectMoveHasCollision) {
+        ghostFill   = xlColor(200, 40,  40,  100);
+        ghostBorder = xlColor(220, 0,   0,   230);
+    } else if (mEffectMoveCopyMode) {
+        ghostFill   = xlColor(40,  180, 40,  100);
+        ghostBorder = xlColor(0,   200, 0,   230);
+    } else {
+        ghostFill   = xlColor(220, 220, 220, 80);
+        ghostBorder = xlColor(160, 160, 255, 230);
+    }
 
     xlVertexColorAccumulator* fills = ctx->createVertexColorAccumulator();
     xlVertexColorAccumulator* borders = ctx->createVertexColorAccumulator();
 
     for (auto& snap : mEffectMoveSnapshots) {
-        // Dim overlay on original position
-        int ox1 = mTimeline->GetPositionFromTimeMS(snap.origStartTimeMS);
-        int ox2 = mTimeline->GetPositionFromTimeMS(snap.origEndTimeMS);
-        float oy1 = snap.origVisibleRow * DEFAULT_ROW_HEADING_HEIGHT + 2;
-        float oy2 = (snap.origVisibleRow + 1) * DEFAULT_ROW_HEADING_HEIGHT - 2;
-        fills->AddRectAsTriangles(ox1, oy1, ox2, oy2, dimColor);
+        // Dim originals during move; leave them bright during copy (they stay)
+        if (!mEffectMoveCopyMode) {
+            int ox1 = mTimeline->GetPositionFromTimeMS(snap.origStartTimeMS);
+            int ox2 = mTimeline->GetPositionFromTimeMS(snap.origEndTimeMS);
+            float oy1 = snap.origVisibleRow * DEFAULT_ROW_HEADING_HEIGHT + 2;
+            float oy2 = (snap.origVisibleRow + 1) * DEFAULT_ROW_HEADING_HEIGHT - 2;
+            fills->AddRectAsTriangles(ox1, oy1, ox2, oy2, dimColor);
+        }
 
         // Ghost at target position
         int snapTargetRow = snap.origVisibleRow + rowDelta;

--- a/src-ui-wx/sequencer/EffectsGrid.h
+++ b/src-ui-wx/sequencer/EffectsGrid.h
@@ -284,7 +284,7 @@ private:
     void MoveAllSelectedEffects(int deltaMS, bool offset) const;
     void ResetEffectMoveDragState();
     int SnapCursorToTimingMark(int timeMS, int x) const;
-    void UpdateEffectMoveDragState(int x, int y, bool snapToTiming);
+    void UpdateEffectMoveDragState(int x, int y, bool snapToTiming, bool altDown);
     void ApplyEffectMoveDrag();
     void DrawEffectMoveDragOverlay(xlGraphicsContext* ctx);
     void StretchAllSelectedEffects(int deltaMS, bool offset) const;
@@ -395,6 +395,7 @@ private:
     int mEffectMoveTargetRow = 0;
     int mEffectMoveTargetDeltaMS = 0;
     bool mEffectMoveHasCollision = false;
+    bool mEffectMoveCopyMode = false;
     std::vector<EffectMoveSnapshot> mEffectMoveSnapshots;
 
     bool mCellRangeSelected;


### PR DESCRIPTION
Add copy on drag to the sequencer effects move. Instead of just being able to move effects, hold alt(PC)/option(Mac) will allow copying of effects as well. 

- Alt+drag single effect — green ghost, copy-arrow cursor, original stays, copy lands at target
- Alt+drag a multi-selection — all copy together, originals intact
- Alt+drag into occupied slot — red ghost, no-entry cursor, drop blocked
- Alt+drag same row — copy lands at time offset, original stays
- Alt+drag then release Alt mid-drag — ghost switches back to gray (move mode) live
- Normal drag (no Alt) — behavior unchanged from master
- Undo after Alt+drag — copies removed, originals untouched