### PR TITLE
Fix crash when cancelling a polyline drag that leaves a single point

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -39,6 +39,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -bug (dan)                   Fix crash closing/switching sequences with a Moving Head effect selected (programmatic default
                                  reset fired live update handlers that dereferenced a stale model)
     -bug (dan)                   Fix crash clicking a sequencer row heading when the visible row information was momentarily unavailable
+    -bug (charlie)               Fix crash when pressing Escape to cancel a polyline drag during creation that leaves the model with a single point
     -bug (dan)                   Fix crash importing/downloading a DmxServo3Axis model (factory didn't recognize the legacy type alias);
                                  unrecognized/malformed model files now cancel the import with an error instead of crashing
     -bug (dan)                   Don't crash drawing when a Metal pipeline fails to compile (e.g. older macOS); skip the draw instead

--- a/src-core/models/PolyLineModel.cpp
+++ b/src-core/models/PolyLineModel.cpp
@@ -223,7 +223,19 @@ void PolyLineModel::InitModel()
 
     _numSegments = screenLocation.num_points - 1;
     _numDropPoints = 0;
-    
+
+    // A polyline needs at least two points (one segment). Deleting the
+    // in-flight handle mid-create (e.g. Escape while dragging) can shrink
+    // num_points to 1, leaving zero segments. The per-segment vectors then
+    // resize to empty below, but _totalLightCount is still > 0 so
+    // DistributeLightsEvenly would run and index _polyLineSegDropSizes[0] on
+    // an empty vector and crash. Bail out — the caller (FinalizeModel) deletes
+    // the degenerate model right after this returns.
+    if (_numSegments < 1) {
+        Nodes.clear();
+        return;
+    }
+
     // Ensure per-segment vectors match the current segment count exactly.
     // During polyline creation, screenLocation may have more points than
     // the per-segment vectors which are grown via AddHandle(); deleting a

--- a/src-core/models/PolyLineModel.cpp
+++ b/src-core/models/PolyLineModel.cpp
@@ -224,13 +224,6 @@ void PolyLineModel::InitModel()
     _numSegments = screenLocation.num_points - 1;
     _numDropPoints = 0;
 
-    // A polyline needs at least two points (one segment). Deleting the
-    // in-flight handle mid-create (e.g. Escape while dragging) can shrink
-    // num_points to 1, leaving zero segments. The per-segment vectors then
-    // resize to empty below, but _totalLightCount is still > 0 so
-    // DistributeLightsEvenly would run and index _polyLineSegDropSizes[0] on
-    // an empty vector and crash. Bail out — the caller (FinalizeModel) deletes
-    // the degenerate model right after this returns.
     if (_numSegments < 1) {
         Nodes.clear();
         return;


### PR DESCRIPTION
## Problem

xLights crashes (out-of-bounds `std::vector` access) when you cancel a polyline drag during model creation:

1. Start creating a polyline in the Layout tab
2. Click and drag a vertex
3. Press **Escape** while still dragging

The crash aborts in `PolyLineModel::DistributeLightsEvenly` (PolyLineModel.cpp), reached via `OnCharHook` (Escape) → `LayoutPanel::FinalizeModel` → `PolyLineModel::DeleteHandle` → `InitModel`.

## Root cause

`DeleteHandle` removes the in-flight vertex. If the polyline had only two points, `num_points` drops to **1**, so `_numSegments` becomes `0` and the per-segment vectors (`_polyLineSizes` / `_polyLineSegDropSizes`) resize to **empty**. But `_totalLightCount` is still > 0, so `DistributeLightsEvenly` runs anyway and indexes `_polyLineSegDropSizes[0]` on an empty vector, aborting.

The existing resize guard in `InitModel` keeps those vectors *consistent* in size but doesn't handle the degenerate zero-segment case.

## Fix

Bail out of `InitModel` early when there are no segments (`_numSegments < 1`). A polyline with fewer than two points is degenerate, and `FinalizeModel` deletes such a model immediately after `DeleteHandle` returns — so skipping light distribution is safe and avoids the crash.

## Testing

- Reproduced the crash on master, confirmed the fix resolves it.
- macOS desktop Debug build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)