### PR TITLE
Make KeyBindings generic not show folder specific (#6545)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -30,6 +30,10 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                  right-click single controller FPPConnect functionality
     -enh (cybercop23)            Show/base show folder settings moved to a Directories dialog opened from the
                                  Layout tab; controller list columns can be shown/hidden from the header
+    -enh (cybercop23)            Key bindings are now stored in both the show folder and the platform app-data
+                                 folder, kept in sync on every save, backup and restore; a new Preferences >
+                                 Other > "Use keybindings from" option (Show Folder / AppData-shared, default
+                                 Show Folder) controls which copy is authoritative
     -enh (heffneil)              Import Previews and Models: added a filter box above the tree to
                                  quickly find models/groups in a long list
     -enh (heffneil)              Vendor model download: added a live filter box above the catalog tree

--- a/src-ui-wx/app-shell/KeyBindings.cpp
+++ b/src-ui-wx/app-shell/KeyBindings.cpp
@@ -1117,6 +1117,9 @@ void KeyBindingMap::Load(const wxFileName &fileName) noexcept
 void KeyBindingMap::Save() const noexcept
 {
     Save(_openedFile);
+    if (_secondaryFile.IsOk() && _secondaryFile.GetFullPath() != _openedFile.GetFullPath()) {
+        Save(_secondaryFile);
+    }
 }
 
 int KeyBindingMap::AddKey(const KeyBinding& kb)

--- a/src-ui-wx/app-shell/KeyBindings.h
+++ b/src-ui-wx/app-shell/KeyBindings.h
@@ -152,6 +152,7 @@ public:
     void Load(const wxFileName& file) noexcept;
     void Save(const wxFileName& file) const noexcept;
     void Save() const noexcept;
+    void SetAdditionalSaveLocation(const wxFileName& file) noexcept { _secondaryFile = file; }
     int AddKey(const KeyBinding& kb);
     void DeleteKey(int id);
 
@@ -166,4 +167,5 @@ public:
 private:
     std::vector<KeyBinding> _bindings;
     wxFileName _openedFile;
+    wxFileName _secondaryFile;
 };

--- a/src-ui-wx/app-shell/TabSetup.cpp
+++ b/src-ui-wx/app-shell/TabSetup.cpp
@@ -440,8 +440,19 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
     spdlog::debug("    Networks updated.");
 
     wxFileName kbf;
-    kbf.AssignDir(CurrentDir);
+    kbf.AssignDir(GetSettingsFilePath().parent_path().string());
     kbf.SetFullName(XLIGHTS_KEYBINDING_FILE);
+
+    // One-time migration: copy from show folder to AppData if not yet there
+    if (!kbf.FileExists()) {
+        wxFileName legacy;
+        legacy.AssignDir(CurrentDir);
+        legacy.SetFullName(XLIGHTS_KEYBINDING_FILE);
+        if (legacy.FileExists()) {
+            wxCopyFile(legacy.GetFullPath(), kbf.GetFullPath());
+        }
+    }
+
     mainSequencer->keyBindings.Load(kbf);
 
     // Merge controllers from base show folder before loading effects file

--- a/src-ui-wx/app-shell/TabSetup.cpp
+++ b/src-ui-wx/app-shell/TabSetup.cpp
@@ -439,24 +439,21 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
     _outputModelManager.AddImmediateWork(OutputModelManager::WORK_UPDATE_NETWORK_LIST, "SetDir");
     spdlog::debug("    Networks updated.");
 
-    wxFileName kbf;
-    kbf.AssignDir(wxString(GetSettingsFilePath().parent_path().wstring()));
-    kbf.SetFullName(XLIGHTS_KEYBINDING_FILE);
+    wxFileName showFolderKbf;
+    showFolderKbf.AssignDir(CurrentDir);
+    showFolderKbf.SetFullName(XLIGHTS_KEYBINDING_FILE);
 
-    // One-time migration: copy from show folder to AppData if not yet there
-    if (!kbf.FileExists()) {
-        wxFileName legacy;
-        legacy.AssignDir(CurrentDir);
-        legacy.SetFullName(XLIGHTS_KEYBINDING_FILE);
-        if (legacy.FileExists()) {
-            if (!wxCopyFile(legacy.GetFullPath(), kbf.GetFullPath())) {
-                spdlog::warn("Failed to migrate key bindings from show folder to AppData: {}",
-                             legacy.GetFullPath().ToStdString());
-            }
-        }
-    }
+    wxFileName appDataKbf;
+    appDataKbf.AssignDir(wxString(GetSettingsFilePath().parent_path().wstring()));
+    appDataKbf.SetFullName(XLIGHTS_KEYBINDING_FILE);
 
-    mainSequencer->keyBindings.Load(kbf);
+    // Key bindings can live in the show folder and/or AppData
+    bool useAppData = (GetKeybindingsLocation() == "AppData-shared");
+    const wxFileName& preferredKbf = useAppData ? appDataKbf : showFolderKbf;
+    const wxFileName& otherKbf = useAppData ? showFolderKbf : appDataKbf;
+
+    mainSequencer->keyBindings.SetAdditionalSaveLocation(otherKbf);
+    mainSequencer->keyBindings.Load(preferredKbf);
 
     // Merge controllers from base show folder before loading effects file
     // (model/view object XML merging now happens inside LoadEffectsFile before LoadModels)

--- a/src-ui-wx/app-shell/TabSetup.cpp
+++ b/src-ui-wx/app-shell/TabSetup.cpp
@@ -451,7 +451,7 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
         if (legacy.FileExists()) {
             if (!wxCopyFile(legacy.GetFullPath(), kbf.GetFullPath())) {
                 spdlog::warn("Failed to migrate key bindings from show folder to AppData: {}",
-                             (const char*)legacy.GetFullPath().c_str());
+                             legacy.GetFullPath().ToStdString());
             }
         }
     }

--- a/src-ui-wx/app-shell/TabSetup.cpp
+++ b/src-ui-wx/app-shell/TabSetup.cpp
@@ -440,7 +440,7 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
     spdlog::debug("    Networks updated.");
 
     wxFileName kbf;
-    kbf.AssignDir(GetSettingsFilePath().parent_path().string());
+    kbf.AssignDir(wxString(GetSettingsFilePath().parent_path().wstring()));
     kbf.SetFullName(XLIGHTS_KEYBINDING_FILE);
 
     // One-time migration: copy from show folder to AppData if not yet there
@@ -449,7 +449,10 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
         legacy.AssignDir(CurrentDir);
         legacy.SetFullName(XLIGHTS_KEYBINDING_FILE);
         if (legacy.FileExists()) {
-            wxCopyFile(legacy.GetFullPath(), kbf.GetFullPath());
+            if (!wxCopyFile(legacy.GetFullPath(), kbf.GetFullPath())) {
+                spdlog::warn("Failed to migrate key bindings from show folder to AppData: {}",
+                             (const char*)legacy.GetFullPath().c_str());
+            }
         }
     }
 

--- a/src-ui-wx/preferences/OtherSettingsPanel.cpp
+++ b/src-ui-wx/preferences/OtherSettingsPanel.cpp
@@ -48,6 +48,8 @@ const wxWindowID OtherSettingsPanel::ID_STATICTEXT2 = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_CHOICE2 = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_STATICTEXT6 = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_CHOICE_ALIASPROMPT = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_STATICTEXT8 = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHOICE_KEYBINDINGSLOCATION = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_TEXTCTRL1 = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_CHECKBOX9 = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_STATICTEXT7 = wxNewId();
@@ -75,6 +77,7 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     wxFlexGridSizer* FlexGridSizer6;
     wxFlexGridSizer* FlexGridSizer7;
     wxFlexGridSizer* FlexGridSizer8;
+    wxFlexGridSizer* FlexGridSizer9;
     wxGridBagSizer* GridBagSizer1;
     wxGridBagSizer* GridBagSizer2;
     wxStaticBoxSizer* StaticBoxSizer1;
@@ -173,6 +176,14 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     Choice_AliasPromptBehavior->Append(_("Always No"));
     FlexGridSizer7->Add(Choice_AliasPromptBehavior, 1, wxALL|wxEXPAND, 5);
     GridBagSizer1->Add(FlexGridSizer7, wxGBPosition(8, 0), wxDefaultSpan, wxALL|wxEXPAND, 0);
+    FlexGridSizer9 = new wxFlexGridSizer(0, 2, 0, 0);
+    StaticText9 = new wxStaticText(this, ID_STATICTEXT8, _("Use keybindings from:"), wxDefaultPosition, wxDefaultSize, 0, _T("ID_STATICTEXT8"));
+    FlexGridSizer9->Add(StaticText9, 1, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 5);
+    Choice_KeybindingsLocation = new wxChoice(this, ID_CHOICE_KEYBINDINGSLOCATION, wxDefaultPosition, wxDefaultSize, 0, 0, 0, wxDefaultValidator, _T("ID_CHOICE_KEYBINDINGSLOCATION"));
+    Choice_KeybindingsLocation->SetSelection( Choice_KeybindingsLocation->Append(_("Show Folder")) );
+    Choice_KeybindingsLocation->Append(_("AppData-shared"));
+    FlexGridSizer9->Add(Choice_KeybindingsLocation, 1, wxALL|wxEXPAND, 5);
+    GridBagSizer1->Add(FlexGridSizer9, wxGBPosition(6, 0), wxDefaultSpan, wxALL|wxEXPAND, 0);
     FlexGridSizer6 = new wxFlexGridSizer(0, 2, 0, 0);
     StaticText1 = new wxStaticText(this, wxID_ANY, _("eMail Address:"), wxDefaultPosition, wxDefaultSize, 0, _T("wxID_ANY"));
     FlexGridSizer6->Add(StaticText1, 1, wxALL|wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL, 5);
@@ -220,6 +231,7 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     Connect(ID_CHECKBOX8, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
     Connect(ID_CHOICE2, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
     Connect(ID_CHOICE_ALIASPROMPT, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    Connect(ID_CHOICE_KEYBINDINGSLOCATION, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
     Connect(ID_TEXTCTRL1, wxEVT_COMMAND_TEXT_UPDATED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
     Connect(ID_TEXTCTRL1, wxEVT_COMMAND_TEXT_ENTER, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
     Connect(ID_CHECKBOX9, wxEVT_COMMAND_CHECKBOX_CLICKED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
@@ -290,6 +302,7 @@ bool OtherSettingsPanel::TransferDataFromWindow() {
     frame->SetShadersOnBackgroundThreads(ShaderCheckbox->IsChecked());
     frame->SetUserEMAIL(eMailTextControl->GetValue());
     frame->SetRenameModelAliasPromptBehavior(Choice_AliasPromptBehavior->GetStringSelection());
+    frame->SetKeybindingsLocation(Choice_KeybindingsLocation->GetStringSelection());
 	frame->SetPromptBatchRenderIssues(CheckBox_BatchRenderPromptIssues->GetValue());
 	frame->SetIgnoreVendorModelRecommendations(CheckBox_IgnoreVendorModelRecommendations->GetValue());
     frame->SetControllerPingInterval(CtrlPingInterval->GetValue());
@@ -324,6 +337,7 @@ bool OtherSettingsPanel::TransferDataToWindow() {
     eMailTextControl->ChangeValue(frame->UserEMAIL());
 	Choice_LinkControllerUpload->SetStringSelection(frame->GetLinkedControllerUpload());
     Choice_AliasPromptBehavior->SetStringSelection(frame->GetRenameModelAliasPromptBehavior());
+    Choice_KeybindingsLocation->SetStringSelection(frame->GetKeybindingsLocation());
 	CheckBox_BatchRenderPromptIssues->SetValue(frame->GetPromptBatchRenderIssues());
 	CheckBox_IgnoreVendorModelRecommendations->SetValue(frame->GetIgnoreVendorModelRecommendations());
     CtrlPingInterval->SetValue(frame->GetControllerPingInterval());

--- a/src-ui-wx/preferences/OtherSettingsPanel.h
+++ b/src-ui-wx/preferences/OtherSettingsPanel.h
@@ -47,6 +47,7 @@ class OtherSettingsPanel: public wxPanel
 		wxCheckBox* ShaderCheckbox;
 		wxChoice* ChoiceCodec;
 		wxChoice* Choice_AliasPromptBehavior;
+		wxChoice* Choice_KeybindingsLocation;
 		wxChoice* Choice_LinkControllerUpload;
 		wxChoice* Choice_MinTipLevel;
 		wxChoice* HardwareVideoRenderChoice;
@@ -58,6 +59,7 @@ class OtherSettingsPanel: public wxPanel
 		wxStaticText* StaticText6;
 		wxStaticText* StaticText7;
 		wxStaticText* StaticText8;
+		wxStaticText* StaticText9;
 		wxTextCtrl* eMailTextControl;
 		//*)
 		// Hand-added (outside the wxSmith guards): preview graphics backend
@@ -89,6 +91,8 @@ class OtherSettingsPanel: public wxPanel
 		static const wxWindowID ID_CHOICE2;
 		static const wxWindowID ID_STATICTEXT6;
 		static const wxWindowID ID_CHOICE_ALIASPROMPT;
+		static const wxWindowID ID_STATICTEXT8;
+		static const wxWindowID ID_CHOICE_KEYBINDINGSLOCATION;
 		static const wxWindowID ID_TEXTCTRL1;
 		static const wxWindowID ID_CHECKBOX9;
 		static const wxWindowID ID_STATICTEXT7;

--- a/src-ui-wx/settings/XLightsConfigAdapter.cpp
+++ b/src-ui-wx/settings/XLightsConfigAdapter.cpp
@@ -30,7 +30,7 @@ XLightsConfigAdapter* GetXLightsBookmarksConfig()  { return &s_bookmarksConfig; 
 // ---------------------------------------------------------------------------
 // Platform-specific AppData path
 // ---------------------------------------------------------------------------
-static std::filesystem::path GetSettingsFilePath()
+std::filesystem::path GetSettingsFilePath()
 {
     std::filesystem::path dir;
 

--- a/src-ui-wx/settings/XLightsConfigAdapter.h
+++ b/src-ui-wx/settings/XLightsConfigAdapter.h
@@ -97,6 +97,9 @@ XLightsConfigAdapter* GetXLightsBookmarksConfig();
 /// Determines AppData path, loads JSON, and imports legacy wxConfig on first run.
 void InitializeXLightsConfig();
 
+/// Returns the path to the xLights settings file (settings.json in the platform AppData dir).
+std::filesystem::path GetSettingsFilePath();
+
 /// Returns the path to the xLights log file.
 std::filesystem::path GetLogFilePath();
 std::filesystem::path GetLogFileFolder();

--- a/src-ui-wx/wxsmith/OtherSettingsPanel.wxs
+++ b/src-ui-wx/wxsmith/OtherSettingsPanel.wxs
@@ -301,6 +301,36 @@
 				<option>1</option>
 			</object>
 			<object class="sizeritem">
+				<object class="wxFlexGridSizer" variable="FlexGridSizer9" member="no">
+					<cols>2</cols>
+					<object class="sizeritem">
+						<object class="wxStaticText" name="ID_STATICTEXT8" variable="StaticText9" member="yes">
+							<label>Use keybindings from:</label>
+						</object>
+						<flag>wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+					<object class="sizeritem">
+						<object class="wxChoice" name="ID_CHOICE_KEYBINDINGSLOCATION" variable="Choice_KeybindingsLocation" member="yes">
+							<content>
+								<item>Show Folder</item>
+								<item>AppData-shared</item>
+							</content>
+							<selection>0</selection>
+							<handler function="OnControlChanged" entry="EVT_CHOICE" />
+						</object>
+						<flag>wxALL|wxEXPAND</flag>
+						<border>5</border>
+						<option>1</option>
+					</object>
+				</object>
+				<col>0</col>
+				<row>6</row>
+				<flag>wxALL|wxEXPAND</flag>
+				<option>1</option>
+			</object>
+			<object class="sizeritem">
 				<object class="wxFlexGridSizer" variable="FlexGridSizer6" member="no">
 					<cols>2</cols>
 					<object class="sizeritem">

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -3265,7 +3265,7 @@ void xLightsFrame::DoBackup(bool prompt, bool startup, bool forceallfiles)
             wxString kbfDest = newDir + GetPathSeparator() + XLIGHTS_KEYBINDING_FILE;
             if (!wxCopyFile(appDataKbf.GetFullPath(), kbfDest)) {
                 spdlog::warn("Failed to backup key bindings from AppData: {}",
-                             (const char*)appDataKbf.GetFullPath().c_str());
+                             appDataKbf.GetFullPath().ToStdString());
             }
         }
     }

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -1768,6 +1768,10 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     config->Read("xLightsEnablePositionZones", &_enablePositionZones, true);
     config->Read("xLightsShowZoneIndicator", &_showZoneIndicator, false);
 
+    // Read before the initial SetDir() call below so the preference is honored on the first show folder load.
+    config->Read("xLightsKeybindingsLocation", &_keybindingsLocation, "Show Folder");
+    spdlog::debug("Keybindings location: {}.", _keybindingsLocation.ToStdString());
+
     config->Read("xLightsVideoExportCodec", &_videoExportCodec, "H.264");
     spdlog::debug("Video Export Codec: {}.", (const char*)_videoExportCodec.c_str());
 
@@ -3256,16 +3260,21 @@ void xLightsFrame::DoBackup(bool prompt, bool startup, bool forceallfiles)
     std::string errors = "";
     BackupDirectory(CurrentDir, newDir, newDir, forceallfiles, _backupSubfolders, errors);
 
-    // Key bindings live in AppData, not the show folder — copy them into the backup too
+    // Key bindings can live in the show folder and/or AppData
     {
-        wxFileName appDataKbf;
-        appDataKbf.AssignDir(wxString(GetSettingsFilePath().parent_path().wstring()));
-        appDataKbf.SetFullName(XLIGHTS_KEYBINDING_FILE);
-        if (appDataKbf.FileExists()) {
+        bool useAppData = (GetKeybindingsLocation() == "AppData-shared");
+        wxFileName preferredKbf;
+        preferredKbf.AssignDir(useAppData ? wxString(GetSettingsFilePath().parent_path().wstring()) : CurrentDir);
+        preferredKbf.SetFullName(XLIGHTS_KEYBINDING_FILE);
+        wxFileName otherKbf;
+        otherKbf.AssignDir(useAppData ? CurrentDir : wxString(GetSettingsFilePath().parent_path().wstring()));
+        otherKbf.SetFullName(XLIGHTS_KEYBINDING_FILE);
+
+        wxFileName backupSource = FileExists(preferredKbf) ? preferredKbf : otherKbf;
+        if (FileExists(backupSource)) {
             wxString kbfDest = newDir + GetPathSeparator() + XLIGHTS_KEYBINDING_FILE;
-            if (!wxCopyFile(appDataKbf.GetFullPath(), kbfDest)) {
-                spdlog::warn("Failed to backup key bindings from AppData: {}",
-                             appDataKbf.GetFullPath().ToStdString());
+            if (!wxCopyFile(backupSource.GetFullPath(), kbfDest)) {
+                spdlog::warn("Failed to backup key bindings from {}", backupSource.GetFullPath().ToStdString());
             }
         }
     }
@@ -8604,12 +8613,40 @@ void xLightsFrame::SetUserEMAIL(const wxString& e)
 
 void xLightsFrame::SetRenameModelAliasPromptBehavior(const wxString& e)
 {
-    
+
     _aliasRenameBehavior = e;
     auto* config = GetXLightsConfig();
     config->Write("xLightsModelRename", _aliasRenameBehavior);
     config->Flush();
     spdlog::info("Rename Alias Prompt Behavior set to {}", _aliasRenameBehavior.ToStdString());
+}
+
+void xLightsFrame::SetKeybindingsLocation(const wxString& e)
+{
+    // If switching to a location that has no keybindings file yet, seed it with a
+    // one-time copy from the other (existing) location, so we don't lose bindings
+    bool useAppData = (e == "AppData-shared");
+    wxFileName showFolderKbf;
+    showFolderKbf.AssignDir(CurrentDir);
+    showFolderKbf.SetFullName(XLIGHTS_KEYBINDING_FILE);
+    wxFileName appDataKbf;
+    appDataKbf.AssignDir(wxString(GetSettingsFilePath().parent_path().wstring()));
+    appDataKbf.SetFullName(XLIGHTS_KEYBINDING_FILE);
+
+    const wxFileName& newKbf = useAppData ? appDataKbf : showFolderKbf;
+    const wxFileName& otherKbf = useAppData ? showFolderKbf : appDataKbf;
+    if (!FileExists(newKbf) && FileExists(otherKbf)) {
+        if (!wxCopyFile(otherKbf.GetFullPath(), newKbf.GetFullPath())) {
+            spdlog::warn("Failed to seed key bindings file {} from {}",
+                         newKbf.GetFullPath().ToStdString(), otherKbf.GetFullPath().ToStdString());
+        }
+    }
+
+    _keybindingsLocation = e;
+    auto* config = GetXLightsConfig();
+    config->Write("xLightsKeybindingsLocation", _keybindingsLocation);
+    config->Flush();
+    spdlog::info("Keybindings location set to {}", _keybindingsLocation.ToStdString());
 }
 
 void xLightsFrame::CollectUserEmail()
@@ -9041,13 +9078,20 @@ void xLightsFrame::OnMenuItemRestoreBackupSelected(wxCommandEvent& event)
         std::string errors;
         for (auto const& file : restoreFiles) {
             prgs.Pulse("Restoring '" + file + "'...");
-            // Key bindings are stored in AppData, not the show folder
-            wxString destDir = showDirectory;
             if (file == XLIGHTS_KEYBINDING_FILE) {
-                destDir = wxString(GetSettingsFilePath().parent_path().wstring());
+                // Key bindings are kept in sync in both the show folder and AppData
+                wxString appDataDir = wxString(GetSettingsFilePath().parent_path().wstring());
+                bool successShowFolder = wxCopyFile(restoreFolder + GetPathSeparator() + file,
+                                                     showDirectory + GetPathSeparator() + file);
+                bool successAppData = wxCopyFile(restoreFolder + GetPathSeparator() + file,
+                                                  appDataDir + GetPathSeparator() + file);
+                if (!successShowFolder || !successAppData) {
+                    errors += "Unable to copy file \"" + file + "\"\n";
+                }
+                continue;
             }
             bool success = wxCopyFile(restoreFolder + GetPathSeparator() + file,
-                                      destDir + GetPathSeparator() + file);
+                                      showDirectory + GetPathSeparator() + file);
             if (!success) {
                 errors += "Unable to copy file \"" + file + "\"\n";
             }

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -3256,6 +3256,20 @@ void xLightsFrame::DoBackup(bool prompt, bool startup, bool forceallfiles)
     std::string errors = "";
     BackupDirectory(CurrentDir, newDir, newDir, forceallfiles, _backupSubfolders, errors);
 
+    // Key bindings live in AppData, not the show folder — copy them into the backup too
+    {
+        wxFileName appDataKbf;
+        appDataKbf.AssignDir(wxString(GetSettingsFilePath().parent_path().wstring()));
+        appDataKbf.SetFullName(XLIGHTS_KEYBINDING_FILE);
+        if (appDataKbf.FileExists()) {
+            wxString kbfDest = newDir + GetPathSeparator() + XLIGHTS_KEYBINDING_FILE;
+            if (!wxCopyFile(appDataKbf.GetFullPath(), kbfDest)) {
+                spdlog::warn("Failed to backup key bindings from AppData: {}",
+                             (const char*)appDataKbf.GetFullPath().c_str());
+            }
+        }
+    }
+
     if (errors != "") {
         DisplayError(errors, this);
     }
@@ -9027,8 +9041,13 @@ void xLightsFrame::OnMenuItemRestoreBackupSelected(wxCommandEvent& event)
         std::string errors;
         for (auto const& file : restoreFiles) {
             prgs.Pulse("Restoring '" + file + "'...");
+            // Key bindings are stored in AppData, not the show folder
+            wxString destDir = showDirectory;
+            if (file == XLIGHTS_KEYBINDING_FILE) {
+                destDir = wxString(GetSettingsFilePath().parent_path().wstring());
+            }
             bool success = wxCopyFile(restoreFolder + GetPathSeparator() + file,
-                                      showDirectory + GetPathSeparator() + file);
+                                      destDir + GetPathSeparator() + file);
             if (!success) {
                 errors += "Unable to copy file \"" + file + "\"\n";
             }

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -428,6 +428,7 @@ public:
     wxString _userEmail;
     wxString _linkedControllerUpload = "None";
     wxString _aliasRenameBehavior = "Always Prompt";
+    wxString _keybindingsLocation = "Show Folder";
     static wxString CurrentDir; //expose current folder name -DJ
     static wxString FseqDir; //expose current fseq name
     static wxString PlaybackMarker; //keep track of where we are within grid -DJ
@@ -1226,6 +1227,9 @@ public:
     
     std::string GetRenameModelAliasPromptBehavior() const override { return _aliasRenameBehavior.ToStdString(); }
     void SetRenameModelAliasPromptBehavior(const wxString& e);
+
+    const wxString& GetKeybindingsLocation() const { return _keybindingsLocation; }
+    void SetKeybindingsLocation(const wxString& e);
 
     int SaveFSEQVersion() const { return _fseqVersion; }
     void SetSaveFSEQVersion(int i) { _fseqVersion = i; }


### PR DESCRIPTION
Also, include in startup backup and restore to AppData when restoring