### PR TITLE
Fix Replace Model "keep position and size" silently ignored for locked/base/two-point models

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -9507,13 +9507,26 @@ void LayoutPanel::ReplaceModel()
             }
         }
         if (copySizePos) {
-            clone->GetModelScreenLocation().SetRotation(target->GetModelScreenLocation().GetRotation());
-            clone->SetHcenterPos(target->GetHcenterPos());
-            clone->SetVcenterPos(target->GetVcenterPos());
-            clone->SetDcenterPos(target->GetDcenterPos());
-            clone->SetHeight(target->GetHeight());
-            clone->SetWidth(target->GetWidth());
-            clone->SetDepth(target->GetDepth());
+            // Copy the target's geometry onto the replacement directly through the
+            // screen location. Going via Model::SetHcenterPos/SetWidth/etc. would
+            // silently no-op when the clone is locked or fromBase (those guards
+            // live in BaseObject), so a locked/base-folder source kept its own
+            // position instead of the target's. Size is applied BEFORE the centre
+            // because two-point/poly-point locations derive their centre from the
+            // current width/height/depth (worldPos = centre - size/2); setting the
+            // centre first would leave the model off by half the size delta once
+            // the size changed.
+            ModelScreenLocation& cloc = clone->GetModelScreenLocation();
+            const ModelScreenLocation& tloc = target->GetModelScreenLocation();
+            cloc.SetMWidth(tloc.GetMWidth());
+            cloc.SetMHeight(tloc.GetMHeight());
+            cloc.SetMDepth(tloc.GetMDepth());
+            cloc.SetHcenterPos(target->GetHcenterPos());
+            cloc.SetVcenterPos(target->GetVcenterPos());
+            cloc.SetDcenterPos(target->GetDcenterPos());
+            cloc.SetRotation(tloc.GetRotation());
+            clone->Setup();
+            clone->IncrementChangeCount();
         }
 
         // Rename dance: swap the target out and the clone in under the target's

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -9377,13 +9377,12 @@ namespace {
 // replacement clone, taking a single consistent snapshot from the target's
 // screen location.
 //
-// Applied directly through the screen location, NOT via Model::SetHcenterPos /
-// SetWidth / etc. Those go through BaseObject, which silently no-ops when the
-// model IsLocked() or IsFromBase(); the clone inherits those flags from its
-// source, so a locked or base-show-folder source would otherwise keep its own
-// geometry instead of the target's. A replace is an explicit, user-authorized
-// repositioning of the new model onto the target it is replacing, so it is
-// allowed to override those guards here.
+// Applied directly through the screen location rather than via
+// Model::SetHcenterPos / SetWidth / etc. The clone is cloned from the source's
+// XML and may inherit the source's locked flag; the Model::Set* setters no-op
+// when IsLocked(), so going straight to the screen location keeps the copy
+// working for a locked source. (Base linkage is not a concern here: the caller
+// clears FromBase on the clone, and base-linked targets are blocked up front.)
 //
 // Size MUST be set before the centre: two-point / poly-point screen locations
 // derive their centre from the current width/height/depth
@@ -9411,11 +9410,17 @@ void LayoutPanel::ReplaceModel()
     if (sourceModel == nullptr) return;
 
     // Build alphabetised candidate list - everything in the preview except the source itself.
+    // Base-folder models are collected separately so the dialog can show them
+    // disabled: replacing one would delete a model the base folder owns.
     std::vector<std::string> candidates;
+    std::set<std::string> baseLinked;
     candidates.reserve(modelPreview->GetModels().size());
     for (auto* m : modelPreview->GetModels()) {
         if (m != nullptr && m != sourceModel) {
             candidates.push_back(m->GetName());
+            if (m->IsFromBase()) {
+                baseLinked.insert(m->GetName());
+            }
         }
     }
     if (candidates.empty()) {
@@ -9425,7 +9430,7 @@ void LayoutPanel::ReplaceModel()
     }
     std::sort(candidates.begin(), candidates.end());
 
-    ReplaceModelDialog dlg(this, sourceModel->GetName(), candidates);
+    ReplaceModelDialog dlg(this, sourceModel->GetName(), candidates, baseLinked);
     OptimiseDialogPosition(&dlg);
     if (dlg.ShowModal() != wxID_OK) return;
 
@@ -9512,6 +9517,14 @@ void LayoutPanel::ReplaceModel()
         const std::string tmpNewName = uniqueTempName("__xl_rmm_new_", successCount);
         clone->Rename(tmpNewName);
         xlights->AllModels.AddModel(clone);
+
+        // The replacement is a brand-new local model standing in for the
+        // target; it is not managed by the base show folder even if the source
+        // was. Clearing FromBase keeps us from creating a fake base-linked
+        // model and lets its geometry be set to the target's below without
+        // overriding a real base lock. (Base-linked targets are themselves
+        // blocked in the dialog.)
+        clone->SetFromBase(false);
 
         // Per-target carryovers. These match the semantics of the three Yes/No
         // prompts in the existing single-replace flow (see ReplaceModel()).

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -9372,6 +9372,37 @@ void LayoutPanel::EditSubModelAlias() {
     }
 }
 
+namespace {
+// Copy a target model's geometry (size, centre, rotation) onto a freshly-built
+// replacement clone, taking a single consistent snapshot from the target's
+// screen location.
+//
+// Applied directly through the screen location, NOT via Model::SetHcenterPos /
+// SetWidth / etc. Those go through BaseObject, which silently no-ops when the
+// model IsLocked() or IsFromBase(); the clone inherits those flags from its
+// source, so a locked or base-show-folder source would otherwise keep its own
+// geometry instead of the target's. A replace is an explicit, user-authorized
+// repositioning of the new model onto the target it is replacing, so it is
+// allowed to override those guards here.
+//
+// Size MUST be set before the centre: two-point / poly-point screen locations
+// derive their centre from the current width/height/depth
+// (worldPos = centre - size/2), so a centre set against a stale size lands the
+// model off by half the size delta.
+void CopyGeometryFromTarget(Model* clone, const Model* target) {
+    ModelScreenLocation& cloc = clone->GetModelScreenLocation();
+    const ModelScreenLocation& tloc = target->GetModelScreenLocation();
+    cloc.SetMWidth(tloc.GetMWidth());
+    cloc.SetMHeight(tloc.GetMHeight());
+    cloc.SetMDepth(tloc.GetMDepth());
+    cloc.SetHcenterPos(tloc.GetHcenterPos());
+    cloc.SetVcenterPos(tloc.GetVcenterPos());
+    cloc.SetDcenterPos(tloc.GetDcenterPos());
+    cloc.SetRotation(tloc.GetRotation());
+    clone->Setup();
+    clone->IncrementChangeCount();
+}
+} // namespace
 
 void LayoutPanel::ReplaceModel()
 {
@@ -9507,26 +9538,7 @@ void LayoutPanel::ReplaceModel()
             }
         }
         if (copySizePos) {
-            // Copy the target's geometry onto the replacement directly through the
-            // screen location. Going via Model::SetHcenterPos/SetWidth/etc. would
-            // silently no-op when the clone is locked or fromBase (those guards
-            // live in BaseObject), so a locked/base-folder source kept its own
-            // position instead of the target's. Size is applied BEFORE the centre
-            // because two-point/poly-point locations derive their centre from the
-            // current width/height/depth (worldPos = centre - size/2); setting the
-            // centre first would leave the model off by half the size delta once
-            // the size changed.
-            ModelScreenLocation& cloc = clone->GetModelScreenLocation();
-            const ModelScreenLocation& tloc = target->GetModelScreenLocation();
-            cloc.SetMWidth(tloc.GetMWidth());
-            cloc.SetMHeight(tloc.GetMHeight());
-            cloc.SetMDepth(tloc.GetMDepth());
-            cloc.SetHcenterPos(target->GetHcenterPos());
-            cloc.SetVcenterPos(target->GetVcenterPos());
-            cloc.SetDcenterPos(target->GetDcenterPos());
-            cloc.SetRotation(tloc.GetRotation());
-            clone->Setup();
-            clone->IncrementChangeCount();
+            CopyGeometryFromTarget(clone, target);
         }
 
         // Rename dance: swap the target out and the clone in under the target's

--- a/src-ui-wx/layout/ReplaceModelDialog.h
+++ b/src-ui-wx/layout/ReplaceModelDialog.h
@@ -15,6 +15,7 @@
 #include <string>
 #include <vector>
 
+#include <wx/artprov.h>
 #include <wx/button.h>
 #include <wx/checkbox.h>
 #include <wx/dialog.h>
@@ -22,6 +23,7 @@
 #include <wx/panel.h>
 #include <wx/scrolwin.h>
 #include <wx/sizer.h>
+#include <wx/statbmp.h>
 #include <wx/statbox.h>
 #include <wx/stattext.h>
 #include <wx/statline.h>
@@ -36,12 +38,14 @@ class ReplaceModelDialog : public wxDialog {
 public:
     ReplaceModelDialog(wxWindow* parent,
                        const wxString& sourceName,
-                       const std::vector<std::string>& candidateNames)
+                       const std::vector<std::string>& candidateNames,
+                       const std::set<std::string>& baseLinkedNames = {})
         : wxDialog(parent, wxID_ANY,
                    wxString::Format("Replace Model(s) With: %s", sourceName),
                    wxDefaultPosition, wxSize(460, 560),
                    wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
-          _allCandidates(candidateNames)
+          _allCandidates(candidateNames),
+          _baseLinked(baseLinkedNames)
     {
         auto* top = new wxBoxSizer(wxVERTICAL);
 
@@ -188,6 +192,27 @@ private:
 
         for (const auto& name : _allCandidates) {
             if (!PassesFilter(name, filterLower)) continue;
+
+            // Base-folder models can't be replaced - doing so would delete a
+            // model the base show folder owns. Show them disabled with the
+            // link icon so the user sees why they're off-limits, and keep them
+            // out of _rows / _checkedSet so master select-all and the result
+            // never include them.
+            if (_baseLinked.count(name) > 0) {
+                auto* row = new wxBoxSizer(wxHORIZONTAL);
+                auto* cb = new wxCheckBox(_rowsWindow, wxID_ANY, name);
+                cb->SetValue(false);
+                cb->Disable();
+                cb->SetToolTip("Linked from the base show folder - cannot be replaced");
+                auto* icon = new wxStaticBitmap(_rowsWindow, wxID_ANY,
+                    wxArtProvider::GetBitmapBundle("xlART_LINK", wxART_OTHER, FromDIP(wxSize(16, 16))));
+                icon->SetToolTip("Linked from the base show folder");
+                row->Add(cb, 0, wxALIGN_CENTER_VERTICAL);
+                row->Add(icon, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, 4);
+                _rowsSizer->Add(row, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 2);
+                continue;
+            }
+
             auto* cb = new wxCheckBox(_rowsWindow, wxID_ANY, name);
             cb->SetValue(_checkedSet.count(name) > 0);
             _rowsSizer->Add(cb, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, 2);
@@ -252,6 +277,7 @@ private:
     wxButton*   _okBtn = nullptr;
 
     std::vector<std::string> _allCandidates;
+    std::set<std::string> _baseLinked;
     std::vector<RowEntry> _rows;
     std::set<std::string> _checkedSet;
 };


### PR DESCRIPTION
## Important bug fix

The **"Keep each target's position and size"** option in **Replace Model(s) With This Model…** (added in #4462) silently failed: the replacement could land at the wrong position. This corrupts layouts on replace.

## Root cause

Two defects in `LayoutPanel::ReplaceModel()`'s geometry copy:

1. **Centre set before size.** Two-point / poly-point screen locations derive their centre from the current width/height/depth (`worldPos = centre − size/2`). Setting the centre before the size left **Lines, Arches, Canes, DMX movers, etc.** off by half the size delta.
2. **Locked / base-folder sources.** The clone is built from the source's XML, so it inherited the source's `Locked`/`FromBase` flags; `Model::SetHcenterPos/SetWidth/…` no-op under those guards, so the position copy was silently dropped.

## Fix

- **Order:** apply size before centre, and snapshot all geometry (size, centre, rotation) from the target's screen location in one place via a small `CopyGeometryFromTarget` helper.
- **Base linkage is respected, not overridden:**
  - The clone's `FromBase` flag is cleared — it's a brand-new **local** model standing in for the target, not something the base show folder manages. So positioning it is legitimate, and we never produce a fake base-linked model from a base source.
  - **Base-linked models can't be replace targets** (that would delete a model the base folder owns). They now show in the dialog **disabled, with the (base) link icon** and a tooltip, and are excluded from select-all and the returned selection.
- **Locked (non-base) models stay replaceable** — the geometry copy goes straight through the screen location so a locked source's clone is still positioned.

## Test plan

- [x] macOS Release build — `BUILD SUCCEEDED`
- [ ] Replace an unlocked boxed model → lands at target's position/size
- [ ] Replace a **two-point** model (Line/Arch/Cane/DMX) → centre correct (was off by half the size delta)
- [ ] Source is **locked** → replacement still positioned at target
- [ ] Source is **base-linked** → replacements become local models, positioned correctly
- [ ] **Base-linked targets** appear disabled with the link icon and can't be selected / OK'd
- [ ] Multi-select replace with the checkbox on → every (non-base) target replaced in place

Fixes the position/size regression in #4462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
