### PR TITLE
Add live filter to the Choose Model(s) checklist dialog

### DIFF
--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -8702,7 +8702,8 @@ void EffectsGrid::CopyModelEffectsToModels(int row_number) {
         return;
     }
 
-    CheckboxSelectDialog dlg((wxWindow*)mParent, "Choose Model(s)", choices);
+    CheckboxSelectDialog dlg((wxWindow*)mParent, "Choose Model(s)", choices, wxArrayString(),
+                             _("Copying layers/submodels from: "), wxString(source_name));
     dlg.SetMinSize(wxSize(400, -1));
     dlg.SetSize(wxSize(400, dlg.GetSize().GetHeight()));
     if (dlg.ShowModal() != wxID_OK)

--- a/src-ui-wx/shared/dialogs/CheckboxSelectDialog.cpp
+++ b/src-ui-wx/shared/dialogs/CheckboxSelectDialog.cpp
@@ -30,6 +30,7 @@ const long CheckboxSelectDialog::ID_MCU_SELECTALL = wxNewId();
 const long CheckboxSelectDialog::ID_MCU_SELECTNONE = wxNewId();
 const long CheckboxSelectDialog::ID_MCU_SELECT_HIGH = wxNewId();
 const long CheckboxSelectDialog::ID_MCU_DESELECT_HIGH = wxNewId();
+const long CheckboxSelectDialog::ID_FILTERTIMER = wxNewId();
 
 BEGIN_EVENT_TABLE(CheckboxSelectDialog,wxDialog)
 	//(*EventTable(CheckboxSelectDialog)
@@ -100,10 +101,11 @@ CheckboxSelectDialog::CheckboxSelectDialog(wxWindow* parent, const wxString &tit
 
     _filterCtrl->Bind(wxEVT_TEXT, &CheckboxSelectDialog::OnFilterText, this);
     _filterCtrl->Bind(wxEVT_TEXT_ENTER, &CheckboxSelectDialog::OnFilterText, this);
-    _filterCtrl->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN, &CheckboxSelectDialog::OnFilterText, this);
+    _filterCtrl->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN, &CheckboxSelectDialog::OnFilterCancel, this);
 
-    _filterTimer.SetOwner(this);
-    Bind(wxEVT_TIMER, &CheckboxSelectDialog::OnFilterTimer, this);
+    _filterTimer.SetOwner(this, ID_FILTERTIMER);
+    Bind(wxEVT_TIMER, &CheckboxSelectDialog::OnFilterTimer, this, ID_FILTERTIMER);
+    Bind(wxEVT_CLOSE_WINDOW, &CheckboxSelectDialog::OnCloseWindow, this);
 
     PopulateList();
 
@@ -216,6 +218,22 @@ void CheckboxSelectDialog::PopulateList()
 void CheckboxSelectDialog::OnFilterText(wxCommandEvent& event)
 {
     _filterTimer.StartOnce(200);
+}
+
+void CheckboxSelectDialog::OnFilterCancel(wxCommandEvent& event)
+{
+    _filterTimer.Stop();
+    SyncCheckedFromList();
+    _filterCtrl->ChangeValue(wxEmptyString);
+    _filter.Clear();
+    PopulateList();
+    ValidateWindow();
+}
+
+void CheckboxSelectDialog::OnCloseWindow(wxCloseEvent& event)
+{
+    _filterTimer.Stop();
+    event.Skip();
 }
 
 void CheckboxSelectDialog::OnFilterTimer(wxTimerEvent& event)

--- a/src-ui-wx/shared/dialogs/CheckboxSelectDialog.cpp
+++ b/src-ui-wx/shared/dialogs/CheckboxSelectDialog.cpp
@@ -15,6 +15,7 @@
 #include <wx/string.h>
 //*)
 
+#include <wx/font.h>
 #include <wx/menu.h>
 #include <wx/srchctrl.h>
 #include <wx/tokenzr.h>
@@ -35,7 +36,7 @@ BEGIN_EVENT_TABLE(CheckboxSelectDialog,wxDialog)
 	//*)
 END_EVENT_TABLE()
 
-CheckboxSelectDialog::CheckboxSelectDialog(wxWindow* parent, const wxString &title, const wxArrayString& items, const wxArrayString& itemsSelected, wxWindowID id,const wxPoint& pos,const wxSize& size)
+CheckboxSelectDialog::CheckboxSelectDialog(wxWindow* parent, const wxString &title, const wxArrayString& items, const wxArrayString& itemsSelected, const wxString& header, const wxString& headerBold, wxWindowID id,const wxPoint& pos,const wxSize& size)
 {
 	//(*Initialize(CheckboxSelectDialog)
 	wxFlexGridSizer* FlexGridSizer1;
@@ -71,12 +72,31 @@ CheckboxSelectDialog::CheckboxSelectDialog(wxWindow* parent, const wxString &tit
         _checked.insert(item);
     }
 
+    int insertRow = 0;
+    if (!header.IsEmpty() || !headerBold.IsEmpty()) {
+        wxBoxSizer* headerSizer = new wxBoxSizer(wxHORIZONTAL);
+        if (!header.IsEmpty()) {
+            wxStaticText* normalLabel = new wxStaticText(this, wxID_ANY, header);
+            headerSizer->Add(normalLabel, 0, wxALIGN_CENTER_VERTICAL, 0);
+        }
+        if (!headerBold.IsEmpty()) {
+            wxStaticText* boldLabel = new wxStaticText(this, wxID_ANY, headerBold);
+            wxFont f = boldLabel->GetFont();
+            f.SetWeight(wxFONTWEIGHT_BOLD);
+            boldLabel->SetFont(f);
+            headerSizer->Add(boldLabel, 0, wxALIGN_CENTER_VERTICAL, 0);
+        }
+        FlexGridSizer1->Insert(insertRow++, headerSizer, 0, wxALL, 5);
+    }
+
     _filterCtrl = new wxSearchCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
     _filterCtrl->ShowCancelButton(true);
     _filterCtrl->SetDescriptiveText(_("Filter"));
-    FlexGridSizer1->Insert(0, _filterCtrl, 0, wxALL | wxEXPAND, 5);
+    FlexGridSizer1->Insert(insertRow++, _filterCtrl, 0, wxALL | wxEXPAND, 5);
+
+    // The checklist has shifted down by the rows we inserted; keep it the growable one.
     FlexGridSizer1->RemoveGrowableRow(0);
-    FlexGridSizer1->AddGrowableRow(1);
+    FlexGridSizer1->AddGrowableRow(insertRow);
 
     _filterCtrl->Bind(wxEVT_TEXT, &CheckboxSelectDialog::OnFilterText, this);
     _filterCtrl->Bind(wxEVT_TEXT_ENTER, &CheckboxSelectDialog::OnFilterText, this);
@@ -90,6 +110,11 @@ CheckboxSelectDialog::CheckboxSelectDialog(wxWindow* parent, const wxString &tit
 	SetTitle(title);
 
     SetEscapeId(Button_Cancel->GetId());
+
+    // Recompute the layout hints now that the header/filter rows exist, otherwise
+    // the min size (set by the generated code before these inserts) clips the buttons.
+    Layout();
+    FlexGridSizer1->SetSizeHints(this);
 
     ValidateWindow();
 }

--- a/src-ui-wx/shared/dialogs/CheckboxSelectDialog.cpp
+++ b/src-ui-wx/shared/dialogs/CheckboxSelectDialog.cpp
@@ -16,6 +16,8 @@
 //*)
 
 #include <wx/menu.h>
+#include <wx/srchctrl.h>
+#include <wx/tokenzr.h>
 
 //(*IdInit(CheckboxSelectDialog)
 const wxWindowID CheckboxSelectDialog::ID_CHECKLISTBOXITEMS = wxNewId();
@@ -64,14 +66,26 @@ CheckboxSelectDialog::CheckboxSelectDialog(wxWindow* parent, const wxString &tit
 
 	Connect(ID_CHECKLISTBOXITEMS, wxEVT_CONTEXT_MENU, (wxObjectEventFunction)& CheckboxSelectDialog::OnListRClick);
 
-    for (const auto & item : items)
-    {
-        CheckListBox_Items->Append(item);
-        if (std::find(itemsSelected.begin(), itemsSelected.end(), item) != itemsSelected.end()) 
-        {
-            CheckListBox_Items->Check(CheckListBox_Items->GetCount() - 1);
-        }
+    _allItems = items;
+    for (const auto& item : itemsSelected) {
+        _checked.insert(item);
     }
+
+    _filterCtrl = new wxSearchCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+    _filterCtrl->ShowCancelButton(true);
+    _filterCtrl->SetDescriptiveText(_("Filter"));
+    FlexGridSizer1->Insert(0, _filterCtrl, 0, wxALL | wxEXPAND, 5);
+    FlexGridSizer1->RemoveGrowableRow(0);
+    FlexGridSizer1->AddGrowableRow(1);
+
+    _filterCtrl->Bind(wxEVT_TEXT, &CheckboxSelectDialog::OnFilterText, this);
+    _filterCtrl->Bind(wxEVT_TEXT_ENTER, &CheckboxSelectDialog::OnFilterText, this);
+    _filterCtrl->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN, &CheckboxSelectDialog::OnFilterText, this);
+
+    _filterTimer.SetOwner(this);
+    Bind(wxEVT_TIMER, &CheckboxSelectDialog::OnFilterTimer, this);
+
+    PopulateList();
 
 	SetTitle(title);
 
@@ -88,12 +102,14 @@ CheckboxSelectDialog::~CheckboxSelectDialog()
 
 wxArrayString CheckboxSelectDialog::GetSelectedItems() const
 {
-    wxArrayString res = wxArrayString();
-    wxArrayInt items;
-    CheckListBox_Items->GetCheckedItems(items);
-    for (const auto& it : items)
+    // _checked is the source of truth so items hidden by an active filter are still returned.
+    wxArrayString res;
+    for (const auto& item : _allItems)
     {
-        res.Add(CheckListBox_Items->GetString(it));
+        if (_checked.find(item) != _checked.end())
+        {
+            res.Add(item);
+        }
     }
 
     return res;
@@ -101,16 +117,87 @@ wxArrayString CheckboxSelectDialog::GetSelectedItems() const
 
 void CheckboxSelectDialog::OnButton_CancelClick(wxCommandEvent& event)
 {
+    _filterTimer.Stop();
     EndDialog(wxID_CANCEL);
 }
 
 void CheckboxSelectDialog::OnButton_OkClick(wxCommandEvent& event)
 {
+    _filterTimer.Stop();
+    SyncCheckedFromList();
     EndDialog(wxID_OK);
 }
 
 void CheckboxSelectDialog::OnCheckListBox_ItemsToggled(wxCommandEvent& event)
 {
+    SyncCheckedFromList();
+    ValidateWindow();
+}
+
+bool CheckboxSelectDialog::MatchesFilter(const wxString& item) const
+{
+    if (_filter.IsEmpty())
+    {
+        return true;
+    }
+
+    const wxString itemLower = item.Lower();
+    wxStringTokenizer tok(_filter.Lower());
+    while (tok.HasMoreTokens())
+    {
+        if (!itemLower.Contains(tok.GetNextToken()))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+void CheckboxSelectDialog::SyncCheckedFromList()
+{
+    // Merge visible check state into _checked; filtered-out items keep their prior state.
+    for (size_t i = 0; i < CheckListBox_Items->GetCount(); ++i)
+    {
+        const wxString name = CheckListBox_Items->GetString(i);
+        if (CheckListBox_Items->IsChecked(i))
+        {
+            _checked.insert(name);
+        }
+        else
+        {
+            _checked.erase(name);
+        }
+    }
+}
+
+void CheckboxSelectDialog::PopulateList()
+{
+    CheckListBox_Items->Freeze();
+    CheckListBox_Items->Clear();
+    for (const auto& item : _allItems)
+    {
+        if (MatchesFilter(item))
+        {
+            CheckListBox_Items->Append(item);
+            if (_checked.find(item) != _checked.end())
+            {
+                CheckListBox_Items->Check(CheckListBox_Items->GetCount() - 1);
+            }
+        }
+    }
+    CheckListBox_Items->Thaw();
+}
+
+void CheckboxSelectDialog::OnFilterText(wxCommandEvent& event)
+{
+    _filterTimer.StartOnce(200);
+}
+
+void CheckboxSelectDialog::OnFilterTimer(wxTimerEvent& event)
+{
+    SyncCheckedFromList();
+    _filter = _filterCtrl->GetValue().Trim(true).Trim(false);
+    PopulateList();
     ValidateWindow();
 }
 
@@ -157,6 +244,7 @@ void CheckboxSelectDialog::SelectAllLayers(bool select)
     {
         CheckListBox_Items->Check(i, select);
     }
+    SyncCheckedFromList();
     ValidateWindow();
 }
 
@@ -169,5 +257,6 @@ void CheckboxSelectDialog::SelectHighLightedLayers(bool select)
             CheckListBox_Items->Check(i, select);
         }
 	}
+    SyncCheckedFromList();
     ValidateWindow();
 }

--- a/src-ui-wx/shared/dialogs/CheckboxSelectDialog.h
+++ b/src-ui-wx/shared/dialogs/CheckboxSelectDialog.h
@@ -51,6 +51,7 @@ class CheckboxSelectDialog: public wxDialog
 		static const long ID_MCU_SELECTNONE;
 		static const long ID_MCU_SELECT_HIGH;
         static const long ID_MCU_DESELECT_HIGH;
+		static const long ID_FILTERTIMER;
 
 	private:
 
@@ -67,6 +68,8 @@ class CheckboxSelectDialog: public wxDialog
 		void SelectHighLightedLayers(bool select = true);
 
 		void OnFilterText(wxCommandEvent& event);
+		void OnFilterCancel(wxCommandEvent& event);
+		void OnCloseWindow(wxCloseEvent& event);
 		void OnFilterTimer(wxTimerEvent& event);
 		void PopulateList();
 		void SyncCheckedFromList();

--- a/src-ui-wx/shared/dialogs/CheckboxSelectDialog.h
+++ b/src-ui-wx/shared/dialogs/CheckboxSelectDialog.h
@@ -17,6 +17,11 @@
  #include <wx/sizer.h>
  //*)
 
+#include <wx/srchctrl.h>
+#include <wx/timer.h>
+
+#include <set>
+
 class CheckboxSelectDialog: public wxDialog
 {
     void ValidateWindow();
@@ -59,6 +64,18 @@ class CheckboxSelectDialog: public wxDialog
 
         void SelectAllLayers(bool select = true);
 		void SelectHighLightedLayers(bool select = true);
+
+		void OnFilterText(wxCommandEvent& event);
+		void OnFilterTimer(wxTimerEvent& event);
+		void PopulateList();
+		void SyncCheckedFromList();
+		bool MatchesFilter(const wxString& item) const;
+
+		wxSearchCtrl* _filterCtrl = nullptr;
+		wxTimer _filterTimer;
+		wxString _filter;
+		wxArrayString _allItems;
+		std::set<wxString> _checked;
 
 		DECLARE_EVENT_TABLE()
 };

--- a/src-ui-wx/shared/dialogs/CheckboxSelectDialog.h
+++ b/src-ui-wx/shared/dialogs/CheckboxSelectDialog.h
@@ -18,6 +18,7 @@
  //*)
 
 #include <wx/srchctrl.h>
+#include <wx/stattext.h>
 #include <wx/timer.h>
 
 #include <set>
@@ -28,7 +29,7 @@ class CheckboxSelectDialog: public wxDialog
 
 	public:
 
-        CheckboxSelectDialog(wxWindow* parent, const wxString &title, const wxArrayString& items, const wxArrayString& itemsSelected = wxArrayString(), wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize);
+        CheckboxSelectDialog(wxWindow* parent, const wxString &title, const wxArrayString& items, const wxArrayString& itemsSelected = wxArrayString(), const wxString& header = wxEmptyString, const wxString& headerBold = wxEmptyString, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize);
 		virtual ~CheckboxSelectDialog();
         wxArrayString GetSelectedItems() const;
 


### PR DESCRIPTION
## What

Two usability improvements to the **Choose Model(s)** dialog shown by **Copy Layers/Submodels → to Models** (`CheckboxSelectDialog`):

### 1. Donor model shown in the header
The dialog now shows which model you are copying **from** at the top:

> Copying layers/submodels from: **&lt;model name&gt;**

("Copying layers/submodels from:" in normal weight, the donor model name in **bold**.) Previously the dialog gave no indication of the source model once it opened.

### 2. Live filter box
A **filter box** above the checklist so long model lists can be narrowed as you type:

- Debounced (200 ms) `wxSearchCtrl` with a cancel button and "Filter" placeholder.
- Match is **case-insensitive**, whitespace-tokenized **AND** (e.g. `arch left` matches "Left Arch Mega").
- Check state is held in a persistent set that is the source of truth, so:
  - toggles survive filter rebuilds, and
  - a model checked, then hidden by a narrower filter, is **still returned** by `GetSelectedItems()`.
- Select All / Deselect All / (De)select Highlighted right-click actions and OK all reconcile through that set.

Also fixes the Ok/Cancel buttons being clipped at the bottom — the sizer hints are now recomputed after the header/filter rows are inserted (the generated code had sized the dialog before those rows existed).

## Scope / parity

Desktop-only: this is a wxWidgets dialog (`src-ui-wx/shared/dialogs/`) with no iPad counterpart — the Copy-Layers-to-Models flow is desktop-only. No `src-core/` changes.

## Notes

- Edits are entirely **outside** the wxSmith `//(* … *)` guards, so no `.wxs` change is required.
- The new header is an optional `CheckboxSelectDialog` parameter (normal prefix + bold value); only the Copy-Layers caller passes it.
- Builds clean on macOS (Release, arm64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
