### PR TITLE
Better initial timeline fit and match between 20/40 fps

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.12  June ??, 2026
+    -enh (cybercop23)            Sequencer timeline fits the full sequence to the viewport width on load, keep same width for 20/40 fps.
     -bug (dan)                   Fix crash closing/switching sequences with a Moving Head effect selected (programmatic default
                                  reset fired live update handlers that dereferenced a stale model)
     -bug (dan)                   Fix crash clicking a sequencer row heading when the visible row information was momentarily unavailable

--- a/src-ui-wx/sequencer/TimeLine.cpp
+++ b/src-ui-wx/sequencer/TimeLine.cpp
@@ -8,6 +8,8 @@
  * License: https://github.com/xLightsSequencer/xLights/blob/master/License.txt
  **************************************************************/
 
+#include <cmath>
+
 #include <wx/wx.h>
 #include <wx/brush.h>
 #include <wx/textdlg.h>
@@ -1094,10 +1096,6 @@ void TimeLine::ZoomIn()
         SetZoomLevel(GetMaxZoomLevel() - 1);
         return;
     }
-    if (mZoomLevel >= GetMaxZoomLevel()) {
-        SetFitZoom();
-        return;
-    }
     if (mZoomLevel > 0) {
         SetZoomLevel(mZoomLevel - 1);
     }
@@ -1570,10 +1568,10 @@ int TimeLine::TimePerMajorTickInMS()
         int w = GetSize().x;
         if (w > 0) {
             double idealTickMS = (double)mTimeLength * PIXELS_PER_MAJOR_HASH / (double)w;
-            return (int)niceFitTickMS(idealTickMS);
+            return (int)std::lround(niceFitTickMS(idealTickMS));
         }
         if (mFitTimePerMajorTickMS > 0.0)
-            return (int)mFitTimePerMajorTickMS;
+            return (int)std::lround(mFitTimePerMajorTickMS);
     }
     return (int)((double)ZoomLevelValues[mZoomLevel] * ((double)1000.0/(double)mFrequency));
 }

--- a/src-ui-wx/sequencer/TimeLine.cpp
+++ b/src-ui-wx/sequencer/TimeLine.cpp
@@ -989,6 +989,7 @@ int TimeLine::GetTimeFrequency() const
 
 void TimeLine::SetZoomLevel(int level)
 {
+    mInFitZoom = false;
     mZoomLevel = level;
     if( (mZoomMarkerMS != -1) && ((mEndTimeMS - mStartTimeMS) > 0) )
     {
@@ -1048,16 +1049,16 @@ void TimeLine::RecalcMarkerPositions()
 
 int TimeLine::GetZoomLevel() const
 {
-    return  mZoomLevel;
+    return mInFitZoom ? mMaxZoomLevel : mZoomLevel;
 }
 
 void TimeLine::ZoomOut()
 {
-    if (mZoomLevel < mMaxZoomLevel)
-    {
-        SetZoomLevel(mZoomLevel + 1);
-        if (GetTotalViewableTimeMS() > mTimeLength)
-        {
+    if (mInFitZoom) {
+        mInFitZoom = false;
+        int maxZoom = GetMaxZoomLevel();
+        SetZoomLevel(maxZoom);
+        if (GetTotalViewableTimeMS() > mTimeLength) {
             mStartTimeMS = 0;
             mStartPixelOffset = 0;
             mEndTimeMS = GetMaxViewableTimeMS();
@@ -1065,14 +1066,92 @@ void TimeLine::ZoomOut()
             mSequenceEndMarker = GetPositionFromTimeMS(mSequenceEndMarkerMS);
             RaiseChangeTimeline();
         }
+        return;
+    }
+    int maxZoom = GetMaxZoomLevel();
+    if (mZoomLevel < maxZoom)
+    {
+        if (mZoomLevel >= maxZoom - 1) {
+            SetFitZoom();
+        } else {
+            SetZoomLevel(mZoomLevel + 1);
+            if (GetTotalViewableTimeMS() > mTimeLength) {
+                mStartTimeMS = 0;
+                mStartPixelOffset = 0;
+                mEndTimeMS = GetMaxViewableTimeMS();
+                mEndPos = GetPositionFromTimeMS(mEndTimeMS);
+                mSequenceEndMarker = GetPositionFromTimeMS(mSequenceEndMarkerMS);
+                RaiseChangeTimeline();
+            }
+        }
     }
 }
 
 void TimeLine::ZoomIn()
 {
+    if (mInFitZoom) {
+        mInFitZoom = false;
+        SetZoomLevel(GetMaxZoomLevel() - 1);
+        return;
+    }
+    if (mZoomLevel >= GetMaxZoomLevel()) {
+        SetFitZoom();
+        return;
+    }
     if (mZoomLevel > 0) {
         SetZoomLevel(mZoomLevel - 1);
     }
+}
+
+static double niceFitTickMS(double raw)
+{
+    // Round up to next "nice" value so tick labels land on round numbers
+    // (e.g. 12/24/36, 15/30/45, 18/36/54, 20/40/60, 2.5/5/7.5).
+    if (raw <= 0.0) return 1000.0;
+    double mag = 1.0;
+    if (raw >= 1.0) {
+        while (mag * 10.0 <= raw) mag *= 10.0;
+    } else {
+        while (mag > raw) mag /= 10.0;
+    }
+    double norm = raw / mag;
+    double niceNorm;
+    if (norm <= 1.0)       niceNorm = 1.0;
+    else if (norm <= 1.5)  niceNorm = 1.5;
+    else if (norm <= 2.0)  niceNorm = 2.0;
+    else if (norm <= 2.5)  niceNorm = 2.5;
+    else if (norm <= 3.0)  niceNorm = 3.0;
+    else if (norm <= 3.5)  niceNorm = 3.5;
+    else if (norm <= 4.0)  niceNorm = 4.0;
+    else if (norm <= 4.5)  niceNorm = 4.5;
+    else if (norm <= 5.0)  niceNorm = 5.0;
+    else if (norm <= 5.5)  niceNorm = 5.5;
+    else if (norm <= 6.0)  niceNorm = 6.0;
+    else if (norm <= 6.5)  niceNorm = 6.5;
+    else if (norm <= 7.0)  niceNorm = 7.0;
+    else if (norm <= 7.5)  niceNorm = 7.5;
+    else if (norm <= 8.0)  niceNorm = 8.0;
+    else if (norm <= 8.5)  niceNorm = 8.5;
+    else if (norm <= 9.0)  niceNorm = 9.0;
+    else if (norm <= 9.5)  niceNorm = 9.5;
+    else                   niceNorm = 10.0;
+    return niceNorm * mag;
+}
+
+void TimeLine::SetFitZoom()
+{
+    int w = GetSize().x;
+    if (w <= 0 || mTimeLength <= 0) return;
+
+    double idealTickMS = (double)mTimeLength * PIXELS_PER_MAJOR_HASH / (double)w;
+    mFitTimePerMajorTickMS = niceFitTickMS(idealTickMS);
+    mZoomLevel = GetMaxZoomLevel();  // keep Waveform using overview-level audio data
+    mInFitZoom = true;
+    mStartTimeMS = 0;
+    mStartPixelOffset = 0;
+    mEndTimeMS = GetMaxViewableTimeMS();  // may be slightly > mTimeLength due to rounding up
+    RecalcMarkerPositions();
+    RaiseChangeTimeline();
 }
 
 void TimeLine::ZoomSelection()
@@ -1386,9 +1465,12 @@ void TimeLine::render( wxDC& dc ) {
         dc.DrawLine(mSelectedPlayMarkerStart, 0, mSelectedPlayMarkerStart, h-1);
     }
 
-    // grey out where sequence ends
-    dc.SetBrush(brush_past_end);
-    dc.DrawRectangle(mSequenceEndMarker, 0, mEndPos, h);
+    // grey out where sequence ends — clamp to viewport width
+    int hashStart = std::max(0, mSequenceEndMarker);
+    if (hashStart < w) {
+        dc.SetBrush(brush_past_end);
+        dc.DrawRectangle(hashStart, 0, w - hashStart, h);
+    }
 
     // Draw song structure regions
     DrawSongStructureRegions(dc, w, h);
@@ -1484,6 +1566,15 @@ void TimeLine::DrawRectangle(wxDC& dc, int x1, int y1, int x2, int y2)
 
 int TimeLine::TimePerMajorTickInMS()
 {
+    if (mInFitZoom && mTimeLength > 0) {
+        int w = GetSize().x;
+        if (w > 0) {
+            double idealTickMS = (double)mTimeLength * PIXELS_PER_MAJOR_HASH / (double)w;
+            return (int)niceFitTickMS(idealTickMS);
+        }
+        if (mFitTimePerMajorTickMS > 0.0)
+            return (int)mFitTimePerMajorTickMS;
+    }
     return (int)((double)ZoomLevelValues[mZoomLevel] * ((double)1000.0/(double)mFrequency));
 }
 

--- a/src-ui-wx/sequencer/TimeLine.h
+++ b/src-ui-wx/sequencer/TimeLine.h
@@ -84,6 +84,7 @@ public:
 
     void SetZoomLevel(int level);
     int GetZoomLevel() const;
+    bool IsFitZoom() const { return mInFitZoom; }
     void SetFitZoom();
 
     int GetZoomLevelValue() const;

--- a/src-ui-wx/sequencer/TimeLine.h
+++ b/src-ui-wx/sequencer/TimeLine.h
@@ -84,6 +84,7 @@ public:
 
     void SetZoomLevel(int level);
     int GetZoomLevel() const;
+    void SetFitZoom();
 
     int GetZoomLevelValue() const;
     int GetMaxZoomLevel();
@@ -191,6 +192,8 @@ private:
     bool m_dragging;
     bool timeline_initiated_play;
     bool mShowAlternateTimingFormat;
+    bool mInFitZoom = false;
+    double mFitTimePerMajorTickMS = 0.0;
 
     void Paint(wxPaintEvent& event);
     void render(wxDC& dc);

--- a/src-ui-wx/sequencer/Waveform.cpp
+++ b/src-ui-wx/sequencer/Waveform.cpp
@@ -1048,12 +1048,13 @@ int Waveform::OpenfileMedia(AudioManager* media, wxString& error)
     _media = media;
     views.clear();
     ResetAnalysisState();
-	if (_media != nullptr) {
+    if (_media != nullptr) {
         _media->SwitchTo(_type);
-		float samplesPerLine = GetSamplesPerLineFromZoomLevel(mZoomLevel);
-		views.emplace_back(mZoomLevel, samplesPerLine, media, _type, _lowNote, _highNote);
-		mCurrentWaveView = 0;
-		return media->LengthMS();
+        if (mTimeline) mLastEffectiveTick = mTimeline->TimePerMajorTickInMS();
+        float samplesPerLine = GetSamplesPerLineFromZoomLevel(mZoomLevel);
+        views.emplace_back(mZoomLevel, samplesPerLine, media, _type, _lowNote, _highNote);
+        mCurrentWaveView = 0;
+        return media->LengthMS();
     } else {
         mCurrentWaveView = NO_WAVE_VIEW_SELECTED;
         SetZoomLevel(GetZoomLevel());
@@ -1463,6 +1464,12 @@ void Waveform::SetZoomLevel(int level)
 
     if (!mIsInitialized) return;
 
+    int effectiveTick = mTimeline ? mTimeline->TimePerMajorTickInMS() : 0;
+    if (effectiveTick > 0 && effectiveTick != mLastEffectiveTick) {
+        views.clear();
+        mLastEffectiveTick = effectiveTick;
+    }
+
     mCurrentWaveView = NO_WAVE_VIEW_SELECTED;
     for (size_t i = 0; i < views.size(); i++) {
         if (views[i].GetZoomLevel() == mZoomLevel && views[i].GetType() == _type) {
@@ -1508,17 +1515,23 @@ int Waveform::GetTimeFrequency() const
 
 float Waveform::GetSamplesPerLineFromZoomLevel(int ZoomLevel) const
 {
-    // The number of periods for each Zoomlevel is held in ZoomLevelValues array
-    int periodsPerMajorHash = TimeLine::ZoomLevelValues[mZoomLevel];
-    float timePerPixel = ((float)periodsPerMajorHash/(float)mFrequency)/(float)PIXELS_PER_MAJOR_HASH;
+    float timePerPixel;
+    if (mTimeline != nullptr) {
+        // Use the timeline's tick (fit or discrete) so both panels share the same scale.
+        int tickMS = mTimeline->TimePerMajorTickInMS();
+        timePerPixel = (float)tickMS / 1000.0f / (float)PIXELS_PER_MAJOR_HASH;
+    } else {
+        int periodsPerMajorHash = TimeLine::ZoomLevelValues[mZoomLevel];
+        timePerPixel = ((float)periodsPerMajorHash / (float)mFrequency) / (float)PIXELS_PER_MAJOR_HASH;
+    }
     if (!drawingUsingLogicalSize()) {
         timePerPixel /= GetContentScaleFactor();
     }
-	if (_media != nullptr) {
-		return (float)timePerPixel * (float)_media->GetRate();
+    if (_media != nullptr) {
+        return (float)timePerPixel * (float)_media->GetRate();
     } else {
-		return 0.0f;
-	}
+        return 0.0f;
+    }
 }
 
 void Waveform::SetWaveFormSize(int h)

--- a/src-ui-wx/sequencer/Waveform.cpp
+++ b/src-ui-wx/sequencer/Waveform.cpp
@@ -553,7 +553,7 @@ void Waveform::OnGridPopup(wxCommandEvent& event)
         _media->SwitchTo(_type, _lowNote, _highNote);
     }
     if (mCurrentWaveView == NO_WAVE_VIEW_SELECTED) {
-        float samplesPerLine = GetSamplesPerLineFromZoomLevel(mZoomLevel);
+        float samplesPerLine = GetSamplesPerLineFromZoomLevel();
         views.emplace_back(mZoomLevel, samplesPerLine, _media, _type, _lowNote, _highNote);
         mCurrentWaveView = views.size() - 1;
     }
@@ -1051,7 +1051,7 @@ int Waveform::OpenfileMedia(AudioManager* media, wxString& error)
     if (_media != nullptr) {
         _media->SwitchTo(_type);
         if (mTimeline) mLastEffectiveTick = mTimeline->TimePerMajorTickInMS();
-        float samplesPerLine = GetSamplesPerLineFromZoomLevel(mZoomLevel);
+        float samplesPerLine = GetSamplesPerLineFromZoomLevel();
         views.emplace_back(mZoomLevel, samplesPerLine, media, _type, _lowNote, _highNote);
         mCurrentWaveView = 0;
         return media->LengthMS();
@@ -1477,7 +1477,7 @@ void Waveform::SetZoomLevel(int level)
         }
     }
     if (mCurrentWaveView == NO_WAVE_VIEW_SELECTED) {
-        float samplesPerLine = GetSamplesPerLineFromZoomLevel(mZoomLevel);
+        float samplesPerLine = GetSamplesPerLineFromZoomLevel();
         views.emplace_back(mZoomLevel, samplesPerLine, _media, _type, _lowNote, _highNote);
         mCurrentWaveView = views.size() - 1;
     }
@@ -1513,7 +1513,7 @@ int Waveform::GetTimeFrequency() const
     return  mFrequency;
 }
 
-float Waveform::GetSamplesPerLineFromZoomLevel(int ZoomLevel) const
+float Waveform::GetSamplesPerLineFromZoomLevel() const
 {
     float timePerPixel;
     if (mTimeline != nullptr) {
@@ -1552,7 +1552,7 @@ void Waveform::SetWaveFormSize(int h)
     views.clear();
 
     if (_media != nullptr) {
-        float samplesPerLine = GetSamplesPerLineFromZoomLevel(mZoomLevel);
+        float samplesPerLine = GetSamplesPerLineFromZoomLevel();
         views.emplace_back(0, samplesPerLine, _media, _type, _lowNote, _highNote);
     }
 

--- a/src-ui-wx/sequencer/Waveform.h
+++ b/src-ui-wx/sequencer/Waveform.h
@@ -122,6 +122,7 @@ class Waveform : public GRAPHICS_BASE_CLASS
         //int mMediaTrackSize;
         int mFrequency;
         int mZoomLevel;
+        int mLastEffectiveTick = 0;
         //bool mPointSize;
         bool m_dragging;
         DRAG_MODE m_drag_mode;

--- a/src-ui-wx/sequencer/Waveform.h
+++ b/src-ui-wx/sequencer/Waveform.h
@@ -112,7 +112,7 @@ class Waveform : public GRAPHICS_BASE_CLASS
     private:
       	DECLARE_EVENT_TABLE()
         //void GetMinMaxSampleSet(int setSize, float*sampleData,int trackSize, MINMAX* minMax);
-        float GetSamplesPerLineFromZoomLevel(int ZoomLevel) const;
+        float GetSamplesPerLineFromZoomLevel() const;
 		TimeLine* mTimeline;
         wxPanel* mParent;
         //wxWindow* mMainWindow;

--- a/src-ui-wx/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/sequencer/tabSequencer.cpp
@@ -936,7 +936,7 @@ void xLightsFrame::LoadAudioData(SequenceFile& xml_file)
     mainSequencer->PanelTimeLine->SetTimeLength(mMediaLengthMS);
     mainSequencer->PanelTimeLine->Initialize();
     int maxZoom = mainSequencer->PanelTimeLine->GetMaxZoomLevel();
-    mainSequencer->PanelTimeLine->SetZoomLevel(maxZoom);
+    mainSequencer->PanelTimeLine->SetFitZoom();  // default: sequence fills the full viewport
     mainSequencer->PanelWaveForm->SetZoomLevel(maxZoom);
     mainSequencer->PanelTimeLine->RaiseChangeTimeline();  // force refresh when new media is loaded
     mainSequencer->PanelWaveForm->UpdatePlayMarker();

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -4167,7 +4167,7 @@ void xLightsFrame::UpdateSequenceLength()
         mainSequencer->PanelTimeLine->SetTimeLength(CurrentSeqXmlFile->GetSequenceDurationMS());
         mainSequencer->PanelTimeLine->Initialize();
         int maxZoom = mainSequencer->PanelTimeLine->GetMaxZoomLevel();
-        mainSequencer->PanelTimeLine->SetZoomLevel(maxZoom);
+        mainSequencer->PanelTimeLine->SetFitZoom();
         mainSequencer->PanelWaveForm->SetZoomLevel(maxZoom);
         mainSequencer->PanelTimeLine->RaiseChangeTimeline();
         mainSequencer->PanelWaveForm->UpdatePlayMarker();


### PR DESCRIPTION
Make better use of the sequencer grid for the initial width. Now 20 and 40 FPS will both match width

<img width="2001" height="136" alt="image" src="https://github.com/user-attachments/assets/b51debfd-8db7-4fb1-89af-9dd8ba923afb" />
<img width="2020" height="103" alt="image" src="https://github.com/user-attachments/assets/76ac6859-cb43-40a5-a097-6ffc0d139687" />

vs current:
<img width="2022" height="108" alt="image" src="https://github.com/user-attachments/assets/74cbe7f4-10bf-4094-b230-a58886f83d67" />
<img width="2010" height="100" alt="image" src="https://github.com/user-attachments/assets/d0a49d25-c92f-47fd-9761-be98655036e7" />
