### PR TITLE
Layout Model Sets: link props so they move as one (#3703)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -51,6 +51,9 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                  alpha-preserving, bit-exact uncompressed .mov at any size) and FFmpeg for AVI/MPEG-4.
     -enh (dkulp)                 Add a "ProRes 4444 Video, *.mov" model export option: 4:4:4 near-lossless, much smaller than uncompressed RGB, and
                                  decodes on all platforms.
+    -enh (heffneil)              Layout Model Sets: link props together (right-click > Link as Set) so dragging or rotating any member moves
+                                 the whole Set as one, in 2D and 3D. Hold Alt/Option to reposition a single member within its Set.
+                                 A Set containing a locked model will not move. Manage via the right-click Set menu (#3703).
     -bug (dkulp)                 Fix crash selecting a view after a view was deleted (out-of-bounds current view in PopulateRowInformation).
     -bug (dkulp)                 Guard EffectsGrid selection-rectangle update against a torn-down sequence to fix a crash on close.
     -bug (dkulp)                 Fix render-buffer crash building per-preview 3D node positions when no house preview is available.
@@ -90,7 +93,6 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -bug (dkulp)                 Fix PolyLine model crash when deleting a handle during placement (stale per-segment sizes ran the light distribution
                                  past the point array).
     -bug (dkulp)                 Fix Windows crash drawing color-vertex primitives when the accumulator type doesn't match (null-check the dynamic_cast).
-
 2026.10  May 31, 2026
     -enh (cybercop23)            Add State effect on SubModels. Ensure only nodes that are part of the SubModel are lit.
                                  Same node-index translation on Faces effect if using Faces effect on a SubModel.

--- a/README.txt
+++ b/README.txt
@@ -51,9 +51,6 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                  alpha-preserving, bit-exact uncompressed .mov at any size) and FFmpeg for AVI/MPEG-4.
     -enh (dkulp)                 Add a "ProRes 4444 Video, *.mov" model export option: 4:4:4 near-lossless, much smaller than uncompressed RGB, and
                                  decodes on all platforms.
-    -enh (heffneil)              Layout Model Sets: link props together (right-click > Link as Set) so dragging or rotating any member moves
-                                 the whole Set as one, in 2D and 3D. Hold Alt/Option to reposition a single member within its Set.
-                                 A Set containing a locked model will not move. Manage via the right-click Set menu (#3703).
     -bug (dkulp)                 Fix crash selecting a view after a view was deleted (out-of-bounds current view in PopulateRowInformation).
     -bug (dkulp)                 Guard EffectsGrid selection-rectangle update against a torn-down sequence to fix a crash on close.
     -bug (dkulp)                 Fix render-buffer crash building per-preview 3D node positions when no house preview is available.
@@ -93,6 +90,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -bug (dkulp)                 Fix PolyLine model crash when deleting a handle during placement (stale per-segment sizes ran the light distribution
                                  past the point array).
     -bug (dkulp)                 Fix Windows crash drawing color-vertex primitives when the accumulator type doesn't match (null-check the dynamic_cast).
+
 2026.10  May 31, 2026
     -enh (cybercop23)            Add State effect on SubModels. Ensure only nodes that are part of the SubModel are lit.
                                  Same node-index translation on Faces effect if using Faces effect on a SubModel.

--- a/plans/ipad-parity/06-layout-models-preview.md
+++ b/plans/ipad-parity/06-layout-models-preview.md
@@ -197,6 +197,16 @@
 
 ### P2
 
+- **Model Sets (layout move-linking).** Desktop links props into a
+  persistent "Set" (`<modelSets>` in `xlights_rgbeffects.xml`,
+  `src-core/models/ModelSetManager.h`) so dragging/rotating any member
+  moves the whole Set; Alt-drag repositions a single member; a Set
+  with a locked member is frozen. The data layer is in `src-core/` so
+  the iPad already loads/saves it — the gap is honoring Set membership
+  in `LayoutEditorView` drag gestures plus a management UI
+  (link/unlink, member checklist). Desktop UI: `LayoutPanel.cpp`
+  (`AddModelSetOptionsToMenu`, `DoLinkAsSet`, `DoManageSet`). See
+  `plans/layout-group-move-lock.md`. Ease: medium.
 - **Faces / States rich editor — visual node picker landed.** iPad
   `FaceStateEditorSheet` (`LayoutEditorView.swift`) edits the
   `faceInfo` / `stateInfo` attribute maps and is fully wired

--- a/plans/layout-group-move-lock.md
+++ b/plans/layout-group-move-lock.md
@@ -1,0 +1,270 @@
+# Layout: Model Sets (linked-translation)
+
+**Status:** implemented on desktop (branch `model-sets`); iPad parity pending
+(tracked in `plans/ipad-parity/06-layout-models-preview.md`).
+Decisions made during implementation: name prompt on Link-as-Set
+(auto-name pre-filled, in-place collision re-prompt); Manage dialog =
+filterable checkbox list with editable name field; right-click shows a
+single "Set" submenu; Alt/Option-drag repositions a single member; a Set
+containing a locked model is frozen (no member moves); 3D axis-arrow
+translate and axis-ring rotate propagate to the Set; scale stays
+per-model.
+**Issue:** [#3703](https://github.com/xLightsSequencer/xLights/issues/3703)
+**Author:** heffneil
+**Target release:** 2026.11+
+
+## Background
+
+xLights has two existing "grouping" concepts on the Layout tab:
+
+- **Model Group** (`src-core/models/ModelGroup.h`, stored under
+  `<modelGroup>` in `xlights_rgbeffects.xml`) — a *sequencer* aggregation
+  used to route effects to multiple models with one drop. Does NOT
+  constrain layout positions.
+- **Multi-selection** — a transient set of selected models that translate
+  together while you drag. Once you click away, the relationship is gone.
+
+Issue [#3703](https://github.com/xLightsSequencer/xLights/issues/3703)
+asks for a *third*, distinct concept: a **persistent positional
+relationship** between props, so that e.g. an EFL tree and its star always
+translate together as one logical prop, even after deselecting. The user
+explicitly wants this kept separate from sequencer Groups (different word,
+different XML element, no effect-routing side effects).
+
+The chosen name is **Set** (or "Model Set"). Word "group" is reserved for
+the existing sequencer concept.
+
+## The rule
+
+**Translation propagates across Set membership. Everything else does not.**
+
+| User action | Behavior |
+|---|---|
+| Click a prop that belongs to a Set | That single prop is selected. Normal property-grid editing, normal resize/rotate handles, normal everything. |
+| Click + drag any Set member | Drag delta is applied to **every** member. The relative arrangement of members is preserved. |
+| Resize corner / rotate handle on a Set member | Operates on that one prop only. Reshape is per-prop; Sets exist to preserve translation invariants, not geometry. |
+| Property-grid edit on a Set member | Applies to that one prop only. Sets do not propagate property changes. |
+| Right-click a Set member | Menu includes: **Add to Set…** / **Remove from Set** / **Manage Set…** |
+| Right-click a multi-selection of 2+ props | Menu includes: **Link as Set** (creates new auto-named Set, or merges into an existing Set if any member is already in one). |
+
+There is **no visual indicator** (no bracket, no bbox highlight) when a
+Set is selected. The user knows the prop is in a Set because they put it
+there; the right-click menu and the per-prop property grid both surface
+"belongs to Set: `Set 3`" for confirmation.
+
+A prop belongs to **at most one Set**. Adding a prop to a Set while it
+already belongs to another prompts the user: *"`<prop>` is already in
+`<Set X>`. Move it to `<Set Y>`?"* — Yes / Cancel.
+
+## Goals
+
+1. Persistent translation lock between any user-chosen set of props.
+2. Survives save / reload (lives in `xlights_rgbeffects.xml`).
+3. Rotation around the Set's bounding-box centroid when applied to a
+   Set (via the rotation handle or via Bulk Edit Rotate — see #6521).
+4. Works in 2D and 3D layout.
+5. iPad app: parity ships in a follow-up PR (this doc is desktop-first).
+
+## Non-goals
+
+- Scaling a Set as a unit (defer — most users don't want this).
+- Property propagation across Set members (effects, dimming, pixel
+  style, etc. — all per-prop, by design).
+- A new top-level "Composite Model" type with rendering/effect surface
+  of its own — overkill for this feature.
+- Bundling images or physical-dimension metadata into the Set (that's
+  what #3825 covers, already resolved).
+- A dedicated "Sets" tree-pane row — canvas right-click is the only
+  management UI for v1. (Can be added later if users ask.)
+
+## Design — `<modelSet>` XML element
+
+A new lightweight XML element, sibling to `<modelGroup>`, stored in
+`xlights_rgbeffects.xml`:
+
+```xml
+<modelSets>
+    <modelSet name="Set 1" models="Tree,Star" />
+    <modelSet name="Set 2" models="Wreath,Bow,Ribbon" />
+</modelSets>
+```
+
+The element holds **only** a name and a comma-separated list of member
+model names. No coordinates of its own — each member retains its own
+absolute coords exactly as today. The Set is a *constraint*, not a
+container.
+
+Default name is `Set N` where N is the lowest unused integer. User can
+rename via the right-click → Manage Set… dialog (or via the property
+grid surface mentioned below).
+
+### Why a new element instead of extending `<modelGroup>`
+
+| Approach | Pros | Cons | Verdict |
+|---|---|---|---|
+| Extend `ModelGroup` with `_moveLocked` flag | Reuses existing aggregation, minimal new code | Conflates sequencer-group and positional-link in one object. Users who want a positional link but no sequencer aggregation get one anyway (or vice versa). Word "group" already overloaded. | **Rejected** |
+| Parent/anchor link on each Model | Compact, no new top-level structure | Per-model field; chain depth unbounded; "anchor" model gets implicit special status which users find confusing | **Rejected** |
+| New `<modelSet>` sibling element | Clean separation of concerns. Models themselves unchanged. Sequencer paths untouched. New name = no terminology conflict. | One new top-level structure to serialize / load / migrate | **Chosen** |
+
+Models themselves get **zero new attributes**. The Set knows its members;
+the members don't know they're in a Set (except via a runtime lookup
+helper).
+
+### Runtime API
+
+A new `ModelSetManager` (or fold into existing `ModelManager`):
+
+```cpp
+class ModelSetManager {
+public:
+    ModelSet* GetSetContaining(const std::string& modelName) const;
+    std::vector<std::string> GetMemberModels(const ModelSet* set) const;
+    ModelSet* CreateSet(const std::vector<std::string>& members);
+    void AddToSet(ModelSet* set, const std::string& modelName);
+    void RemoveFromSet(const std::string& modelName);  // also deletes the set if it falls below 2 members
+    void DeleteSet(ModelSet* set);
+    void RenameSet(ModelSet* set, const std::string& newName);
+
+    void Load(wxXmlNode* rgbEffects);
+    void Save(wxXmlNode* rgbEffects);
+};
+```
+
+Living in `src-core/models/`. iPad picks this up automatically via
+`src-core/` linkage.
+
+### Drag-time propagation
+
+In `LayoutPanel::OnPreviewMouseMove`, the existing drag loop at
+`LayoutPanel.cpp:6011-6023` iterates models with `Selected() ||
+GroupSelected()` and applies the delta. The minimal new piece:
+
+- On `OnPreviewLeftDown`, when a model is clicked and added to selection,
+  check `ModelSetManager::GetSetContaining(model)`. If non-null, mark
+  every other Set member as `GroupSelected = true`. The existing drag
+  loop now naturally translates them all.
+- On `OnPreviewMouseUp` (drag end), clear the `GroupSelected` flags that
+  were set by Set propagation (so single-click after drag still selects
+  one prop for property editing).
+
+This is intentionally tiny — Sets piggyback on machinery that already
+exists for multi-selection drag.
+
+### Rotation around the Set centroid
+
+When the rotation handle is used on a Set member, or when `BulkEditRotateZ`
+runs on a selection that maps to a Set, compute the union bbox centroid
+of all Set members, then rotate each member's center around that point
+while also setting `loc.SetRotateZ(angle)` on each. Reuse the
+`BulkEditRotateAxis` plumbing from #6521; the only new piece is the
+"translate around centroid" step.
+
+Phase 1 can ship without centroid rotation (rotation-handle on a Set
+member rotates only that member, same as today); centroid rotation is
+Phase 3.
+
+### Right-click affordances
+
+**On a single prop:**
+
+- *not in any Set:* — no Set-related items in the menu.
+- *in Set X:* — submenu **Set 'X' →** with:
+  - *Remove from Set*
+  - *Rename Set…*
+  - *Delete Set*
+  - *Show Set Members* (highlights all members on the canvas briefly)
+
+**On a multi-selection of 2+ props:**
+
+- If none of the selection is in a Set: **Link as Set** → creates new
+  auto-named `Set N`.
+- If some are already in Set X and others aren't: **Add to Set 'X'** →
+  pulls the loose ones in. Conflict prompt if multiple Sets are
+  represented.
+- If all are in the same Set: **Remove from Set** / **Delete Set**.
+
+### Property-grid surface
+
+When a single Set member is selected, the property grid shows an extra
+read-only-ish field:
+
+```
+Set                Set 3   [Manage…]
+```
+
+The `[Manage…]` button opens the same dialog as the right-click *Manage
+Set…* item (member add/remove, rename, delete).
+
+This satisfies "I need a way to edit the set" without adding a dedicated
+tree pane.
+
+## Implementation phases
+
+Each phase is a self-contained PR.
+
+| # | PR | Scope | Approx size |
+|---|---|---|---|
+| 1 | **Data + persistence + Manage dialog** | `ModelSet` + `ModelSetManager` in `src-core/models/`. `<modelSets>` XML load/save in `xlights_rgbeffects.xml`. Right-click → Link as Set / Manage Set… / Remove from Set. Manage Set… dialog (member list, rename, delete). NO drag behavior change yet — Sets are creatable and persistable but don't do anything on drag. | ~400 LOC |
+| 2 | **Drag-time propagation** | In `LayoutPanel::OnPreviewLeftDown`, propagate `GroupSelected` to other Set members when one is clicked. Clear on mouse-up. Set membership conflict prompt on Add-to-Set. | ~150 LOC |
+| 3 | **Centroid rotation** | When rotating a Set member (via handle or `BulkEditRotateZ`), rotate around the union centroid instead of per-member origin. | ~200 LOC |
+| 4 | **Property-grid surface + polish** | `Set: Set 3 [Manage…]` row on selected member's property grid. Set name shown in tooltip. Undo grouping: a Set drag is one undo step, not one-per-member. | ~150 LOC |
+| 5 | **iPad parity** (separate PR, after desktop ships) | `ModelSetManager` is already in `src-core/`, so the data is automatic; iPad's `SequencerViewModel` and drag handlers honor Set membership; long-press-drag moves the whole set. | TBD |
+
+## Risks
+
+- **Undo granularity.** A drag of a Set must be one undo step covering
+  all members, not one-per-member. The existing
+  `CreateUndoPoint("SingleModel", ...)` at `LayoutPanel.cpp:6014` fires
+  per drag start — fine — but the label should read `LockedSetMove` or
+  similar so the undo label is meaningful.
+- **Membership conflict at load.** If a project file lists a model in
+  two different `<modelSet>` elements (corruption, manual editing, merge
+  artifacts), the loader picks the first occurrence and logs the
+  conflict — no crash, no silent data loss.
+- **Renaming a model.** When a model is renamed via the Layout tree,
+  every Set that references it by name needs to update. Existing
+  rename plumbing in `ModelManager` walks ModelGroup references; we
+  hook the same point.
+- **Deleting a model.** Same — strip from all Sets, delete the Set
+  itself if it drops below 2 members.
+- **File-format compatibility.** Older xLights opening a project with
+  `<modelSets>` simply ignores the unknown element — no crash, Sets
+  become invisible until reopened with current xLights. Forward-compat
+  is free.
+- **Performance.** Set membership lookup happens on every left-click on
+  the canvas. With a `std::unordered_map<modelName → setPtr>` cache
+  rebuilt on Set mutation, lookup is O(1). Negligible.
+
+## Open questions for review
+
+1. **Property-grid `[Manage…]` button placement.** Top of the model's
+   own property panel, or in a new "Set" category section at the bottom?
+2. **"Show Set Members" indicator.** Brief flash / outline highlight? Or
+   add a momentary bracket bbox just for the "show me" affordance (since
+   we agreed no persistent indicator)?
+3. **Phase 2 mouse-up cleanup.** Should `GroupSelected` propagation
+   persist after a click (so the user sees the Set highlighted as a
+   multi-selection in the tree until they click elsewhere)? Or revert
+   immediately on mouse-up so the visible selection matches "single
+   prop"? I lean toward reverting — matches the "no special handle / no
+   persistent indicator" rule — but worth confirming.
+
+## Acceptance criteria
+
+- [ ] Select two props, right-click → Link as Set. Save and reload the
+      project. Dragging either prop translates both by the same delta.
+- [ ] Resizing a prop in a Set affects only that prop.
+- [ ] Editing a prop's property (e.g. pixel size) affects only that prop.
+- [ ] Right-click → Remove from Set un-links a single prop. Set itself
+      persists if 2+ remain; auto-deletes if it falls to 0 or 1.
+- [ ] Right-click → Delete Set removes the Set; members revert to
+      independent props with their current absolute positions intact.
+- [ ] Renaming a model updates every Set that references it.
+- [ ] Deleting a model strips it from any Set it belonged to.
+- [ ] Adding a prop to a Set while it's in another Set prompts the user
+      to confirm the move.
+- [ ] Older xLights opens the same project without crashing or losing
+      non-Set data.
+- [ ] One undo step rolls back a Set drag.
+- [ ] iPad app opens the project without errors (parity in a follow-up
+      PR; must not crash).

--- a/src-core/models/ModelManager.cpp
+++ b/src-core/models/ModelManager.cpp
@@ -133,6 +133,7 @@ void ModelManager::clear()
         }
     }
     models.clear();
+    _setManager.Clear();
     _modelGeneration++;
 }
 
@@ -212,6 +213,9 @@ bool ModelManager::Rename(const std::string& oldName, const std::string& newName
                 changed |= mg->ModelRenamed(on, nn);
             }
         }
+
+        // Keep Model Sets coherent with the rename.
+        _setManager.OnModelRenamed(on, nn);
 
         return changed;
     }
@@ -2141,6 +2145,7 @@ bool ModelManager::Delete(const std::string& name)
                         group->ModelRemoved(mn);
                     }
                 }
+                _setManager.OnModelDeleted(mn);
                 models.erase(it);
                 ResetModelGroups();
 

--- a/src-core/models/ModelManager.h
+++ b/src-core/models/ModelManager.h
@@ -17,6 +17,7 @@
 #include <atomic>
 
 #include "ObjectManager.h"
+#include "ModelSetManager.h"
 #include <pugixml.hpp>
 
 class Model;
@@ -115,6 +116,11 @@ class ModelManager : public ObjectManager
         // parallel.
         unsigned int GetModelGeneration() const { return _modelGeneration.load(); }
 
+        // Model Sets - persistent translation-only links between models.
+        // See plans/layout-group-move-lock.md and ModelSetManager.h.
+        ModelSetManager& GetSetManager() { return _setManager; }
+        const ModelSetManager& GetSetManager() const { return _setManager; }
+
     private:
 
     OutputManager* _outputManager = nullptr;
@@ -127,5 +133,6 @@ class ModelManager : public ObjectManager
     std::atomic<bool> _modelsLoading;
     std::atomic<unsigned int> _modelGeneration{ 0 };
     mutable std::string lastGeneratedModelName = "";
+    ModelSetManager _setManager;
 };
 

--- a/src-core/models/ModelSet.cpp
+++ b/src-core/models/ModelSet.cpp
@@ -48,19 +48,28 @@ void ModelSet::Load(pugi::xml_node node)
     std::stringstream ss(modelsAttr);
     std::string token;
     while (std::getline(ss, token, ',')) {
-        if (!token.empty()) {
-            _members.push_back(token);
-        }
+        // Trim and dedupe (via AddMember) so hand-edited files with padded
+        // or repeated names can't fake the >= 2 member rule or break the
+        // name-based lookups.
+        size_t b = token.find_first_not_of(" \t\r\n");
+        if (b == std::string::npos) continue;
+        size_t e = token.find_last_not_of(" \t\r\n");
+        AddMember(token.substr(b, e - b + 1));
     }
 }
 
-void ModelSet::Save(pugi::xml_node node) const
+std::string ModelSet::GetMembersCsv() const
 {
-    node.append_attribute("name") = _name.c_str();
     std::string list;
     for (size_t i = 0; i < _members.size(); ++i) {
         if (i > 0) list += ",";
         list += _members[i];
     }
-    node.append_attribute("models") = list.c_str();
+    return list;
+}
+
+void ModelSet::Save(pugi::xml_node node) const
+{
+    node.append_attribute("name") = _name.c_str();
+    node.append_attribute("models") = GetMembersCsv().c_str();
 }

--- a/src-core/models/ModelSet.cpp
+++ b/src-core/models/ModelSet.cpp
@@ -1,0 +1,66 @@
+/***************************************************************
+ * This source files comes from the xLights project
+ * https://www.xlights.org
+ * https://github.com/xLightsSequencer/xLights
+ * See the github commit history for a record of contributing
+ * developers.
+ * Copyright claimed based on commit dates recorded in Github
+ * License: https://github.com/xLightsSequencer/xLights/blob/master/License.txt
+ **************************************************************/
+
+#include "ModelSet.h"
+
+#include <algorithm>
+#include <sstream>
+
+bool ModelSet::HasMember(const std::string& modelName) const
+{
+    return std::find(_members.begin(), _members.end(), modelName) != _members.end();
+}
+
+void ModelSet::AddMember(const std::string& modelName)
+{
+    if (!HasMember(modelName)) {
+        _members.push_back(modelName);
+    }
+}
+
+void ModelSet::RemoveMember(const std::string& modelName)
+{
+    _members.erase(std::remove(_members.begin(), _members.end(), modelName),
+                   _members.end());
+}
+
+void ModelSet::RenameMember(const std::string& oldName, const std::string& newName)
+{
+    for (auto& m : _members) {
+        if (m == oldName) {
+            m = newName;
+        }
+    }
+}
+
+void ModelSet::Load(pugi::xml_node node)
+{
+    _name = node.attribute("name").as_string();
+    _members.clear();
+    std::string modelsAttr = node.attribute("models").as_string();
+    std::stringstream ss(modelsAttr);
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+        if (!token.empty()) {
+            _members.push_back(token);
+        }
+    }
+}
+
+void ModelSet::Save(pugi::xml_node node) const
+{
+    node.append_attribute("name") = _name.c_str();
+    std::string list;
+    for (size_t i = 0; i < _members.size(); ++i) {
+        if (i > 0) list += ",";
+        list += _members[i];
+    }
+    node.append_attribute("models") = list.c_str();
+}

--- a/src-core/models/ModelSet.cpp
+++ b/src-core/models/ModelSet.cpp
@@ -1,5 +1,5 @@
 /***************************************************************
- * This source files comes from the xLights project
+ * This source file comes from the xLights project
  * https://www.xlights.org
  * https://github.com/xLightsSequencer/xLights
  * See the github commit history for a record of contributing

--- a/src-core/models/ModelSet.h
+++ b/src-core/models/ModelSet.h
@@ -37,6 +37,8 @@ public:
     void RemoveMember(const std::string& modelName);
     void RenameMember(const std::string& oldName, const std::string& newName);
 
+    std::string GetMembersCsv() const;
+
     // XML round-trip.
     void Load(pugi::xml_node node);
     void Save(pugi::xml_node node) const;

--- a/src-core/models/ModelSet.h
+++ b/src-core/models/ModelSet.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /***************************************************************
- * This source files comes from the xLights project
+ * This source file comes from the xLights project
  * https://www.xlights.org
  * https://github.com/xLightsSequencer/xLights
  * See the github commit history for a record of contributing

--- a/src-core/models/ModelSet.h
+++ b/src-core/models/ModelSet.h
@@ -1,0 +1,47 @@
+#pragma once
+
+/***************************************************************
+ * This source files comes from the xLights project
+ * https://www.xlights.org
+ * https://github.com/xLightsSequencer/xLights
+ * See the github commit history for a record of contributing
+ * developers.
+ * Copyright claimed based on commit dates recorded in Github
+ * License: https://github.com/xLightsSequencer/xLights/blob/master/License.txt
+ **************************************************************/
+
+// A Model Set is a persistent, name-based association between models on the
+// Layout tab that constrains translation only: when any member is dragged,
+// every member translates by the same delta. Geometry, properties, effects,
+// and sequencer Model Group membership are untouched. Distinct from
+// <modelGroup> (effect routing).
+//
+// A model belongs to at most one Set. Persistence: <modelSet> elements
+// inside a top-level <modelSets> node in xlights_rgbeffects.xml.
+
+#include <pugixml.hpp>
+#include <string>
+#include <vector>
+
+class ModelSet {
+public:
+    ModelSet() = default;
+    explicit ModelSet(const std::string& name) : _name(name) {}
+
+    const std::string& GetName() const { return _name; }
+    void SetName(const std::string& n) { _name = n; }
+
+    const std::vector<std::string>& GetMembers() const { return _members; }
+    bool HasMember(const std::string& modelName) const;
+    void AddMember(const std::string& modelName);
+    void RemoveMember(const std::string& modelName);
+    void RenameMember(const std::string& oldName, const std::string& newName);
+
+    // XML round-trip.
+    void Load(pugi::xml_node node);
+    void Save(pugi::xml_node node) const;
+
+private:
+    std::string _name;
+    std::vector<std::string> _members;
+};

--- a/src-core/models/ModelSetManager.cpp
+++ b/src-core/models/ModelSetManager.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <string_view>
+#include <unordered_set>
 
 void ModelSetManager::RebuildIndex()
 {
@@ -150,18 +151,20 @@ void ModelSetManager::Load(pugi::xml_node setsNode)
         RebuildIndex();
         return;
     }
+    std::unordered_set<std::string> claimed;
     for (pugi::xml_node e = setsNode.first_child(); e; e = e.next_sibling()) {
         if (std::string_view(e.name()) == "modelSet") {
             auto set = std::make_unique<ModelSet>();
             set->Load(e);
-            // Drop members that already belong to a previously-loaded Set
-            // (collision protection). First occurrence wins.
-            for (auto it = _sets.begin(); it != _sets.end(); ++it) {
-                for (const auto& m : (*it)->GetMembers()) {
-                    set->RemoveMember(m);
-                }
+            // Drop members already claimed by a previously-loaded Set.
+            // O(members) per Set using the claimed set instead of a nested loop.
+            std::vector<std::string> toRemove;
+            for (const auto& m : set->GetMembers()) {
+                if (claimed.count(m)) toRemove.push_back(m);
             }
+            for (const auto& m : toRemove) set->RemoveMember(m);
             if (set->GetMembers().size() >= 2 && !set->GetName().empty()) {
+                for (const auto& m : set->GetMembers()) claimed.insert(m);
                 _sets.push_back(std::move(set));
             }
         }

--- a/src-core/models/ModelSetManager.cpp
+++ b/src-core/models/ModelSetManager.cpp
@@ -1,5 +1,5 @@
 /***************************************************************
- * This source files comes from the xLights project
+ * This source file comes from the xLights project
  * https://www.xlights.org
  * https://github.com/xLightsSequencer/xLights
  * See the github commit history for a record of contributing

--- a/src-core/models/ModelSetManager.cpp
+++ b/src-core/models/ModelSetManager.cpp
@@ -1,0 +1,183 @@
+/***************************************************************
+ * This source files comes from the xLights project
+ * https://www.xlights.org
+ * https://github.com/xLightsSequencer/xLights
+ * See the github commit history for a record of contributing
+ * developers.
+ * Copyright claimed based on commit dates recorded in Github
+ * License: https://github.com/xLightsSequencer/xLights/blob/master/License.txt
+ **************************************************************/
+
+#include "ModelSetManager.h"
+
+#include <algorithm>
+#include <cstdlib>
+
+void ModelSetManager::RebuildIndex()
+{
+    _memberIndex.clear();
+    for (auto& s : _sets) {
+        for (const auto& m : s->GetMembers()) {
+            _memberIndex[m] = s.get();
+        }
+    }
+}
+
+std::string ModelSetManager::GenerateUniqueName(const std::string& candidate) const
+{
+    if (!candidate.empty() && GetSetByName(candidate) == nullptr) {
+        return candidate;
+    }
+    // Auto-name: pick lowest unused "Set N".
+    for (int i = 1; i < 100000; ++i) {
+        std::string n = "Set " + std::to_string(i);
+        if (GetSetByName(n) == nullptr) {
+            return n;
+        }
+    }
+    return "Set"; // unreachable in practice
+}
+
+ModelSet* ModelSetManager::CreateSet(const std::vector<std::string>& memberModels,
+                                      const std::string& suggestedName)
+{
+    if (memberModels.size() < 2) {
+        return nullptr;
+    }
+    auto set = std::make_unique<ModelSet>(GenerateUniqueName(suggestedName));
+    for (const auto& m : memberModels) {
+        set->AddMember(m);
+    }
+    ModelSet* raw = set.get();
+    _sets.push_back(std::move(set));
+    RebuildIndex();
+    return raw;
+}
+
+void ModelSetManager::DeleteSet(ModelSet* set)
+{
+    if (set == nullptr) return;
+    _sets.erase(std::remove_if(_sets.begin(), _sets.end(),
+                               [set](const std::unique_ptr<ModelSet>& s) { return s.get() == set; }),
+                _sets.end());
+    RebuildIndex();
+}
+
+bool ModelSetManager::RenameSet(ModelSet* set, const std::string& newName)
+{
+    if (set == nullptr || newName.empty()) return false;
+    // Name uniqueness - if another Set already has this name, reject.
+    ModelSet* existing = GetSetByName(newName);
+    if (existing != nullptr && existing != set) {
+        return false;
+    }
+    set->SetName(newName);
+    return true;
+}
+
+void ModelSetManager::AddMember(ModelSet* set, const std::string& modelName)
+{
+    if (set == nullptr || modelName.empty()) return;
+    // If the model is in a different Set, remove it from that Set first.
+    auto it = _memberIndex.find(modelName);
+    if (it != _memberIndex.end() && it->second != set) {
+        it->second->RemoveMember(modelName);
+    }
+    set->AddMember(modelName);
+    RebuildIndex();
+}
+
+bool ModelSetManager::RemoveMember(const std::string& modelName)
+{
+    auto it = _memberIndex.find(modelName);
+    if (it == _memberIndex.end()) return false;
+    ModelSet* set = it->second;
+    set->RemoveMember(modelName);
+    bool autoDeleted = false;
+    if (set->GetMembers().size() < 2) {
+        DeleteSet(set);
+        autoDeleted = true;
+    }
+    RebuildIndex();
+    return autoDeleted;
+}
+
+ModelSet* ModelSetManager::GetSetContaining(const std::string& modelName) const
+{
+    auto it = _memberIndex.find(modelName);
+    return (it == _memberIndex.end()) ? nullptr : it->second;
+}
+
+ModelSet* ModelSetManager::GetSetByName(const std::string& setName) const
+{
+    for (const auto& s : _sets) {
+        if (s->GetName() == setName) return s.get();
+    }
+    return nullptr;
+}
+
+void ModelSetManager::OnModelRenamed(const std::string& oldName, const std::string& newName)
+{
+    if (oldName == newName) return;
+    bool changed = false;
+    for (auto& s : _sets) {
+        if (s->HasMember(oldName)) {
+            s->RenameMember(oldName, newName);
+            changed = true;
+        }
+    }
+    if (changed) {
+        RebuildIndex();
+    }
+}
+
+void ModelSetManager::OnModelDeleted(const std::string& modelName)
+{
+    RemoveMember(modelName);
+}
+
+void ModelSetManager::Load(pugi::xml_node setsNode)
+{
+    _sets.clear();
+    if (!setsNode) {
+        RebuildIndex();
+        return;
+    }
+    for (pugi::xml_node e = setsNode.first_child(); e; e = e.next_sibling()) {
+        if (std::string_view(e.name()) == "modelSet") {
+            auto set = std::make_unique<ModelSet>();
+            set->Load(e);
+            // Drop members that already belong to a previously-loaded Set
+            // (collision protection). First occurrence wins.
+            for (auto it = _sets.begin(); it != _sets.end(); ++it) {
+                for (const auto& m : (*it)->GetMembers()) {
+                    set->RemoveMember(m);
+                }
+            }
+            if (set->GetMembers().size() >= 2 && !set->GetName().empty()) {
+                _sets.push_back(std::move(set));
+            }
+        }
+    }
+    RebuildIndex();
+}
+
+void ModelSetManager::Save(pugi::xml_node setsNode) const
+{
+    if (!setsNode) return;
+    // Wipe and rewrite. Caller guarantees setsNode is the <modelSets> node.
+    while (setsNode.first_child()) {
+        setsNode.remove_child(setsNode.first_child());
+    }
+    for (const auto& s : _sets) {
+        if (s->GetMembers().size() < 2) continue;
+        pugi::xml_node node = setsNode.append_child("modelSet");
+        s->Save(node);
+    }
+}
+
+void ModelSetManager::Clear()
+{
+    _sets.clear();
+    _memberIndex.clear();
+}

--- a/src-core/models/ModelSetManager.cpp
+++ b/src-core/models/ModelSetManager.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <string_view>
 
 void ModelSetManager::RebuildIndex()
 {
@@ -78,10 +79,16 @@ bool ModelSetManager::RenameSet(ModelSet* set, const std::string& newName)
 void ModelSetManager::AddMember(ModelSet* set, const std::string& modelName)
 {
     if (set == nullptr || modelName.empty()) return;
-    // If the model is in a different Set, remove it from that Set first.
+    // If the model is in a different Set, remove it from that Set first -
+    // and dissolve that Set if the removal leaves it under 2 members, the
+    // same invariant RemoveMember() enforces.
     auto it = _memberIndex.find(modelName);
     if (it != _memberIndex.end() && it->second != set) {
-        it->second->RemoveMember(modelName);
+        ModelSet* old = it->second;
+        old->RemoveMember(modelName);
+        if (old->GetMembers().size() < 2) {
+            DeleteSet(old);
+        }
     }
     set->AddMember(modelName);
     RebuildIndex();
@@ -166,9 +173,7 @@ void ModelSetManager::Save(pugi::xml_node setsNode) const
 {
     if (!setsNode) return;
     // Wipe and rewrite. Caller guarantees setsNode is the <modelSets> node.
-    while (setsNode.first_child()) {
-        setsNode.remove_child(setsNode.first_child());
-    }
+    setsNode.remove_children();
     for (const auto& s : _sets) {
         if (s->GetMembers().size() < 2) continue;
         pugi::xml_node node = setsNode.append_child("modelSet");

--- a/src-core/models/ModelSetManager.h
+++ b/src-core/models/ModelSetManager.h
@@ -1,0 +1,68 @@
+#pragma once
+
+/***************************************************************
+ * This source files comes from the xLights project
+ * https://www.xlights.org
+ * https://github.com/xLightsSequencer/xLights
+ * See the github commit history for a record of contributing
+ * developers.
+ * Copyright claimed based on commit dates recorded in Github
+ * License: https://github.com/xLightsSequencer/xLights/blob/master/License.txt
+ **************************************************************/
+
+// Owns the collection of Model Sets and provides CRUD + lookup. Lives
+// alongside ModelManager (not a member, to avoid pulling Model* into Set
+// data). Persistence is the <modelSets> XML node in
+// xlights_rgbeffects.xml.
+
+#include "ModelSet.h"
+
+#include <memory>
+#include <pugixml.hpp>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class ModelSetManager {
+public:
+    ModelSetManager() = default;
+    ModelSetManager(const ModelSetManager&) = delete;
+    ModelSetManager& operator=(const ModelSetManager&) = delete;
+
+    // CRUD
+    ModelSet* CreateSet(const std::vector<std::string>& memberModels,
+                        const std::string& suggestedName = "");
+    // Next free auto-name ("Set N") for pre-filling a naming prompt.
+    std::string SuggestName() const { return GenerateUniqueName(""); }
+    void DeleteSet(ModelSet* set);
+    bool RenameSet(ModelSet* set, const std::string& newName);
+
+    // Membership
+    void AddMember(ModelSet* set, const std::string& modelName);
+    // Returns true if the Set is now too small (<2 members) and was auto-deleted.
+    bool RemoveMember(const std::string& modelName);
+
+    // Lookup
+    ModelSet* GetSetContaining(const std::string& modelName) const;
+    ModelSet* GetSetByName(const std::string& setName) const;
+    const std::vector<std::unique_ptr<ModelSet>>& GetAllSets() const { return _sets; }
+
+    // Model lifecycle hooks - call these when a model is renamed / deleted
+    // in ModelManager so Sets stay coherent.
+    void OnModelRenamed(const std::string& oldName, const std::string& newName);
+    void OnModelDeleted(const std::string& modelName);
+
+    // Persistence. Load reads child <modelSet> elements from setsNode.
+    // Save clears setsNode's children and writes the current state.
+    void Load(pugi::xml_node setsNode);
+    void Save(pugi::xml_node setsNode) const;
+
+    void Clear();
+
+private:
+    std::vector<std::unique_ptr<ModelSet>> _sets;
+    // model name -> Set pointer. Rebuilt on every mutation.
+    mutable std::unordered_map<std::string, ModelSet*> _memberIndex;
+    void RebuildIndex();
+    std::string GenerateUniqueName(const std::string& candidate) const;
+};

--- a/src-core/models/ModelSetManager.h
+++ b/src-core/models/ModelSetManager.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /***************************************************************
- * This source files comes from the xLights project
+ * This source file comes from the xLights project
  * https://www.xlights.org
  * https://github.com/xLightsSequencer/xLights
  * See the github commit history for a record of contributing

--- a/src-ui-wx/app-shell/TabSequence.cpp
+++ b/src-ui-wx/app-shell/TabSequence.cpp
@@ -150,12 +150,7 @@ void xLightsFrame::SerializeModelSets(BaseSerializingVisitor &visitor)
         if (s->GetMembers().size() < 2) continue;
         BaseSerializingVisitor::AttrCollector attr;
         attr.Add("name", s->GetName());
-        std::string list;
-        for (size_t i = 0; i < s->GetMembers().size(); ++i) {
-            if (i > 0) list += ",";
-            list += s->GetMembers()[i];
-        }
-        attr.Add("models", list);
+        attr.Add("models", s->GetMembersCsv());
         visitor.WriteOpenTag("modelSet", attr, true);
     }
     visitor.WriteCloseTag();

--- a/src-ui-wx/app-shell/TabSequence.cpp
+++ b/src-ui-wx/app-shell/TabSequence.cpp
@@ -108,6 +108,7 @@ std::string xLightsFrame::BuildEffectsXml()
     serializer.SerializeAllLayoutGroups(lgData, visitor);
     SerializePerspectives(visitor);
     SerializeSettings(visitor);
+    SerializeModelSets(visitor);
     _sequenceViewManager.Save(visitor);
     color_mgr.Save(visitor);
     viewpoint_mgr.Save(visitor);
@@ -138,6 +139,24 @@ void xLightsFrame::SerializePerspectives(BaseSerializingVisitor &visitor)
         attr.Add("settings", p.settings);
         attr.Add("version", p.version.empty() ? "2.0" : p.version);
         visitor.WriteOpenTag("perspective", attr, true);
+    }
+    visitor.WriteCloseTag();
+}
+
+void xLightsFrame::SerializeModelSets(BaseSerializingVisitor &visitor)
+{
+    visitor.WriteOpenTag("modelSets");
+    for (const auto& s : AllModels.GetSetManager().GetAllSets()) {
+        if (s->GetMembers().size() < 2) continue;
+        BaseSerializingVisitor::AttrCollector attr;
+        attr.Add("name", s->GetName());
+        std::string list;
+        for (size_t i = 0; i < s->GetMembers().size(); ++i) {
+            if (i > 0) list += ",";
+            list += s->GetMembers()[i];
+        }
+        attr.Add("models", list);
+        visitor.WriteOpenTag("modelSet", attr, true);
     }
     visitor.WriteCloseTag();
 }
@@ -1184,6 +1203,11 @@ void xLightsFrame::LoadModels(pugi::xml_node modelsNode,
     AllModels.LoadGroups(modelGroupsNode,
         modelPreview->GetVirtualCanvasWidth(),
         modelPreview->GetVirtualCanvasHeight());
+
+    // Load Model Sets (translation-only links between models). Lives in a
+    // <modelSets> sibling element under <xrgb>. See ModelSetManager.h.
+    pugi::xml_node modelSetsNode = modelGroupsNode.parent().child("modelSets");
+    AllModels.GetSetManager().Load(modelSetsNode);
 
     // Add all models to default House Preview that are set to Default or All Previews
     for (const auto& it : AllModels) {

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -30,6 +30,7 @@
 #include <wx/propgrid/advprops.h>
 #include <wx/tglbtn.h>
 #include <wx/srchctrl.h>
+#include <wx/checklst.h>
 #include <pugixml.hpp>
 #include <cmath>
 #include <fstream>
@@ -381,6 +382,12 @@ const long LayoutPanel::ID_PREVIEW_MODEL_UNLINKFROMBASE = wxNewId();
 const long LayoutPanel::ID_PREVIEW_MODEL_EXPORTASCUSTOM = wxNewId();
 const long LayoutPanel::ID_PREVIEW_MODEL_EXPORTASCUSTOM3D = wxNewId();
 const long LayoutPanel::ID_PREVIEW_MODEL_CREATEGROUP = wxNewId();
+const long LayoutPanel::ID_PREVIEW_MODEL_LINKASSET = wxNewId();
+const long LayoutPanel::ID_PREVIEW_MODEL_ADDTOSET = wxNewId();
+const long LayoutPanel::ID_PREVIEW_MODEL_REMOVEFROMSET = wxNewId();
+const long LayoutPanel::ID_PREVIEW_MODEL_DELETESET = wxNewId();
+const long LayoutPanel::ID_PREVIEW_MODEL_RENAMESET = wxNewId();
+const long LayoutPanel::ID_PREVIEW_MODEL_MANAGESET = wxNewId();
 const long LayoutPanel::ID_PREVIEW_MODEL_WIRINGVIEW = wxNewId();
 const long LayoutPanel::ID_PREVIEW_MODEL_ASPECTRATIO = wxNewId();
 const long LayoutPanel::ID_PREVIEW_MODEL_EXPORTXLIGHTSMODEL = wxNewId();
@@ -2388,6 +2395,19 @@ void LayoutPanel::BulkEditRotateX() { BulkEditRotateAxis('X'); }
 void LayoutPanel::BulkEditRotateY() { BulkEditRotateAxis('Y'); }
 void LayoutPanel::BulkEditRotateZ() { BulkEditRotateAxis('Z'); }
 
+namespace {
+// A Set containing a locked model is frozen: no member may be translated
+// or rotated as part of Set movement, so the locked arrangement survives.
+bool ModelSetHasLockedMember(ModelManager& mgr, ModelSet* s) {
+    if (s == nullptr) return false;
+    for (const auto& n : s->GetMembers()) {
+        Model* m = mgr[n];
+        if (m != nullptr && m->IsLocked()) return true;
+    }
+    return false;
+}
+} // namespace
+
 void LayoutPanel::BulkEditRotateAxis(char axis) {
     std::vector<Model*> modelsToEdit = GetSelectedModelsForEdit();
 
@@ -2446,7 +2466,119 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
                     wxString::Format("BulkRotate%c", axis).ToStdString(),
                     entered);
 
+    // Model Sets: if any selected model belongs to a Set, rotate the whole
+    // Set around its bounding-box centroid (positions arc around the
+    // centroid; per-member rotation still goes to newAngle). Loose models
+    // get the simple per-model rotation as before.
+    auto& setMgr = xlights->AllModels.GetSetManager();
+    std::set<ModelSet*> touchedSets;
+    for (Model* m : editableModels) {
+        if (ModelSet* s = setMgr.GetSetContaining(m->GetName())) {
+            touchedSets.insert(s);
+        }
+    }
+
+    // Sets containing a locked model are frozen - no member rotates, so the
+    // locked arrangement survives.
+    std::set<ModelSet*> blockedSets;
+    for (ModelSet* s : touchedSets) {
+        if (ModelSetHasLockedMember(xlights->AllModels, s)) {
+            blockedSets.insert(s);
+        }
+    }
+    for (ModelSet* s : blockedSets) {
+        touchedSets.erase(s);
+    }
+
+    auto rotateAround = [axis](Model* m, float cx, float cy, float cz, float deltaDeg) {
+        const float r = deltaDeg * (float)M_PI / 180.0f;
+        const float s = std::sin(r);
+        const float co = std::cos(r);
+        float x = m->GetHcenterPos();
+        float y = m->GetVcenterPos();
+        float z = m->GetDcenterPos();
+        float dx = x - cx, dy = y - cy, dz = z - cz;
+        switch (axis) {
+            case 'Z': {
+                float nx = dx * co - dy * s;
+                float ny = dx * s + dy * co;
+                m->SetHcenterPos(cx + nx);
+                m->SetVcenterPos(cy + ny);
+                break;
+            }
+            case 'X': {
+                float ny = dy * co - dz * s;
+                float nz = dy * s + dz * co;
+                m->SetVcenterPos(cy + ny);
+                m->SetDcenterPos(cz + nz);
+                break;
+            }
+            case 'Y': {
+                float nx = dx * co + dz * s;
+                float nz = -dx * s + dz * co;
+                m->SetHcenterPos(cx + nx);
+                m->SetDcenterPos(cz + nz);
+                break;
+            }
+        }
+    };
+
+    // First: handle each touched Set as a group (use ALL its members, not
+    // just the selected ones, so the relative arrangement is preserved).
+    std::set<Model*> doneViaSet;
+    for (ModelSet* s : touchedSets) {
+        std::vector<Model*> members;
+        members.reserve(s->GetMembers().size());
+        for (const auto& name : s->GetMembers()) {
+            Model* mm = xlights->AllModels[name];
+            if (mm != nullptr && !mm->GetBaseObjectScreenLocation().IsLocked()) {
+                members.push_back(mm);
+            }
+        }
+        if (members.empty()) continue;
+
+        // Centroid is the mean of member centers.
+        float cx = 0, cy = 0, cz = 0;
+        for (Model* mm : members) {
+            cx += mm->GetHcenterPos();
+            cy += mm->GetVcenterPos();
+            cz += mm->GetDcenterPos();
+        }
+        cx /= members.size();
+        cy /= members.size();
+        cz /= members.size();
+
+        // Delta from first member's current rotation on this axis.
+        float oldAngle = 0.0f;
+        switch (axis) {
+            case 'X': oldAngle = members.front()->GetBaseObjectScreenLocation().GetRotateX(); break;
+            case 'Y': oldAngle = members.front()->GetBaseObjectScreenLocation().GetRotateY(); break;
+            case 'Z': oldAngle = members.front()->GetBaseObjectScreenLocation().GetRotateZ(); break;
+        }
+        const float delta = newAngle - oldAngle;
+
+        for (Model* mm : members) {
+            rotateAround(mm, cx, cy, cz, delta);
+            auto& loc = mm->GetBaseObjectScreenLocation();
+            switch (axis) {
+                case 'X': loc.SetRotateX(newAngle); break;
+                case 'Y': loc.SetRotateY(newAngle); break;
+                case 'Z': loc.SetRotateZ(newAngle); break;
+            }
+            loc.Reload();
+            loc.Init();
+            doneViaSet.insert(mm);
+        }
+    }
+
+    // Loose models: original per-model rotation (rotate around own origin).
+    // Members of frozen Sets are excluded so they don't rotate individually.
     for (Model* model : editableModels) {
+        if (doneViaSet.count(model)) continue;
+        if (!blockedSets.empty()) {
+            ModelSet* s = setMgr.GetSetContaining(model->GetName());
+            if (s != nullptr && blockedSets.count(s) != 0) continue;
+        }
         auto& loc = model->GetBaseObjectScreenLocation();
         switch (axis) {
             case 'X': loc.SetRotateX(newAngle); break;
@@ -2460,6 +2592,438 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
     xlights->GetOutputModelManager()->AddASAPWork(
         OutputModelManager::WORK_SCREEN_LOCATION_CHANGE,
         wxString::Format("BulkEditRotate%c", axis).ToStdString());
+
+    if (!blockedSets.empty()) {
+        wxString names;
+        for (ModelSet* s : blockedSets) {
+            if (!names.empty()) names += ", ";
+            names += wxString::Format("'%s'", s->GetName());
+        }
+        wxMessageBox(wxString::Format("Set %s was not rotated because it contains a locked model.", names),
+                     "Bulk Edit Rotate", wxOK | wxICON_INFORMATION, this);
+    }
+}
+
+// -- Model Set helpers --
+//
+// A Model Set is a persistent translation-only link between models. See
+// plans/layout-group-move-lock.md. The right-click menu surfaces Set
+// management; drag-time propagation lives in OnPreviewLeftDown/Up; the
+// rest of the runtime API lives in ModelSetManager.
+
+std::vector<Model*> LayoutPanel::GetSelectedModelsForSetActions() const
+{
+    std::vector<Model*> out;
+    // Include models that have Selected() or GroupSelected() set on the
+    // canvas. Cover both tree-selection and click-selection paths.
+    for (auto* m : modelPreview->GetModels()) {
+        if (m != nullptr && (m->Selected() || m->GroupSelected())) {
+            // Skip submodels and ModelGroups - Sets only operate on real
+            // top-level models.
+            if (m->GetDisplayAs() == DisplayAsType::ModelGroup) continue;
+            if (m->GetDisplayAs() == DisplayAsType::SubModel) continue;
+            if (std::find(out.begin(), out.end(), m) == out.end()) {
+                out.push_back(m);
+            }
+        }
+    }
+    return out;
+}
+
+void LayoutPanel::AddModelSetOptionsToMenu(wxMenu& menu)
+{
+    auto selected = GetSelectedModelsForSetActions();
+    if (selected.empty()) return;
+
+    auto& setMgr = xlights->AllModels.GetSetManager();
+
+    // Find which Sets the selection touches.
+    std::vector<ModelSet*> touchedSets;
+    int loose = 0;
+    for (auto* m : selected) {
+        ModelSet* s = setMgr.GetSetContaining(m->GetName());
+        if (s == nullptr) {
+            ++loose;
+        } else if (std::find(touchedSets.begin(), touchedSets.end(), s) == touchedSets.end()) {
+            touchedSets.push_back(s);
+        }
+    }
+
+    if (touchedSets.empty()) {
+        if (selected.size() >= 2) {
+            // 2+ loose models - single action, keep it top-level.
+            menu.AppendSeparator();
+            menu.Append(ID_PREVIEW_MODEL_LINKASSET, _("Link as Set..."));
+        }
+        return;
+    }
+
+    if (touchedSets.size() == 1) {
+        wxMenu* setMenu = new wxMenu();
+        if (selected.size() >= 2 && loose > 0) {
+            // Some are in this Set, some are loose - offer to add the loose ones.
+            setMenu->Append(ID_PREVIEW_MODEL_ADDTOSET, _("Add Selected to Set"));
+        }
+        setMenu->Append(ID_PREVIEW_MODEL_REMOVEFROMSET, _("Remove from Set"));
+        setMenu->Append(ID_PREVIEW_MODEL_RENAMESET, _("Rename..."));
+        setMenu->Append(ID_PREVIEW_MODEL_MANAGESET, _("Manage..."));
+        setMenu->Append(ID_PREVIEW_MODEL_DELETESET, _("Delete"));
+        setMenu->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnPreviewModelPopup, nullptr, this);
+        menu.AppendSeparator();
+        menu.AppendSubMenu(setMenu, _("Set"));
+    }
+}
+
+void LayoutPanel::DoLinkAsSet()
+{
+    auto selected = GetSelectedModelsForSetActions();
+    if (selected.size() < 2) return;
+    auto& setMgr = xlights->AllModels.GetSetManager();
+
+    // Re-prompt on a name collision (keeping what the user typed) rather
+    // than making them start the whole action over.
+    std::string setName;
+    wxString prompt = "Name for the new Set:";
+    wxString current = setMgr.SuggestName();
+    while (true) {
+        wxTextEntryDialog dlg(this, prompt, "Link as Set", current);
+        OptimiseDialogPosition(&dlg);
+        if (dlg.ShowModal() != wxID_OK) return;
+        setName = dlg.GetValue().Trim(true).Trim(false).ToStdString();
+        if (setName.empty()) {
+            setName = setMgr.SuggestName();
+        }
+        if (setMgr.GetSetByName(setName) == nullptr) break;
+        prompt = wxString::Format("A Set named '%s' already exists. Choose another name:", setName);
+        current = setName;
+    }
+
+    std::vector<std::string> names;
+    names.reserve(selected.size());
+    for (auto* m : selected) {
+        names.push_back(m->GetName());
+    }
+    setMgr.CreateSet(names, setName);
+    xlights->UnsavedRgbEffectsChanges = true;
+    xlights->GetOutputModelManager()->AddASAPWork(
+        OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::DoLinkAsSet");
+}
+
+void LayoutPanel::DoAddSelectedToSet(const std::string& setName)
+{
+    auto selected = GetSelectedModelsForSetActions();
+    if (selected.empty()) return;
+    auto& setMgr = xlights->AllModels.GetSetManager();
+    ModelSet* target = setMgr.GetSetByName(setName);
+    if (target == nullptr) return;
+
+    bool anyMoved = false;
+    for (auto* m : selected) {
+        ModelSet* existing = setMgr.GetSetContaining(m->GetName());
+        if (existing == target) continue;
+        if (existing != nullptr) {
+            wxString prompt = wxString::Format(
+                "'%s' is already in Set '%s'. Move it to Set '%s'?",
+                m->GetName(), existing->GetName(), target->GetName());
+            if (wxMessageBox(prompt, "Confirm Move", wxYES_NO | wxICON_QUESTION, this) != wxYES) {
+                continue;
+            }
+        }
+        setMgr.AddMember(target, m->GetName());
+        anyMoved = true;
+    }
+    if (anyMoved) {
+        xlights->UnsavedRgbEffectsChanges = true;
+        xlights->GetOutputModelManager()->AddASAPWork(
+            OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::DoAddSelectedToSet");
+    }
+}
+
+void LayoutPanel::DoRemoveSelectedFromSet()
+{
+    auto selected = GetSelectedModelsForSetActions();
+    if (selected.empty()) return;
+    auto& setMgr = xlights->AllModels.GetSetManager();
+    bool anyRemoved = false;
+    for (auto* m : selected) {
+        if (setMgr.GetSetContaining(m->GetName()) != nullptr) {
+            setMgr.RemoveMember(m->GetName());
+            anyRemoved = true;
+        }
+    }
+    if (anyRemoved) {
+        xlights->UnsavedRgbEffectsChanges = true;
+        xlights->GetOutputModelManager()->AddASAPWork(
+            OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::DoRemoveSelectedFromSet");
+    }
+}
+
+void LayoutPanel::DoDeleteSet()
+{
+    auto selected = GetSelectedModelsForSetActions();
+    if (selected.empty()) return;
+    auto& setMgr = xlights->AllModels.GetSetManager();
+    ModelSet* s = nullptr;
+    for (auto* m : selected) {
+        s = setMgr.GetSetContaining(m->GetName());
+        if (s != nullptr) break;
+    }
+    if (s == nullptr) return;
+    wxString prompt = wxString::Format("Delete Set '%s'? Member models will not be affected.", s->GetName());
+    if (wxMessageBox(prompt, "Confirm Delete", wxYES_NO | wxICON_QUESTION, this) != wxYES) {
+        return;
+    }
+    setMgr.DeleteSet(s);
+    xlights->UnsavedRgbEffectsChanges = true;
+    xlights->GetOutputModelManager()->AddASAPWork(
+        OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::DoDeleteSet");
+}
+
+void LayoutPanel::DoRenameSet()
+{
+    auto selected = GetSelectedModelsForSetActions();
+    if (selected.empty()) return;
+    auto& setMgr = xlights->AllModels.GetSetManager();
+    ModelSet* s = nullptr;
+    for (auto* m : selected) {
+        s = setMgr.GetSetContaining(m->GetName());
+        if (s != nullptr) break;
+    }
+    if (s == nullptr) return;
+
+    // Re-prompt on a name collision (keeping what the user typed) rather
+    // than making them start over.
+    wxString prompt = "New Set name:";
+    wxString current = s->GetName();
+    while (true) {
+        wxTextEntryDialog dlg(this, prompt, "Rename Set", current);
+        OptimiseDialogPosition(&dlg);
+        if (dlg.ShowModal() != wxID_OK) return;
+        std::string newName = dlg.GetValue().Trim(true).Trim(false).ToStdString();
+        if (newName.empty() || newName == s->GetName()) return;
+        if (setMgr.RenameSet(s, newName)) break;
+        prompt = wxString::Format("A Set named '%s' already exists. Choose another name:", newName);
+        current = newName;
+    }
+    xlights->UnsavedRgbEffectsChanges = true;
+    xlights->GetOutputModelManager()->AddASAPWork(
+        OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::DoRenameSet");
+}
+
+namespace {
+// Checkbox-list dialog with realtime filtering for Model Set membership.
+class ManageSetDialog : public wxDialog {
+public:
+    ManageSetDialog(wxWindow* parent, const wxString& setName,
+                    const std::vector<std::string>& candidates,
+                    const std::vector<wxString>& labels,
+                    const std::set<std::string>& initialChecked,
+                    std::function<bool(const std::string&)> nameAvailable) :
+        wxDialog(parent, wxID_ANY, "Manage Set", wxDefaultPosition, wxDefaultSize,
+                 wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+        _candidates(candidates),
+        _labels(labels),
+        _checked(initialChecked),
+        _originalName(setName.ToStdString()),
+        _nameAvailable(std::move(nameAvailable))
+    {
+        auto* sizer = new wxBoxSizer(wxVERTICAL);
+        auto* nameSizer = new wxBoxSizer(wxHORIZONTAL);
+        nameSizer->Add(new wxStaticText(this, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 6);
+        _name = new wxTextCtrl(this, wxID_ANY, setName);
+        nameSizer->Add(_name, 1, wxEXPAND);
+        sizer->Add(nameSizer, 0, wxEXPAND | wxALL, 8);
+        sizer->Add(new wxStaticText(this, wxID_ANY,
+                                    "Checked models are members of this Set.\nCheck to add, uncheck to remove."),
+                   0, wxLEFT | wxRIGHT | wxBOTTOM, 8);
+        _filter = new wxSearchCtrl(this, wxID_ANY);
+        _filter->ShowCancelButton(true);
+        _filter->SetDescriptiveText("Filter models");
+        sizer->Add(_filter, 0, wxEXPAND | wxLEFT | wxRIGHT, 8);
+        _list = new wxCheckListBox(this, wxID_ANY);
+        sizer->Add(_list, 1, wxEXPAND | wxALL, 8);
+        sizer->Add(CreateStdDialogButtonSizer(wxOK | wxCANCEL), 0, wxEXPAND | wxALL, 8);
+        SetSizer(sizer);
+        SetSize(FromDIP(wxSize(450, 600)));
+
+        _filter->Bind(wxEVT_TEXT, [this](wxCommandEvent&) { Rebuild(); });
+        _filter->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN, [this](wxCommandEvent&) { _filter->Clear(); });
+        _list->Bind(wxEVT_CHECKLISTBOX, [this](wxCommandEvent& e) {
+            int idx = e.GetInt();
+            if (idx >= 0 && idx < (int)_visible.size()) {
+                if (_list->IsChecked(idx)) {
+                    _checked.insert(_visible[idx]);
+                } else {
+                    _checked.erase(_visible[idx]);
+                }
+            }
+        });
+        // Validate the name on OK so a collision keeps the dialog open for
+        // an in-place fix instead of discarding the user's work.
+        Bind(wxEVT_BUTTON, [this](wxCommandEvent& e) {
+            const std::string n = GetSetName();
+            if (!n.empty() && n != _originalName && _nameAvailable && !_nameAvailable(n)) {
+                wxMessageBox(wxString::Format("A Set named '%s' already exists. Choose another name.", n),
+                             "Manage Set", wxOK | wxICON_WARNING, this);
+                _name->SetFocus();
+                _name->SelectAll();
+                return;
+            }
+            e.Skip();
+        }, wxID_OK);
+        Rebuild();
+    }
+
+    const std::set<std::string>& GetChecked() const { return _checked; }
+    std::string GetSetName() const { return _name->GetValue().Trim(true).Trim(false).ToStdString(); }
+
+private:
+    void Rebuild() {
+        const wxString f = _filter->GetValue().Lower();
+        _list->Freeze();
+        _list->Clear();
+        _visible.clear();
+        for (size_t i = 0; i < _candidates.size(); ++i) {
+            if (!f.empty() && _labels[i].Lower().Find(f) == wxNOT_FOUND) continue;
+            int pos = _list->Append(_labels[i]);
+            _visible.push_back(_candidates[i]);
+            if (_checked.count(_candidates[i]) != 0) {
+                _list->Check(pos);
+            }
+        }
+        _list->Thaw();
+    }
+
+    std::vector<std::string> _candidates;
+    std::vector<wxString> _labels;
+    std::set<std::string> _checked;
+    std::vector<std::string> _visible;
+    std::string _originalName;
+    std::function<bool(const std::string&)> _nameAvailable;
+    wxSearchCtrl* _filter = nullptr;
+    wxCheckListBox* _list = nullptr;
+    wxTextCtrl* _name = nullptr;
+};
+} // namespace
+
+void LayoutPanel::DoManageSet()
+{
+    auto selected = GetSelectedModelsForSetActions();
+    if (selected.empty()) return;
+    auto& setMgr = xlights->AllModels.GetSetManager();
+    ModelSet* s = nullptr;
+    for (auto* m : selected) {
+        s = setMgr.GetSetContaining(m->GetName());
+        if (s != nullptr) break;
+    }
+    if (s == nullptr) return;
+
+    // Checkbox list: current members first (checked), then the remaining
+    // models, each section alphabetized. Checking adds, unchecking removes.
+    std::vector<std::string> members;
+    std::vector<std::string> nonMembers;
+    for (const auto& it : xlights->AllModels) {
+        Model* m = it.second;
+        if (m == nullptr) continue;
+        if (m->GetDisplayAs() == DisplayAsType::ModelGroup) continue;
+        if (m->GetDisplayAs() == DisplayAsType::SubModel) continue;
+        if (setMgr.GetSetContaining(m->GetName()) == s) {
+            members.push_back(m->GetName());
+        } else {
+            nonMembers.push_back(m->GetName());
+        }
+    }
+    std::sort(members.begin(), members.end());
+    std::sort(nonMembers.begin(), nonMembers.end());
+
+    std::vector<std::string> candidates = members;
+    candidates.insert(candidates.end(), nonMembers.begin(), nonMembers.end());
+
+    std::vector<wxString> labels;
+    std::set<std::string> initialChecked;
+    labels.reserve(candidates.size());
+    for (const auto& name : candidates) {
+        wxString label = name;
+        // Show foreign-Set membership so the user knows checking it will
+        // move the model out of its current Set.
+        ModelSet* owner = setMgr.GetSetContaining(name);
+        if (owner != nullptr && owner != s) {
+            label += wxString::Format(" (in Set '%s')", owner->GetName());
+        }
+        labels.push_back(label);
+        if (owner == s) {
+            initialChecked.insert(name);
+        }
+    }
+
+    ManageSetDialog dlg(this, s->GetName(), candidates, labels, initialChecked,
+                        [&setMgr, s](const std::string& n) {
+                            ModelSet* existing = setMgr.GetSetByName(n);
+                            return existing == nullptr || existing == s;
+                        });
+    OptimiseDialogPosition(&dlg);
+    if (dlg.ShowModal() != wxID_OK) return;
+
+    const std::set<std::string>& finalMembers = dlg.GetChecked();
+
+    if (finalMembers.size() < 2) {
+        if (wxMessageBox(wxString::Format("A Set needs at least 2 members. Delete Set '%s' instead?", s->GetName()),
+                         "Manage Set", wxYES_NO | wxICON_QUESTION, this) == wxYES) {
+            setMgr.DeleteSet(s);
+            xlights->UnsavedRgbEffectsChanges = true;
+            xlights->GetOutputModelManager()->AddASAPWork(
+                OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::DoManageSet");
+        }
+        return;
+    }
+
+    bool changed = false;
+
+    // Apply a rename typed into the dialog's name field.
+    const std::string newName = dlg.GetSetName();
+    if (!newName.empty() && newName != s->GetName()) {
+        if (setMgr.RenameSet(s, newName)) {
+            changed = true;
+        } else {
+            wxMessageBox(wxString::Format("A Set named '%s' already exists. Name unchanged.", newName),
+                         "Manage Set", wxOK | wxICON_WARNING, this);
+        }
+    }
+
+    // Adds first so membership never dips below 2 mid-stream (RemoveMember
+    // auto-deletes Sets that fall under 2 members).
+    for (const auto& name : finalMembers) {
+        if (s->HasMember(name)) continue;
+        ModelSet* owner = setMgr.GetSetContaining(name);
+        if (owner != nullptr && owner != s) {
+            wxString prompt = wxString::Format(
+                "'%s' is already in Set '%s'. Move it to Set '%s'?",
+                name, owner->GetName(), s->GetName());
+            if (wxMessageBox(prompt, "Confirm Move", wxYES_NO | wxICON_QUESTION, this) != wxYES) {
+                continue;
+            }
+        }
+        setMgr.AddMember(s, name);
+        changed = true;
+    }
+
+    // Then removals.
+    std::vector<std::string> toRemove;
+    for (const auto& name : s->GetMembers()) {
+        if (finalMembers.count(name) == 0) {
+            toRemove.push_back(name);
+        }
+    }
+    for (const auto& name : toRemove) {
+        setMgr.RemoveMember(name);
+        changed = true;
+    }
+
+    if (changed) {
+        xlights->UnsavedRgbEffectsChanges = true;
+        xlights->GetOutputModelManager()->AddASAPWork(
+            OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::DoManageSet");
+    }
 }
 
 void LayoutPanel::BulkEditPixelStyle() {
@@ -3989,6 +4553,27 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
                                     handledByNewApi = true;
                                 }
                             } else {
+                                // Model Sets: a Set containing a locked model is
+                                // frozen - block the 3D translate/rotate gizmo
+                                // drag at the source so the grabbed member can't
+                                // move away from the rest. Alt still allows an
+                                // unlocked member to be moved individually.
+                                if ((hit->id.role == handles::Role::AxisArrow ||
+                                     hit->id.role == handles::Role::AxisRing) &&
+                                    !event.AltDown()) {
+                                    Model* selModel = dynamic_cast<Model*>(selectedBaseObject);
+                                    if (selModel != nullptr) {
+                                        ModelSet* ms = xlights->AllModels.GetSetManager().GetSetContaining(selModel->GetName());
+                                        if (ms != nullptr && ModelSetHasLockedMember(xlights->AllModels, ms)) {
+                                            xlights->SetStatusText(wxString::Format(
+                                                "Set '%s' contains a locked model - unlock it to move the Set.", ms->GetName()));
+                                            handledByNewApi = true;
+                                            m_last_mouse_x = event.GetX();
+                                            m_last_mouse_y = event.GetY();
+                                            return;
+                                        }
+                                    }
+                                }
                                 handles::WorldRay startRay{ray_origin, ray_direction};
                                 if (auto session = selectedBaseObject->BeginDrag(hit->id, startRay)) {
                                     xlights->AbortRender();
@@ -4373,24 +4958,35 @@ void LayoutPanel::OnPreviewLeftDown(wxMouseEvent& event)
                                 "LayoutPanel::OnPreviewLeftDown-NewAPI2D-Segment");
                             handledByNewApi = true;
                         } else {
+                            // Model Sets: a centre-handle translate on a Set
+                            // member routes through the body-drag path instead
+                            // of a single-model session, so the whole Set
+                            // moves (or stays frozen if a member is locked).
+                            // Alt keeps the single-model session.
+                            bool deferToSetDrag = false;
+                            if (hit->id.role == handles::Role::Move && !event.AltDown()) {
+                                deferToSetDrag = xlights->AllModels.GetSetManager().GetSetContaining(model->GetName()) != nullptr;
+                            }
                             handles::WorldRay startRay;
                             GetMouseLocation(event.GetX(), event.GetY(),
                                               startRay.origin, startRay.direction);
-                            if (auto session = model->BeginDrag(hit->id, startRay)) {
-                                xlights->AbortRender();
-                                if (selectedBaseObject != _newModel) {
-                                    CreateUndoPoint("SingleModel", selectedBaseObject->name, "");
+                            if (!deferToSetDrag) {
+                                if (auto session = model->BeginDrag(hit->id, startRay)) {
+                                    xlights->AbortRender();
+                                    if (selectedBaseObject != _newModel) {
+                                        CreateUndoPoint("SingleModel", selectedBaseObject->name, "");
+                                    }
+                                    m_dragSession = std::move(session);
+                                    m_moving_handle = true;
+                                    m_mouse_down = true;
+                                    last_centerpos   = selectedBaseObject->GetBaseObjectScreenLocation().GetCenterPosition();
+                                    last_worldrotate = glm::vec3(0.0f); // accumulated resets to 0 at session start
+                                    last_worldscale  = selectedBaseObject->GetBaseObjectScreenLocation().GetScaleMatrix();
+                                    xlights->GetOutputModelManager()->AddASAPWork(
+                                        OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW,
+                                        "LayoutPanel::OnPreviewLeftDown-NewAPI2D");
+                                    handledByNewApi = true;
                                 }
-                                m_dragSession = std::move(session);
-                                m_moving_handle = true;
-                                m_mouse_down = true;
-                                last_centerpos   = selectedBaseObject->GetBaseObjectScreenLocation().GetCenterPosition();
-                                last_worldrotate = glm::vec3(0.0f); // accumulated resets to 0 at session start
-                                last_worldscale  = selectedBaseObject->GetBaseObjectScreenLocation().GetScaleMatrix();
-                                xlights->GetOutputModelManager()->AddASAPWork(
-                                    OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW,
-                                    "LayoutPanel::OnPreviewLeftDown-NewAPI2D");
-                                handledByNewApi = true;
                             }
                         }
                     }
@@ -4422,9 +5018,26 @@ void LayoutPanel::OnPreviewLeftDown(wxMouseEvent& event)
     }
     else if (event.AltDown())
     {
-        m_previous_mouse_x = event.GetX();
-        m_previous_mouse_y = event.GetY();
-        m_wheel_down = true;
+        // Alt+click on a model starts a single-model drag - the move handler
+        // suppresses Model Set propagation while Alt is held, which is how a
+        // member is repositioned within its Set. Alt+drag on empty space
+        // pans the canvas, as before.
+        std::vector<int> found;
+        if (FindModelsClicked(event.GetX(), event.GetY(), found) > 0) {
+            m_moving_handle = false;
+            m_creating_bound_rect = false;
+            Model* singleModel = SelectSingleModel(event.GetX(), event.GetY());
+            if (singleModel != nullptr) {
+                SelectModelInTree(singleModel);
+                m_dragging = true;
+            }
+            m_previous_mouse_x = event.GetX();
+            m_previous_mouse_y = event.GetY();
+        } else {
+            m_previous_mouse_x = event.GetX();
+            m_previous_mouse_y = event.GetY();
+            m_wheel_down = true;
+        }
     }
     else if (selectedButton != nullptr)
     {
@@ -5604,7 +6217,49 @@ void LayoutPanel::OnPreviewMouseMove3D(wxMouseEvent& event)
                         const int selectedModelCnt      = ModelsSelectedCount();
                         const int selectedViewObjectCnt = ViewObjectsSelectedCount();
                         const bool multiSel = (selectedModelCnt > 1 || selectedViewObjectCnt > 1);
-                        if (multiSel) {
+
+                        // Model Sets: members of any Set touched by the moved
+                        // selection follow translate/rotate even when only one
+                        // model is selected. Holding Alt/Option during the drag
+                        // suppresses this, allowing a single member to be
+                        // repositioned within its Set. See
+                        // plans/layout-group-move-lock.md.
+                        auto& setMgr = xlights->AllModels.GetSetManager();
+                        std::set<ModelSet*> touchedSets;
+                        if (!event.AltDown()) {
+                            for (auto* mm : modelPreview->GetModels()) {
+                                if (mm != nullptr && (mm->Selected() || mm->GroupSelected())) {
+                                    if (ModelSet* ts = setMgr.GetSetContaining(mm->GetName())) {
+                                        touchedSets.insert(ts);
+                                    }
+                                }
+                            }
+                        }
+                        // Sets containing a locked model are frozen - drop
+                        // them from propagation and keep their selected
+                        // members from following a multi-select drag.
+                        std::set<ModelSet*> blockedSets;
+                        for (auto* ts : touchedSets) {
+                            if (ModelSetHasLockedMember(xlights->AllModels, ts)) {
+                                blockedSets.insert(ts);
+                            }
+                        }
+                        for (auto* ts : blockedSets) {
+                            touchedSets.erase(ts);
+                        }
+                        auto isBlockedSetMember = [&](Model* mm) {
+                            if (mm == nullptr || blockedSets.empty()) return false;
+                            ModelSet* ts = setMgr.GetSetContaining(mm->GetName());
+                            return ts != nullptr && blockedSets.count(ts) != 0;
+                        };
+                        auto isUnselectedSetMember = [&](Model* mm) {
+                            if (mm == nullptr || mm == selectedBaseObject) return false;
+                            if (mm->Selected() || mm->GroupSelected()) return false;
+                            ModelSet* ts = setMgr.GetSetContaining(mm->GetName());
+                            return ts != nullptr && touchedSets.count(ts) != 0;
+                        };
+
+                        if (multiSel || !touchedSets.empty()) {
                             auto& sloc = selectedBaseObject->GetBaseObjectScreenLocation();
                             const handles::Role dragRole = m_dragSession->GetHandleId().role;
                             if (dragRole == handles::Role::AxisArrow) {
@@ -5612,14 +6267,17 @@ void LayoutPanel::OnPreviewMouseMove3D(wxMouseEvent& event)
                                 glm::vec3 pos_offset    = new_centerpos - last_centerpos;
                                 for (size_t i = 0; i < modelPreview->GetModels().size(); i++) {
                                     Model* mm = modelPreview->GetModels()[i];
-                                    if ((mm->GroupSelected() || mm->Selected()) && mm != selectedBaseObject) {
+                                    bool follow = multiSel && (mm->GroupSelected() || mm->Selected()) && mm != selectedBaseObject && !isBlockedSetMember(mm);
+                                    if (follow || isUnselectedSetMember(mm)) {
                                         mm->AddOffset(pos_offset.x, pos_offset.y, pos_offset.z);
                                     }
                                 }
-                                for (const auto& it : xlights->AllObjects) {
-                                    ViewObject* vo = it.second;
-                                    if ((vo->GroupSelected() || vo->Selected()) && vo != selectedBaseObject) {
-                                        vo->AddOffset(pos_offset.x, pos_offset.y, pos_offset.z);
+                                if (multiSel) {
+                                    for (const auto& it : xlights->AllObjects) {
+                                        ViewObject* vo = it.second;
+                                        if ((vo->GroupSelected() || vo->Selected()) && vo != selectedBaseObject) {
+                                            vo->AddOffset(pos_offset.x, pos_offset.y, pos_offset.z);
+                                        }
                                     }
                                 }
                                 last_centerpos = new_centerpos;
@@ -5636,22 +6294,25 @@ void LayoutPanel::OnPreviewMouseMove3D(wxMouseEvent& event)
                                         const glm::vec3 pivot = ri->pivot;
                                         for (size_t i = 0; i < modelPreview->GetModels().size(); i++) {
                                             Model* mm = modelPreview->GetModels()[i];
-                                            if ((mm->GroupSelected() || mm->Selected()) && mm != selectedBaseObject) {
+                                            bool follow = multiSel && (mm->GroupSelected() || mm->Selected()) && mm != selectedBaseObject && !isBlockedSetMember(mm);
+                                            if (follow || isUnselectedSetMember(mm)) {
                                                 xlights->AbortRender();
                                                 mm->RotateAboutPoint(pivot, angle);
                                             }
                                         }
-                                        for (const auto& it : xlights->AllObjects) {
-                                            ViewObject* vo = it.second;
-                                            if ((vo->GroupSelected() || vo->Selected()) && vo != selectedBaseObject) {
-                                                xlights->AbortRender();
-                                                vo->RotateAboutPoint(pivot, angle);
+                                        if (multiSel) {
+                                            for (const auto& it : xlights->AllObjects) {
+                                                ViewObject* vo = it.second;
+                                                if ((vo->GroupSelected() || vo->Selected()) && vo != selectedBaseObject) {
+                                                    xlights->AbortRender();
+                                                    vo->RotateAboutPoint(pivot, angle);
+                                                }
                                             }
                                         }
                                         last_worldrotate.x = ri->accumulated;
                                     }
                                 }
-                            } else if (dragRole == handles::Role::AxisCube) {
+                            } else if (multiSel && dragRole == handles::Role::AxisCube) {
                                 glm::vec3 new_worldscale = sloc.GetScaleMatrix();
                                 if (last_worldscale.x == 0 || last_worldscale.y == 0 || last_worldscale.z == 0) {
                                     spdlog::critical("11 multi-select scale: last_worldscale has a zero component");
@@ -6018,13 +6679,57 @@ void LayoutPanel::OnPreviewMouseMove(wxMouseEvent& event)
         delta_y /= modelPreview->GetZoom() / scale;
         int wi, ht;
         modelPreview->GetVirtualCanvasSize(wi, ht);
+        bool setDragBlocked = false;
         if (wi > 0 && ht > 0) {
+            // Model Sets: identify Sets touched by the current selection so
+            // their members translate together as one logical prop. Holding
+            // Alt/Option during the drag suppresses this, allowing a single
+            // member to be repositioned within its Set. See
+            // plans/layout-group-move-lock.md.
+            auto& setMgr = xlights->AllModels.GetSetManager();
+            std::set<ModelSet*> touchedSets;
+            if (!event.AltDown()) {
+                for (auto* sm : modelPreview->GetModels()) {
+                    if (sm != nullptr && (sm->Selected() || sm->GroupSelected())) {
+                        if (ModelSet* s = setMgr.GetSetContaining(sm->GetName())) {
+                            touchedSets.insert(s);
+                        }
+                    }
+                }
+            }
+            // Sets containing a locked model are frozen: no member moves
+            // (the dragged one included), so the locked arrangement survives.
+            std::set<ModelSet*> blockedSets;
+            for (auto* ts : touchedSets) {
+                if (ModelSetHasLockedMember(xlights->AllModels, ts)) {
+                    blockedSets.insert(ts);
+                }
+            }
+            for (auto* ts : blockedSets) {
+                touchedSets.erase(ts);
+            }
+
             for (size_t i = 0; i < modelPreview->GetModels().size(); i++) {
-                if (modelPreview->GetModels()[i]->Selected() || modelPreview->GetModels()[i]->GroupSelected()) {
+                Model* cur = modelPreview->GetModels()[i];
+                bool isSelected = cur->Selected() || cur->GroupSelected();
+                bool inTouchedSet = false;
+                if ((isSelected || !touchedSets.empty()) && !blockedSets.empty()) {
+                    ModelSet* s = setMgr.GetSetContaining(cur->GetName());
+                    if (s != nullptr && blockedSets.count(s) != 0) {
+                        continue;
+                    }
+                }
+                if (!isSelected && !touchedSets.empty()) {
+                    ModelSet* s = setMgr.GetSetContaining(cur->GetName());
+                    if (s != nullptr && touchedSets.count(s) != 0) {
+                        inTouchedSet = true;
+                    }
+                }
+                if (isSelected || inTouchedSet) {
                     if(!m->IsLocked()) {
                         CreateUndoPoint("SingleModel", m->name, "location");
                     }
-                    modelPreview->GetModels()[i]->AddOffset(delta_x, delta_y, 0.0);
+                    cur->AddOffset(delta_x, delta_y, 0.0);
                     //SetupPropGrid(modelPreview->GetModels()[i]);
                     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RELOAD_PROPERTYGRID, "LayoutPanel::OnPreviewMouseMove");
                     // dont need these until finished moving
@@ -6032,10 +6737,15 @@ void LayoutPanel::OnPreviewMouseMove(wxMouseEvent& event)
                     //xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_MODELS_CHANGE_REQUIRING_RERENDER, "LayoutPanel::OnPreviewMouseMove");
                 }
             }
+            setDragBlocked = !blockedSets.empty();
         }
         m_previous_mouse_x = event.GetPosition().x;
         m_previous_mouse_y = event.GetPosition().y;
-        xlights->SetStatusText(wxString::Format("x=%d y=%d", m_previous_mouse_x, m_previous_mouse_y));
+        if (setDragBlocked) {
+            xlights->SetStatusText("Model Set contains a locked model - unlock it to move the Set (Alt-drag moves a single model).");
+        } else {
+            xlights->SetStatusText(wxString::Format("x=%d y=%d", m_previous_mouse_x, m_previous_mouse_y));
+        }
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::OnPreviewMouseMove");
     }
     else {
@@ -6327,6 +7037,10 @@ void LayoutPanel::OnPreviewRightDown(wxMouseEvent& event)
         AddSingleModelOptionsToBaseMenu(mnu);
     }
 
+    if (editing_models && selectedObjectCnt > 0) {
+        AddModelSetOptionsToMenu(mnu);
+    }
+
     if( currentLayoutGroup != "Default" && currentLayoutGroup != "All Models" && currentLayoutGroup != "Unassigned" ) {
         if (selectedObjectCnt > 0) {
             mnu.AppendSeparator();
@@ -6397,6 +7111,25 @@ void LayoutPanel::OnPreviewModelPopup(wxCommandEvent& event)
     if (event.GetId() == ID_PREVIEW_RESET) {
         modelPreview->Reset();
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::OnPreviewModelPopup::ID_PREVIEW_RESET");
+    } else if (event.GetId() == ID_PREVIEW_MODEL_LINKASSET) {
+        DoLinkAsSet();
+    } else if (event.GetId() == ID_PREVIEW_MODEL_ADDTOSET) {
+        // Find the touched Set and route through DoAddSelectedToSet.
+        auto sel = GetSelectedModelsForSetActions();
+        ModelSet* target = nullptr;
+        for (auto* m : sel) {
+            target = xlights->AllModels.GetSetManager().GetSetContaining(m->GetName());
+            if (target != nullptr) break;
+        }
+        if (target != nullptr) DoAddSelectedToSet(target->GetName());
+    } else if (event.GetId() == ID_PREVIEW_MODEL_REMOVEFROMSET) {
+        DoRemoveSelectedFromSet();
+    } else if (event.GetId() == ID_PREVIEW_MODEL_DELETESET) {
+        DoDeleteSet();
+    } else if (event.GetId() == ID_PREVIEW_MODEL_RENAMESET) {
+        DoRenameSet();
+    } else if (event.GetId() == ID_PREVIEW_MODEL_MANAGESET) {
+        DoManageSet();
     } else if (event.GetId() == ID_PREVIEW_REPLACEMODEL) {
         ReplaceModel();
     } else if (event.GetId() == ID_PREVIEW_ALIGN_TOP) {

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -33,7 +33,6 @@
 #include <wx/checklst.h>
 #include <pugixml.hpp>
 #include <cmath>
-#include <numbers>
 #include <fstream>
 #include <functional>
 #include <limits>
@@ -2492,7 +2491,8 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
     }
 
     auto rotateAround = [axis](Model* m, float cx, float cy, float cz, float deltaDeg) {
-        const float r = deltaDeg * std::numbers::pi_v<float> / 180.0f;
+        static constexpr float kPi = 3.14159265358979323846f;
+        const float r = deltaDeg * kPi / 180.0f;
         const float s = std::sin(r);
         const float co = std::cos(r);
         float x = m->GetHcenterPos();
@@ -2550,6 +2550,10 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
         cz /= members.size();
 
         // Delta from first member's current rotation on this axis.
+        // Use the first member as the rotation reference. All Set members
+        // share the same rotation after being moved together, so any member
+        // would give the same delta; front() is deterministic for a given
+        // save/load cycle.
         float oldAngle = 0.0f;
         switch (axis) {
             case 'X': oldAngle = members.front()->GetBaseObjectScreenLocation().GetRotateX(); break;
@@ -2669,7 +2673,7 @@ void LayoutPanel::AddModelSetOptionsToMenu(wxMenu& menu)
         setMenu->Append(ID_PREVIEW_MODEL_RENAMESET, _("Rename..."));
         setMenu->Append(ID_PREVIEW_MODEL_MANAGESET, _("Manage..."));
         setMenu->Append(ID_PREVIEW_MODEL_DELETESET, _("Delete"));
-        setMenu->Connect(wxEVT_MENU, (wxObjectEventFunction)&LayoutPanel::OnPreviewModelPopup, nullptr, this);
+        setMenu->Bind(wxEVT_MENU, &LayoutPanel::OnPreviewModelPopup, this);
         menu.AppendSeparator();
         menu.AppendSubMenu(setMenu, _("Set"));
     }

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -33,6 +33,7 @@
 #include <wx/checklst.h>
 #include <pugixml.hpp>
 #include <cmath>
+#include <numbers>
 #include <fstream>
 #include <functional>
 #include <limits>
@@ -2491,7 +2492,7 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
     }
 
     auto rotateAround = [axis](Model* m, float cx, float cy, float cz, float deltaDeg) {
-        const float r = deltaDeg * (float)M_PI / 180.0f;
+        const float r = deltaDeg * std::numbers::pi_v<float> / 180.0f;
         const float s = std::sin(r);
         const float co = std::cos(r);
         float x = m->GetHcenterPos();
@@ -2599,8 +2600,8 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
             if (!names.empty()) names += ", ";
             names += wxString::Format("'%s'", s->GetName());
         }
-        wxMessageBox(wxString::Format("Set %s was not rotated because it contains a locked model.", names),
-                     "Bulk Edit Rotate", wxOK | wxICON_INFORMATION, this);
+        wxMessageBox(wxString::Format(_("Set %s was not rotated because it contains a locked model."), names),
+                     _("Bulk Edit Rotate"), wxOK | wxICON_INFORMATION, this);
     }
 }
 
@@ -2683,10 +2684,10 @@ void LayoutPanel::DoLinkAsSet()
     // Re-prompt on a name collision (keeping what the user typed) rather
     // than making them start the whole action over.
     std::string setName;
-    wxString prompt = "Name for the new Set:";
+    wxString prompt = _("Name for the new Set:");
     wxString current = setMgr.SuggestName();
     while (true) {
-        wxTextEntryDialog dlg(this, prompt, "Link as Set", current);
+        wxTextEntryDialog dlg(this, prompt, _("Link as Set"), current);
         OptimiseDialogPosition(&dlg);
         if (dlg.ShowModal() != wxID_OK) return;
         setName = dlg.GetValue().Trim(true).Trim(false).ToStdString();
@@ -2694,7 +2695,7 @@ void LayoutPanel::DoLinkAsSet()
             setName = setMgr.SuggestName();
         }
         if (setMgr.GetSetByName(setName) == nullptr) break;
-        prompt = wxString::Format("A Set named '%s' already exists. Choose another name:", setName);
+        prompt = wxString::Format(_("A Set named '%s' already exists. Choose another name:"), setName);
         current = setName;
     }
 
@@ -2769,8 +2770,8 @@ void LayoutPanel::DoDeleteSet()
         if (s != nullptr) break;
     }
     if (s == nullptr) return;
-    wxString prompt = wxString::Format("Delete Set '%s'? Member models will not be affected.", s->GetName());
-    if (wxMessageBox(prompt, "Confirm Delete", wxYES_NO | wxICON_QUESTION, this) != wxYES) {
+    wxString prompt = wxString::Format(_("Delete Set '%s'? Member models will not be affected."), s->GetName());
+    if (wxMessageBox(prompt, _("Confirm Delete"), wxYES_NO | wxICON_QUESTION, this) != wxYES) {
         return;
     }
     setMgr.DeleteSet(s);
@@ -2793,16 +2794,16 @@ void LayoutPanel::DoRenameSet()
 
     // Re-prompt on a name collision (keeping what the user typed) rather
     // than making them start over.
-    wxString prompt = "New Set name:";
+    wxString prompt = _("New Set name:");
     wxString current = s->GetName();
     while (true) {
-        wxTextEntryDialog dlg(this, prompt, "Rename Set", current);
+        wxTextEntryDialog dlg(this, prompt, _("Rename Set"), current);
         OptimiseDialogPosition(&dlg);
         if (dlg.ShowModal() != wxID_OK) return;
         std::string newName = dlg.GetValue().Trim(true).Trim(false).ToStdString();
         if (newName.empty() || newName == s->GetName()) return;
         if (setMgr.RenameSet(s, newName)) break;
-        prompt = wxString::Format("A Set named '%s' already exists. Choose another name:", newName);
+        prompt = wxString::Format(_("A Set named '%s' already exists. Choose another name:"), newName);
         current = newName;
     }
     xlights->UnsavedRgbEffectsChanges = true;
@@ -2819,7 +2820,7 @@ public:
                     const std::vector<wxString>& labels,
                     const std::set<std::string>& initialChecked,
                     std::function<bool(const std::string&)> nameAvailable) :
-        wxDialog(parent, wxID_ANY, "Manage Set", wxDefaultPosition, wxDefaultSize,
+        wxDialog(parent, wxID_ANY, _("Manage Set"), wxDefaultPosition, wxDefaultSize,
                  wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
         _candidates(candidates),
         _labels(labels),
@@ -2829,16 +2830,16 @@ public:
     {
         auto* sizer = new wxBoxSizer(wxVERTICAL);
         auto* nameSizer = new wxBoxSizer(wxHORIZONTAL);
-        nameSizer->Add(new wxStaticText(this, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 6);
+        nameSizer->Add(new wxStaticText(this, wxID_ANY, _("Name:")), 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, 6);
         _name = new wxTextCtrl(this, wxID_ANY, setName);
         nameSizer->Add(_name, 1, wxEXPAND);
         sizer->Add(nameSizer, 0, wxEXPAND | wxALL, 8);
         sizer->Add(new wxStaticText(this, wxID_ANY,
-                                    "Checked models are members of this Set.\nCheck to add, uncheck to remove."),
+                                    _("Checked models are members of this Set.\nCheck to add, uncheck to remove.")),
                    0, wxLEFT | wxRIGHT | wxBOTTOM, 8);
         _filter = new wxSearchCtrl(this, wxID_ANY);
         _filter->ShowCancelButton(true);
-        _filter->SetDescriptiveText("Filter models");
+        _filter->SetDescriptiveText(_("Filter models"));
         sizer->Add(_filter, 0, wxEXPAND | wxLEFT | wxRIGHT, 8);
         _list = new wxCheckListBox(this, wxID_ANY);
         sizer->Add(_list, 1, wxEXPAND | wxALL, 8);
@@ -2863,8 +2864,8 @@ public:
         Bind(wxEVT_BUTTON, [this](wxCommandEvent& e) {
             const std::string n = GetSetName();
             if (!n.empty() && n != _originalName && _nameAvailable && !_nameAvailable(n)) {
-                wxMessageBox(wxString::Format("A Set named '%s' already exists. Choose another name.", n),
-                             "Manage Set", wxOK | wxICON_WARNING, this);
+                wxMessageBox(wxString::Format(_("A Set named '%s' already exists. Choose another name."), n),
+                             _("Manage Set"), wxOK | wxICON_WARNING, this);
                 _name->SetFocus();
                 _name->SelectAll();
                 return;
@@ -2948,7 +2949,7 @@ void LayoutPanel::DoManageSet()
         // move the model out of its current Set.
         ModelSet* owner = setMgr.GetSetContaining(name);
         if (owner != nullptr && owner != s) {
-            label += wxString::Format(" (in Set '%s')", owner->GetName());
+            label += wxString::Format(_(" (in Set '%s')"), owner->GetName());
         }
         labels.push_back(label);
         if (owner == s) {
@@ -2967,8 +2968,8 @@ void LayoutPanel::DoManageSet()
     const std::set<std::string>& finalMembers = dlg.GetChecked();
 
     if (finalMembers.size() < 2) {
-        if (wxMessageBox(wxString::Format("A Set needs at least 2 members. Delete Set '%s' instead?", s->GetName()),
-                         "Manage Set", wxYES_NO | wxICON_QUESTION, this) == wxYES) {
+        if (wxMessageBox(wxString::Format(_("A Set needs at least 2 members. Delete Set '%s' instead?"), s->GetName()),
+                         _("Manage Set"), wxYES_NO | wxICON_QUESTION, this) == wxYES) {
             setMgr.DeleteSet(s);
             xlights->UnsavedRgbEffectsChanges = true;
             xlights->GetOutputModelManager()->AddASAPWork(
@@ -2985,8 +2986,8 @@ void LayoutPanel::DoManageSet()
         if (setMgr.RenameSet(s, newName)) {
             changed = true;
         } else {
-            wxMessageBox(wxString::Format("A Set named '%s' already exists. Name unchanged.", newName),
-                         "Manage Set", wxOK | wxICON_WARNING, this);
+            wxMessageBox(wxString::Format(_("A Set named '%s' already exists. Name unchanged."), newName),
+                         _("Manage Set"), wxOK | wxICON_WARNING, this);
         }
     }
 
@@ -2997,9 +2998,9 @@ void LayoutPanel::DoManageSet()
         ModelSet* owner = setMgr.GetSetContaining(name);
         if (owner != nullptr && owner != s) {
             wxString prompt = wxString::Format(
-                "'%s' is already in Set '%s'. Move it to Set '%s'?",
+                _("'%s' is already in Set '%s'. Move it to Set '%s'?"),
                 name, owner->GetName(), s->GetName());
-            if (wxMessageBox(prompt, "Confirm Move", wxYES_NO | wxICON_QUESTION, this) != wxYES) {
+            if (wxMessageBox(prompt, _("Confirm Move"), wxYES_NO | wxICON_QUESTION, this) != wxYES) {
                 continue;
             }
         }
@@ -4566,7 +4567,7 @@ void LayoutPanel::ProcessLeftMouseClick3D(wxMouseEvent& event)
                                         ModelSet* ms = xlights->AllModels.GetSetManager().GetSetContaining(selModel->GetName());
                                         if (ms != nullptr && ModelSetHasLockedMember(xlights->AllModels, ms)) {
                                             xlights->SetStatusText(wxString::Format(
-                                                "Set '%s' contains a locked model - unlock it to move the Set.", ms->GetName()));
+                                                _("Set '%s' contains a locked model - unlock it to move the Set."), ms->GetName()));
                                             handledByNewApi = true;
                                             m_last_mouse_x = event.GetX();
                                             m_last_mouse_y = event.GetY();
@@ -6742,7 +6743,7 @@ void LayoutPanel::OnPreviewMouseMove(wxMouseEvent& event)
         m_previous_mouse_x = event.GetPosition().x;
         m_previous_mouse_y = event.GetPosition().y;
         if (setDragBlocked) {
-            xlights->SetStatusText("Model Set contains a locked model - unlock it to move the Set (Alt-drag moves a single model).");
+            xlights->SetStatusText(_("Model Set contains a locked model - unlock it to move the Set (Alt-drag moves a single model)."));
         } else {
             xlights->SetStatusText(wxString::Format("x=%d y=%d", m_previous_mouse_x, m_previous_mouse_y));
         }

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -2468,8 +2468,8 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
                     entered);
 
     // Model Sets: if any selected model belongs to a Set, rotate the whole
-    // Set around its bounding-box centroid (positions arc around the
-    // centroid; per-member rotation still goes to newAngle). Loose models
+    // Set around the mean of member centers (positions arc around that
+    // pivot; per-member rotation still goes to newAngle). Loose models
     // get the simple per-model rotation as before.
     auto& setMgr = xlights->AllModels.GetSetManager();
     std::set<ModelSet*> touchedSets;
@@ -2598,7 +2598,7 @@ void LayoutPanel::BulkEditRotateAxis(char axis) {
         wxString names;
         for (ModelSet* s : blockedSets) {
             if (!names.empty()) names += ", ";
-            names += wxString::Format("'%s'", s->GetName());
+            names += wxString::Format("'%s'", wxString(s->GetName()));
         }
         wxMessageBox(wxString::Format(_("Set %s was not rotated because it contains a locked model."), names),
                      _("Bulk Edit Rotate"), wxOK | wxICON_INFORMATION, this);
@@ -2695,7 +2695,7 @@ void LayoutPanel::DoLinkAsSet()
             setName = setMgr.SuggestName();
         }
         if (setMgr.GetSetByName(setName) == nullptr) break;
-        prompt = wxString::Format(_("A Set named '%s' already exists. Choose another name:"), setName);
+        prompt = wxString::Format(_("A Set named '%s' already exists. Choose another name:"), wxString(setName));
         current = setName;
     }
 
@@ -2724,9 +2724,9 @@ void LayoutPanel::DoAddSelectedToSet(const std::string& setName)
         if (existing == target) continue;
         if (existing != nullptr) {
             wxString prompt = wxString::Format(
-                "'%s' is already in Set '%s'. Move it to Set '%s'?",
-                m->GetName(), existing->GetName(), target->GetName());
-            if (wxMessageBox(prompt, "Confirm Move", wxYES_NO | wxICON_QUESTION, this) != wxYES) {
+                _("'%s' is already in Set '%s'. Move it to Set '%s'?"),
+                wxString(m->GetName()), wxString(existing->GetName()), wxString(target->GetName()));
+            if (wxMessageBox(prompt, _("Confirm Move"), wxYES_NO | wxICON_QUESTION, this) != wxYES) {
                 continue;
             }
         }
@@ -2770,7 +2770,7 @@ void LayoutPanel::DoDeleteSet()
         if (s != nullptr) break;
     }
     if (s == nullptr) return;
-    wxString prompt = wxString::Format(_("Delete Set '%s'? Member models will not be affected."), s->GetName());
+    wxString prompt = wxString::Format(_("Delete Set '%s'? Member models will not be affected."), wxString(s->GetName()));
     if (wxMessageBox(prompt, _("Confirm Delete"), wxYES_NO | wxICON_QUESTION, this) != wxYES) {
         return;
     }
@@ -2803,7 +2803,7 @@ void LayoutPanel::DoRenameSet()
         std::string newName = dlg.GetValue().Trim(true).Trim(false).ToStdString();
         if (newName.empty() || newName == s->GetName()) return;
         if (setMgr.RenameSet(s, newName)) break;
-        prompt = wxString::Format(_("A Set named '%s' already exists. Choose another name:"), newName);
+        prompt = wxString::Format(_("A Set named '%s' already exists. Choose another name:"), wxString(newName));
         current = newName;
     }
     xlights->UnsavedRgbEffectsChanges = true;
@@ -2949,7 +2949,7 @@ void LayoutPanel::DoManageSet()
         // move the model out of its current Set.
         ModelSet* owner = setMgr.GetSetContaining(name);
         if (owner != nullptr && owner != s) {
-            label += wxString::Format(_(" (in Set '%s')"), owner->GetName());
+            label += wxString::Format(_(" (in Set '%s')"), wxString(owner->GetName()));
         }
         labels.push_back(label);
         if (owner == s) {
@@ -2968,7 +2968,7 @@ void LayoutPanel::DoManageSet()
     const std::set<std::string>& finalMembers = dlg.GetChecked();
 
     if (finalMembers.size() < 2) {
-        if (wxMessageBox(wxString::Format(_("A Set needs at least 2 members. Delete Set '%s' instead?"), s->GetName()),
+        if (wxMessageBox(wxString::Format(_("A Set needs at least 2 members. Delete Set '%s' instead?"), wxString(s->GetName())),
                          _("Manage Set"), wxYES_NO | wxICON_QUESTION, this) == wxYES) {
             setMgr.DeleteSet(s);
             xlights->UnsavedRgbEffectsChanges = true;
@@ -2986,7 +2986,7 @@ void LayoutPanel::DoManageSet()
         if (setMgr.RenameSet(s, newName)) {
             changed = true;
         } else {
-            wxMessageBox(wxString::Format(_("A Set named '%s' already exists. Name unchanged."), newName),
+            wxMessageBox(wxString::Format(_("A Set named '%s' already exists. Name unchanged."), wxString(newName)),
                          _("Manage Set"), wxOK | wxICON_WARNING, this);
         }
     }
@@ -6727,8 +6727,8 @@ void LayoutPanel::OnPreviewMouseMove(wxMouseEvent& event)
                     }
                 }
                 if (isSelected || inTouchedSet) {
-                    if(!m->IsLocked()) {
-                        CreateUndoPoint("SingleModel", m->name, "location");
+                    if(!cur->IsLocked()) {
+                        CreateUndoPoint("SingleModel", cur->name, "location");
                     }
                     cur->AddOffset(delta_x, delta_y, 0.0);
                     //SetupPropGrid(modelPreview->GetModels()[i]);

--- a/src-ui-wx/layout/LayoutPanel.h
+++ b/src-ui-wx/layout/LayoutPanel.h
@@ -191,6 +191,12 @@ class LayoutPanel: public wxPanel
         static const long ID_PREVIEW_MODEL_EXPORTASCUSTOM;
         static const long ID_PREVIEW_MODEL_EXPORTASCUSTOM3D;
         static const long ID_PREVIEW_MODEL_CREATEGROUP;
+        static const long ID_PREVIEW_MODEL_LINKASSET;
+        static const long ID_PREVIEW_MODEL_ADDTOSET;
+        static const long ID_PREVIEW_MODEL_REMOVEFROMSET;
+        static const long ID_PREVIEW_MODEL_DELETESET;
+        static const long ID_PREVIEW_MODEL_RENAMESET;
+        static const long ID_PREVIEW_MODEL_MANAGESET;
         static const long ID_PREVIEW_MODEL_WIRINGVIEW;
         static const long ID_PREVIEW_MODEL_ASPECTRATIO;
         static const long ID_PREVIEW_MODEL_EXPORTXLIGHTSMODEL;
@@ -434,6 +440,15 @@ class LayoutPanel: public wxPanel
         bool IsAllSelectedModelsArePixelProtocol() const;
         void AddSingleModelOptionsToBaseMenu(wxMenu &menu);
         void AddBulkEditOptionsToMenu(wxMenu* bulkEditMenu);
+        void AddModelSetOptionsToMenu(wxMenu& menu);
+        void DoLinkAsSet();
+        void DoAddSelectedToSet(const std::string& setName);
+        void DoRemoveSelectedFromSet();
+        void DoDeleteSet();
+        void DoRenameSet();
+        void DoManageSet();
+        // Returns models present in the current selection (canvas + tree).
+        std::vector<Model*> GetSelectedModelsForSetActions() const;
         void AddAlignOptionsToMenu(wxMenu* mnuAlign);
         void AddDistributeOptionsToMenu(wxMenu* mnuDistribute);
         void AddResizeOptionsToMenu(wxMenu* mnuResize);

--- a/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
+++ b/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
@@ -456,6 +456,16 @@ void ModelPropertyAdapter::AddProperties(wxPropertyGridInterface* grid, OutputMa
         p->ChangeFlag(wxPGFlags::ReadOnly, true);
     }
 
+    // Model Set membership (read-only row). See plans/layout-group-move-lock.md.
+    if (auto* set = _model.GetModelManager().GetSetManager().GetSetContaining(_model.GetName())) {
+        p = grid->Append(new wxStringProperty("In Model Set", "ModelSet", set->GetName()));
+        p->SetHelpString("This model belongs to a Model Set. Dragging any member of the Set moves them all together.\n"
+                         "Hold Alt/Option while dragging to move only this model and reposition it within the Set.\n"
+                         "Manage Sets via the right-click menu on the Layout tab.");
+        p->SetTextColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+        p->ChangeFlag(wxPGFlags::ReadOnly, true);
+    }
+
     AddControllerProperties(grid);
 
     p = grid->Append(new wxPropertyCategory("String Properties", "ModelStringProperties"));

--- a/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
+++ b/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
@@ -458,10 +458,10 @@ void ModelPropertyAdapter::AddProperties(wxPropertyGridInterface* grid, OutputMa
 
     // Model Set membership (read-only row). See plans/layout-group-move-lock.md.
     if (auto* set = _model.GetModelManager().GetSetManager().GetSetContaining(_model.GetName())) {
-        p = grid->Append(new wxStringProperty("In Model Set", "ModelSet", set->GetName()));
-        p->SetHelpString("This model belongs to a Model Set. Dragging any member of the Set moves them all together.\n"
-                         "Hold Alt/Option while dragging to move only this model and reposition it within the Set.\n"
-                         "Manage Sets via the right-click menu on the Layout tab.");
+        p = grid->Append(new wxStringProperty(_("In Model Set"), "ModelSet", set->GetName()));
+        p->SetHelpString(_("This model belongs to a Model Set. Dragging any member of the Set moves them all together.\n"
+                           "Hold Alt/Option while dragging to move only this model and reposition it within the Set.\n"
+                           "Manage Sets via the right-click menu on the Layout tab."));
         p->SetTextColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
         p->ChangeFlag(wxPGFlags::ReadOnly, true);
     }

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -379,6 +379,7 @@ public:
     void LoadPerspectivesMenu();
     void SerializePerspectives(BaseSerializingVisitor &visitor);
     void SerializeSettings(BaseSerializingVisitor &visitor);
+    void SerializeModelSets(BaseSerializingVisitor &visitor);
     struct Perspective {
         std::string name;
         std::string settings;

--- a/xLights/Xlights.vcxproj
+++ b/xLights/Xlights.vcxproj
@@ -845,6 +845,8 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
     <ClCompile Include="..\src-core\models\ModelGroup.cpp" />
     <ClCompile Include="..\src-core\models\ModelManager.cpp" />
     <ClCompile Include="..\src-core\models\ModelScreenLocation.cpp" />
+    <ClCompile Include="..\src-core\models\ModelSet.cpp" />
+    <ClCompile Include="..\src-core\models\ModelSetManager.cpp" />
     <ClCompile Include="..\src-core\models\Node.cpp" />
     <ClCompile Include="..\src-core\models\PolyLineModel.cpp" />
     <ClCompile Include="..\src-core\models\Shapes.cpp" />
@@ -1453,6 +1455,8 @@ xcopy "$(SolutionDir)..\bin64\Vamp\" "$(TargetDir)Vamp\" /e /y /i /r
     <ClInclude Include="..\src-core\models\ModelGroup.h" />
     <ClInclude Include="..\src-core\models\ModelManager.h" />
     <ClInclude Include="..\src-core\models\ModelScreenLocation.h" />
+    <ClInclude Include="..\src-core\models\ModelSet.h" />
+    <ClInclude Include="..\src-core\models\ModelSetManager.h" />
     <ClInclude Include="..\src-core\models\Node.h" />
     <ClInclude Include="..\src-core\models\PolyLineModel.h" />
     <ClInclude Include="..\src-core\models\Shapes.h" />

--- a/xLights/Xlights.vcxproj.filters
+++ b/xLights/Xlights.vcxproj.filters
@@ -216,6 +216,12 @@
     <ClCompile Include="..\src-core\models\ModelManager.cpp">
       <Filter>Models</Filter>
     </ClCompile>
+    <ClCompile Include="..\src-core\models\ModelSet.cpp">
+      <Filter>Models</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src-core\models\ModelSetManager.cpp">
+      <Filter>Models</Filter>
+    </ClCompile>
     <ClCompile Include="..\src-core\models\Model.cpp">
       <Filter>Models</Filter>
     </ClCompile>
@@ -1598,6 +1604,12 @@
     </ClInclude>
     <ClInclude Include="..\src-core\models\OutputModelManager.h" />
     <ClInclude Include="..\src-core\models\ModelManager.h">
+      <Filter>Models</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src-core\models\ModelSet.h">
+      <Filter>Models</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src-core\models\ModelSetManager.h">
       <Filter>Models</Filter>
     </ClInclude>
     <ClInclude Include="..\src-core\models\Model.h">

--- a/xLights/xLights.cbp
+++ b/xLights/xLights.cbp
@@ -1114,6 +1114,10 @@
 		<Unit filename="../src-core/models/ModelManager.h" />
 		<Unit filename="../src-core/models/ModelScreenLocation.cpp" />
 		<Unit filename="../src-core/models/ModelScreenLocation.h" />
+		<Unit filename="../src-core/models/ModelSet.cpp" />
+		<Unit filename="../src-core/models/ModelSet.h" />
+		<Unit filename="../src-core/models/ModelSetManager.cpp" />
+		<Unit filename="../src-core/models/ModelSetManager.h" />
 		<Unit filename="../src-core/models/MultiPointModel.cpp" />
 		<Unit filename="../src-core/models/MultiPointModel.h" />
 		<Unit filename="../src-core/models/MultiPointScreenLocation.cpp" />


### PR DESCRIPTION
## Summary

Implements #3703 ("Group Props on the Layout") as **Model Sets** — a persistent positional link between props on the Layout tab, deliberately named "Set" to avoid colliding with sequencer Model Groups.

The rule: **translation/rotation propagates across Set membership; everything else doesn't.** Link an EFL tree and its star once, and from then on dragging either one moves both, in 2D and 3D — while each prop can still be reshaped, resized, and property-edited individually.

## Data model

- New `ModelSet` / `ModelSetManager` in `src-core/models/`, owned by `ModelManager` (`AllModels.GetSetManager()`).
- Persisted as a `<modelSets>` element in `xlights_rgbeffects.xml` (sibling to `<modelGroup>`): just a name + member model names. **Models carry zero new attributes.** Older xLights builds ignore the element harmlessly; nothing goes into `.xsq`.
- Model rename/delete propagate into Sets; a Set auto-dissolves below 2 members; a model belongs to at most one Set (move prompts for confirmation).
- The data layer is in `src-core/`, so the iPad app loads/saves Sets already; gesture parity is tracked in `plans/ipad-parity/06-layout-models-preview.md`. Design doc: `plans/layout-group-move-lock.md`.

## UI

- **Link as Set…** — right-click with 2+ loose models selected. Name prompt pre-filled with the next free `Set N`; collisions re-prompt in place.
- **Set submenu** — right-click a member: *Add Selected to Set / Remove from Set / Rename… / Manage… / Delete*.
- **Manage dialog** — checkbox list of every model (members first, checked), realtime filter with a clear button, editable name field validated on OK.
- **Property grid** — read-only "In Model Set" row with help tooltip on members.

## Move semantics

| Action | Behavior |
|---|---|
| 2D body drag / centre-handle drag on a member | Whole Set translates |
| 3D axis-arrow drag | Whole Set translates |
| 3D axis-ring drag | Whole Set rotates about the gizmo pivot |
| Bulk Edit → Rotate X/Y/Z | Set arcs around its bounding-box centroid as one |
| Resize / scale (corners, 3D cube) | That model only — reshaping members is the point |
| Property edits | That model only |
| **Alt/Option + drag** | **That model only — how you reposition a member within its Set** (2D and 3D) |
| Any member locked | **Whole Set frozen** — no member translates/rotates via Set movement; status-bar/info messages explain why. Alt-drag of an *unlocked* member remains as a deliberate override. |

Note on Alt in 2D: Alt+click **on a model** now starts the single-model drag; Alt+drag **on empty space** still pans the canvas. (Previously Alt anywhere panned, which made the modifier unreachable.)

All code is wx-platform-neutral — no `#ifdef`s; works identically on Windows/macOS/Linux. New core files are in `.cbp` / `.vcxproj` / filters; macOS picks them up via the synced root group.

## Test plan

**Setup:** show folder with ≥6 models incl. an Arch or Line; create `Set A` = {Matrix1, Star1}, `Set B` = {Wreath, Bow, Ribbon}.

**Create / manage**
- [ ] Link as Set prompts for a name (pre-filled `Set N`); duplicate name re-prompts keeping typed text
- [ ] Manage: members listed first & checked; filter narrows in realtime; ✕ clears; check-state survives filtering; rename via Name field; collision keeps dialog open
- [ ] Remove from Set on a 2-member Set dissolves it; Delete Set leaves models in place
- [ ] Add Selected to Set with mixed selection; moving a model between Sets prompts

**2D**
- [ ] Drag any member → whole Set translates, arrangement preserved
- [ ] Centre-handle drag → same Set behavior
- [ ] Alt+click+drag a member → only that model moves
- [ ] Alt+drag on empty canvas → pans
- [ ] Resize / rotate handle → that model only

**3D**
- [ ] Axis-arrow drag → Set translates together
- [ ] Axis-ring drag → Set rotates about pivot together
- [ ] Axis-cube scale → single model
- [ ] Alt + axis-arrow → single model

**Locked member**
- [ ] Lock one member: 2D drag of another member moves nothing; status bar explains
- [ ] 3D axis-arrow won't start; status message
- [ ] Bulk Edit Rotate skips the Set with an info box naming it
- [ ] Multi-select Set + loose model: loose moves, Set stays
- [ ] Alt+drag unlocked member of a frozen Set → moves (override)
- [ ] Unlock → normal behavior returns

**Persistence / integrity**
- [ ] Save → `<modelSets>` in `xlights_rgbeffects.xml`; reload → Sets work
- [ ] Rename a member model → Set follows; delete one of a 2-member Set → Set dissolves
- [ ] Open the file in the previous xLights release → no crash, Sets silently absent
- [ ] Undo after a Set drag → one step restores all members

**Cross-checks**
- [ ] Property grid "In Model Set" row + tooltip
- [ ] Bulk Edit Rotate on mixed selection: Set arcs around centroid, loose models rotate in place
- [ ] Windows: Alt+click on a model doesn't trigger menu-accelerator focus
- [x] macOS Release build (Xcode 26.5); manually exercised create/manage/2D/3D/locked flows during development

🤖 Generated with [Claude Code](https://claude.com/claude-code)
