### PR TITLE
Add live filter to the Import Previews and Models dialog

### DIFF
--- a/src-ui-wx/model/ImportPreviewsModelsDialog.cpp
+++ b/src-ui-wx/model/ImportPreviewsModelsDialog.cpp
@@ -106,7 +106,7 @@ ImportPreviewsModelsDialog::ImportPreviewsModelsDialog(wxWindow* parent, const w
     FlexGridSizer2->Insert(0, _filterCtrl, 0, wxALL | wxEXPAND, 2);
     FlexGridSizer2->RemoveGrowableRow(0);
     FlexGridSizer2->AddGrowableRow(1);
-    _filterTimer.SetOwner(this);
+    _filterTimer.SetOwner(this, wxNewId());
     Bind(wxEVT_TIMER, [this](wxTimerEvent&) { PopulateTree(); }, _filterTimer.GetId());
     _filterCtrl->Bind(wxEVT_TEXT, [this](wxCommandEvent&) {
         _filter = _filterCtrl->GetValue().Lower().Trim().Trim(false);
@@ -115,7 +115,7 @@ ImportPreviewsModelsDialog::ImportPreviewsModelsDialog(wxWindow* parent, const w
     _filterCtrl->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN, [this](wxCommandEvent&) {
         _filterTimer.Stop();
         _filterCtrl->ChangeValue("");
-        _filter.clear();
+        _filter.Clear();
         PopulateTree();
     });
 
@@ -217,7 +217,7 @@ bool ImportPreviewsModelsDialog::MatchesFilter(const wxString& name, const wxStr
 {
     if (filterLower.empty()) return true;
     const wxString hay = name.Lower();
-    wxStringTokenizer tok(filterLower, " ");
+    wxStringTokenizer tok(filterLower);
     while (tok.HasMoreTokens()) {
         if (hay.Find(tok.GetNextToken()) == wxNOT_FOUND) return false;
     }
@@ -504,6 +504,7 @@ void ImportPreviewsModelsDialog::SelectAllModelGroups(bool checked)
 
 void ImportPreviewsModelsDialog::OnButton_CancelClick(wxCommandEvent& event)
 {
+    _filterTimer.Stop();
     EndDialog(wxID_CANCEL);
 }
 
@@ -514,7 +515,7 @@ void ImportPreviewsModelsDialog::OnButton_OkClick(wxCommandEvent& event)
     _filterTimer.Stop();
     if (!_filter.empty()) {
         if (_filterCtrl != nullptr) _filterCtrl->ChangeValue("");
-        _filter.clear();
+        _filter.Clear();
         PopulateTree();
     }
     EndDialog(wxID_OK);

--- a/src-ui-wx/model/ImportPreviewsModelsDialog.cpp
+++ b/src-ui-wx/model/ImportPreviewsModelsDialog.cpp
@@ -22,6 +22,8 @@
 #include <wx/menu.h>
 #include <wx/treebase.h>
 #include <wx/dataview.h>
+#include <wx/tokenzr.h>
+#include <vector>
 
 #include "layout/LayoutGroup.h"
 #include "UtilFunctions.h"
@@ -96,46 +98,29 @@ ImportPreviewsModelsDialog::ImportPreviewsModelsDialog(wxWindow* parent, const w
     Connect(idd, wxEVT_TREELIST_ITEM_CONTEXT_MENU, (wxObjectEventFunction)& ImportPreviewsModelsDialog::OnContextMenu);
     Connect(idd, wxEVT_COMMAND_TREELIST_ITEM_CHECKED, (wxObjectEventFunction)& ImportPreviewsModelsDialog::OnTreeListCtrlCheckboxtoggled);
 
-    wxTreeListItem defaultItem = TreeListCtrl1->AppendItem(TreeListCtrl1->GetRootItem(), "Default");
-    wxTreeListItem unassignedItem = TreeListCtrl1->AppendItem(TreeListCtrl1->GetRootItem(), "Unassigned");
+    // Live filter above the tree (manual code, no wxSmith/.wxs change needed).
+    // Debounced so typing in a large model list does not rebuild every keystroke.
+    _filterCtrl = new wxSearchCtrl(this, wxNewId());
+    _filterCtrl->ShowCancelButton(true);
+    _filterCtrl->SetDescriptiveText(_("Filter models"));
+    FlexGridSizer2->Insert(0, _filterCtrl, 0, wxALL | wxEXPAND, 2);
+    FlexGridSizer2->RemoveGrowableRow(0);
+    FlexGridSizer2->AddGrowableRow(1);
+    _filterTimer.SetOwner(this);
+    Bind(wxEVT_TIMER, [this](wxTimerEvent&) { PopulateTree(); }, _filterTimer.GetId());
+    _filterCtrl->Bind(wxEVT_TEXT, [this](wxCommandEvent&) {
+        _filter = _filterCtrl->GetValue().Lower().Trim().Trim(false);
+        _filterTimer.StartOnce(200);
+    });
+    _filterCtrl->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN, [this](wxCommandEvent&) {
+        _filterTimer.Stop();
+        _filterCtrl->ChangeValue("");
+        _filter.clear();
+        PopulateTree();
+    });
 
-    pugi::xml_parse_result parseResult = _doc.load_file(filename.ToStdString().c_str());
-    if (parseResult)
-    {
-        pugi::xml_node root = _doc.document_element();
-        pugi::xml_node models = root.child("models");
-        pugi::xml_node modelgroups = root.child("modelGroups");
-
-        if (models || modelgroups)
-        {
-            AddModels(TreeListCtrl1, defaultItem, models, modelgroups, "Default");
-            AddModels(TreeListCtrl1, unassignedItem, models, modelgroups, "Unassigned");
-
-            pugi::xml_node layoutGroupsNode = root.child("layoutGroups");
-            if (layoutGroupsNode)
-            {
-                for (pugi::xml_node nnn = layoutGroupsNode.first_child(); nnn; nnn = nnn.next_sibling())
-                {
-                    if (std::string_view(nnn.name()) == "layoutGroup") {
-                        wxString lg = nnn.attribute("name").as_string();
-                        if (lg != "")
-                        {
-                            wxTreeListItem t = TreeListCtrl1->AppendItem(TreeListCtrl1->GetRootItem(), lg);
-                            AddModels(TreeListCtrl1, t, models, modelgroups, lg);
-                        }
-                    }
-                }
-            }
-        }
-        
-        // set tree sort after it's populated or it is really slow when adding items above
-        TreeListCtrl1->Freeze();
-        TreeListCtrl1->SetItemComparator(&previewItemComparator);
-        TreeListCtrl1->SetSortColumn(0);
-        TreeListCtrl1->GetDataView()->GetModel()->Resort();
-        TreeListCtrl1->Thaw();
-        TreeListCtrl1->Refresh();
-    }
+    _doc.load_file(filename.ToStdString().c_str());
+    PopulateTree();
     ValidateWindow();
 
     Fit();
@@ -198,7 +183,7 @@ std::list<impTreeItemData*> ImportPreviewsModelsDialog::GetModelsInPreview(wxStr
 }
 
 
-void ImportPreviewsModelsDialog::AddModels(wxTreeListCtrl* tree, wxTreeListItem item, pugi::xml_node models, pugi::xml_node modelgroups, wxString preview)
+void ImportPreviewsModelsDialog::AddModels(wxTreeListCtrl* tree, wxTreeListItem item, pugi::xml_node models, pugi::xml_node modelgroups, wxString preview, const wxString& filter)
 {
     if (modelgroups)
     {
@@ -207,6 +192,7 @@ void ImportPreviewsModelsDialog::AddModels(wxTreeListCtrl* tree, wxTreeListItem 
             if (wxString(m.attribute("LayoutGroup").as_string()) == preview)
             {
                 wxString mn = m.attribute("name").as_string();
+                if (!MatchesFilter(mn, filter)) continue;
                 tree->AppendItem(item, mn + " - Group", -1, -1, new impTreeItemData(mn, m, true));
                 if (!tree->IsExpanded(item)) tree->Expand(item);
             }
@@ -219,11 +205,112 @@ void ImportPreviewsModelsDialog::AddModels(wxTreeListCtrl* tree, wxTreeListItem 
             if (wxString(m.attribute("LayoutGroup").as_string()) == preview)
             {
                 wxString mn = m.attribute("name").as_string();
+                if (!MatchesFilter(mn, filter)) continue;
                 tree->AppendItem(item, mn, -1, -1, new impTreeItemData(mn, m, false));
                 if (!tree->IsExpanded(item)) tree->Expand(item);
             }
         }
     }
+}
+
+bool ImportPreviewsModelsDialog::MatchesFilter(const wxString& name, const wxString& filterLower)
+{
+    if (filterLower.empty()) return true;
+    const wxString hay = name.Lower();
+    wxStringTokenizer tok(filterLower, " ");
+    while (tok.HasMoreTokens()) {
+        if (hay.Find(tok.GetNextToken()) == wxNOT_FOUND) return false;
+    }
+    return true;
+}
+
+void ImportPreviewsModelsDialog::SyncCheckedFromTree()
+{
+    // Merge the visible tree's check state into the persistent sets. Filtered-out
+    // rows aren't visited, so their checked state is retained.
+    for (wxTreeListItem p = TreeListCtrl1->GetFirstChild(TreeListCtrl1->GetRootItem()); p.IsOk(); p = TreeListCtrl1->GetNextSibling(p)) {
+        const std::string pk = TreeListCtrl1->GetItemText(p).ToStdString();
+        if (TreeListCtrl1->GetCheckedState(p) == wxCHK_CHECKED) _checkedPreviews.insert(pk);
+        else _checkedPreviews.erase(pk);
+        for (wxTreeListItem c = TreeListCtrl1->GetFirstChild(p); c.IsOk(); c = TreeListCtrl1->GetNextSibling(c)) {
+            auto* d = dynamic_cast<impTreeItemData*>(TreeListCtrl1->GetItemData(c));
+            if (d == nullptr) continue;
+            const std::string ck = d->GetName().ToStdString() + (d->IsModelGroup() ? "|G" : "|M");
+            if (TreeListCtrl1->GetCheckedState(c) == wxCHK_CHECKED) _checkedModels.insert(ck);
+            else _checkedModels.erase(ck);
+        }
+    }
+}
+
+void ImportPreviewsModelsDialog::RestoreChecksToTree()
+{
+    for (wxTreeListItem p = TreeListCtrl1->GetFirstChild(TreeListCtrl1->GetRootItem()); p.IsOk(); p = TreeListCtrl1->GetNextSibling(p)) {
+        if (_checkedPreviews.count(TreeListCtrl1->GetItemText(p).ToStdString()) != 0)
+            TreeListCtrl1->CheckItem(p, wxCHK_CHECKED);
+        for (wxTreeListItem c = TreeListCtrl1->GetFirstChild(p); c.IsOk(); c = TreeListCtrl1->GetNextSibling(c)) {
+            auto* d = dynamic_cast<impTreeItemData*>(TreeListCtrl1->GetItemData(c));
+            if (d == nullptr) continue;
+            const std::string ck = d->GetName().ToStdString() + (d->IsModelGroup() ? "|G" : "|M");
+            if (_checkedModels.count(ck) != 0) TreeListCtrl1->CheckItem(c, wxCHK_CHECKED);
+        }
+    }
+}
+
+void ImportPreviewsModelsDialog::PopulateTree()
+{
+    SyncCheckedFromTree();
+
+    TreeListCtrl1->Freeze();
+    TreeListCtrl1->DeleteAllItems();
+
+    pugi::xml_node root = _doc.document_element();
+    pugi::xml_node models = root.child("models");
+    pugi::xml_node modelgroups = root.child("modelGroups");
+
+    if (models || modelgroups) {
+        std::vector<wxTreeListItem> previews;
+        wxTreeListItem defaultItem = TreeListCtrl1->AppendItem(TreeListCtrl1->GetRootItem(), "Default");
+        wxTreeListItem unassignedItem = TreeListCtrl1->AppendItem(TreeListCtrl1->GetRootItem(), "Unassigned");
+        AddModels(TreeListCtrl1, defaultItem, models, modelgroups, "Default", _filter);
+        AddModels(TreeListCtrl1, unassignedItem, models, modelgroups, "Unassigned", _filter);
+        previews.push_back(defaultItem);
+        previews.push_back(unassignedItem);
+
+        pugi::xml_node layoutGroupsNode = root.child("layoutGroups");
+        if (layoutGroupsNode) {
+            for (pugi::xml_node nnn = layoutGroupsNode.first_child(); nnn; nnn = nnn.next_sibling()) {
+                if (std::string_view(nnn.name()) == "layoutGroup") {
+                    wxString lg = nnn.attribute("name").as_string();
+                    if (lg != "") {
+                        wxTreeListItem t = TreeListCtrl1->AppendItem(TreeListCtrl1->GetRootItem(), lg);
+                        AddModels(TreeListCtrl1, t, models, modelgroups, lg, _filter);
+                        previews.push_back(t);
+                    }
+                }
+            }
+        }
+
+        // While filtering, drop preview rows with no matching children.
+        if (!_filter.empty()) {
+            for (wxTreeListItem p : previews) {
+                if (!TreeListCtrl1->GetFirstChild(p).IsOk()) TreeListCtrl1->DeleteItem(p);
+            }
+        }
+    }
+
+    RestoreChecksToTree();
+
+    TreeListCtrl1->SetItemComparator(&previewItemComparator);
+    TreeListCtrl1->SetSortColumn(0);
+    TreeListCtrl1->GetDataView()->GetModel()->Resort();
+
+    if (!_filter.empty()) {
+        for (wxTreeListItem p = TreeListCtrl1->GetFirstChild(TreeListCtrl1->GetRootItem()); p.IsOk(); p = TreeListCtrl1->GetNextSibling(p))
+            TreeListCtrl1->Expand(p);
+    }
+
+    TreeListCtrl1->Thaw();
+    TreeListCtrl1->Refresh();
 }
 
 void ImportPreviewsModelsDialog::OnTreeListCtrlCheckboxtoggled(wxTreeListEvent& event)
@@ -422,20 +509,23 @@ void ImportPreviewsModelsDialog::OnButton_CancelClick(wxCommandEvent& event)
 
 void ImportPreviewsModelsDialog::OnButton_OkClick(wxCommandEvent& event)
 {
+    // Drop any active filter so the full tree (with every checked row) is present
+    // for the caller's GetPreviews()/GetModelsInPreview() to read.
+    _filterTimer.Stop();
+    if (!_filter.empty()) {
+        if (_filterCtrl != nullptr) _filterCtrl->ChangeValue("");
+        _filter.clear();
+        PopulateTree();
+    }
     EndDialog(wxID_OK);
 }
 
 void ImportPreviewsModelsDialog::ValidateWindow()
 {
-    for (wxTreeListItem it = TreeListCtrl1->GetFirstItem(); it.IsOk(); it = TreeListCtrl1->GetNextItem(it))
-    {
-        if (TreeListCtrl1->GetCheckedState(it) == wxCheckBoxState::wxCHK_CHECKED)
-        {
-            Button_Ok->Enable();
-            return;
-        }
-    }
-    Button_Ok->Disable();
+    // Drive the OK button off the persistent check sets so it stays correct even
+    // when checked rows are hidden by the current filter.
+    SyncCheckedFromTree();
+    Button_Ok->Enable(!_checkedModels.empty() || !_checkedPreviews.empty());
 }
 
 float ImportPreviewsModelsDialog::GetSourceRulerPerUnit() const

--- a/src-ui-wx/model/ImportPreviewsModelsDialog.h
+++ b/src-ui-wx/model/ImportPreviewsModelsDialog.h
@@ -18,7 +18,12 @@
 //*)
 
 #include <wx/treelist.h>
+#include <wx/srchctrl.h>
+#include <wx/timer.h>
 #include <pugixml.hpp>
+
+#include <set>
+#include <string>
 
 #include "models/ModelManager.h"
 
@@ -46,7 +51,13 @@ class ImportPreviewsModelsDialog: public wxDialog
     const std::map<std::string, std::unique_ptr<LayoutGroup>>& _layoutGroups;
 
     void ValidateWindow();
-    void AddModels(wxTreeListCtrl* tree, wxTreeListItem item, pugi::xml_node models, pugi::xml_node modelgroups, wxString preview);
+    void PopulateTree();
+    void AddModels(wxTreeListCtrl* tree, wxTreeListItem item, pugi::xml_node models, pugi::xml_node modelgroups, wxString preview, const wxString& filter);
+    static bool MatchesFilter(const wxString& name, const wxString& filterLower);
+    // Filtering rebuilds the tree, so checked state is kept in these sets
+    // (which survive filtered-out rows) and synced to/from the visible tree.
+    void SyncCheckedFromTree();
+    void RestoreChecksToTree();
     void SelectAll(bool checked);
     void SelectHighlighted(bool checked);
     void SelectRecursiveModel(wxString m, bool checked);
@@ -112,6 +123,12 @@ class ImportPreviewsModelsDialog: public wxDialog
         };
     
         PreviewItemComparator previewItemComparator;
+
+        wxSearchCtrl* _filterCtrl = nullptr;
+        wxString _filter; // lower-cased; whitespace-tokenised AND match
+        wxTimer _filterTimer; // debounce tree rebuilds while typing
+        std::set<std::string> _checkedModels;   // "name|G" (group) or "name|M" (model)
+        std::set<std::string> _checkedPreviews; // checked preview/layout-group rows
 
 		DECLARE_EVENT_TABLE()
 };


### PR DESCRIPTION
## Summary

Adds a live **filter box** above the model/group tree in the **Import Previews and Models** dialog, so users can quickly find props in a long list instead of scrolling. Matches the filtering UX already used in the vendor model catalog and the layout model tree.

## Behavior
- `wxSearchCtrl` above the tree (with clear button), **debounced ~200ms** so typing a large list doesn't rebuild the tree on every keystroke.
- **Whitespace-tokenized AND**, case-insensitive match on model **and** group names.
- Preview/layout-group rows with **no matching children are pruned**; surviving branches **auto-expand** while a filter is active; clearing the filter restores everything.

## Correctness (no lost selections)
`wxTreeListCtrl` can't hide rows, so the tree is **rebuilt** per filter. To avoid dropping the user's checkboxes:
- Checked state is held in **persistent sets** (`_checkedModels` / `_checkedPreviews`) synced from the visible tree on each rebuild (filtered-out rows retain their state) and restored after.
- **OK clears the filter first**, so the caller's `GetPreviews()` / `GetModelsInPreview()` see the full tree with every checked row.
- The **OK button** is driven off those sets, so it stays enabled when checked rows are scrolled out by the filter.

wx-platform-neutral (no `#ifdef`s); the filter control is added as manual code, so **no `.wxs` change** is needed.

## Test plan
- [x] macOS Release build
- [ ] Type "tree" / "star" / "mega" → tree narrows live, empty groups vanish, matches auto-expand
- [ ] ✕ / clearing the box restores the full tree
- [ ] Check a few models, filter them out of view, then OK → they still import
- [ ] OK stays enabled while checked rows are hidden by the filter; disabled when nothing is checked
- [ ] Existing context-menu actions (Select All, Select Highlighted, etc.) still work
- [ ] Verify on Windows/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)
