### PR TITLE
Fix Moving Head Advanced effect corruption on copy/paste between fixtures (#6701)

### DIFF
--- a/src-ui-wx/effectpanels/MovingHeadPanel.cpp
+++ b/src-ui-wx/effectpanels/MovingHeadPanel.cpp
@@ -1248,6 +1248,7 @@ void MovingHeadPanel::ValidateWindow()
 
     // if single model make sure the effect setting is on correct head...if not move it
     auto model = models.front();
+    bool remapped_fixture = false;
     if (single_model) {
         if( model->GetDisplayAs() == DisplayAsType::DmxMovingHeadAdv ||
             model->GetDisplayAs() == DisplayAsType::DmxMovingHead) {
@@ -1296,12 +1297,24 @@ void MovingHeadPanel::ValidateWindow()
                                         }
                                     }
                                 }
+                                remapped_fixture = true;
                             }
                         }
                     }
                 }
             }
         }
+    }
+
+    // The remap above mutates the hidden per-head textctrls directly (not via
+    // user input), so no wxEVT_TEXT ever fires for them. Without an explicit
+    // FireChangeEvent() here, the fixed-up head assignment stays a display-only
+    // artifact: the effect's persisted SettingsMap keeps referencing the old
+    // (wrong) head slot, so copy/pasting this effect to yet another model
+    // propagates the stale head number and the status pane starts showing
+    // settings for multiple heads at once.
+    if (remapped_fixture) {
+        FireChangeEvent();
     }
 
     // updates the status panel if its already active and a new effect is selected

--- a/src-ui-wx/effectpanels/MovingHeadPanel.cpp
+++ b/src-ui-wx/effectpanels/MovingHeadPanel.cpp
@@ -1306,11 +1306,10 @@ void MovingHeadPanel::ValidateWindow()
         }
     }
 
-    // The remap above mutates the hidden per-head textctrls directly (not via
-    // user input), so no wxEVT_TEXT ever fires for them. Without an explicit
-    // FireChangeEvent() here, the fixed-up head assignment stays a display-only
-    // artifact: the effect's persisted SettingsMap keeps referencing the old
-    // (wrong) head slot, so copy/pasting this effect to yet another model
+    // The remap above updates the hidden per-head textctrls, but our wxEVT_TEXT
+    // handler doesn't call FireChangeEvent() for the MH*_Settings fields.
+    // Trigger it explicitly so the effect's SettingsMap is reserialized with the
+    // corrected head assignment (avoids copy/paste propagating a stale fixture).
     // propagates the stale head number and the status pane starts showing
     // settings for multiple heads at once.
     if (remapped_fixture) {


### PR DESCRIPTION
When you copy effect from MH-1 to other MH-x the fixture wasnt always being correctly remapped.