### PR TITLE
Effect sequence now gets a default New Timing track on create

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,6 +13,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
 2026.12  June ??, 2026
     -change (derwin12)           Remove Keep Channel Numbers for FPP devices (#5459)
     -change (scott)              Preferences dialog (Windows/Linux) uses a list of pages on the left with icons instead of tabs across the top
+    -enh (derwin12)              Effect sequence wizard now adds a default New Timing track (#6612)
     -enh (derwin12)              Add Timing Track option to Single Strand chase (cycles per timing mark) (#4771)
     -enh (derwin12)              Allow timeline to zoom out to see any effects outside the duration (#6528)
     -enh (derwin12)              Sync smart remote type across port block for controllers requiring it (#3468)

--- a/src-ui-wx/import_export/SeqFileUtilities.cpp
+++ b/src-ui-wx/import_export/SeqFileUtilities.cpp
@@ -170,12 +170,9 @@ void xLightsFrame::NewSequence(const std::string& media, uint32_t durationMS, ui
     CurrentSeqXmlFile->SetSequenceLoaded(true);
     CurrentSeqXmlFile->ApplyPendingTimings(this);
     if (_sequenceElements.GetNumberOfTimingElements() == 0) {
-        if (CurrentSeqXmlFile->GetSequenceType() != "Effect") {
-            // only add timing if the user didnt set up timings (effect sequences start with none)
-            std::string new_timing = "New Timing";
-            CurrentSeqXmlFile->AddNewTimingSection(new_timing, this);
-            _sequenceElements.AddTimingToAllViews(new_timing);
-        }
+        std::string new_timing = "New Timing";
+        CurrentSeqXmlFile->AddNewTimingSection(new_timing, this);
+        _sequenceElements.AddTimingToAllViews(new_timing);
     } else {
         _sequenceElements.GetTimingElement(0)->SetActive(true);
     }


### PR DESCRIPTION
[skip ci]