### PR TITLE
Sequencer: Fix for dblclick/shift+dblclick hide or show strands

### DIFF
--- a/src-ui-wx/sequencer/RowHeading.cpp
+++ b/src-ui-wx/sequencer/RowHeading.cpp
@@ -538,14 +538,25 @@ void RowHeading::leftDoubleClick(wxMouseEvent& event)
     if (element->GetType() == ElementType::ELEMENT_TYPE_MODEL) {
         ModelElement* me = dynamic_cast<ModelElement*>(element);
         if (event.ShiftDown()) {
+            // Shift+DblClick: submodels + strands
             bool showAll = !(me->ShowSubModels() && me->ShowStrands());
             me->ShowSubModels(showAll);
             me->ShowStrands(showAll);
-        } else if (me->ShowSubModels()) {
-            me->ShowSubModels(false);
-            me->ShowStrands(false);
         } else {
-            me->ShowSubModels(true);
+            Model* m = xLightsApp::GetFrame()->AllModels[me->GetModelName()];
+            bool isGroup = m && m->GetDisplayAs() == DisplayAsType::ModelGroup;
+            if (isGroup) {
+                // Groups expand via ShowStrands — ShowSubModels has no effect on them
+                me->ShowStrands(!me->ShowStrands());
+            } else {
+                // Plain DblClick: submodels only (no strands)
+                if (me->ShowSubModels()) {
+                    me->ShowSubModels(false);
+                    me->ShowStrands(false);
+                } else {
+                    me->ShowSubModels(true);
+                }
+            }
         }
         wxCommandEvent evt(EVT_ROW_HEADINGS_CHANGED);
         evt.SetString(element->GetModelName());


### PR DESCRIPTION
ModelGroup (e.g. "All Pixels")
  - DblClick → group members expand (rows appear beneath)
  - DblClick again → collapses
  - Shift+DblClick → same expand (group members show), but also sets SubModels flag (no visible difference for groups)

  Regular model WITH user-defined submodels (e.g. a Mega Tree with "Left", "Right" submodels)
  - DblClick → submodel rows appear, strand rows do NOT appear
  - DblClick again → collapses
  - Shift+DblClick → both submodel rows AND strand rows appear
  - Shift+DblClick again → collapses

  Regular model WITHOUT user-defined submodels (e.g. a simple matrix with only strands)
  - DblClick → nothing visible happens (ShowSubModels=true but no submodels exist to display)
  - Shift+DblClick → strand rows appear
  - Shift+DblClick again → collapses