### PR TITLE
#6609 Lyric Track Unable to move - Fix

### DIFF
--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -2205,7 +2205,9 @@ void EffectsGrid::mouseDown(wxMouseEvent& event) {
     }
 
     if (!mMouseOperationsCancelled) {
-        if (mResizingMode == EFFECT_RESIZE_MOVE && selectedEffect != nullptr) {
+        Row_Information_Struct* anchorRI = mSequenceElements->GetVisibleRowInformation(row);
+        bool isTimingDrag = (anchorRI != nullptr && anchorRI->element->GetType() == ElementType::ELEMENT_TYPE_TIMING);
+        if (!isTimingDrag && mResizingMode == EFFECT_RESIZE_MOVE && selectedEffect != nullptr) {
             // Ghost drag-to-move/copy: non-destructive drag with dim originals and ghost at target
             if (selectedEffect->GetSelected() == EFFECT_NOT_SELECTED)
                 selectedEffect->SetSelected(EFFECT_SELECTED);


### PR DESCRIPTION
Lyric/Timing Track Drag Broken Since PR #6479

  What broke

  PR #6479 (ghost drag-to-move) inserted a new code path in mouseDown() that intercepts all EFFECT_RESIZE_MOVE clicks — including clicks on timing track items (words, phrases, phonemes). It builds a list of selected effects to drag (mEffectMoveSnapshots), but explicitly skips
  timing rows when doing so (line 2226). The result: timing effects always produce an empty snapshot list, UpdateEffectMoveDragState() returns immediately, and dragging a lyric item does nothing.

  How timing drag worked before

  Before PR #6479, clicking a timing effect's center with EFFECT_RESIZE_MOVE fell into the mResizing = true branch → Resize() → ResizeMoveMultipleEffectsMS() → MoveAllSelectedEffects(). That chain handles timing effects correctly and skips re-rendering (timing tracks don't need
  it).

  The fix

  Two lines added in EffectsGrid.cpp at the top of the drag-dispatch block:

  Row_Information_Struct* anchorRI = mSequenceElements->GetVisibleRowInformation(row);
  bool isTimingDrag = (anchorRI != nullptr && anchorRI->element->GetType() == ElementType::ELEMENT_TYPE_TIMING);
  if (!isTimingDrag && mResizingMode == EFFECT_RESIZE_MOVE && selectedEffect != nullptr) {
      // Ghost drag path — model effects only

  When the clicked row is a timing element, isTimingDrag = true gates out the ghost drag block. The code falls through to the existing else if (mResizingMode != EFFECT_RESIZE_NO) branch, sets mResizing = true, and restores the pre-#6479 drag behavior for timing tracks. Model effect
  drag (the ghost drag feature) is completely unchanged.