### PR TITLE
Fix floating sequencer panes shifting on macOS after tab switch (#6631)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -28,13 +28,14 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -enh (cybercop23)            Add cylinder shape and offset to cube model (#4369)
     -enh (neil)                  Add ability to link props into "sets" so they move as one (#3703)
     -enh (derwin12)              House Preview: right-click "Keep on Top" keeps the popped-out window above other apps (#5533)
+    -enh (AlexB)                 During a multi-effect drag, only the colliding ghost effects turn red instead of all of them (#6553)
+    -enh (neil)                  Bulk Edit Rotate skips models whose type doesn't support that axis and reports the skipped models (#6521)
+    -enh (derwin12)              Grey out Symmetrize/Combine Strands in the SubModels menu when they don't apply (#6554)
+    -bug (derwin12)              Fix floating sequencer panes shifting position on macOS after switching to the Layout tab and back (#6631)
     -bug (dkulp)                 Wait for renders to abort before deleting models/groups so a render worker can't crash on freed model data
     -bug (dkulp)                 Fix waveform render crash when the audio/zoom view list is rebuilt mid-paint (stale view index)
     -bug (dkulp)                 Fix crash hovering the layout preview in 3D mode when the model list contains a null entry
     -bug (dkulp)                 Fix crash mousing over the sequencer grid when a row's effect layer is momentarily unavailable
-    -enh (AlexB)                 During a multi-effect drag, only the colliding ghost effects turn red instead of all of them (#6553)
-    -enh (neil)                  Bulk Edit Rotate skips models whose type doesn't support that axis and reports the skipped models (#6521)
-    -enh (derwin12)              Grey out Symmetrize/Combine Strands in the SubModels menu when they don't apply (#6554)
     -bug (derwin12)              Allow multiple timing tracks to be active simultaneously in master view (was limited to one)
     -bug (derwin12)              Fix missing video display and re-render in Select Videos panel
     -bug (derwin12)              Fix State/Face effect dropdowns resetting on icon click (#6595)

--- a/src-ui-wx/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/sequencer/tabSequencer.cpp
@@ -3348,8 +3348,11 @@ void xLightsFrame::DoLoadPerspective(Perspective* perspective)
             std::string name = panes[x].name.ToStdString();
             if (name != "HousePreview" && name != "ModelPreview") continue;
             recoverNames.push_back(name);
-            recoverPos.push_back(panes[x].frame->GetPosition());
-            recoverSize.push_back(panes[x].frame->GetSize());
+            // Use AUI's stored floating_pos/floating_size rather than the live
+            // native frame position, which on macOS may already be shifted by
+            // Cocoa after a Hide()/Show() cycle.
+            recoverPos.push_back(panes[x].floating_pos);
+            recoverSize.push_back(panes[x].floating_size);
         }
         if (!recoverNames.empty()) {
             for (const auto& nm : recoverNames) {

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -2927,8 +2927,13 @@ void xLightsFrame::ShowHideAllSequencerWindows(bool show)
             if (info[x].IsOk() &&
                 savedPaneShown.find(info[x].name) != savedPaneShown.end() &&
                 savedPaneShown[info[x].name]) {
-                if (info[x].frame != nullptr)
+                if (info[x].frame != nullptr) {
                     info[x].frame->Show();
+                    // On macOS, Cocoa repositions native floating frames during
+                    // Hide()/Show() cycles. Mark update=true so m_mgr->Update()
+                    // reapplies floating_pos/floating_size from the pane info.
+                    update = true;
+                }
             }
         }
         savedPaneShown.clear();


### PR DESCRIPTION
Need to test this on the MAC build .. check that perspectives are restored and maintained switching from sequencer to layout and back.

[skip ci]