### PR TITLE
Sequencer: auto-scroll during effect drag

### DIFF
--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -8044,6 +8044,7 @@ void EffectsGrid::ResetEffectMoveDragState() {
 void EffectsGrid::OnScrollTimer(wxTimerEvent&)
 {
     MainSequencer* ms = static_cast<MainSequencer*>(mParent);
+    bool scrolled = false;
 
     if (mScrollDir != 0) {
         int cur = mSequenceElements->GetFirstVisibleModelRow();
@@ -8053,6 +8054,7 @@ void EffectsGrid::OnScrollTimer(wxTimerEvent&)
             int scroll = mSequenceElements->SetFirstVisibleModelRow(next);
             ScrollBy(scroll);
             ms->UpdateEffectGridVerticalScrollBar();
+            scrolled = true;
         }
     }
 
@@ -8068,12 +8070,13 @@ void EffectsGrid::OnScrollTimer(wxTimerEvent&)
                 hsb->SetThumbPosition(next);
                 wxCommandEvent eventScroll(EVT_HORIZ_SCROLL);
                 ms->HorizontalScrollChanged(eventScroll);
+                scrolled = true;
             }
         }
     }
 
     UpdateEffectMoveDragState(mLastDragX, mLastDragY, mLastDragSnap);
-    Draw();
+    if (scrolled) Draw();
 }
 
 int EffectsGrid::SnapCursorToTimingMark(int timeMS, int x) const {

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -233,6 +233,7 @@ EffectsGrid::EffectsGrid(MainSequencer* parent, wxWindowID id, const wxPoint& po
     mSearchRow = -1;
 
     SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    mScrollTimer.Bind(wxEVT_TIMER, &EffectsGrid::OnScrollTimer, this);
 
     SetDropTarget(new EffectDropTarget(this));
     playArgs = new EventPlayEffectArgs();
@@ -1778,7 +1779,10 @@ void EffectsGrid::mouseMoved(wxMouseEvent& event) {
             }
         }
         if (mEffectMoveDragThresholdExceeded) {
-            UpdateEffectMoveDragState(event.GetX(), event.GetY(), event.ControlDown());
+            mLastDragX = event.GetX();
+            mLastDragY = event.GetY();
+            mLastDragSnap = event.ControlDown();
+            UpdateEffectMoveDragState(mLastDragX, mLastDragY, mLastDragSnap);
             Draw();
         }
     } else if (mDragging) {
@@ -8026,12 +8030,50 @@ void EffectsGrid::MoveAllSelectedEffects(int deltaMS, bool offset) const {
 }
 
 void EffectsGrid::ResetEffectMoveDragState() {
+    mScrollTimer.Stop();
+    mScrollDir = 0;
+    mHScrollDir = 0;
     mEffectMoveDragging = false;
     mEffectMoveDragThresholdExceeded = false;
     mEffectMoveDragGroup = false;
     mEffectMoveHasCollision = false;
     mEffectMoveSnapshots.clear();
     mEffectMoveAnchorEffect = nullptr;
+}
+
+void EffectsGrid::OnScrollTimer(wxTimerEvent&)
+{
+    MainSequencer* ms = static_cast<MainSequencer*>(mParent);
+
+    if (mScrollDir != 0) {
+        int cur = mSequenceElements->GetFirstVisibleModelRow();
+        int maxRow = mSequenceElements->GetTotalNumberOfModelRows() - mSequenceElements->GetMaxModelsDisplayed();
+        int next = std::clamp(cur + mScrollDir, 0, std::max(0, maxRow));
+        if (next != cur) {
+            int scroll = mSequenceElements->SetFirstVisibleModelRow(next);
+            ScrollBy(scroll);
+            ms->UpdateEffectGridVerticalScrollBar();
+        }
+    }
+
+    if (mHScrollDir != 0) {
+        wxScrollBar* hsb = ms->ScrollBarEffectsHorizontal;
+        int thumbSize = hsb->GetThumbSize();
+        int maxPos = std::max(0, hsb->GetRange() - thumbSize);
+        if (maxPos > 0) {
+            int position = hsb->GetThumbPosition();
+            int step = std::max(1, thumbSize / 10);
+            int next = std::clamp(position + mHScrollDir * step, 0, maxPos);
+            if (next != position) {
+                hsb->SetThumbPosition(next);
+                wxCommandEvent eventScroll(EVT_HORIZ_SCROLL);
+                ms->HorizontalScrollChanged(eventScroll);
+            }
+        }
+    }
+
+    UpdateEffectMoveDragState(mLastDragX, mLastDragY, mLastDragSnap);
+    Draw();
 }
 
 int EffectsGrid::SnapCursorToTimingMark(int timeMS, int x) const {
@@ -8136,6 +8178,18 @@ void EffectsGrid::UpdateEffectMoveDragState(int x, int y, bool snapToTiming) {
     }
     mEffectMoveHasCollision = collision;
     SetCursor(collision ? s_noEntry : s_sizing);
+
+    wxSize sz = GetSize();
+    int zone = FromDIP(40);
+
+    mScrollDir = (y < zone) ? -1 : (y > sz.GetHeight() - zone) ? 1 : 0;
+    mHScrollDir = (x < zone) ? -1 : (x > sz.GetWidth() - zone) ? 1 : 0;
+
+    if (mScrollDir != 0 || mHScrollDir != 0) {
+        if (!mScrollTimer.IsRunning()) mScrollTimer.Start(150);
+    } else {
+        mScrollTimer.Stop();
+    }
 }
 
 void EffectsGrid::ApplyEffectMoveDrag() {

--- a/src-ui-wx/sequencer/EffectsGrid.h
+++ b/src-ui-wx/sequencer/EffectsGrid.h
@@ -285,6 +285,7 @@ private:
     void ResetEffectMoveDragState();
     int SnapCursorToTimingMark(int timeMS, int x) const;
     void UpdateEffectMoveDragState(int x, int y, bool snapToTiming);
+    void OnScrollTimer(wxTimerEvent& event);
     void ApplyEffectMoveDrag();
     void DrawEffectMoveDragOverlay(xlGraphicsContext* ctx);
     void StretchAllSelectedEffects(int deltaMS, bool offset) const;
@@ -396,6 +397,12 @@ private:
     int mEffectMoveTargetDeltaMS = 0;
     bool mEffectMoveHasCollision = false;
     std::vector<EffectMoveSnapshot> mEffectMoveSnapshots;
+    int mScrollDir = 0;
+    int mHScrollDir = 0;
+    int mLastDragX = 0;
+    int mLastDragY = 0;
+    bool mLastDragSnap = false;
+    wxTimer mScrollTimer;
 
     bool mCellRangeSelected;
     bool mPartialCellSelected;


### PR DESCRIPTION
When dragging an effect to move it, the grid now auto-scrolls in all four directions when the cursor approaches any edge of the visible area. Previously it was impossible to drag an effect past the visible boundary without releasing and repositioning.

- Vertical scroll moves model rows up or down
- Horizontal scroll moves the timeline left or right