### PR TITLE
Sync smart remote type across port block for controllers requiring it (#3468)

### DIFF
--- a/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
+++ b/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
@@ -1345,21 +1345,19 @@ int ModelPropertyAdapter::OnPropertyGridChange(wxPropertyGridInterface* grid, wx
         _model.SetSmartRemoteType(newType);
         if (caps != nullptr && caps->AllSmartRemoteTypesPerPortMustBeSame()) {
             int port = _model.GetControllerPort();
-            int smartRemote = _model.GetSmartRemote();
-            int block = (port - 1) / 4;
-            for (const auto& it : _model.GetModelManager()) {
-                Model* other = it.second;
-                if (other == &_model || other->GetControllerName() != _model.GetControllerName()) {
-                    continue;
+            if (port > 0) {
+                int block = (port - 1) / 4;
+                for (const auto& it : _model.GetModelManager()) {
+                    Model* other = it.second;
+                    if (other == &_model || other->GetControllerName() != _model.GetControllerName()) {
+                        continue;
+                    }
+                    int otherPort = other->GetControllerPort();
+                    if (otherPort <= 0 || (otherPort - 1) / 4 != block || other->GetSmartRemote() == 0) {
+                        continue;
+                    }
+                    other->SetSmartRemoteType(newType);
                 }
-                int otherPort = other->GetControllerPort();
-                if (otherPort <= 0 || (otherPort - 1) / 4 != block) {
-                    continue;
-                }
-                if (other->GetSmartRemote() != smartRemote) {
-                    continue;
-                }
-                other->SetSmartRemoteType(newType);
             }
         }
         return 0;

--- a/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
+++ b/src-ui-wx/modelproperties/ModelPropertyAdapter.cpp
@@ -1341,7 +1341,27 @@ int ModelPropertyAdapter::OnPropertyGridChange(wxPropertyGridInterface* grid, wx
         _model.SetControllerSerialProtocolSpeed((int)std::strtol(cs[event.GetValue().GetLong()].c_str(), nullptr, 10));
         return 0;
     } else if (event.GetPropertyName() == "SmartRemoteType") {
-        _model.SetSmartRemoteType(_model.GetSmartRemoteTypeName(wxAtoi(event.GetValue().GetString())));
+        std::string newType = _model.GetSmartRemoteTypeName(wxAtoi(event.GetValue().GetString()));
+        _model.SetSmartRemoteType(newType);
+        if (caps != nullptr && caps->AllSmartRemoteTypesPerPortMustBeSame()) {
+            int port = _model.GetControllerPort();
+            int smartRemote = _model.GetSmartRemote();
+            int block = (port - 1) / 4;
+            for (const auto& it : _model.GetModelManager()) {
+                Model* other = it.second;
+                if (other == &_model || other->GetControllerName() != _model.GetControllerName()) {
+                    continue;
+                }
+                int otherPort = other->GetControllerPort();
+                if (otherPort <= 0 || (otherPort - 1) / 4 != block) {
+                    continue;
+                }
+                if (other->GetSmartRemote() != smartRemote) {
+                    continue;
+                }
+                other->SetSmartRemoteType(newType);
+            }
+        }
         return 0;
     } else if (event.GetPropertyName() == "ModelControllerConnectionProtocol") {
         std::vector<std::string> cp;

--- a/src-ui-wx/setup/ControllerModelDialog.cpp
+++ b/src-ui-wx/setup/ControllerModelDialog.cpp
@@ -641,7 +641,11 @@ public:
             mnu.Append(ControllerModelDialog::CONTROLLER_PROTOCOL, "Set Protocol");
         }
         if (_caps != nullptr && (_type == PORTTYPE::PIXEL) && _caps->SupportsSmartRemotes() && (_caps->GetSmartRemoteTypes().size() > 1)) {
-            mnu.Append(ControllerModelDialog::CONTROLLER_SMARTREMOTETYPE, "Set Smart Remote Type");
+            std::string label = "Set Smart Remote Type";
+            if (_caps->AllSmartRemoteTypesPerPortMustBeSame()) {
+                label += " (All Ports In Block)";
+            }
+            mnu.Append(ControllerModelDialog::CONTROLLER_SMARTREMOTETYPE, label);
         }
         if (_caps != nullptr && (_type == PORTTYPE::PIXEL) && _caps->SupportsSmartRemotes()) {
             mnu.Append(ControllerModelDialog::CONTROLLER_SETSMARTREMOTE, "Set Smart Remote ID and Increment");
@@ -786,9 +790,20 @@ public:
                     dlg.SetSelection(selection);
                 }
                 if (dlg.ShowModal() == wxID_OK) {
-                    int basePort = GetBasePort();
-                    for (uint8_t p = 0; p < 4; ++p) {
-                        for (const auto& it : _cud->GetControllerPixelPort(basePort + p)->GetModels()) {
+                    if (_caps->AllSmartRemoteTypesPerPortMustBeSame()) {
+                        int basePort = GetBasePort();
+                        for (uint8_t p = 0; p < 4; ++p) {
+                            for (const auto& it : _cud->GetControllerPixelPort(basePort + p)->GetModels()) {
+                                auto* model = it->GetModel();
+                                if (model->GetSmartRemote() == 0) {
+                                    model->SetSmartRemote(1);
+                                }
+                                model->SetControllerProperty(CtrlProps::USE_SMART_REMOTE);
+                                model->SetSmartRemoteType(choices[dlg.GetSelection()]);
+                            }
+                        }
+                    } else {
+                        for (const auto& it : GetUDPort()->GetModels()) {
                             auto* model = it->GetModel();
                             if (model->GetSmartRemote() == 0) {
                                 model->SetSmartRemote(1);


### PR DESCRIPTION
The right click now updates all the 4 port block to the same type for those controllers that require it.