### PR TITLE
Fix indefinite hang changing a linked Effect Symbol effect's color to a gradient

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,10 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.13  July ??, 2026
+    -bug (charlie)               Fix the app hanging indefinitely when changing a color to a gradient/color
+                                 curve on an effect linked to an Effect Symbol - symbol propagation re-rendered
+                                 linked effects synchronously while holding the effect's settings lock,
+                                 deadlocking the render workers; the re-render is now posted to the event loop
     -enh (dkulp)                 macOS/iPad: the Shader effect now renders natively on Metal (shaders are
                                  translated GLSL -> SPIR-V -> Metal at load and cached) instead of through
                                  OpenGL/ANGLE - faster, no longer depends on the deprecated OpenGL stack, and

--- a/src-core/render/Effect.cpp
+++ b/src-core/render/Effect.cpp
@@ -528,7 +528,11 @@ void Effect::IncrementChangeCount()
                             if (effect != this && effect != nullptr) {
                                 EffectLayer* el = effect->GetParentEffectLayer();
                                 if (el != nullptr && el->GetParentElement() != nullptr) {
-                                    ctx->RenderEffectForModel(
+                                    // Async: must NOT render synchronously here — we hold
+                                    // this effect's settingsLock, and the render workers
+                                    // would deadlock waiting for it (the indefinite hang
+                                    // when changing a linked effect's color to a gradient).
+                                    ctx->RequestRenderForModel(
                                         el->GetParentElement()->GetModelName(),
                                         effect->GetStartTimeMS(),
                                         effect->GetEndTimeMS());

--- a/src-core/render/RenderContext.h
+++ b/src-core/render/RenderContext.h
@@ -76,6 +76,20 @@ public:
                                       int startms,
                                       int endms,
                                       bool clear = false) = 0;
+
+    // Request a re-render WITHOUT rendering synchronously on the caller's
+    // thread. RenderEffectForModel runs the render pipeline inline and is only
+    // safe at the top of the event loop; calling it from deep inside a settings
+    // mutation (e.g. Effect::IncrementChangeCount, which holds the effect's
+    // settingsLock) deadlocks against the render worker threads that need that
+    // lock. The desktop overrides this to post the render to the event loop so
+    // it runs once the lock is released. Headless contexts render synchronously
+    // by design, so the default falls back to RenderEffectForModel.
+    virtual void RequestRenderForModel(const std::string& model,
+                                       int startms,
+                                       int endms) {
+        RenderEffectForModel(model, startms, endms);
+    }
     virtual TimingElement* AddTimingElement(const std::string& name,
                                             const std::string& subType = "") = 0;
 

--- a/src-ui-wx/render/RenderUI.cpp
+++ b/src-ui-wx/render/RenderUI.cpp
@@ -125,6 +125,17 @@ void xLightsFrame::RenderEffectForModel(const std::string &model, int startms, i
                                         _suspendRender, modelsChangeCount, clear);
 }
 
+void xLightsFrame::RequestRenderForModel(const std::string &model, int startms, int endms) {
+    // Post the render to the event loop instead of running it inline. Callers
+    // such as Effect::IncrementChangeCount (effect-symbol propagation) invoke
+    // this while holding an effect's settingsLock; rendering synchronously there
+    // deadlocks the render workers. EVT_RENDER_RANGE is handled by RenderRange
+    // at the top of the event loop once the lock has been released.
+    if (_suspendRender) return;
+    RenderCommandEvent event(model, startms, endms, false, false);
+    wxPostEvent(this, event);
+}
+
 // ---------------------------------------------------------------------------
 // RenderRange — dispatches RenderCommandEvent to the appropriate engine call
 // ---------------------------------------------------------------------------

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -1632,6 +1632,7 @@ public:
     void UpdateRenderStatus();
     void LogRenderStatus();
     void RenderEffectForModel(const std::string &model, int startms, int endms, bool clear = false) override;
+    void RequestRenderForModel(const std::string &model, int startms, int endms) override;
     void RenderTimeSlice(int startms, int endms, bool clear);
 
     void RenderRange(RenderCommandEvent &cmd);


### PR DESCRIPTION
## Problem

With Effect Symbols (#6260), changing a color to a **gradient/color curve** on an effect that is linked to a symbol hangs the app indefinitely (beach ball on macOS).

Symbol propagation re-renders every linked effect **synchronously** from inside `Effect::IncrementChangeCount()`, which runs while the effect's `settingsLock` is held. The render worker threads need that lock to read the effect's settings, so they deadlock against the UI thread. Solid colors usually escape it because their serialized settings round-trip identically and short-circuit propagation; gradients/color curves do not.

## Fix

- Add `RenderContext::RequestRenderForModel()` — a "request a re-render, don't render inline" entry point. The default implementation falls back to the synchronous `RenderEffectForModel()` so headless contexts keep their by-design synchronous behavior.
- `xLightsFrame` overrides it to post a `RenderCommandEvent` (`EVT_RENDER_RANGE`) to the event loop, so the render runs at the top of the event loop after the settings lock has been released.
- Symbol propagation in `Effect::IncrementChangeCount()` now uses `RequestRenderForModel()`.

## Repro (before this fix)

1. New sequence, add any effect (e.g. On) to a model
2. Right-click the effect → create an Effect Symbol from it; add a second effect linked to the same symbol
3. Select one linked effect and change a palette color to a **gradient** or color curve
4. App hangs indefinitely (render pool deadlocked); with a solid color it does not

## Testing

- Built and verified on macOS (Debug) against current master
- Gradient/color-curve edits on symbol-linked effects propagate and re-render without hanging; headless render unaffected (uses the synchronous fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)