### PR TITLE
Identify base and locked items in layout tab

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -25,6 +25,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                  cores by compressing seekable blocks in parallel instead of single threaded
     -enh (cybercop23)            Effect Presets now track unsaved changes independently from the RGB effects file.
                                  Preset-only edits no longer mark the RGB effects file dirty.
+    -enh (cybercop23)            Show a chain-link icon for models linked from a base show folder and a lock icon for locked models
     -enh (dkulp)                 Linux/Windows: GPU-accelerated rendering (Vulkan) for blur, rotozoom, transitions,
                                  layer blending and most effects, mirroring the Metal backend on macOS; falls back
                                  to CPU when no Vulkan driver is present.  Enable via Preferences > Other > GPU rendering

--- a/plans/ipad-parity/06-layout-models-preview.md
+++ b/plans/ipad-parity/06-layout-models-preview.md
@@ -58,7 +58,7 @@
 | Move/Rotate/Scale tool picker + axis lock | toolbar | 🟡 | ✅ | desktop-missing | P2 | medium | feasible | iPad LayoutEditorToolToolbar (touch idiom). Desktop uses centre-cycle + direct gizmo handles. |
 | 3D transform gizmo with axis tools (move/scale/rotate/elevate) | gesture | ✅ | 🟡 | ipad-weaker | P2 | hard | feasible | iPad ray-cast 3D drag follows gizmo + cycleAxisTool (XLMetalBridge.h:246-247, :276); handle set narrower than desktop's per-axis grab handles. |
 | Model position/size property fields (X/Y/Z/W/H/D/rot) | panel | ✅ | ✅ | parity | P1 | easy | feasible | iPad descriptor-driven, branches by ScreenLocation kind (two/three-point endpoints vs boxed). |
-| Model lock / unlock | panel | ✅ | ✅ | parity | P1 | easy | feasible | iPad lockedBinding toggle + desktop menu/keybinding. |
+| Model lock / unlock | panel | ✅ | ✅ | parity | P1 | easy | feasible | iPad lockedBinding toggle + desktop menu/keybinding. Both roster lists now surface lock state visually: desktop LayoutPanel tree has a dedicated Info column (chain-link + padlock icons, LayoutPanel.cpp); iPad's shared `rosterRow` (LayoutEditorView.swift) shows a `lock.fill` badge next to the existing base-link badge for locked/base-linked Models, Groups, and Objects, reusing the existing `"locked"` summary key (XLSequenceDocument.mm). |
 | Model description / memo | panel | ✅ | ✅ | parity | P2 | easy | feasible | Both editable. |
 | Model rename | dialog | ✅ | ✅ | parity | P1 | easy | feasible | iPad renameModel + rename sheet. |
 | Model duplicate | toolbar/menu | 🟡 | ✅ | parity | P2 | medium | feasible | iPad explicit Duplicate (XLMetalBridge.duplicateModels, +offset). Desktop has Copy/Paste, no 1-click Duplicate. |

--- a/src-iPad/App/LayoutEditorView.swift
+++ b/src-iPad/App/LayoutEditorView.swift
@@ -1144,8 +1144,10 @@ struct LayoutEditorView: View {
                         let firstCh    = (s["firstChannel"] as? NSNumber)?.uint32Value ?? 0
                         let lastCh     = (s["lastChannel"]  as? NSNumber)?.uint32Value ?? 0
                         let fromBase   = (s["isFromBase"]   as? NSNumber)?.boolValue ?? false
+                        let locked     = (s["locked"]       as? NSNumber)?.boolValue ?? false
                         rosterRow(name: name,
                                   isFromBase: fromBase,
+                                  isLocked: locked,
                                   leadingSystemImage: Self.modelTypeSFSymbol(forDisplayAs: displayAs),
                                   secondary: Self.modelRowSecondary(scString: scString,
                                                                      firstCh: firstCh,
@@ -1178,8 +1180,10 @@ struct LayoutEditorView: View {
                         let style    = (s["layoutStyle"] as? String) ?? ""
                         let gridSize = (s["gridSize"]   as? NSNumber)?.intValue ?? 0
                         let fromBase = (s["isFromBase"] as? NSNumber)?.boolValue ?? false
+                        let locked   = (s["locked"]     as? NSNumber)?.boolValue ?? false
                         rosterRow(name: name,
                                   isFromBase: fromBase,
+                                  isLocked: locked,
                                   leadingSystemImage: "square.stack.3d.up",
                                   secondary: Self.groupRowSecondary(modelCount: count,
                                                                      layoutStyle: style,
@@ -1250,6 +1254,7 @@ struct LayoutEditorView: View {
                         let s = objectSummaries[name] ?? [:]
                         let displayAs = (s["displayAs"] as? String) ?? ""
                         let fromBase  = (s["isFromBase"] as? NSNumber)?.boolValue ?? false
+                        let locked    = (s["locked"]     as? NSNumber)?.boolValue ?? false
                         // 2D Background is a synthetic pseudo-object;
                         // skip the delete swipe so the user can't try
                         // to remove it.
@@ -1262,6 +1267,7 @@ struct LayoutEditorView: View {
                         } else {
                             rosterRow(name: name,
                                       isFromBase: fromBase,
+                                      isLocked: locked,
                                       leadingSystemImage: Self.viewObjectTypeSFSymbol(forDisplayAs: displayAs),
                                       secondary: displayAs)
                                 .tag(name)
@@ -2208,6 +2214,7 @@ struct LayoutEditorView: View {
     @ViewBuilder
     private func rosterRow(name: String,
                             isFromBase: Bool,
+                            isLocked: Bool = false,
                             leadingSystemImage: String? = nil,
                             secondary: String? = nil) -> some View {
         VStack(alignment: .leading, spacing: 1) {
@@ -2226,6 +2233,12 @@ struct LayoutEditorView: View {
                         .font(.caption2)
                         .foregroundStyle(.blue)
                         .help("Linked to base show folder — most edits are disabled until Unlink from Base Show Folder.")
+                }
+                if isFromBase || isLocked {
+                    Image(systemName: "lock.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .help(isFromBase ? "Locked (linked to base show folder)" : "Locked")
                 }
             }
             if let s = secondary, !s.isEmpty {

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -1042,10 +1042,10 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
     PreviewGLPanel->GetSizer()->Add(layoutControlsBar, 0, wxEXPAND | wxALIGN_BOTTOM, 3);
     PreviewGLPanel->Layout();
 
-    TreeListViewModels->SetColumnWidth(0, wxCOL_WIDTH_AUTOSIZE);
-    TreeListViewModels->SetColumnWidth(1, TreeListViewModels->WidthFor(CHNUMWIDTH));
-    TreeListViewModels->SetColumnWidth(2, TreeListViewModels->WidthFor(CHNUMWIDTH));
-    TreeListViewModels->SetColumnWidth(3, wxCOL_WIDTH_AUTOSIZE);
+    TreeListViewModels->SetColumnWidth(Col_Model, wxCOL_WIDTH_AUTOSIZE);
+    TreeListViewModels->SetColumnWidth(Col_StartChan, TreeListViewModels->WidthFor(CHNUMWIDTH));
+    TreeListViewModels->SetColumnWidth(Col_EndChan, TreeListViewModels->WidthFor(CHNUMWIDTH));
+    TreeListViewModels->SetColumnWidth(Col_ControllerConnection, wxCOL_WIDTH_AUTOSIZE);
     TreeListViewModels->SetColumnWidth(Col_Info, wxCOL_WIDTH_AUTOSIZE);
 
 }
@@ -1737,8 +1737,8 @@ void LayoutPanel::FreezeTreeListView() {
     TreeListViewModels->Freeze();
 
     //turn off the column width auto-resize.  Makes it REALLY slow to populate the tree
-    TreeListViewModels->SetColumnWidth(0, TreeListViewModels->GetColumnWidth(0));
-    TreeListViewModels->SetColumnWidth(3, TreeListViewModels->GetColumnWidth(3));
+    TreeListViewModels->SetColumnWidth(Col_Model, TreeListViewModels->GetColumnWidth(Col_Model));
+    TreeListViewModels->SetColumnWidth(Col_ControllerConnection, TreeListViewModels->GetColumnWidth(Col_ControllerConnection));
     TreeListViewModels->SetColumnWidth(Col_Info, TreeListViewModels->GetColumnWidth(Col_Info));
     treeSorted = TreeListViewModels->GetSortColumn(&treeSortCol, &treeSortAscending);
     
@@ -1767,19 +1767,19 @@ void LayoutPanel::ThawTreeListView(const std::list<wxTreeListItem> &toExpand) {
     if (_firstTreeLoad) {
         _firstTreeLoad = false;
 
-        TreeListViewModels->SetColumnWidth(1, wxCOL_WIDTH_AUTOSIZE);
-        int width = TreeListViewModels->GetColumnWidth(1);
+        TreeListViewModels->SetColumnWidth(Col_StartChan, wxCOL_WIDTH_AUTOSIZE);
+        int width = TreeListViewModels->GetColumnWidth(Col_StartChan);
         if (width < 20) {
             width = TreeListViewModels->WidthFor(STARTCHANCOLNAME);
         }
-        TreeListViewModels->SetColumnWidth(1, width);
+        TreeListViewModels->SetColumnWidth(Col_StartChan, width);
 
-        TreeListViewModels->SetColumnWidth(2, wxCOL_WIDTH_AUTOSIZE);
-        width = TreeListViewModels->GetColumnWidth(2);
+        TreeListViewModels->SetColumnWidth(Col_EndChan, wxCOL_WIDTH_AUTOSIZE);
+        width = TreeListViewModels->GetColumnWidth(Col_EndChan);
         if (width < 20) {
             width = TreeListViewModels->WidthFor(STARTCHANCOLNAME);
         }
-        TreeListViewModels->SetColumnWidth(2, width);
+        TreeListViewModels->SetColumnWidth(Col_EndChan, width);
     }
     //turn the sorting back on
     TreeListViewModels->SetItemComparator(&comparator);
@@ -1799,27 +1799,27 @@ void LayoutPanel::ThawTreeListView(const std::list<wxTreeListItem> &toExpand) {
     TreeListViewModels->Thaw();
     TreeListViewModels->Refresh();
 
-    TreeListViewModels->SetColumnWidth(0, wxCOL_WIDTH_AUTOSIZE);
+    TreeListViewModels->SetColumnWidth(Col_Model, wxCOL_WIDTH_AUTOSIZE);
     {
-        int w = TreeListViewModels->GetColumnWidth(0);
+        int w = TreeListViewModels->GetColumnWidth(Col_Model);
         if (w < 20) {
             w = TreeListViewModels->GetClientSize().GetWidth() / 3;
         }
         if (w < 20) {
             w = 150;
         }
-        TreeListViewModels->SetColumnWidth(0, w);
+        TreeListViewModels->SetColumnWidth(Col_Model, w);
     }
-    TreeListViewModels->SetColumnWidth(3, wxCOL_WIDTH_AUTOSIZE);
+    TreeListViewModels->SetColumnWidth(Col_ControllerConnection, wxCOL_WIDTH_AUTOSIZE);
     {
-        int w = TreeListViewModels->GetColumnWidth(3);
+        int w = TreeListViewModels->GetColumnWidth(Col_ControllerConnection);
         if (w < 20) {
             w = TreeListViewModels->WidthFor(CONTCONNCOLNAME);
         }
         if (w < 20) {
             w = 100;
         }
-        TreeListViewModels->SetColumnWidth(3, w);
+        TreeListViewModels->SetColumnWidth(Col_ControllerConnection, w);
     }
     TreeListViewModels->SetColumnWidth(Col_Info, wxCOL_WIDTH_AUTOSIZE);
     {
@@ -1858,10 +1858,7 @@ void LayoutPanel::refreshModelList() {
         Model *model = data != nullptr ? data->GetModel() : nullptr;
 
         if (model != nullptr ) {
-            wxString infoStr = GetModelInfoText(TreeListViewModels, model);
-            if (TreeListViewModels->GetItemText(item, Col_Info) != infoStr) {
-                SetTreeListViewItemText(item, Col_Info, infoStr);
-            }
+            SetTreeListViewItemText(item, Col_Info, GetModelInfoText(TreeListViewModels, model));
 
             if( model->GetDisplayAs() != DisplayAsType::ModelGroup ) {
                 wxString cv = TreeListViewModels->GetItemText(item, Col_StartChan);

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -318,6 +318,33 @@ wxEND_EVENT_TABLE()
 #define STARTCHANCOLNAME "Start Chan"
 #define ENDCHANCOLNAME "End Chan"
 #define CONTCONNCOLNAME "Ctrlr Conn"
+#define INFOCOLNAME "Info"
+
+// Build a run of spaces whose rendered width approximates that of icon, so that a
+// missing icon still consumes about the same horizontal space as a present one and
+// later icons in the same cell line up between rows.
+static wxString MakeIconPlaceholder(wxWindow* wnd, const wxString& icon)
+{
+    wxClientDC dc(wnd);
+    dc.SetFont(wnd->GetFont());
+    int iconWidth = dc.GetTextExtent(icon).GetWidth();
+    int spaceWidth = dc.GetTextExtent(" ").GetWidth();
+    int numSpaces = spaceWidth > 0 ? std::max(1, (int)std::lround(iconWidth / (double)spaceWidth)) : 2;
+    return wxString(' ', numSpaces);
+}
+
+static wxString GetModelInfoText(wxWindow* wnd, const Model* model)
+{
+    static wxString linkIcon = wxString::FromUTF8("\xF0\x9F\x94\x97\xEF\xB8\x8E");
+    static wxString lockIcon = wxString::FromUTF8("\xF0\x9F\x94\x92\xEF\xB8\x8E");
+    static wxString linkPlaceholder = MakeIconPlaceholder(wnd, linkIcon);
+    static wxString lockPlaceholder = MakeIconPlaceholder(wnd, lockIcon);
+
+    wxString info;
+    info += model->IsFromBase() ? linkIcon : linkPlaceholder;
+    info += (model->IsFromBase() || model->IsLocked()) ? lockIcon : lockPlaceholder;
+    return info;
+}
 
 static wxRect scaledRect(int srcWidth, int srcHeight, int dstWidth, int dstHeight)
 {
@@ -1019,6 +1046,7 @@ LayoutPanel::LayoutPanel(wxWindow* parent, xLightsFrame *xl, wxPanel* sequencer)
     TreeListViewModels->SetColumnWidth(1, TreeListViewModels->WidthFor(CHNUMWIDTH));
     TreeListViewModels->SetColumnWidth(2, TreeListViewModels->WidthFor(CHNUMWIDTH));
     TreeListViewModels->SetColumnWidth(3, wxCOL_WIDTH_AUTOSIZE);
+    TreeListViewModels->SetColumnWidth(Col_Info, wxCOL_WIDTH_AUTOSIZE);
 
 }
 
@@ -1069,11 +1097,13 @@ wxTreeListCtrl* LayoutPanel::CreateTreeListCtrl(long style, wxPanel* panel)
         if (std::find(begin(cols), end(cols), STARTCHANCOLNAME) ==  end(cols)) cols.push_back(STARTCHANCOLNAME);
         if (std::find(begin(cols), end(cols), ENDCHANCOLNAME) == end(cols)) cols.push_back(ENDCHANCOLNAME);
         if (std::find(begin(cols), end(cols), CONTCONNCOLNAME) == end(cols)) cols.push_back(CONTCONNCOLNAME);
+        if (std::find(begin(cols), end(cols), INFOCOLNAME) == end(cols)) cols.push_back(INFOCOLNAME);
     }
     else {
         cols.push_back(STARTCHANCOLNAME);
         cols.push_back(ENDCHANCOLNAME);
         cols.push_back(CONTCONNCOLNAME);
+        cols.push_back(INFOCOLNAME);
     }
 
     int i = 1;
@@ -1098,6 +1128,13 @@ wxTreeListCtrl* LayoutPanel::CreateTreeListCtrl(long style, wxPanel* panel)
                 wxALIGN_LEFT,
                 wxCOL_RESIZABLE | wxCOL_SORTABLE | wxCOL_REORDERABLE);
             Col_ControllerConnection = i++;
+        }
+        else if (c == INFOCOLNAME) {
+            tree->AppendColumn(INFOCOLNAME,
+                wxCOL_WIDTH_AUTOSIZE,
+                wxALIGN_LEFT,
+                wxCOL_RESIZABLE | wxCOL_SORTABLE | wxCOL_REORDERABLE);
+            Col_Info = i++;
         }
     }
 
@@ -1215,6 +1252,8 @@ void LayoutPanel::SaveModelsListColumns()
 
 void LayoutPanel::SaveLayoutPerspective()
 {
+    SaveModelsListColumns();
+
     if (layout_mgr == nullptr) {
         return;
     }
@@ -1700,6 +1739,7 @@ void LayoutPanel::FreezeTreeListView() {
     //turn off the column width auto-resize.  Makes it REALLY slow to populate the tree
     TreeListViewModels->SetColumnWidth(0, TreeListViewModels->GetColumnWidth(0));
     TreeListViewModels->SetColumnWidth(3, TreeListViewModels->GetColumnWidth(3));
+    TreeListViewModels->SetColumnWidth(Col_Info, TreeListViewModels->GetColumnWidth(Col_Info));
     treeSorted = TreeListViewModels->GetSortColumn(&treeSortCol, &treeSortAscending);
     
     //turn off the sorting as that is ALSO really slow
@@ -1781,6 +1821,17 @@ void LayoutPanel::ThawTreeListView(const std::list<wxTreeListItem> &toExpand) {
         }
         TreeListViewModels->SetColumnWidth(3, w);
     }
+    TreeListViewModels->SetColumnWidth(Col_Info, wxCOL_WIDTH_AUTOSIZE);
+    {
+        int w = TreeListViewModels->GetColumnWidth(Col_Info);
+        if (w < 20) {
+            w = TreeListViewModels->WidthFor(INFOCOLNAME);
+        }
+        if (w < 20) {
+            w = 50;
+        }
+        TreeListViewModels->SetColumnWidth(Col_Info, w);
+    }
 }
 
 void LayoutPanel::SetTreeListViewItemText(wxTreeListItem &item, int col, const wxString &txt) {
@@ -1807,6 +1858,10 @@ void LayoutPanel::refreshModelList() {
         Model *model = data != nullptr ? data->GetModel() : nullptr;
 
         if (model != nullptr ) {
+            wxString infoStr = GetModelInfoText(TreeListViewModels, model);
+            if (TreeListViewModels->GetItemText(item, Col_Info) != infoStr) {
+                SetTreeListViewItemText(item, Col_Info, infoStr);
+            }
 
             if( model->GetDisplayAs() != DisplayAsType::ModelGroup ) {
                 wxString cv = TreeListViewModels->GetItemText(item, Col_StartChan);
@@ -1871,6 +1926,8 @@ int LayoutPanel::AddModelToTree(Model *model, wxTreeListItem* parent, bool expan
                                                          LayoutUtils::GetModelTreeIcon(DisplayAsTypeToString(model->GetDisplayAs()), LayoutUtils::GroupMode::Closed),
                                                          LayoutUtils::GetModelTreeIcon(DisplayAsTypeToString(model->GetDisplayAs()), LayoutUtils::GroupMode::Opened),
                                                          new ModelTreeData(model, nativeOrder, fullName));
+
+    SetTreeListViewItemText(item, Col_Info, GetModelInfoText(TreeListViewModels, model));
 
     if (model->GetDisplayAs() != DisplayAsType::ModelGroup) {
         wxString startStr = model->GetStartChannelInDisplayFormat(xlights->GetOutputManager());
@@ -4244,6 +4301,14 @@ int LayoutPanel::ModelListComparator::SortElementsFunction(wxTreeListCtrl* treel
         else {
             return NumberAwareStringCompare(sna, snb);
         }
+    }
+    else if (colobj->GetTitle() == INFOCOLNAME) {
+        wxString txt1 = treelist->GetItemText(item1, sortColumn);
+        wxString txt2 = treelist->GetItemText(item2, sortColumn);
+        if (txt1 != txt2) {
+            return txt1.Cmp(txt2);
+        }
+        return NumberAwareStringCompare(a->name, b->name);
     }
 
     // Dont sort things with parents
@@ -9775,6 +9840,7 @@ void LayoutPanel::UnlinkSelectedModels()
         model->SetFromBase(false);
     }
 
+    refreshModelList();
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::LockSelectedModels");
 }
 
@@ -9786,6 +9852,7 @@ void LayoutPanel::LockSelectedModels(bool lock)
         model->Lock(lock);
     }
 
+    refreshModelList();
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::LockSelectedModels");
 }
 

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -9841,7 +9841,7 @@ void LayoutPanel::UnlinkSelectedModels()
     }
 
     refreshModelList();
-    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::LockSelectedModels");
+    xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "LayoutPanel::UnlinkSelectedModels");
 }
 
 void LayoutPanel::LockSelectedModels(bool lock)

--- a/src-ui-wx/layout/LayoutPanel.h
+++ b/src-ui-wx/layout/LayoutPanel.h
@@ -621,6 +621,7 @@ class LayoutPanel: public wxPanel
         int Col_StartChan = 1;
         int Col_EndChan = 2;
         int Col_ControllerConnection = 3;
+        int Col_Info = 4;
 
         ModelPreview *modelPreview = nullptr;
         wxImage *background = nullptr;


### PR DESCRIPTION
Adds a new movable Info column that shows item is linked from base or that the item is locked. Base items are always locked.

<img width="706" height="609" alt="image" src="https://github.com/user-attachments/assets/08e0d5d1-90a2-4ec9-b514-9fbe7a299e5d" />
