### PR TITLE
Fix for #6611 - Face Effect on submodels was using the wrong nodes *DONT MERGE*

### DIFF
--- a/src-core/effects/FacesEffect.cpp
+++ b/src-core/effects/FacesEffect.cpp
@@ -872,10 +872,9 @@ void FacesEffect::RenderFaces(RenderBuffer& buffer,
     }
 
     bool group = false;
-    const SubModel* subModel = nullptr;
     // if this is a submodel find the parent so we can find the face definition there
     if (model_info->GetDisplayAs() == DisplayAsType::SubModel) {
-        subModel = dynamic_cast<const SubModel*>(model_info);
+        auto* subModel = dynamic_cast<const SubModel*>(model_info);
         if (subModel == nullptr) return;
         model_info = subModel->GetParent();
         if (model_info == nullptr) return;
@@ -888,12 +887,6 @@ void FacesEffect::RenderFaces(RenderBuffer& buffer,
             return;
         }
     }
-    auto toLocalNode = [&](int parentIdx) -> int {
-        if (subModel == nullptr) return parentIdx;
-        const auto& nim = subModel->GetNodeIndexMap();
-        auto mapped = nim.find(parentIdx);
-        return (mapped != nim.end()) ? mapped->second : -1;
-    };
 
     if (cache->nodeNameCache.empty()) {
         for (size_t x = 0; x < model_info->GetNodeCount(); x++) {
@@ -1345,8 +1338,7 @@ void FacesEffect::RenderFaces(RenderBuffer& buffer,
             const auto& nodeInfo = model_info->GetFaceInfoNodes().find(definition);
             if (nodeInfo != model_info->GetFaceInfoNodes().end() && nodeInfo->second.find(todo[t]) != nodeInfo->second.end()) {
                 for (const auto it : nodeInfo->second.find(todo[t])->second) {
-                    int localIdx = toLocalNode(it);
-                    if (localIdx >= 0) buffer.SetNodePixel(localIdx, colors[t], true);
+                    buffer.SetNodePixel(it, colors[t], true);
                 }
             }
         } else {
@@ -1355,8 +1347,8 @@ void FacesEffect::RenderFaces(RenderBuffer& buffer,
                 if (type == 0) {
                     auto it2 = cache->nodeNameCache.find(valstr);
                     if (it2 != cache->nodeNameCache.end()) {
-                        int localIdx = toLocalNode(it2->second);
-                        if (localIdx >= 0) buffer.SetNodePixel(localIdx, colors[t], true);
+                        int n = it2->second;
+                        buffer.SetNodePixel(n, colors[t], true);
                     }
                 }
             }
@@ -1367,11 +1359,8 @@ void FacesEffect::RenderFaces(RenderBuffer& buffer,
                 const auto& sts = model_info->GetStateInfo().find(outlineState)->second;
                 if (findKey(sts, "CustomColors") == "1") {
                     if (findKey(sts, "Type") == "NodeRange") {
-                        const auto& stateNodes = model_info->GetStateInfoNodes();
-                        const auto outerIt = stateNodes.find(outlineState);
                         for (size_t i = 1; i <= 200; i++) {
-                            const std::string k = fmt::format("s{:03d}", (int)i);
-                            auto r = findKey(sts, k);
+                            auto r = findKey(sts, fmt::format("s{:03d}", (int)i));
                             auto c = findKey(sts, fmt::format("s{:03d}-Color", (int)i));
                             if (r != "") {
                                 xlColor colour = xlColor(c);
@@ -1379,13 +1368,12 @@ void FacesEffect::RenderFaces(RenderBuffer& buffer,
                                     colour = xlWHITE;
                                 }
                                 colour.alpha = ((int)alpha * colour.alpha) / 255;
-                                if (outerIt != stateNodes.end()) {
-                                    const auto innerIt = outerIt->second.find(k);
-                                    if (innerIt != outerIt->second.end()) {
-                                        for (const auto it : innerIt->second) {
-                                            int localIdx = toLocalNode(it);
-                                            if (localIdx >= 0) buffer.SetNodePixel(localIdx, colour, true);
-                                        }
+                                
+                                // use the nodes as it is faster
+                                if (model_info->GetStateInfoNodes().find(outlineState) != model_info->GetStateInfoNodes().end()) {
+                                    const std::string k2 = fmt::format("s{:03d}", (int)i);
+                                    for (const auto it : model_info->GetStateInfoNodes().find(outlineState)->second.find(k2)->second) {
+                                        buffer.SetNodePixel(it, colour, true);
                                     }
                                 }
                             }


### PR DESCRIPTION
This was a breaking change - the face definitions are still using the full model numbering. It corrects the reported issue but perhaps @cybercop23 wants to confirm it still works with his states and faces change.