### PR TITLE
VideoReader: fix sws_scale crash with CUDA/NVDEC hardware decoded video

### DIFF
--- a/src-core/media/FFmpegVideoReader.cpp
+++ b/src-core/media/FFmpegVideoReader.cpp
@@ -768,9 +768,6 @@ bool FFmpegVideoReader::readFrame(int timestampMS) {
                     }
                 }
                 if (f != nullptr && _swsCtx != nullptr) {
-                    spdlog::debug("VideoReader: sws_scale fmt={} {}x{} linesize={} -> fmt={} {}x{} linesize={}",
-                        av_get_pix_fmt_name((AVPixelFormat)f->format), f->width, f->height, f->linesize[0],
-                        av_get_pix_fmt_name(_pixelFmt), _width, _height, _dstFrame2->linesize[0]);
                     sws_scale(_swsCtx, f->data, f->linesize, 0,
                         f->height, _dstFrame2->data,
                         _dstFrame2->linesize);

--- a/src-core/media/FFmpegVideoReader.cpp
+++ b/src-core/media/FFmpegVideoReader.cpp
@@ -690,7 +690,15 @@ bool FFmpegVideoReader::readFrame(int timestampMS) {
 
             if (!hardwareScaled) {
                 AVFrame* f = nullptr;
-                if (IsHardwareAcceleratedVideo() && _codecContext->hw_device_ctx != nullptr && _srcFrame->format == __hw_pix_fmt && !_abandonHardwareDecode) {
+                // Detect hw-backed frames via hw_frames_ctx OR a matching hw pixel format.
+                // h264_cuvid can report format=NV12 while data is in CUDA device memory,
+                // so hw_frames_ctx is the reliable indicator.
+                bool srcIsHwBacked = IsHardwareAcceleratedVideo() &&
+                                     _codecContext->hw_device_ctx != nullptr &&
+                                     !_abandonHardwareDecode &&
+                                     (_srcFrame->hw_frames_ctx != nullptr ||
+                                      (_srcFrame->format == __hw_pix_fmt && __hw_pix_fmt != AV_PIX_FMT_NONE));
+                if (srcIsHwBacked) {
                     bool hwscale = false;
                     if (!hwscale) {
                         if (av_hwframe_transfer_data(_srcFrame2, _srcFrame, 0) < 0) {
@@ -718,7 +726,7 @@ bool FFmpegVideoReader::readFrame(int timestampMS) {
                     if (_abandonHardwareDecode) {
                         spdlog::debug("VideoReader: Using software decode (hardware decoding unavailable for this file).");
                     }
-                    if (IsHardwareAcceleratedVideo() && _codecContext->hw_device_ctx != nullptr && _srcFrame->format == __hw_pix_fmt && !_abandonHardwareDecode) {
+                    if (srcIsHwBacked) {
                         spdlog::debug("Hardware format {} -> Software format {}.", av_get_pix_fmt_name((AVPixelFormat)_srcFrame->format), av_get_pix_fmt_name((AVPixelFormat)_srcFrame2->format));
                         _swsCtx = sws_getContext(f->width, f->height, (AVPixelFormat)f->format,
                             _width, _height, _pixelFmt, scaleAlgorithm, nullptr, nullptr, nullptr);

--- a/src-core/media/FFmpegVideoReader.cpp
+++ b/src-core/media/FFmpegVideoReader.cpp
@@ -740,6 +740,10 @@ bool FFmpegVideoReader::readFrame(int timestampMS) {
                     }
                 }
 
+                if (f != nullptr && f->hw_frames_ctx != nullptr) {
+                    spdlog::warn("VideoReader: frame passed to sws_scale is still GPU-backed (fmt={}) — skipping.", av_get_pix_fmt_name((AVPixelFormat)f->format));
+                    f = nullptr;
+                }
                 if (f != nullptr && _swsCtx != nullptr) {
                     sws_scale(_swsCtx, f->data, f->linesize, 0,
                         f->height, _dstFrame2->data,

--- a/src-core/media/FFmpegVideoReader.cpp
+++ b/src-core/media/FFmpegVideoReader.cpp
@@ -694,26 +694,26 @@ bool FFmpegVideoReader::readFrame(int timestampMS) {
                     bool hwscale = false;
                     if (!hwscale) {
                         if (av_hwframe_transfer_data(_srcFrame2, _srcFrame, 0) < 0) {
-                            f = _srcFrame;
+                            spdlog::warn("VideoReader: av_hwframe_transfer_data failed for {} — abandoning hardware decode.", _filename);
+                            _abandonHardwareDecode = true;
+                            if (_swsCtx != nullptr) {
+                                sws_freeContext(_swsCtx);
+                                _swsCtx = nullptr;
+                            }
                         } else {
                             unrefSrcFrame2 = true;
                             f = _srcFrame2;
                         }
-                    }
-
-                    if (_abandonHardwareDecode && _swsCtx != nullptr) {
-                        spdlog::warn("VideoReader: This could get ugly ... we have abandoned hardware decode but we already had a sws Context.");
                     }
                 } else {
                     f = _srcFrame;
                 }
 
                 if (f == nullptr) {
-                    spdlog::warn("VideoReader: Strange f was not valid so setting it to the source frame.");
-                    f = _srcFrame;
+                    spdlog::warn("VideoReader: No valid CPU frame available — skipping sws_scale for this frame.");
                 }
 
-                if (_swsCtx == nullptr) {
+                if (f != nullptr && _swsCtx == nullptr) {
                     if (_abandonHardwareDecode) {
                         spdlog::debug("VideoReader: Using software decode (hardware decoding unavailable for this file).");
                     }
@@ -740,7 +740,7 @@ bool FFmpegVideoReader::readFrame(int timestampMS) {
                     }
                 }
 
-                if (_swsCtx != nullptr) {
+                if (f != nullptr && _swsCtx != nullptr) {
                     sws_scale(_swsCtx, f->data, f->linesize, 0,
                         f->height, _dstFrame2->data,
                         _dstFrame2->linesize);

--- a/src-core/media/FFmpegVideoReader.cpp
+++ b/src-core/media/FFmpegVideoReader.cpp
@@ -695,6 +695,7 @@ bool FFmpegVideoReader::readFrame(int timestampMS) {
                     if (!hwscale) {
                         if (av_hwframe_transfer_data(_srcFrame2, _srcFrame, 0) < 0) {
                             spdlog::warn("VideoReader: av_hwframe_transfer_data failed for {} — abandoning hardware decode.", _filename);
+                            spdlog::default_logger()->flush();
                             _abandonHardwareDecode = true;
                             if (_swsCtx != nullptr) {
                                 sws_freeContext(_swsCtx);
@@ -740,11 +741,28 @@ bool FFmpegVideoReader::readFrame(int timestampMS) {
                     }
                 }
 
-                if (f != nullptr && f->hw_frames_ctx != nullptr) {
-                    spdlog::warn("VideoReader: frame passed to sws_scale is still GPU-backed (fmt={}) — skipping.", av_get_pix_fmt_name((AVPixelFormat)f->format));
-                    f = nullptr;
+                if (f != nullptr) {
+                    // Guard: reject any frame that is still hardware-backed — either
+                    // because hw_frames_ctx is set, or because the pixel format is a
+                    // hardware-accelerated format (AV_PIX_FMT_FLAG_HWACCEL). Passing
+                    // such a frame to sws_scale causes an access violation reading
+                    // GPU/device memory as if it were CPU data.
+                    bool isHwFrame = (f->hw_frames_ctx != nullptr);
+                    if (!isHwFrame) {
+                        const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get((AVPixelFormat)f->format);
+                        isHwFrame = (desc != nullptr && (desc->flags & AV_PIX_FMT_FLAG_HWACCEL));
+                    }
+                    if (isHwFrame) {
+                        spdlog::warn("VideoReader: frame is still hardware-backed (fmt={}, hw_frames_ctx={}) — skipping sws_scale.",
+                            av_get_pix_fmt_name((AVPixelFormat)f->format), (void*)f->hw_frames_ctx);
+                        spdlog::default_logger()->flush();
+                        f = nullptr;
+                    }
                 }
                 if (f != nullptr && _swsCtx != nullptr) {
+                    spdlog::debug("VideoReader: sws_scale fmt={} {}x{} linesize={} -> fmt={} {}x{} linesize={}",
+                        av_get_pix_fmt_name((AVPixelFormat)f->format), f->width, f->height, f->linesize[0],
+                        av_get_pix_fmt_name(_pixelFmt), _width, _height, _dstFrame2->linesize[0]);
                     sws_scale(_swsCtx, f->data, f->linesize, 0,
                         f->height, _dstFrame2->data,
                         _dstFrame2->linesize);

--- a/src-core/media/FFmpegVideoReader.cpp
+++ b/src-core/media/FFmpegVideoReader.cpp
@@ -761,8 +761,9 @@ bool FFmpegVideoReader::readFrame(int timestampMS) {
                         isHwFrame = (desc != nullptr && (desc->flags & AV_PIX_FMT_FLAG_HWACCEL));
                     }
                     if (isHwFrame) {
+                        const char* fmtName = av_get_pix_fmt_name((AVPixelFormat)f->format);
                         spdlog::warn("VideoReader: frame is still hardware-backed (fmt={}, hw_frames_ctx={}) — skipping sws_scale.",
-                            av_get_pix_fmt_name((AVPixelFormat)f->format), (void*)f->hw_frames_ctx);
+                            fmtName ? fmtName : "unknown", (void*)f->hw_frames_ctx);
                         spdlog::default_logger()->flush();
                         f = nullptr;
                     }


### PR DESCRIPTION
## Summary

- When a sequence containing Video effects is loaded, render threads open the video via `FFmpegVideoReader` using `h264_cuvid` (NVDEC on NVIDIA GPUs). The `h264_cuvid` decoder produces frames whose `format` field reports `AV_PIX_FMT_NV12` while the actual pixel data lives in CUDA device memory. The old hw-frame routing gate used `_srcFrame->format == __hw_pix_fmt` (`NV12 == CUDA`) which evaluated false, so `f` was set to `_srcFrame` (the GPU-backed frame). `sws_getContext` accepted NV12 as a valid software format, created a context, then `sws_scale` read from a CUDA device address as if it were CPU memory → access violation in `swscale-7.dll`.
- Fix: use `_srcFrame->hw_frames_ctx != nullptr` as the authoritative indicator that a frame is hardware-backed (regardless of reported pixel format), routing it through `av_hwframe_transfer_data` to obtain a real CPU copy before passing to `sws_scale`.
- Also guard against `av_hwframe_transfer_data` returning failure (abandon hw decode for that reader), and add a final safety check rejecting any frame still carrying `AV_PIX_FMT_FLAG_HWACCEL` before the `sws_scale` call.

## Test plan

- [ ] Load a sequence with Video effects using an MP4 on a machine with an NVIDIA GPU (NVDEC/h264_cuvid path) — previously crashed immediately on load
- [ ] Confirm `sws_scale` is called with `fmt=nv12` CPU data (visible in debug log) and no access violation occurs
- [ ] Verify video effects render correctly during playback
- [ ] Test on a machine without hardware acceleration (software decode path) to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)