### PR TITLE
Sequencer: Drag/Drop collision fix

### DIFF
--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -2262,8 +2262,25 @@ void EffectsGrid::mouseDown(wxMouseEvent& event) {
                 mDragEndX = event.GetX();
                 mDragEndY = event.GetY();
                 if (event.ShiftDown()) {
+                    mDragAddToSelection = false;
+                    mAdditiveDragBaseSelection.clear();
                     UpdateSelectionRectangle();
+                } else if (event.ControlDown()) {
+                    mDragAddToSelection = true;
+                    mAdditiveDragBaseSelection.clear();
+                    for (int vrow = 0; vrow < (int)mSequenceElements->GetVisibleRowInformationSize(); vrow++) {
+                        EffectLayer* el = mSequenceElements->GetVisibleEffectLayer(vrow);
+                        if (el == nullptr) continue;
+                        for (int i = 0; i < el->GetEffectCount(); i++) {
+                            Effect* e = el->GetEffect(i);
+                            if (e->GetSelected() != EFFECT_NOT_SELECTED)
+                                mAdditiveDragBaseSelection.push_back(e);
+                        }
+                    }
+                    EstablishSelectionRectangle();
                 } else {
+                    mDragAddToSelection = false;
+                    mAdditiveDragBaseSelection.clear();
                     EstablishSelectionRectangle();
                 }
                 CaptureMouse();
@@ -3895,8 +3912,7 @@ void EffectsGrid::mouseReleased(wxMouseEvent& event) {
             if (mEffectMoveDragThresholdExceeded && !mEffectMoveHasCollision && !mEffectMoveSnapshots.empty()) {
                 ApplyEffectMoveDrag();
             } else if (!mEffectMoveDragThresholdExceeded && mEffectMoveDragGroup && mEffectMoveAnchorEffect != nullptr) {
-                mSequenceElements->UnSelectAllEffects();
-                mEffectMoveAnchorEffect->SetSelected(EFFECT_SELECTED);
+                // Keep the group selected; just update the settings panel to the clicked effect
                 mSelectedEffect = mEffectMoveAnchorEffect;
                 RaiseSelectedEffectChanged(mSelectedEffect, false);
             }
@@ -3989,6 +4005,8 @@ void EffectsGrid::mouseReleased(wxMouseEvent& event) {
             UnsetToolTip();
             mDragging = false;
             mDragThresholdExceeded = false;
+            mDragAddToSelection = false;
+            mAdditiveDragBaseSelection.clear();
             if ((mDragStartX == event.GetX() && mDragStartY == event.GetY()) || (mSequenceElements->GetNumberOfActiveTimingEffects() > 0)) {
                 checkForEmptyCell = true;
             }
@@ -6893,7 +6911,12 @@ void EffectsGrid::UpdateZoomPosition(int time) const {
 }
 
 void EffectsGrid::EstablishSelectionRectangle() {
-    mSequenceElements->UnSelectAllEffects();
+    if (mDragAddToSelection) {
+        for (Effect* e : mAdditiveDragBaseSelection)
+            e->SetSelected(EFFECT_SELECTED);
+    } else {
+        mSequenceElements->UnSelectAllEffects();
+    }
     int first_row = mSequenceElements->GetFirstVisibleModelRow();
     int row1 = GetRow(mDragStartY);
     if (row1 >= mSequenceElements->GetNumberOfTimingRows()) {
@@ -6950,9 +6973,12 @@ void EffectsGrid::UpdateSelectionRectangle() {
     if (mSequenceElements == nullptr || mTimeline == nullptr) {
         return;
     }
-    // Unselect all effects and clear mSelectedEffect
     UnselectEffect();
     mSequenceElements->UnSelectAllEffects();
+    if (mDragAddToSelection) {
+        for (Effect* e : mAdditiveDragBaseSelection)
+            e->SetSelected(EFFECT_SELECTED);
+    }
 
     if (GetRow(mDragEndY) < mSequenceElements->GetNumberOfTimingRows()) {
         mRangeEndRow = GetRow(mDragEndY);
@@ -8189,6 +8215,47 @@ void EffectsGrid::UpdateEffectMoveDragState(int x, int y, bool snapToTiming, boo
         snap.hasCollision = !tl->GetRangeIsClearMS(ts, te, !mEffectMoveCopyMode);
         if (snap.hasCollision) anyCollision = true;
     }
+
+    // When dragging horizontally within the same rows in move mode, clamp the
+    // delta so effects butt up against the nearest blocking neighbor instead of
+    // bouncing back to their original position on collision.
+    if (anyCollision && rowDelta == 0 && !mEffectMoveCopyMode && rawDelta != 0) {
+        int clampedDelta = rawDelta;
+        for (auto& snap : mEffectMoveSnapshots) {
+            if (!snap.hasCollision) continue;
+            EffectLayer* tl = mSequenceElements->GetVisibleEffectLayer(snap.origVisibleRow);
+            if (tl == nullptr) continue;
+            int ts = snap.origStartTimeMS + rawDelta;
+            int te = snap.origEndTimeMS + rawDelta;
+            for (Effect* e : tl->GetEffects()) {
+                if (e->GetSelected() != EFFECT_NOT_SELECTED) continue;
+                if (e->GetStartTimeMS() >= te || e->GetEndTimeMS() <= ts) continue;
+                if (rawDelta > 0) {
+                    // Moving right: clamp so our end meets the blocker's start
+                    clampedDelta = std::min(clampedDelta, e->GetStartTimeMS() - snap.origEndTimeMS);
+                } else {
+                    // Moving left: clamp so our start meets the blocker's end
+                    clampedDelta = std::max(clampedDelta, e->GetEndTimeMS() - snap.origStartTimeMS);
+                }
+            }
+        }
+        if (clampedDelta != rawDelta && clampedDelta != 0) {
+            bool clampedOk = true;
+            for (auto& snap : mEffectMoveSnapshots) {
+                EffectLayer* tl = mSequenceElements->GetVisibleEffectLayer(snap.origVisibleRow);
+                if (tl == nullptr) { clampedOk = false; break; }
+                int ts = snap.origStartTimeMS + clampedDelta;
+                int te = snap.origEndTimeMS + clampedDelta;
+                if (!tl->GetRangeIsClearMS(ts, te, true)) { clampedOk = false; break; }
+            }
+            if (clampedOk) {
+                mEffectMoveTargetDeltaMS = clampedDelta;
+                anyCollision = false;
+                for (auto& snap : mEffectMoveSnapshots) snap.hasCollision = false;
+            }
+        }
+    }
+
     mEffectMoveHasCollision = anyCollision;
     SetCursor(anyCollision ? s_noEntry : s_sizing);
 
@@ -8244,8 +8311,7 @@ void EffectsGrid::ApplyEffectMoveDrag() {
                 targetLayer->GetIndex(), newEff->GetID());
             if (snap.effect == mEffectMoveAnchorEffect)
                 newAnchorEff = newEff;
-            if (mEffectMoveCopyMode)
-                newEffects.push_back(newEff);
+            newEffects.push_back(newEff);
         }
     }
 
@@ -8257,16 +8323,17 @@ void EffectsGrid::ApplyEffectMoveDrag() {
             if (el) el->DeleteSelectedEffects(mSequenceElements->get_undo_mgr());
         }
     } else {
-        // Copy: deselect originals, select all new copies
+        // Copy: deselect originals
         for (auto& snap : mEffectMoveSnapshots)
             snap.effect->SetSelected(EFFECT_NOT_SELECTED);
-        for (Effect* e : newEffects)
-            e->SetSelected(EFFECT_SELECTED);
     }
+
+    // Select all newly placed effects so the group stays selected after the drop
+    for (Effect* e : newEffects)
+        e->SetSelected(EFFECT_SELECTED);
 
     // Update selected effect pointer so it doesn't dangle
     if (newAnchorEff) {
-        newAnchorEff->SetSelected(EFFECT_SELECTED);
         mSelectedEffect = newAnchorEff;
         mSelectedRow = mEffectMoveTargetRow + mSequenceElements->GetFirstVisibleModelRow();
     } else {

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -2268,8 +2268,8 @@ void EffectsGrid::mouseDown(wxMouseEvent& event) {
                 } else if (event.ControlDown()) {
                     mDragAddToSelection = true;
                     mAdditiveDragBaseSelection.clear();
-                    for (int vrow = 0; vrow < (int)mSequenceElements->GetVisibleRowInformationSize(); vrow++) {
-                        EffectLayer* el = mSequenceElements->GetVisibleEffectLayer(vrow);
+                    for (int row = 0; row < mSequenceElements->GetRowInformationSize(); row++) {
+                        EffectLayer* el = mSequenceElements->GetEffectLayer(row);
                         if (el == nullptr) continue;
                         for (int i = 0; i < el->GetEffectCount(); i++) {
                             Effect* e = el->GetEffect(i);

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -8186,8 +8186,7 @@ void EffectsGrid::UpdateEffectMoveDragState(int x, int y, bool snapToTiming, boo
         }
         int ts = snap.origStartTimeMS + rawDelta;
         int te = snap.origEndTimeMS + rawDelta;
-        bool sameLayer = !mEffectMoveCopyMode && (snapTargetRow == snap.origVisibleRow);
-        snap.hasCollision = !tl->GetRangeIsClearMS(ts, te, sameLayer);
+        snap.hasCollision = !tl->GetRangeIsClearMS(ts, te, !mEffectMoveCopyMode);
         if (snap.hasCollision) anyCollision = true;
     }
     mEffectMoveHasCollision = anyCollision;

--- a/src-ui-wx/sequencer/EffectsGrid.h
+++ b/src-ui-wx/sequencer/EffectsGrid.h
@@ -358,6 +358,8 @@ private:
     bool mDragging;
     bool mDragThresholdExceeded;
     bool mMouseOperationsCancelled;
+    bool mDragAddToSelection = false;
+    std::vector<Effect*> mAdditiveDragBaseSelection;
     int mDragStartRow;
     int mDragStartX;
     int mDragStartY;


### PR DESCRIPTION
## Summary

- **Collision fix**: when moving a selected group to a different row, the destination is now correctly checked against non-selected effects only — previously a drop was incorrectly blocked if the destination overlapped another effect in the same selected group
- **Butt-up on collision**: when dragging effects horizontally within the same row(s), instead of bouncing back on collision the group clamps to sit flush against the nearest blocking neighbor (fixes #6551)
- **Group stays selected after drop**: all moved/copied effects remain selected after the drop, not just the anchor effect
- **Click to re-drag**: clicking any effect in a selected group without moving keeps the whole group selected and re-draggable; clicking away deselects
- **Ctrl+drag box adds to selection**: holding Ctrl while dragging a selection box adds the new effects to the existing selection rather than replacing it (Ctrl+click individual toggle was already supported)

## Selection reference

| Action | Result |
|---|---|
| Click effect | Select that effect only |
| Click empty space | Deselect all |
| Drag box | Select effects in box; deselects everything else |
| Ctrl+click effect | Toggle that effect in/out of selection |
| Ctrl+drag box | Add effects in box to existing selection |
| Drag selected effect(s) | Move the whole group |
| Alt+drag selected effect(s) | Copy the whole group |
| Click selected effect without moving | Keep group selected, update settings panel |
| Drop moved group | All moved effects stay selected |
| Drop copied group | All copies selected, originals deselected |

## Test plan

- [ ] Single effect drag left/right — stops flush against neighbor instead of bouncing
- [ ] Group drag same-row — group clamps together against nearest blocker
- [ ] Group drag to different row with collision — still blocked (no clamping across rows)
- [ ] Alt+drag collision — still blocked (clamping is move-mode only)
- [ ] Cross-row group move — all effects selected after drop
- [ ] Same-row group move — all effects selected after drop
- [ ] Click effect in dropped group without dragging — group stays selected
- [ ] Click different effect after drop — group deselects, single effect selected
- [ ] Ctrl+drag box — adds to existing selection
- [ ] Ctrl+drag box shrink — effects leaving box deselected, original group retained
- [ ] Plain drag box — still replaces selection