### PR TITLE
#6567 Shader: fix dynamic parameter changes not persisting

### DIFF
--- a/src-ui-wx/effectpanels/ShaderPanel.cpp
+++ b/src-ui-wx/effectpanels/ShaderPanel.cpp
@@ -474,6 +474,8 @@ void ShaderPanel::BuildDynamicUI() {
     BuildPropertiesIntoSizer(parentWin, _dynamicSizer,
                              _shaderConfig->GetDynamicPropertiesJson(),
                              dynamicCols);
+
+    AddListeners(parentWin);
 }
 
 void ShaderPanel::ValidateWindow() {


### PR DESCRIPTION
## Summary

- Dynamic shader uniform controls (checkboxes, sliders, etc.) created by `BuildDynamicUI` were never registered with `AddListeners`, so they had no `HandleCommandChange` connection
- `OnFilePickerChanged` converts the settings timer from periodic to one-shot via `FireChangeEvent()`; after that shot fires the timer stops
- Without the wiring, user edits to dynamic params (e.g. unchecking a bool uniform like "color") could not restart the timer and were silently lost — clicking off and back on the effect reverted the control to its shader-defined default
- Fix: call `AddListeners(parentWin)` at the end of `BuildDynamicUI` after dynamic controls are built

## Test plan

- [ ] Open a shader with a bool uniform defaulting to `true` (e.g. `InnerDimensionalMatrix.fs` — "color" checkbox)
- [ ] Uncheck the checkbox
- [ ] Click off the effect and back on — verify checkbox stays unchecked
- [ ] Verify other dynamic parameter types (sliders, choices) also persist changes correctly
- [ ] Verify existing static shader parameters (Speed, Offset X/Y, Zoom) still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)