### PR TITLE
Allow timeline to zoom out to see any effects outside the duration (#6528

### DIFF
--- a/src-core/render/SequenceElements.cpp
+++ b/src-core/render/SequenceElements.cpp
@@ -106,6 +106,28 @@ int SequenceElements::GetSequenceEnd() const
     return mSequenceEndMS;
 }
 
+int SequenceElements::GetMaxEffectEndTimeMS() const
+{
+    int maxEndMS = 0;
+
+    for (size_t i = 0; i < GetElementCount(); i++) {
+        Element* e = GetElement(i);
+        if (e->GetType() != ElementType::ELEMENT_TYPE_TIMING) {
+            for (size_t j = 0; j < e->GetEffectLayerCount(); j++) {
+                EffectLayer* el = e->GetEffectLayer(j);
+                for (int k = 0; k < el->GetEffectCount(); k++) {
+                    Effect* eff = el->GetEffect(k);
+                    if (eff->GetEndTimeMS() > maxEndMS) {
+                        maxEndMS = eff->GetEndTimeMS();
+                    }
+                }
+            }
+        }
+    }
+
+    return maxEndMS;
+}
+
 EffectLayer* SequenceElements::GetEffectLayer(const Row_Information_Struct *s) const
 {
     if (s == nullptr) {

--- a/src-core/render/SequenceElements.h
+++ b/src-core/render/SequenceElements.h
@@ -143,6 +143,7 @@ public:
 
     void SetSequenceEnd(int ms);
     int GetSequenceEnd() const;
+    int GetMaxEffectEndTimeMS() const;
     // Selected Ranges
     size_t GetSelectedRangeCount();
     EffectRange* GetSelectedRange(int index);

--- a/src-ui-wx/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/sequencer/tabSequencer.cpp
@@ -933,7 +933,7 @@ void xLightsFrame::LoadAudioData(SequenceFile& xml_file)
         }
     }
 
-    mainSequencer->PanelTimeLine->SetTimeLength(mMediaLengthMS);
+    mainSequencer->PanelTimeLine->SetTimeLength(std::max(mMediaLengthMS, _sequenceElements.GetMaxEffectEndTimeMS()));
     mainSequencer->PanelTimeLine->Initialize();
     int maxZoom = mainSequencer->PanelTimeLine->GetMaxZoomLevel();
     mainSequencer->PanelTimeLine->SetFitZoom();  // default: sequence fills the full viewport

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -4167,7 +4167,7 @@ void xLightsFrame::UpdateSequenceLength()
             spdlog::error("Could not abort in-flight render before reallocating sequence data; skipping reallocation to avoid a crash.");
         }
 
-        mainSequencer->PanelTimeLine->SetTimeLength(CurrentSeqXmlFile->GetSequenceDurationMS());
+        mainSequencer->PanelTimeLine->SetTimeLength(std::max(CurrentSeqXmlFile->GetSequenceDurationMS(), _sequenceElements.GetMaxEffectEndTimeMS()));
         mainSequencer->PanelTimeLine->Initialize();
         int maxZoom = mainSequencer->PanelTimeLine->GetMaxZoomLevel();
         mainSequencer->PanelTimeLine->SetFitZoom();


### PR DESCRIPTION
if there are effects misplaced outside the duration, they are not accessible. We wont remove them automatically as there may be a reason one has them out there (placeholders? a work area - who knows)