### PR TITLE
Skip preset backup exist prompt if file is empty

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.13  July ??, 2026
+    -change (cybercop23)         Presets: skip newer preset backup file prompt if the backup contains no presets
     -enh (charlie)               Effect Symbols: define a reusable effect (name, color, settings, palette) once and
                                  link any number of effects to it. Editing a linked effect updates the symbol and
                                  propagates to every other linked effect. Symbols round-trip through .xsq and have a

--- a/src-core/effects/EffectPresetManager.cpp
+++ b/src-core/effects/EffectPresetManager.cpp
@@ -476,6 +476,25 @@ void EffectPresetManager::CollectPresetPaths(const EffectPresetGroup& group,
     }
 }
 
+bool EffectPresetManager::IsEmpty() const
+{
+    return !HasPresets(_root);
+}
+
+bool EffectPresetManager::HasPresets(const EffectPresetGroup& group) const
+{
+    for (const auto& child : group.GetChildren()) {
+        if (child->IsGroup()) {
+            if (HasPresets(static_cast<const EffectPresetGroup&>(*child))) {
+                return true;
+            }
+        } else {
+            return true;
+        }
+    }
+    return false;
+}
+
 EffectPresetItem* EffectPresetManager::FindItemByPath(const std::string& path,
                                                        char separator) const
 {

--- a/src-core/effects/EffectPresetManager.h
+++ b/src-core/effects/EffectPresetManager.h
@@ -148,6 +148,7 @@ public:
     const EffectPresetGroup& GetRoot() const { return _root; }
 
     // Queries
+    bool IsEmpty() const;
     std::vector<std::string> GetAllPresetPaths(const std::string& separator = "\\") const;
     EffectPresetItem* FindItemByPath(const std::string& path, char separator = '\\') const;
     EffectPreset* FindPresetByPath(const std::string& path, char separator = '\\') const;
@@ -174,6 +175,7 @@ private:
     void CollectPresetPaths(const EffectPresetGroup& group, const std::string& prefix,
                             const std::string& separator,
                             std::vector<std::string>& result) const;
+    bool HasPresets(const EffectPresetGroup& group) const;
     bool FixGroupNames(EffectPresetGroup& group);
 
     EffectPresetGroup _root;

--- a/src-ui-wx/app-shell/TabSequence.cpp
+++ b/src-ui-wx/app-shell/TabSequence.cpp
@@ -322,19 +322,26 @@ void xLightsFrame::LoadEffectsFile()
                 wxDateTime jsonTime = presetsFile.GetModificationTime();
                 wxDateTime bkpTime = presetsBkp.GetModificationTime();
                 if (bkpTime > jsonTime) {
-                    wxString msg = wxString::Format(
-                        "An autosaved effect presets file was found that is newer than your current file.\n\n"
-                        "Current file:  %s\n"
-                        "Autosave file: %s\n\n"
-                        "Would you like to use the autosave file instead?",
-                        jsonTime.Format("%Y-%m-%d %H:%M:%S"), bkpTime.Format("%Y-%m-%d %H:%M:%S"));
-                    if (wxMessageBox(msg, "Newer Autosave Presets File Found", wxYES_NO | wxICON_QUESTION) == wxYES) {
-                        wxRemoveFile(presetsFile.GetFullPath());
-                        wxRenameFile(presetsBkp.GetFullPath(), presetsFile.GetFullPath());
-                    } else {
-                        wxDateTime older = jsonTime;
-                        older -= wxTimeSpan(0, 0, 3, 0);
-                        presetsBkp.SetTimes(&older, &older, &older);
+                    bool bkpHasPresets = false;
+                    EffectPresetManager bkpManager;
+                    if (bkpManager.LoadJsonFile(presetsBkp.GetFullPath().ToStdString())) {
+                        bkpHasPresets = !bkpManager.IsEmpty();
+                    }
+                    if (bkpHasPresets) {
+                        wxString msg = wxString::Format(
+                            "An autosaved effect presets file was found that is newer than your current file.\n\n"
+                            "Current file:  %s\n"
+                            "Autosave file: %s\n\n"
+                            "Would you like to use the autosave file instead?",
+                            jsonTime.Format("%Y-%m-%d %H:%M:%S"), bkpTime.Format("%Y-%m-%d %H:%M:%S"));
+                        if (wxMessageBox(msg, "Newer Autosave Presets File Found", wxYES_NO | wxICON_QUESTION) == wxYES) {
+                            wxRemoveFile(presetsFile.GetFullPath());
+                            wxRenameFile(presetsBkp.GetFullPath(), presetsFile.GetFullPath());
+                        } else {
+                            wxDateTime older = jsonTime;
+                            older -= wxTimeSpan(0, 0, 3, 0);
+                            presetsBkp.SetTimes(&older, &older, &older);
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Currently, if xlights_effectpresets.jbkp exists, you get a prompt that a newer file exists. This checks if there are actually presets in the file. If the file is empty, it will skip the presets.
