### PR TITLE
Adds auto-scroll to dragging of effects and/or elements list.

### DIFF
--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -8044,7 +8044,6 @@ void EffectsGrid::ResetEffectMoveDragState() {
 void EffectsGrid::OnScrollTimer(wxTimerEvent&)
 {
     MainSequencer* ms = static_cast<MainSequencer*>(mParent);
-    bool scrolled = false;
 
     if (mScrollDir != 0) {
         int cur = mSequenceElements->GetFirstVisibleModelRow();
@@ -8054,7 +8053,6 @@ void EffectsGrid::OnScrollTimer(wxTimerEvent&)
             int scroll = mSequenceElements->SetFirstVisibleModelRow(next);
             ScrollBy(scroll);
             ms->UpdateEffectGridVerticalScrollBar();
-            scrolled = true;
         }
     }
 
@@ -8070,13 +8068,12 @@ void EffectsGrid::OnScrollTimer(wxTimerEvent&)
                 hsb->SetThumbPosition(next);
                 wxCommandEvent eventScroll(EVT_HORIZ_SCROLL);
                 ms->HorizontalScrollChanged(eventScroll);
-                scrolled = true;
             }
         }
     }
 
     UpdateEffectMoveDragState(mLastDragX, mLastDragY, mLastDragSnap);
-    if (scrolled) Draw();
+    Draw();
 }
 
 int EffectsGrid::SnapCursorToTimingMark(int timeMS, int x) const {

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -233,6 +233,7 @@ EffectsGrid::EffectsGrid(MainSequencer* parent, wxWindowID id, const wxPoint& po
     mSearchRow = -1;
 
     SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    mScrollTimer.Bind(wxEVT_TIMER, &EffectsGrid::OnScrollTimer, this);
 
     SetDropTarget(new EffectDropTarget(this));
     playArgs = new EventPlayEffectArgs();
@@ -1778,7 +1779,10 @@ void EffectsGrid::mouseMoved(wxMouseEvent& event) {
             }
         }
         if (mEffectMoveDragThresholdExceeded) {
-            UpdateEffectMoveDragState(event.GetX(), event.GetY(), event.ControlDown());
+            mLastDragX = event.GetX();
+            mLastDragY = event.GetY();
+            mLastDragSnap = event.ControlDown();
+            UpdateEffectMoveDragState(mLastDragX, mLastDragY, mLastDragSnap);
             Draw();
         }
     } else if (mDragging) {
@@ -8026,12 +8030,47 @@ void EffectsGrid::MoveAllSelectedEffects(int deltaMS, bool offset) const {
 }
 
 void EffectsGrid::ResetEffectMoveDragState() {
+    mScrollTimer.Stop();
+    mScrollDir = 0;
+    mHScrollDir = 0;
     mEffectMoveDragging = false;
     mEffectMoveDragThresholdExceeded = false;
     mEffectMoveDragGroup = false;
     mEffectMoveHasCollision = false;
     mEffectMoveSnapshots.clear();
     mEffectMoveAnchorEffect = nullptr;
+}
+
+void EffectsGrid::OnScrollTimer(wxTimerEvent&)
+{
+    MainSequencer* ms = (MainSequencer*)mParent;
+
+    if (mScrollDir != 0) {
+        int cur = mSequenceElements->GetFirstVisibleModelRow();
+        int maxRow = mSequenceElements->GetTotalNumberOfModelRows() - mSequenceElements->GetMaxModelsDisplayed();
+        int next = std::clamp(cur + mScrollDir, 0, std::max(0, maxRow));
+        if (next != cur) {
+            int scroll = mSequenceElements->SetFirstVisibleModelRow(next);
+            ScrollBy(scroll);
+            ms->UpdateEffectGridVerticalScrollBar();
+        }
+    }
+
+    if (mHScrollDir != 0) {
+        wxScrollBar* hsb = ms->ScrollBarEffectsHorizontal;
+        int position = hsb->GetThumbPosition();
+        int limit = hsb->GetRange();
+        int step = std::max(1, hsb->GetThumbSize() / 10);
+        int next = std::clamp(position + mHScrollDir * step, 0, limit - 1);
+        if (next != position) {
+            hsb->SetThumbPosition(next);
+            wxCommandEvent eventScroll(EVT_HORIZ_SCROLL);
+            ms->HorizontalScrollChanged(eventScroll);
+        }
+    }
+
+    UpdateEffectMoveDragState(mLastDragX, mLastDragY, mLastDragSnap);
+    Draw();
 }
 
 int EffectsGrid::SnapCursorToTimingMark(int timeMS, int x) const {
@@ -8136,6 +8175,18 @@ void EffectsGrid::UpdateEffectMoveDragState(int x, int y, bool snapToTiming) {
     }
     mEffectMoveHasCollision = collision;
     SetCursor(collision ? s_noEntry : s_sizing);
+
+    wxSize sz = GetSize();
+    int zone = FromDIP(40);
+
+    mScrollDir = (y < zone) ? -1 : (y > sz.GetHeight() - zone) ? 1 : 0;
+    mHScrollDir = (x < zone) ? -1 : (x > sz.GetWidth() - zone) ? 1 : 0;
+
+    if (mScrollDir != 0 || mHScrollDir != 0) {
+        if (!mScrollTimer.IsRunning()) mScrollTimer.Start(150);
+    } else {
+        mScrollTimer.Stop();
+    }
 }
 
 void EffectsGrid::ApplyEffectMoveDrag() {

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -8044,6 +8044,7 @@ void EffectsGrid::ResetEffectMoveDragState() {
 void EffectsGrid::OnScrollTimer(wxTimerEvent&)
 {
     MainSequencer* ms = static_cast<MainSequencer*>(mParent);
+    bool scrolled = false;
 
     if (mScrollDir != 0) {
         int cur = mSequenceElements->GetFirstVisibleModelRow();
@@ -8053,6 +8054,7 @@ void EffectsGrid::OnScrollTimer(wxTimerEvent&)
             int scroll = mSequenceElements->SetFirstVisibleModelRow(next);
             ScrollBy(scroll);
             ms->UpdateEffectGridVerticalScrollBar();
+            scrolled = true;
         }
     }
 
@@ -8068,12 +8070,13 @@ void EffectsGrid::OnScrollTimer(wxTimerEvent&)
                 hsb->SetThumbPosition(next);
                 wxCommandEvent eventScroll(EVT_HORIZ_SCROLL);
                 ms->HorizontalScrollChanged(eventScroll);
+                scrolled = true;
             }
         }
     }
 
     UpdateEffectMoveDragState(mLastDragX, mLastDragY, mLastDragSnap);
-    Draw();
+    if (scrolled) Draw();
 }
 
 int EffectsGrid::SnapCursorToTimingMark(int timeMS, int x) const {

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -8043,7 +8043,7 @@ void EffectsGrid::ResetEffectMoveDragState() {
 
 void EffectsGrid::OnScrollTimer(wxTimerEvent&)
 {
-    MainSequencer* ms = (MainSequencer*)mParent;
+    MainSequencer* ms = static_cast<MainSequencer*>(mParent);
 
     if (mScrollDir != 0) {
         int cur = mSequenceElements->GetFirstVisibleModelRow();
@@ -8058,14 +8058,17 @@ void EffectsGrid::OnScrollTimer(wxTimerEvent&)
 
     if (mHScrollDir != 0) {
         wxScrollBar* hsb = ms->ScrollBarEffectsHorizontal;
-        int position = hsb->GetThumbPosition();
-        int limit = hsb->GetRange();
-        int step = std::max(1, hsb->GetThumbSize() / 10);
-        int next = std::clamp(position + mHScrollDir * step, 0, limit - 1);
-        if (next != position) {
-            hsb->SetThumbPosition(next);
-            wxCommandEvent eventScroll(EVT_HORIZ_SCROLL);
-            ms->HorizontalScrollChanged(eventScroll);
+        int thumbSize = hsb->GetThumbSize();
+        int maxPos = std::max(0, hsb->GetRange() - thumbSize);
+        if (maxPos > 0) {
+            int position = hsb->GetThumbPosition();
+            int step = std::max(1, thumbSize / 10);
+            int next = std::clamp(position + mHScrollDir * step, 0, maxPos);
+            if (next != position) {
+                hsb->SetThumbPosition(next);
+                wxCommandEvent eventScroll(EVT_HORIZ_SCROLL);
+                ms->HorizontalScrollChanged(eventScroll);
+            }
         }
     }
 

--- a/src-ui-wx/sequencer/EffectsGrid.h
+++ b/src-ui-wx/sequencer/EffectsGrid.h
@@ -285,6 +285,7 @@ private:
     void ResetEffectMoveDragState();
     int SnapCursorToTimingMark(int timeMS, int x) const;
     void UpdateEffectMoveDragState(int x, int y, bool snapToTiming);
+    void OnScrollTimer(wxTimerEvent& event);
     void ApplyEffectMoveDrag();
     void DrawEffectMoveDragOverlay(xlGraphicsContext* ctx);
     void StretchAllSelectedEffects(int deltaMS, bool offset) const;
@@ -396,6 +397,12 @@ private:
     int mEffectMoveTargetDeltaMS = 0;
     bool mEffectMoveHasCollision = false;
     std::vector<EffectMoveSnapshot> mEffectMoveSnapshots;
+    int mScrollDir = 0;
+    int mHScrollDir = 0;
+    int mLastDragX = 0;
+    int mLastDragY = 0;
+    bool mLastDragSnap = false;
+    wxTimer mScrollTimer;
 
     bool mCellRangeSelected;
     bool mPartialCellSelected;

--- a/src-ui-wx/sequencer/RowHeading.cpp
+++ b/src-ui-wx/sequencer/RowHeading.cpp
@@ -317,7 +317,7 @@ void RowHeading::mouseLeave(wxMouseEvent& event)
 
 void RowHeading::OnScrollTimer(wxTimerEvent&)
 {
-    MainSequencer* ms = (MainSequencer*)GetParent();
+    MainSequencer* ms = static_cast<MainSequencer*>(GetParent());
     int cur = mSequenceElements->GetFirstVisibleModelRow();
     int maxRow = mSequenceElements->GetTotalNumberOfModelRows() - mSequenceElements->GetMaxModelsDisplayed();
     int next = std::clamp(cur + _scrollDir, 0, std::max(0, maxRow));
@@ -353,6 +353,7 @@ void RowHeading::ComputeRowDragTarget(int cursorY)
         if (ri && ri->layerIndex == 0 && ri->strandIndex < 0 && ri->nodeIndex < 0 && !ri->submodel) {
             if (!blocks.empty()) blocks.back().blockEndY = r * DEFAULT_ROW_HEADING_HEIGHT;
             int idx = mSequenceElements->GetElementIndex(ri->element->GetFullName(), view);
+            if (idx < 0) continue;
             blocks.push_back({idx, r * DEFAULT_ROW_HEADING_HEIGHT, visCount * DEFAULT_ROW_HEADING_HEIGHT});
         }
     }

--- a/src-ui-wx/sequencer/RowHeading.cpp
+++ b/src-ui-wx/sequencer/RowHeading.cpp
@@ -258,7 +258,7 @@ RowHeading::RowHeading(MainSequencer* parent, wxWindowID id, const wxPoint &pos,
     auto* config = GetXLightsConfig();
     int w = config->ReadLong("xLightsRowHeaderWidth", _minRowHeadingWidth);
     CallAfter(&RowHeading::SetWidth, w);
-    mScrollTimer.Bind(wxEVT_TIMER, &RowHeading::OnScrollTimer, this);
+    _scrollTimer.Bind(wxEVT_TIMER, &RowHeading::OnScrollTimer, this);
 }
 
 RowHeading::~RowHeading()
@@ -317,6 +317,10 @@ void RowHeading::mouseLeave(wxMouseEvent& event)
 
 void RowHeading::OnScrollTimer(wxTimerEvent&)
 {
+    if (!_rowDragging) {
+        _scrollTimer.Stop();
+        return;
+    }
     MainSequencer* ms = static_cast<MainSequencer*>(GetParent());
     int cur = mSequenceElements->GetFirstVisibleModelRow();
     int maxRow = mSequenceElements->GetTotalNumberOfModelRows() - mSequenceElements->GetMaxModelsDisplayed();
@@ -351,9 +355,9 @@ void RowHeading::ComputeRowDragTarget(int cursorY)
     for (int r = 0; r < visCount; ++r) {
         auto* ri = mSequenceElements->GetVisibleRowInformation(r);
         if (ri && ri->layerIndex == 0 && ri->strandIndex < 0 && ri->nodeIndex < 0 && !ri->submodel) {
-            if (!blocks.empty()) blocks.back().blockEndY = r * DEFAULT_ROW_HEADING_HEIGHT;
             int idx = mSequenceElements->GetElementIndex(ri->element->GetFullName(), view);
             if (idx < 0) continue;
+            if (!blocks.empty()) blocks.back().blockEndY = r * DEFAULT_ROW_HEADING_HEIGHT;
             blocks.push_back({idx, r * DEFAULT_ROW_HEADING_HEIGHT, visCount * DEFAULT_ROW_HEADING_HEIGHT});
         }
     }
@@ -382,13 +386,13 @@ void RowHeading::mouseMove(wxMouseEvent& event)
         int zone = FromDIP(40);
         if (cursorY < zone) {
             _scrollDir = -1;
-            if (!mScrollTimer.IsRunning()) mScrollTimer.Start(150);
+            if (!_scrollTimer.IsRunning()) _scrollTimer.Start(150);
         } else if (cursorY > h - zone) {
             _scrollDir = 1;
-            if (!mScrollTimer.IsRunning()) mScrollTimer.Start(150);
+            if (!_scrollTimer.IsRunning()) _scrollTimer.Start(150);
         } else {
             _scrollDir = 0;
-            mScrollTimer.Stop();
+            _scrollTimer.Stop();
         }
 
         static const wxCursor s_hand(wxCURSOR_HAND);
@@ -439,7 +443,7 @@ void RowHeading::mouseLeftUp(wxMouseEvent& event)
             wxPostEvent(GetParent(), evt);
         }
 
-        mScrollTimer.Stop();
+        _scrollTimer.Stop();
         _scrollDir = 0;
         _rowDragSourceIdx = -1;
         _rowDragTargetBefore = -1;

--- a/src-ui-wx/sequencer/RowHeading.cpp
+++ b/src-ui-wx/sequencer/RowHeading.cpp
@@ -258,6 +258,7 @@ RowHeading::RowHeading(MainSequencer* parent, wxWindowID id, const wxPoint &pos,
     auto* config = GetXLightsConfig();
     int w = config->ReadLong("xLightsRowHeaderWidth", _minRowHeadingWidth);
     CallAfter(&RowHeading::SetWidth, w);
+    mScrollTimer.Bind(wxEVT_TIMER, &RowHeading::OnScrollTimer, this);
 }
 
 RowHeading::~RowHeading()
@@ -314,6 +315,21 @@ void RowHeading::mouseLeave(wxMouseEvent& event)
     SetToolTip("");
 }
 
+void RowHeading::OnScrollTimer(wxTimerEvent&)
+{
+    MainSequencer* ms = (MainSequencer*)GetParent();
+    int cur = mSequenceElements->GetFirstVisibleModelRow();
+    int maxRow = mSequenceElements->GetTotalNumberOfModelRows() - mSequenceElements->GetMaxModelsDisplayed();
+    int next = std::clamp(cur + _scrollDir, 0, std::max(0, maxRow));
+    if (next != cur) {
+        int scroll = mSequenceElements->SetFirstVisibleModelRow(next);
+        ms->PanelEffectGrid->ScrollBy(scroll);
+        ms->UpdateEffectGridVerticalScrollBar();
+    }
+    ComputeRowDragTarget(_lastDragY);
+    Refresh(false);
+}
+
 void RowHeading::SetWidth(int w)
 {
     auto minSize = GetMinSize();
@@ -324,35 +340,54 @@ void RowHeading::SetWidth(int w)
     }
 }
 
+void RowHeading::ComputeRowDragTarget(int cursorY)
+{
+    int view = mSequenceElements->GetCurrentView();
+    int visCount = (int)mSequenceElements->GetVisibleRowInformationSize();
+    int elemCount = (int)mSequenceElements->GetElementCount(view);
+
+    struct TopLevelBlock { int viewIdx; int blockStartY; int blockEndY; };
+    std::vector<TopLevelBlock> blocks;
+    for (int r = 0; r < visCount; ++r) {
+        auto* ri = mSequenceElements->GetVisibleRowInformation(r);
+        if (ri && ri->layerIndex == 0 && ri->strandIndex < 0 && ri->nodeIndex < 0 && !ri->submodel) {
+            if (!blocks.empty()) blocks.back().blockEndY = r * DEFAULT_ROW_HEADING_HEIGHT;
+            int idx = mSequenceElements->GetElementIndex(ri->element->GetFullName(), view);
+            blocks.push_back({idx, r * DEFAULT_ROW_HEADING_HEIGHT, visCount * DEFAULT_ROW_HEADING_HEIGHT});
+        }
+    }
+
+    _rowDragTargetBefore = elemCount;
+    _rowDragIndicatorY = visCount * DEFAULT_ROW_HEADING_HEIGHT;
+    for (const auto& b : blocks) {
+        if (cursorY < (b.blockStartY + b.blockEndY) / 2) {
+            _rowDragTargetBefore = b.viewIdx;
+            _rowDragIndicatorY = b.blockStartY;
+            break;
+        }
+        _rowDragTargetBefore = b.viewIdx + 1;
+        _rowDragIndicatorY = b.blockEndY;
+    }
+}
+
 void RowHeading::mouseMove(wxMouseEvent& event)
 {
     if (_rowDragging) {
         int cursorY = std::max(0, event.GetY());
-        int view = mSequenceElements->GetCurrentView();
-        int visCount = (int)mSequenceElements->GetVisibleRowInformationSize();
-        int elemCount = (int)mSequenceElements->GetElementCount(view);
+        _lastDragY = cursorY;
+        ComputeRowDragTarget(cursorY);
 
-        struct TopLevelBlock { int viewIdx; int blockStartY; int blockEndY; };
-        std::vector<TopLevelBlock> blocks;
-        for (int r = 0; r < visCount; ++r) {
-            auto* ri = mSequenceElements->GetVisibleRowInformation(r);
-            if (ri && ri->layerIndex == 0 && ri->strandIndex < 0 && ri->nodeIndex < 0 && !ri->submodel) {
-                if (!blocks.empty()) blocks.back().blockEndY = r * DEFAULT_ROW_HEADING_HEIGHT;
-                int idx = mSequenceElements->GetElementIndex(ri->element->GetFullName(), view);
-                blocks.push_back({idx, r * DEFAULT_ROW_HEADING_HEIGHT, visCount * DEFAULT_ROW_HEADING_HEIGHT});
-            }
-        }
-
-        _rowDragTargetBefore = elemCount;
-        _rowDragIndicatorY = visCount * DEFAULT_ROW_HEADING_HEIGHT;
-        for (const auto& b : blocks) {
-            if (cursorY < (b.blockStartY + b.blockEndY) / 2) {
-                _rowDragTargetBefore = b.viewIdx;
-                _rowDragIndicatorY = b.blockStartY;
-                break;
-            }
-            _rowDragTargetBefore = b.viewIdx + 1;
-            _rowDragIndicatorY = b.blockEndY;
+        int h = GetSize().GetHeight();
+        int zone = FromDIP(40);
+        if (cursorY < zone) {
+            _scrollDir = -1;
+            if (!mScrollTimer.IsRunning()) mScrollTimer.Start(150);
+        } else if (cursorY > h - zone) {
+            _scrollDir = 1;
+            if (!mScrollTimer.IsRunning()) mScrollTimer.Start(150);
+        } else {
+            _scrollDir = 0;
+            mScrollTimer.Stop();
         }
 
         static const wxCursor s_hand(wxCURSOR_HAND);
@@ -403,6 +438,8 @@ void RowHeading::mouseLeftUp(wxMouseEvent& event)
             wxPostEvent(GetParent(), evt);
         }
 
+        mScrollTimer.Stop();
+        _scrollDir = 0;
         _rowDragSourceIdx = -1;
         _rowDragTargetBefore = -1;
         _rowDragIndicatorY = -1;

--- a/src-ui-wx/sequencer/RowHeading.cpp
+++ b/src-ui-wx/sequencer/RowHeading.cpp
@@ -258,7 +258,7 @@ RowHeading::RowHeading(MainSequencer* parent, wxWindowID id, const wxPoint &pos,
     auto* config = GetXLightsConfig();
     int w = config->ReadLong("xLightsRowHeaderWidth", _minRowHeadingWidth);
     CallAfter(&RowHeading::SetWidth, w);
-    _scrollTimer.Bind(wxEVT_TIMER, &RowHeading::OnScrollTimer, this);
+    mScrollTimer.Bind(wxEVT_TIMER, &RowHeading::OnScrollTimer, this);
 }
 
 RowHeading::~RowHeading()
@@ -317,10 +317,6 @@ void RowHeading::mouseLeave(wxMouseEvent& event)
 
 void RowHeading::OnScrollTimer(wxTimerEvent&)
 {
-    if (!_rowDragging) {
-        _scrollTimer.Stop();
-        return;
-    }
     MainSequencer* ms = static_cast<MainSequencer*>(GetParent());
     int cur = mSequenceElements->GetFirstVisibleModelRow();
     int maxRow = mSequenceElements->GetTotalNumberOfModelRows() - mSequenceElements->GetMaxModelsDisplayed();
@@ -355,9 +351,9 @@ void RowHeading::ComputeRowDragTarget(int cursorY)
     for (int r = 0; r < visCount; ++r) {
         auto* ri = mSequenceElements->GetVisibleRowInformation(r);
         if (ri && ri->layerIndex == 0 && ri->strandIndex < 0 && ri->nodeIndex < 0 && !ri->submodel) {
+            if (!blocks.empty()) blocks.back().blockEndY = r * DEFAULT_ROW_HEADING_HEIGHT;
             int idx = mSequenceElements->GetElementIndex(ri->element->GetFullName(), view);
             if (idx < 0) continue;
-            if (!blocks.empty()) blocks.back().blockEndY = r * DEFAULT_ROW_HEADING_HEIGHT;
             blocks.push_back({idx, r * DEFAULT_ROW_HEADING_HEIGHT, visCount * DEFAULT_ROW_HEADING_HEIGHT});
         }
     }
@@ -386,13 +382,13 @@ void RowHeading::mouseMove(wxMouseEvent& event)
         int zone = FromDIP(40);
         if (cursorY < zone) {
             _scrollDir = -1;
-            if (!_scrollTimer.IsRunning()) _scrollTimer.Start(150);
+            if (!mScrollTimer.IsRunning()) mScrollTimer.Start(150);
         } else if (cursorY > h - zone) {
             _scrollDir = 1;
-            if (!_scrollTimer.IsRunning()) _scrollTimer.Start(150);
+            if (!mScrollTimer.IsRunning()) mScrollTimer.Start(150);
         } else {
             _scrollDir = 0;
-            _scrollTimer.Stop();
+            mScrollTimer.Stop();
         }
 
         static const wxCursor s_hand(wxCURSOR_HAND);
@@ -443,7 +439,7 @@ void RowHeading::mouseLeftUp(wxMouseEvent& event)
             wxPostEvent(GetParent(), evt);
         }
 
-        _scrollTimer.Stop();
+        mScrollTimer.Stop();
         _scrollDir = 0;
         _rowDragSourceIdx = -1;
         _rowDragTargetBefore = -1;

--- a/src-ui-wx/sequencer/RowHeading.h
+++ b/src-ui-wx/sequencer/RowHeading.h
@@ -90,7 +90,7 @@ private:
     wxPoint _rowDragStart;
     int _lastDragY = 0;
     int _scrollDir = 0;
-    wxTimer _scrollTimer;
+    wxTimer mScrollTimer;
     bool groupEffectIndicator = true;
 
     

--- a/src-ui-wx/sequencer/RowHeading.h
+++ b/src-ui-wx/sequencer/RowHeading.h
@@ -90,7 +90,7 @@ private:
     wxPoint _rowDragStart;
     int _lastDragY = 0;
     int _scrollDir = 0;
-    wxTimer mScrollTimer;
+    wxTimer _scrollTimer;
     bool groupEffectIndicator = true;
 
     

--- a/src-ui-wx/sequencer/RowHeading.h
+++ b/src-ui-wx/sequencer/RowHeading.h
@@ -58,6 +58,8 @@ private:
     void ProcessTooltip(wxMouseEvent& event);
     void rightClick(wxMouseEvent& event);
     void leftDoubleClick(wxMouseEvent &event);
+    void OnScrollTimer(wxTimerEvent& event);
+    void ComputeRowDragTarget(int cursorY);
     void OnLayerPopup(wxCommandEvent& event);
     std::vector<std::string> ParseTags(const wxString& tagString);
     void DrawHeading(wxPaintDC* dc, pugi::xml_node model, int width, int row);
@@ -86,6 +88,9 @@ private:
     int _rowDragTargetBefore = -1;
     int _rowDragIndicatorY = -1;
     wxPoint _rowDragStart;
+    int _lastDragY = 0;
+    int _scrollDir = 0;
+    wxTimer mScrollTimer;
     bool groupEffectIndicator = true;
 
     

--- a/src-ui-wx/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/sequencer/tabSequencer.cpp
@@ -1102,6 +1102,8 @@ void xLightsFrame::MousePositionUpdated( wxCommandEvent& event)
 
 void xLightsFrame::RowHeadingsChanged( wxCommandEvent& event)
 {
+    if (CurrentSeqXmlFile != nullptr)
+        UnsavedRgbEffectsChanges = true;
     wxString s = event.GetString();
     if ("" != s) {
         for (const auto& it : AllModels) {

--- a/src-ui-wx/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/sequencer/tabSequencer.cpp
@@ -1102,8 +1102,6 @@ void xLightsFrame::MousePositionUpdated( wxCommandEvent& event)
 
 void xLightsFrame::RowHeadingsChanged( wxCommandEvent& event)
 {
-    if (CurrentSeqXmlFile != nullptr)
-        UnsavedRgbEffectsChanges = true;
     wxString s = event.GetString();
     if ("" != s) {
         for (const auto& it : AllModels) {


### PR DESCRIPTION
Sequencer: auto-scroll during drag operations

Row reorder (RowHeading): When dragging a model/group row to reorder, the list now auto-scrolls up or down when the cursor approaches the top or bottom edge of the visible area. Previously it was impossible to drag a row past the visible boundary.

Effect drag-to-move (EffectsGrid): Auto-scroll in all four directions (up, down, left, right) when dragging an effect and the cursor nears any edge of the grid. Vertical mouse drag moves the model rows; horizontal mouse drag moves the timeline position.