### PR TITLE
Fix media filenames containing commas being truncated when saved (#6638)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,7 +11,7 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.12  June ??, 2026
-    =enh (scott)                 Added new Tip of the Day info for recent release updated items
+    -enh (scott)                 Added new Tip of the Day info for recent release updated items
     -enh (derwin12)              Lua automation: expose all video export formats (High Quality MP4, Lossless RGB, ProRes 4444, HD ProRes) via exportModel / exportModelWithRender
     -change (dkulp)              Windows installer and executables are now Authenticode signed (Azure Trusted Signing), reducing SmartScreen/antivirus false positives
     -enh (scott)                 Moving Head effect: new Pattern tab generates pan/tilt from parametric shapes (Circle, Eight, Diamond, Lissajous, etc.) modeled on QLC+ EFX, with a value-curve-animatable rotation
@@ -34,6 +34,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -enh (AlexB)                 During a multi-effect drag, only the colliding ghost effects turn red instead of all of them (#6553)
     -enh (neil)                  Bulk Edit Rotate skips models whose type doesn't support that axis and reports the skipped models (#6521)
     -enh (derwin12)              Grey out Symmetrize/Combine Strands in the SubModels menu when they don't apply (#6554)
+    -bug (derwin12)              Fix video/image/shader filenames containing commas being truncated when saved (#6638)
     -bug (derwin12)              Wheel of Effects was not honoring the Reset Effects on Effect change nor setting defaults
     -bug (derwin12)              Fix floating sequencer panes shifting position on macOS after switching to the Layout tab and back (#6631)
     -bug (dkulp)                 Wait for renders to abort before deleting models/groups so a render worker can't crash on freed model data

--- a/src-ui-wx/effectpanels/EffectPanelUtils.cpp
+++ b/src-ui-wx/effectpanels/EffectPanelUtils.cpp
@@ -552,7 +552,10 @@ static wxString GetEffectStringFromWindow(wxWindow *ParentWin) {
         } else if (ChildName.StartsWith("ID_FILEPICKER") || ChildName.StartsWith("ID_0FILEPICKER")) {
             wxFilePickerCtrl* ctrl = (wxFilePickerCtrl*)ChildWin;
             ObtainAccessToURL(ctrl->GetFileName().GetFullPath());
-            s += AttrName + "=" + ctrl->GetFileName().GetFullPath() + ",";
+            wxString v = ctrl->GetFileName().GetFullPath();
+            v.Replace("&", "&amp;", true);
+            v.Replace(",", "&comma;", true);
+            s += AttrName + "=" + v + ",";
         } else if (ChildName.StartsWith("ID_NOTEBOOK") || ChildName.StartsWith("IDD_NOTEBOOK")) {
             wxNotebook* ctrl = (wxNotebook*)ChildWin;
             //for IDD_ stuff, don't record the value of the actual page selected

--- a/src-ui-wx/media/ManageMediaPanel.cpp
+++ b/src-ui-wx/media/ManageMediaPanel.cpp
@@ -497,6 +497,14 @@ bool MediaViewModel::IsGroup(const wxDataViewItem& item) const
     return node && node->isGroup;
 }
 
+MediaType MediaViewModel::GetMediaType(const wxDataViewItem& item) const
+{
+    if (!item.IsOk()) return MediaType::Image;
+    MediaNode* node = static_cast<MediaNode*>(item.GetID());
+    if (!node || node->isGroup) return MediaType::Image;
+    return node->mediaType;
+}
+
 void MediaViewModel::GetValue(wxVariant& variant, const wxDataViewItem& item, unsigned int col) const
 {
     if (!item.IsOk()) { variant = wxString(); return; }
@@ -1385,7 +1393,9 @@ void ManageMediaPanel::OnTreeContextMenu(wxDataViewEvent& event)
     }
 
     // Broken non-image media options (Shader, SVG, TextFile, BinaryFile, Video)
-    MediaType mtype = MediaTypeFromPath(path);
+    // Use the node's stored type rather than re-deriving from the extension, so
+    // paths with no extension (e.g. comma-truncated) are still handled correctly.
+    MediaType mtype = _model->GetMediaType(item);
     if (mtype != MediaType::Image && mtype != MediaType::Audio) {
         std::shared_ptr<MediaCacheEntry> entry;
         switch (mtype) {

--- a/src-ui-wx/media/ManageMediaPanel.h
+++ b/src-ui-wx/media/ManageMediaPanel.h
@@ -72,6 +72,7 @@ public:
     // Returns the file path for an item, or empty if it's a group node
     std::string GetFilePath(const wxDataViewItem& item) const;
     bool IsGroup(const wxDataViewItem& item) const;
+    MediaType GetMediaType(const wxDataViewItem& item) const;
     // Find the item for a given file path (invalid item if not found)
     wxDataViewItem FindItem(const std::string& filePath) const;
 


### PR DESCRIPTION
Also have it allow you to correct the Not Found file in the media panel as well.