### PR TITLE
Feature(ui): Add 3D layout viewport navigation style preset preference

### DIFF
--- a/src-ui-wx/layout/HousePreviewPanel.cpp
+++ b/src-ui-wx/layout/HousePreviewPanel.cpp
@@ -14,11 +14,11 @@
 //*)
 
 #include <wx/artprov.h>
-#include <wx/config.h>
 
 #include <cmath>
 
 #include "layout/HousePreviewPanel.h"
+#include "settings/XLightsConfigAdapter.h"
 #include "xLightsMain.h"
 #include "layout/ModelPreview.h"
 #include "render/SequenceFile.h"
@@ -283,11 +283,9 @@ void HousePreviewPanel::OnPreviewRightDown(wxMouseEvent& event)
         return;
     }
 
-    wxString navPreset = wxT("Classic");
-    if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
-        navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
-    }
-    bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
+    auto* config = GetXLightsConfig();
+    const std::string navPreset = config->Read("/Options/3DNavigationPreset", "Classic");
+    bool isPanAction = navPreset == "Slicer" ? !event.ShiftDown() : event.ShiftDown();
     const bool isRealRightDown = event.RightDown() || event.RightIsDown();
     if (isRealRightDown && isPanAction) {
         _previousMouseX = event.GetX();
@@ -316,11 +314,9 @@ void HousePreviewPanel::OnPreviewMouseMove(wxMouseEvent& event)
     }
 
     if (_rightPanDragActive) {
-        wxString navPreset = wxT("Classic");
-        if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
-            navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
-        }
-        bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
+        auto* config = GetXLightsConfig();
+        const std::string navPreset = config->Read("/Options/3DNavigationPreset", "Classic");
+        bool isPanAction = navPreset == "Slicer" ? !event.ShiftDown() : event.ShiftDown();
         if (!event.RightIsDown() || !isPanAction) {
             _rightPanDragActive = false;
         } else {

--- a/src-ui-wx/layout/HousePreviewPanel.cpp
+++ b/src-ui-wx/layout/HousePreviewPanel.cpp
@@ -339,8 +339,8 @@ void HousePreviewPanel::OnPreviewMouseMove(wxMouseEvent& event)
             delta_x = new_x * std::cos(angleY) - new_y * std::sin(angleY);
             delta_z = new_y * std::cos(angleY) + new_x * std::sin(angleY);
         } else if (bottom_view) {
-            delta_x = -new_x * std::sin(angleY) - new_y * std::cos(angleY);
-            delta_z = new_y * std::sin(angleY) - new_x * std::cos(angleY);
+            delta_x = new_x * std::cos(angleY) + new_y * std::sin(angleY);
+            delta_z = -new_y * std::cos(angleY) + new_x * std::sin(angleY);
         } else {
             delta_x = new_x * std::cos(angleY);
             delta_y = new_y;

--- a/src-ui-wx/layout/HousePreviewPanel.cpp
+++ b/src-ui-wx/layout/HousePreviewPanel.cpp
@@ -302,13 +302,6 @@ void HousePreviewPanel::OnPreviewRightDown(wxMouseEvent& event)
 
 void HousePreviewPanel::OnPreviewRightUp(wxMouseEvent& event)
 {
-    wxString navPreset = wxT("Classic");
-    if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
-        navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
-    }
-    bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
-    (void)isPanAction;
-
     _shiftRightPanDown = false;
     event.ResumePropagation(1);
     event.Skip();
@@ -322,15 +315,15 @@ void HousePreviewPanel::OnPreviewMouseMove(wxMouseEvent& event)
         return;
     }
 
-    wxString navPreset = wxT("Classic");
-    if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
-        navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
-    }
-    bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
-
-    if (_shiftRightPanDown && (!event.RightIsDown() || !isPanAction)) {
-        _shiftRightPanDown = false;
-    } else if (_shiftRightPanDown) {
+    if (_shiftRightPanDown) {
+        wxString navPreset = wxT("Classic");
+        if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
+            navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
+        }
+        bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
+        if (!event.RightIsDown() || !isPanAction) {
+            _shiftRightPanDown = false;
+        } else {
         float new_x = event.GetX() - _previousMouseX;
         float new_y = event.GetY() - _previousMouseY;
 
@@ -368,6 +361,7 @@ void HousePreviewPanel::OnPreviewMouseMove(wxMouseEvent& event)
         _modelPreview->Refresh();
         _modelPreview->Update();
         return;
+        }
     }
 
     event.ResumePropagation(1);

--- a/src-ui-wx/layout/HousePreviewPanel.cpp
+++ b/src-ui-wx/layout/HousePreviewPanel.cpp
@@ -14,6 +14,9 @@
 //*)
 
 #include <wx/artprov.h>
+#include <wx/config.h>
+
+#include <cmath>
 
 #include "layout/HousePreviewPanel.h"
 #include "xLightsMain.h"
@@ -100,6 +103,9 @@ HousePreviewPanel::HousePreviewPanel(wxWindow* parent, xLightsFrame* frame,
 
     _modelPreview = new ModelPreview(this, _xLights, allowSelected, style, allowPreviewChange);
     ModelPreviewSizer->Add(_modelPreview, 1, wxALL | wxEXPAND, 0);
+    _modelPreview->Connect(wxEVT_RIGHT_DOWN, (wxObjectEventFunction)&HousePreviewPanel::OnPreviewRightDown, nullptr, this);
+    _modelPreview->Connect(wxEVT_RIGHT_UP, (wxObjectEventFunction)&HousePreviewPanel::OnPreviewRightUp, nullptr, this);
+    _modelPreview->Connect(wxEVT_MOTION, (wxObjectEventFunction)&HousePreviewPanel::OnPreviewMouseMove, nullptr, this);
 
     ValidateWindow(GetSize());
 
@@ -267,4 +273,103 @@ void HousePreviewPanel::OnSliderPositionCmdSliderUpdated(wxScrollEvent& event)
     wxPostEvent(_xLights, seekToEvent);
     _xLights->GetMainSequencer()->PanelTimeLine->ResetMarkers(pos);
     StaticText_Time->SetLabel(FORMATTIME(pos));
+}
+
+void HousePreviewPanel::OnPreviewRightDown(wxMouseEvent& event)
+{
+    if (!_modelPreview->Is3D()) {
+        event.ResumePropagation(1);
+        event.Skip();
+        return;
+    }
+
+    wxString navPreset = wxT("Classic");
+    if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
+        navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
+    }
+    bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
+    const bool isRealRightDown = event.RightDown() || event.RightIsDown();
+    if (isRealRightDown && isPanAction) {
+        _previousMouseX = event.GetX();
+        _previousMouseY = event.GetY();
+        _shiftRightPanDown = true;
+        return;
+    }
+
+    event.ResumePropagation(1);
+    event.Skip();
+}
+
+void HousePreviewPanel::OnPreviewRightUp(wxMouseEvent& event)
+{
+    wxString navPreset = wxT("Classic");
+    if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
+        navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
+    }
+    bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
+    (void)isPanAction;
+
+    _shiftRightPanDown = false;
+    event.ResumePropagation(1);
+    event.Skip();
+}
+
+void HousePreviewPanel::OnPreviewMouseMove(wxMouseEvent& event)
+{
+    if (!_modelPreview->Is3D()) {
+        event.ResumePropagation(1);
+        event.Skip();
+        return;
+    }
+
+    wxString navPreset = wxT("Classic");
+    if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
+        navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
+    }
+    bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
+
+    if (_shiftRightPanDown && (!event.RightIsDown() || !isPanAction)) {
+        _shiftRightPanDown = false;
+    } else if (_shiftRightPanDown) {
+        float new_x = event.GetX() - _previousMouseX;
+        float new_y = event.GetY() - _previousMouseY;
+
+        float angleX = glm::radians(_modelPreview->GetCameraRotationX());
+        float angleY = glm::radians(_modelPreview->GetCameraRotationY());
+        float delta_x = 0.0f;
+        float delta_y = 0.0f;
+        float delta_z = 0.0f;
+        bool top_view = (angleX > glm::radians(45.0f)) && (angleX < glm::radians(135.0f));
+        bool bottom_view = (angleX > glm::radians(225.0f)) && (angleX < glm::radians(315.0f));
+        bool upside_down_view = (angleX >= glm::radians(135.0f)) && (angleX <= glm::radians(225.0f));
+        if (top_view) {
+            delta_x = new_x * std::cos(angleY) - new_y * std::sin(angleY);
+            delta_z = new_y * std::cos(angleY) + new_x * std::sin(angleY);
+        } else if (bottom_view) {
+            delta_x = -new_x * std::sin(angleY) - new_y * std::cos(angleY);
+            delta_z = new_y * std::sin(angleY) - new_x * std::cos(angleY);
+        } else {
+            delta_x = new_x * std::cos(angleY);
+            delta_y = new_y;
+            delta_z = new_x * std::sin(angleY);
+            if (!upside_down_view) {
+                delta_y *= -1.0f;
+            }
+        }
+
+        delta_x *= _modelPreview->GetZoom() * 2.0f;
+        delta_y *= _modelPreview->GetZoom() * 2.0f;
+        delta_z *= _modelPreview->GetZoom() * 2.0f;
+        _modelPreview->SetPan(delta_x, delta_y, delta_z);
+
+        _previousMouseX = event.GetX();
+        _previousMouseY = event.GetY();
+
+        _modelPreview->Refresh();
+        _modelPreview->Update();
+        return;
+    }
+
+    event.ResumePropagation(1);
+    event.Skip();
 }

--- a/src-ui-wx/layout/HousePreviewPanel.cpp
+++ b/src-ui-wx/layout/HousePreviewPanel.cpp
@@ -292,7 +292,7 @@ void HousePreviewPanel::OnPreviewRightDown(wxMouseEvent& event)
     if (isRealRightDown && isPanAction) {
         _previousMouseX = event.GetX();
         _previousMouseY = event.GetY();
-        _shiftRightPanDown = true;
+        _rightPanDragActive = true;
         return;
     }
 
@@ -302,7 +302,7 @@ void HousePreviewPanel::OnPreviewRightDown(wxMouseEvent& event)
 
 void HousePreviewPanel::OnPreviewRightUp(wxMouseEvent& event)
 {
-    _shiftRightPanDown = false;
+    _rightPanDragActive = false;
     event.ResumePropagation(1);
     event.Skip();
 }
@@ -315,14 +315,14 @@ void HousePreviewPanel::OnPreviewMouseMove(wxMouseEvent& event)
         return;
     }
 
-    if (_shiftRightPanDown) {
+    if (_rightPanDragActive) {
         wxString navPreset = wxT("Classic");
         if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
             navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
         }
         bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
         if (!event.RightIsDown() || !isPanAction) {
-            _shiftRightPanDown = false;
+            _rightPanDragActive = false;
         } else {
         float new_x = event.GetX() - _previousMouseX;
         float new_y = event.GetY() - _previousMouseY;

--- a/src-ui-wx/layout/HousePreviewPanel.h
+++ b/src-ui-wx/layout/HousePreviewPanel.h
@@ -85,6 +85,9 @@ class HousePreviewPanel: public wxPanel
 		void OnEndButtonClick(wxCommandEvent& event);
 		void OnResize(wxSizeEvent& event);
 		void OnSliderPositionCmdSliderUpdated(wxScrollEvent& event);
+		void OnPreviewRightDown(wxMouseEvent& event);
+		void OnPreviewRightUp(wxMouseEvent& event);
+		void OnPreviewMouseMove(wxMouseEvent& event);
 		//*)
 
 		DECLARE_EVENT_TABLE()
@@ -92,6 +95,9 @@ class HousePreviewPanel: public wxPanel
         xLightsFrame* _xLights;
         bool _showToolbar;
         ModelPreview* _modelPreview;
+		bool _shiftRightPanDown = false;
+		int _previousMouseX = 0;
+		int _previousMouseY = 0;
 
         void ValidateWindow(const wxSize& size);
 };

--- a/src-ui-wx/layout/HousePreviewPanel.h
+++ b/src-ui-wx/layout/HousePreviewPanel.h
@@ -95,7 +95,7 @@ class HousePreviewPanel: public wxPanel
         xLightsFrame* _xLights;
         bool _showToolbar;
         ModelPreview* _modelPreview;
-		bool _shiftRightPanDown = false;
+		bool _rightPanDragActive = false;
 		int _previousMouseX = 0;
 		int _previousMouseY = 0;
 

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -6235,11 +6235,9 @@ void LayoutPanel::OnPreviewMouseMove3D(wxMouseEvent& event)
 
     bool isPanAction = true;
     if (m_right_pan_drag_active) {
-        wxString navPreset = wxT("Classic");
-        if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
-            navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
-        }
-        isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
+        auto* config = GetXLightsConfig();
+        const std::string navPreset = config->Read("/Options/3DNavigationPreset", "Classic");
+        isPanAction = navPreset == "Slicer" ? !event.ShiftDown() : event.ShiftDown();
     }
 
     if (m_creating_bound_rect)
@@ -7102,11 +7100,9 @@ void LayoutPanel::OnPreviewRightDown(wxMouseEvent& event)
     modelPreview->SetFocus();
 
     if (is_3d) {
-        wxString navPreset = wxT("Classic");
-        if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
-            navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
-        }
-        bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
+        auto* config = GetXLightsConfig();
+        const std::string navPreset = config->Read("/Options/3DNavigationPreset", "Classic");
+        bool isPanAction = navPreset == "Slicer" ? !event.ShiftDown() : event.ShiftDown();
         const bool isRealRightDown = event.RightDown() || event.RightIsDown();
         if (isRealRightDown && isPanAction) {
             m_previous_mouse_x = event.GetX();

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -105,6 +105,7 @@
 #include <wx/wfstream.h>
 #include <wx/mstream.h>
 #include <wx/uri.h>
+#include <wx/config.h>
 
 #include <log.h>
 
@@ -712,6 +713,7 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
     modelPreview->Connect(wxEVT_LEFT_DOWN,(wxObjectEventFunction)&LayoutPanel::OnPreviewLeftDown, nullptr,this);
     modelPreview->Connect(wxEVT_LEFT_UP,(wxObjectEventFunction)&LayoutPanel::OnPreviewLeftUp, nullptr,this);
     modelPreview->Connect(wxEVT_RIGHT_DOWN,(wxObjectEventFunction)&LayoutPanel::OnPreviewRightDown, nullptr,this);
+    modelPreview->Connect(wxEVT_RIGHT_UP,(wxObjectEventFunction)&LayoutPanel::OnPreviewRightUp, nullptr,this);
     modelPreview->Connect(wxEVT_MOTION,(wxObjectEventFunction)&LayoutPanel::OnPreviewMouseMove, nullptr,this);
     modelPreview->Connect(wxEVT_LEAVE_WINDOW,(wxObjectEventFunction)&LayoutPanel::OnPreviewMouseLeave, nullptr, this);
     modelPreview->Connect(wxEVT_LEFT_DCLICK, (wxObjectEventFunction)&LayoutPanel::OnPreviewLeftDClick, nullptr, this);
@@ -5881,6 +5883,7 @@ void LayoutPanel::OnPreviewMouseLeave(wxMouseEvent& event)
 {
     m_dragging = false;
     m_wheel_down = false;
+    m_shift_right_pan_down = false;
 }
 
 void LayoutPanel::OnPreviewMouseWheelDown(wxMouseEvent& event)
@@ -5894,6 +5897,19 @@ void LayoutPanel::OnPreviewMouseWheelUp(wxMouseEvent& event)
 {
     m_wheel_down = false;
 }
+
+void LayoutPanel::OnPreviewRightUp(wxMouseEvent& event)
+{
+    wxString navPreset = wxT("Classic");
+    if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
+        navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
+    }
+    bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
+    (void)isPanAction;
+    m_shift_right_pan_down = false;
+    event.Skip();
+}
+
 void LayoutPanel::OnPreviewMotion3DButtonEvent(wxCommandEvent &event) {
     
     if (event.GetString() == "BUTTON_MENU") {
@@ -6223,6 +6239,12 @@ void LayoutPanel::OnPreviewMouseMove3D(wxMouseEvent& event)
         m_3d_lasso_shift_continuous = false;
     }
 
+    wxString navPreset = wxT("Classic");
+    if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
+        navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
+    }
+    bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
+
     if (m_creating_bound_rect)
     {
         xlights->AddTraceMessage("LayoutPanel::OnPreviewMouseMove3D Creating bounding rectangle");
@@ -6232,9 +6254,13 @@ void LayoutPanel::OnPreviewMouseMove3D(wxMouseEvent& event)
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::OnPreviewMouseMove3D");
         return;
     }
-    else if (m_wheel_down)
+    else if (m_shift_right_pan_down && (!event.RightIsDown() || !isPanAction))
     {
-        xlights->AddTraceMessage("LayoutPanel::OnPreviewMouseMove3D Wheel down");
+        m_shift_right_pan_down = false;
+    }
+    else if (m_wheel_down || m_shift_right_pan_down)
+    {
+        xlights->AddTraceMessage("LayoutPanel::OnPreviewMouseMove3D Pan drag");
         float new_x = event.GetX() - m_previous_mouse_x;
         float new_y = event.GetY() - m_previous_mouse_y;
         // account for grid rotation
@@ -7077,6 +7103,22 @@ void LayoutPanel::AddResizeOptionsToMenu(wxMenu* mnuResize) {
 void LayoutPanel::OnPreviewRightDown(wxMouseEvent& event)
 {
     modelPreview->SetFocus();
+
+    if (is_3d) {
+        wxString navPreset = wxT("Classic");
+        if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
+            navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
+        }
+        bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
+        const bool isRealRightDown = event.RightDown() || event.RightIsDown();
+        if (isRealRightDown && isPanAction) {
+            m_previous_mouse_x = event.GetX();
+            m_previous_mouse_y = event.GetY();
+            m_shift_right_pan_down = true;
+            return;
+        }
+    }
+
     wxMenu mnu;
 
     int selectedObjectCnt = editing_models ? ModelsSelectedCount() : ViewObjectsSelectedCount();

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -5883,7 +5883,7 @@ void LayoutPanel::OnPreviewMouseLeave(wxMouseEvent& event)
 {
     m_dragging = false;
     m_wheel_down = false;
-    m_shift_right_pan_down = false;
+    m_right_pan_drag_active = false;
 }
 
 void LayoutPanel::OnPreviewMouseWheelDown(wxMouseEvent& event)
@@ -5900,7 +5900,7 @@ void LayoutPanel::OnPreviewMouseWheelUp(wxMouseEvent& event)
 
 void LayoutPanel::OnPreviewRightUp(wxMouseEvent& event)
 {
-    m_shift_right_pan_down = false;
+    m_right_pan_drag_active = false;
     event.Skip();
 }
 
@@ -6234,7 +6234,7 @@ void LayoutPanel::OnPreviewMouseMove3D(wxMouseEvent& event)
     }
 
     bool isPanAction = true;
-    if (m_shift_right_pan_down) {
+    if (m_right_pan_drag_active) {
         wxString navPreset = wxT("Classic");
         if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
             navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
@@ -6251,11 +6251,11 @@ void LayoutPanel::OnPreviewMouseMove3D(wxMouseEvent& event)
         xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::OnPreviewMouseMove3D");
         return;
     }
-    else if (m_shift_right_pan_down && (!event.RightIsDown() || !isPanAction))
+    else if (m_right_pan_drag_active && (!event.RightIsDown() || !isPanAction))
     {
-        m_shift_right_pan_down = false;
+        m_right_pan_drag_active = false;
     }
-    else if (m_wheel_down || m_shift_right_pan_down)
+    else if (m_wheel_down || m_right_pan_drag_active)
     {
         xlights->AddTraceMessage("LayoutPanel::OnPreviewMouseMove3D Pan drag");
         float new_x = event.GetX() - m_previous_mouse_x;
@@ -7111,7 +7111,7 @@ void LayoutPanel::OnPreviewRightDown(wxMouseEvent& event)
         if (isRealRightDown && isPanAction) {
             m_previous_mouse_x = event.GetX();
             m_previous_mouse_y = event.GetY();
-            m_shift_right_pan_down = true;
+            m_right_pan_drag_active = true;
             return;
         }
     }
@@ -9502,7 +9502,6 @@ namespace {
 // replacement clone, taking a single consistent snapshot from the target's
 // screen location.
 //
-// Applied directly through the screen location rather than via
 // Model::SetHcenterPos / SetWidth / etc. The clone is cloned from the source's
 // XML and may inherit the source's locked flag; the Model::Set* setters no-op
 // when IsLocked(), so going straight to the screen location keeps the copy
@@ -9798,10 +9797,10 @@ void LayoutPanel::DoCut(wxCommandEvent& event) {
         event.Skip();
     } else if (selectedBaseObject != nullptr) {
         DoCopy(event);
-		if (editing_models)
-			DeleteSelectedModels();
-		else
-			DeleteSelectedObject();
+        if (editing_models)
+            DeleteSelectedModels();
+        else
+            DeleteSelectedObject();
     }
 }
 

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -5900,12 +5900,6 @@ void LayoutPanel::OnPreviewMouseWheelUp(wxMouseEvent& event)
 
 void LayoutPanel::OnPreviewRightUp(wxMouseEvent& event)
 {
-    wxString navPreset = wxT("Classic");
-    if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
-        navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
-    }
-    bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
-    (void)isPanAction;
     m_shift_right_pan_down = false;
     event.Skip();
 }

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -6233,11 +6233,14 @@ void LayoutPanel::OnPreviewMouseMove3D(wxMouseEvent& event)
         m_3d_lasso_shift_continuous = false;
     }
 
-    wxString navPreset = wxT("Classic");
-    if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
-        navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
+    bool isPanAction = true;
+    if (m_shift_right_pan_down) {
+        wxString navPreset = wxT("Classic");
+        if (auto* cfg = wxConfig::Get(); cfg != nullptr) {
+            navPreset = cfg->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
+        }
+        isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
     }
-    bool isPanAction = navPreset == wxT("Slicer") ? !event.ShiftDown() : event.ShiftDown();
 
     if (m_creating_bound_rect)
     {

--- a/src-ui-wx/layout/LayoutPanel.h
+++ b/src-ui-wx/layout/LayoutPanel.h
@@ -295,7 +295,7 @@ class LayoutPanel: public wxPanel
 		void OnPreviewLeftDown(wxMouseEvent& event);
 		void OnPreviewLeftDClick(wxMouseEvent& event);
 		void OnPreviewRightDown(wxMouseEvent& event);
-                void OnPreviewRightUp(wxMouseEvent& event);
+        void OnPreviewRightUp(wxMouseEvent& event);
 		void OnPreviewMouseMove(wxMouseEvent& event);
 		void OnPreviewMouseMove3D(wxMouseEvent& event);
 		void OnPreviewMouseWheel(wxMouseEvent& event);
@@ -522,7 +522,7 @@ class LayoutPanel: public wxPanel
         int m_polyline_create_handle = -1;
         bool m_moving_handle = false;
         bool m_wheel_down = false;
-        bool m_shift_right_pan_down = false;
+        bool m_right_pan_drag_active = false;
         bool m_polyline_active = false;
         int m_previous_mouse_x = 0;
         int m_previous_mouse_y = 0;

--- a/src-ui-wx/layout/LayoutPanel.h
+++ b/src-ui-wx/layout/LayoutPanel.h
@@ -295,6 +295,7 @@ class LayoutPanel: public wxPanel
 		void OnPreviewLeftDown(wxMouseEvent& event);
 		void OnPreviewLeftDClick(wxMouseEvent& event);
 		void OnPreviewRightDown(wxMouseEvent& event);
+                void OnPreviewRightUp(wxMouseEvent& event);
 		void OnPreviewMouseMove(wxMouseEvent& event);
 		void OnPreviewMouseMove3D(wxMouseEvent& event);
 		void OnPreviewMouseWheel(wxMouseEvent& event);
@@ -521,6 +522,7 @@ class LayoutPanel: public wxPanel
         int m_polyline_create_handle = -1;
         bool m_moving_handle = false;
         bool m_wheel_down = false;
+        bool m_shift_right_pan_down = false;
         bool m_polyline_active = false;
         int m_previous_mouse_x = 0;
         int m_previous_mouse_y = 0;

--- a/src-ui-wx/preferences/OtherSettingsPanel.cpp
+++ b/src-ui-wx/preferences/OtherSettingsPanel.cpp
@@ -24,7 +24,7 @@
 //*)
 
 #include <wx/preferences.h>
-#include <wx/config.h>
+#include "settings/XLightsConfigAdapter.h"
 #include "xLightsMain.h"
 
 
@@ -307,12 +307,10 @@ bool OtherSettingsPanel::TransferDataFromWindow() {
     frame->SetEnablePositionZones(CheckBox_EnablePositionZones->GetValue());
     frame->SetShowZoneIndicator(CheckBox_ShowZoneIndicator->GetValue());
     xlColourData::INSTANCE.SetUseCustomPicker(CheckBox_UseCustomColorPicker->IsChecked());
-    auto* config = wxConfig::Get();
-    if (config != nullptr) {
-        const wxString navPresetValue =
-            Choice_3DNavigationPreset->GetSelection() == kNavPresetSlicerIndex ? wxT("Slicer") : wxT("Classic");
-        config->Write(wxT("/Options/3DNavigationPreset"), navPresetValue);
-    }
+    auto* config = GetXLightsConfig();
+    const std::string navPresetValue =
+        Choice_3DNavigationPreset->GetSelection() == kNavPresetSlicerIndex ? "Slicer" : "Classic";
+    config->Write("/Options/3DNavigationPreset", navPresetValue);
     return true;
 }
 
@@ -341,11 +339,9 @@ bool OtherSettingsPanel::TransferDataToWindow() {
     CheckBox_ShowZoneIndicator->SetValue(frame->GetShowZoneIndicator());
     CheckBox_UseCustomColorPicker->SetValue(xlColourData::INSTANCE.UseCustomPicker());
     int navPreset = kNavPresetClassicIndex;
-    auto* config = wxConfig::Get();
-    if (config != nullptr) {
-        const wxString navPresetValue = config->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
-        navPreset = navPresetValue == wxT("Slicer") ? kNavPresetSlicerIndex : kNavPresetClassicIndex;
-    }
+    auto* config = GetXLightsConfig();
+    const std::string navPresetValue = config->Read("/Options/3DNavigationPreset", "Classic");
+    navPreset = navPresetValue == "Slicer" ? kNavPresetSlicerIndex : kNavPresetClassicIndex;
     Choice_3DNavigationPreset->SetSelection(navPreset);
 
 // Remove attempt to sneak functionality into the windows build

--- a/src-ui-wx/preferences/OtherSettingsPanel.cpp
+++ b/src-ui-wx/preferences/OtherSettingsPanel.cpp
@@ -24,6 +24,7 @@
 //*)
 
 #include <wx/preferences.h>
+#include <wx/config.h>
 #include "xLightsMain.h"
 
 
@@ -32,6 +33,11 @@ extern "C" {
 extern bool isMetalComputeSupported();
 }
 #endif
+
+namespace {
+constexpr int kNavPresetClassicIndex = 0;
+constexpr int kNavPresetSlicerIndex = 1;
+}
 
 //(*IdInit(OtherSettingsPanel)
 const wxWindowID OtherSettingsPanel::ID_CHECKBOX1 = wxNewId();
@@ -60,6 +66,8 @@ const wxWindowID OtherSettingsPanel::ID_CTRLPINGINTERVAL = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_CHECKBOX10 = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_CHECKBOX11 = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_CHECKBOX_CustomColorPicker = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_STATICTEXT_NAVPRESET = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHOICE_3DNAVPRESET = wxNewId();
 //*)
 
 BEGIN_EVENT_TABLE(OtherSettingsPanel,wxPanel)
@@ -79,12 +87,14 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     wxFlexGridSizer* FlexGridSizer6;
     wxFlexGridSizer* FlexGridSizer7;
     wxFlexGridSizer* FlexGridSizer8;
+    wxFlexGridSizer* FlexGridSizer9;
     wxGridBagSizer* GridBagSizer1;
     wxGridBagSizer* GridBagSizer2;
     wxStaticBoxSizer* StaticBoxSizer1;
     wxStaticBoxSizer* StaticBoxSizer2;
     wxStaticBoxSizer* StaticBoxSizer3;
     wxStaticBoxSizer* StaticBoxSizer4;
+    wxStaticBoxSizer* StaticBoxSizer5;
     wxStaticText* StaticText1;
 
     Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("wxID_ANY"));
@@ -208,6 +218,18 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     CheckBox_UseCustomColorPicker = new wxCheckBox(this, ID_CHECKBOX_CustomColorPicker, _("Use custom color picker (experimental)"), wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_CHECKBOX_CustomColorPicker"));
     CheckBox_UseCustomColorPicker->SetValue(false);
     GridBagSizer1->Add(CheckBox_UseCustomColorPicker, wxGBPosition(13, 0), wxDefaultSpan, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    StaticBoxSizer5 = new wxStaticBoxSizer(wxHORIZONTAL, this, _("3D Viewport Navigation"));
+    FlexGridSizer9 = new wxFlexGridSizer(0, 2, 0, 0);
+    FlexGridSizer9->AddGrowableCol(1);
+    StaticText9 = new wxStaticText(this, ID_STATICTEXT_NAVPRESET, _("3D Navigation Preset:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT_NAVPRESET"));
+    FlexGridSizer9->Add(StaticText9, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
+    Choice_3DNavigationPreset = new wxChoice(this, ID_CHOICE_3DNAVPRESET, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_3DNAVPRESET"));
+    Choice_3DNavigationPreset->Append(_("xLights Classic (RMB: Menu / Shift+RMB: Pan)"));
+    Choice_3DNavigationPreset->Append(_("3D Slicer / CAD Style (RMB: Pan / Shift+RMB: Menu)"));
+    Choice_3DNavigationPreset->SetSelection(kNavPresetClassicIndex);
+    FlexGridSizer9->Add(Choice_3DNavigationPreset, 1, wxALL|wxEXPAND, 5);
+    StaticBoxSizer5->Add(FlexGridSizer9, 1, wxALL|wxEXPAND, 0);
+    GridBagSizer1->Add(StaticBoxSizer5, wxGBPosition(14, 0), wxGBSpan(1, 2), wxALL|wxEXPAND, 0);
     SetSizer(GridBagSizer1);
 
     Connect(ID_CHECKBOX1, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
@@ -231,6 +253,7 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     Connect(ID_CHECKBOX10, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
     Connect(ID_CHECKBOX11, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
     Connect(ID_CHECKBOX_CustomColorPicker, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHOICE_3DNAVPRESET, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
     Connect(wxEVT_PAINT, (wxObjectEventFunction)&OtherSettingsPanel::OnPaint);
     //*)
 
@@ -284,6 +307,12 @@ bool OtherSettingsPanel::TransferDataFromWindow() {
     frame->SetEnablePositionZones(CheckBox_EnablePositionZones->GetValue());
     frame->SetShowZoneIndicator(CheckBox_ShowZoneIndicator->GetValue());
     xlColourData::INSTANCE.SetUseCustomPicker(CheckBox_UseCustomColorPicker->IsChecked());
+    auto* config = wxConfig::Get();
+    if (config != nullptr) {
+        const wxString navPresetValue =
+            Choice_3DNavigationPreset->GetSelection() == kNavPresetSlicerIndex ? wxT("Slicer") : wxT("Classic");
+        config->Write(wxT("/Options/3DNavigationPreset"), navPresetValue);
+    }
     return true;
 }
 
@@ -311,6 +340,13 @@ bool OtherSettingsPanel::TransferDataToWindow() {
     CheckBox_EnablePositionZones->SetValue(frame->GetEnablePositionZones());
     CheckBox_ShowZoneIndicator->SetValue(frame->GetShowZoneIndicator());
     CheckBox_UseCustomColorPicker->SetValue(xlColourData::INSTANCE.UseCustomPicker());
+    int navPreset = kNavPresetClassicIndex;
+    auto* config = wxConfig::Get();
+    if (config != nullptr) {
+        const wxString navPresetValue = config->Read(wxT("/Options/3DNavigationPreset"), wxT("Classic"));
+        navPreset = navPresetValue == wxT("Slicer") ? kNavPresetSlicerIndex : kNavPresetClassicIndex;
+    }
+    Choice_3DNavigationPreset->SetSelection(navPreset);
 
 // Remove attempt to sneak functionality into the windows build
 #ifndef __WXMSW__

--- a/src-ui-wx/preferences/OtherSettingsPanel.h
+++ b/src-ui-wx/preferences/OtherSettingsPanel.h
@@ -46,6 +46,7 @@ class OtherSettingsPanel: public wxPanel
 		wxCheckBox* HardwareVideoDecodingCheckBox;
 		wxCheckBox* ShaderCheckbox;
 		wxChoice* ChoiceCodec;
+		wxChoice* Choice_3DNavigationPreset;
 		wxChoice* Choice_AliasPromptBehavior;
 		wxChoice* Choice_LinkControllerUpload;
 		wxChoice* Choice_MinTipLevel;
@@ -58,6 +59,7 @@ class OtherSettingsPanel: public wxPanel
 		wxStaticText* StaticText6;
 		wxStaticText* StaticText7;
 		wxStaticText* StaticText8;
+		wxStaticText* StaticText9;
 		wxTextCtrl* eMailTextControl;
 		//*)
 
@@ -93,6 +95,8 @@ class OtherSettingsPanel: public wxPanel
 		static const wxWindowID ID_CHECKBOX10;
 		static const wxWindowID ID_CHECKBOX11;
 		static const wxWindowID ID_CHECKBOX_CustomColorPicker;
+		static const wxWindowID ID_STATICTEXT_NAVPRESET;
+		static const wxWindowID ID_CHOICE_3DNAVPRESET;
 		//*)
 
 	private:

--- a/src-ui-wx/wxsmith/OtherSettingsPanel.wxs
+++ b/src-ui-wx/wxsmith/OtherSettingsPanel.wxs
@@ -419,6 +419,45 @@
 				<border>5</border>
 				<option>1</option>
 			</object>
+			<object class="sizeritem">
+				<object class="wxStaticBoxSizer" variable="StaticBoxSizer5" member="no">
+					<label>3D Viewport Navigation</label>
+					<object class="sizeritem">
+						<object class="wxFlexGridSizer" variable="FlexGridSizer9" member="no">
+							<cols>2</cols>
+							<growablecols>1</growablecols>
+							<object class="sizeritem">
+								<object class="wxStaticText" name="ID_STATICTEXT_NAVPRESET" variable="StaticText9" member="yes">
+									<label>3D Navigation Preset:</label>
+								</object>
+								<flag>wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+							<object class="sizeritem">
+								<object class="wxChoice" name="ID_CHOICE_3DNAVPRESET" variable="Choice_3DNavigationPreset" member="yes">
+									<content>
+										<item>xLights Classic (RMB: Menu / Shift+RMB: Pan)</item>
+										<item>3D Slicer / CAD Style (RMB: Pan / Shift+RMB: Menu)</item>
+									</content>
+									<selection>0</selection>
+									<handler function="OnControlChanged" entry="EVT_CHOICE" />
+								</object>
+								<flag>wxALL|wxEXPAND</flag>
+								<border>5</border>
+								<option>1</option>
+							</object>
+						</object>
+						<flag>wxALL|wxEXPAND</flag>
+						<option>1</option>
+					</object>
+				</object>
+				<colspan>2</colspan>
+				<col>0</col>
+				<row>14</row>
+				<flag>wxALL|wxEXPAND</flag>
+				<option>1</option>
+			</object>
 		</object>
 	</object>
 </wxsmith>


### PR DESCRIPTION
### Summary
Adds a user preference dropdown to the "Other Settings" panel allowing users to toggle between two 3D viewport canvas mouse interaction styles. This introduces full 3D viewport translation/panning functionality via the Right Mouse Button (RMB) dynamically across both the main **Layout Viewport** and the **House Preview Panel** windows.

### Motivation
Currently, users transitioning from 3D design software, CAD tools, or modern slicers expect intuitive RMB dragging mechanics to easily pan a 3D workspace view. This addition allows users to opt into a familiar 3D navigation scheme without alienating veteran xLights users who rely on legacy muscle memory.

### Behavioral Breakdown
* **Option 1: xLights Classic (Default)**
  * Plain RMB Drag $\rightarrow$ Viewport Context Menu
  * Shift + RMB $\rightarrow$ Panning / Camera Translation
* **Option 2: 3D Slicer / CAD Style**
  * Plain RMB Drag $\rightarrow$ Panning / Camera Translation
  * Shift + RMB $\rightarrow$ Viewport Context Menu

### Implementation Details
* **No Hardcoded UI Display Strings:** The preferences panel saves/reads a flat identifier (`"Classic"` or `"Slicer"`) to `/Options/3DNavigationPreset`, entirely protecting the backend framework from breaking under international translations.
* **Synchronized & Unified State Logic:** Extracted and synchronized the camera interaction handling in both `LayoutPanel.cpp` and `HousePreviewPanel.cpp` into a streamlined boolean matrix prior to event routing. This guarantees a uniform cross-window user experience.
* **Cross-Platform Safety:** Integrated the UI additions natively into the existing `wxStaticBoxSizer` and `wxFlexGridSizer` constraints within `OtherSettingsPanel.wxs`. Elements dynamically scale and handle boundaries natively across Windows, macOS, and Linux without hardcoded pixel metrics.

### Testing Done
* Built and verified locally using Windows 64-bit Debug builds. 
* Confirmed that selecting "3D Slicer / CAD Style" successfully flips the modifier state on both the Layout canvas and the House Preview canvas without disrupting any Left-Click Drag (Orbit) or Scroll Wheel (Zoom) behaviors.
* Confirmed context menus open as expected under all preset conditions.