### PR TITLE
Provide graceful exit rather than crash on Snapdragon when OpenGL 3.x… unavailable (#6608)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -27,6 +27,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -enh (cybercop23)            Add cylinder shape and offset to cube model (#4369)
     -enh (neil)                  Add ability to link props into "sets" so they move as one (#3703)
     -enh (derwin12)              House Preview: right-click "Keep on Top" keeps the popped-out window above other apps (#5533)
+    -bug (derwin12)              Provide graceful exit rather than crash on Snapdragon/ARM Windows when OpenGL 3.x unavailable (#6608)
     -bug (derwin12)              Allow multiple timing tracks to be active simultaneously in master view (was limited to one)
     -bug (derwin12)              Fix missing video display and re-render in Select Videos panel
     -bug (derwin12)              Fixed missing video files not showing red in the Select Videos panel

--- a/src-ui-wx/graphics/opengl/xlGLCanvas.cpp
+++ b/src-ui-wx/graphics/opengl/xlGLCanvas.cpp
@@ -136,6 +136,7 @@ END_EVENT_TABLE()
 static const int DEPTH_BUFFER_BITS[] = {32, 24, 16, 12, 10, 8};
 
 wxGLContext *xlGLCanvas::m_sharedContext = nullptr;
+static bool s_oglSharedContextValid = false;
 
 static wxGLAttributes GetAttributes(int &zdepth, bool only2d) {
     OpenGLShaders::SetupDebugLogging();
@@ -632,6 +633,8 @@ void xlGLCanvas::CreateGLContext() {
                            (const char*)(vend ? vend : (const GLubyte*)"?"));
             if (!xlOGL3GraphicsContext::InitializeSharedContext()) {
                 m_logger->error("Failed to initialise shared ANGLE GL context.");
+            } else {
+                s_oglSharedContextValid = true;
             }
         }
         InitializeGLContext();
@@ -706,9 +709,10 @@ void xlGLCanvas::CreateGLContext() {
                 }
             }
             
-            if (!xlOGL3GraphicsContext::InitializeSharedContext())
-            {
+            if (!xlOGL3GraphicsContext::InitializeSharedContext()) {
                 m_logger->error("Failed to initialise shared OpenGL context.");
+            } else {
+                s_oglSharedContextValid = true;
             }
 
             m_context = nullptr;
@@ -771,6 +775,9 @@ xlGraphicsContext *xlGLCanvas::PrepareContextForDrawing() {
     return PrepareContextForDrawing(ClearBackgroundColor());
 }
 xlGraphicsContext* xlGLCanvas::PrepareContextForDrawing(const xlColor &bg) {
+    if (!s_oglSharedContextValid) {
+        return nullptr;
+    }
 #ifdef USE_GLES
     // Serialize this on-screen frame against the off-screen ShaderEffect pool so
     // ANGLE's shared D3D11 device is never submitted from two threads at once.


### PR DESCRIPTION
It was noted in the log but the code continues on and crashes rather than exiting.