### PR TITLE
Fix DMX Moving Head Adv / Servo 3D: editing ScaleX/Y/Z in the property grid snapping back to 1.0

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.14  July ??, 2026
+    -bug (derwin12)              DMX Moving Head Adv / Servo 3D: editing ScaleX/Y/Z in the property grid no longer snaps it back to 1.0
     -bug (dkulp)                 Frame-parallel rendering: rows containing canvas-mode effects were not
                                  excluded as designed (wrong settings key) and could render incorrectly
     -enh (dkulp)                 Render: frame-parallel windows now cover large single-model rows

--- a/src-core/models/DMX/Mesh.cpp
+++ b/src-core/models/DMX/Mesh.cpp
@@ -71,7 +71,16 @@ void Mesh::Init(BaseObject* base, bool set_size) {
         width = render_width;
         height = render_height;
         depth = render_depth;
-        base->GetBaseObjectScreenLocation().SetRenderSize(width, height, depth);
+        // Skip until the obj is actually loaded (render_width/height/depth
+        // are still Mesh's 1.0f defaults before then), and scale by this
+        // mesh's own ScaleX/Y/Z to match the formula Draw()'s recalc block
+        // feeds into AdjustRenderSize(). InitModel() re-runs this on
+        // essentially every property-grid edit; any mismatch with Draw()'s
+        // numbers reads as a genuine resize and silently wipes the model's
+        // own ScaleX/Y/Z back to 1.0.
+        if (obj_loaded) {
+            base->GetBaseObjectScreenLocation().SetRenderSize(width * scalex, height * scaley * half_height, depth * scalez);
+        }
     }
 }
 

--- a/src-core/models/ModelScreenLocation.cpp
+++ b/src-core/models/ModelScreenLocation.cpp
@@ -190,7 +190,13 @@ void ModelScreenLocation::SetRenderSize(float NewWi, float NewHt, float NewDp) {
 
 // This function is used when the render size needs to be adjusted after a mesh is loaded during model creation
 void ModelScreenLocation::AdjustRenderSize(float NewWi, float NewHt, float NewDp) {
-    if ((NewWi != RenderWi || NewHt != RenderHt || NewDp != RenderDp) && NewWi != 1.0f) {
+    // RenderWi/Ht/Dp all still at their construction default of 0.0f means
+    // this is the first time real mesh geometry is being synced in (e.g.
+    // right after load from XML) rather than an actual resize (e.g. the
+    // user swapping in a differently-sized obj file). Resetting scale here
+    // would silently discard a ScaleX/Y/Z loaded from the model's XML.
+    bool firstEstablish = (RenderWi == 0.0f && RenderHt == 0.0f && RenderDp == 0.0f);
+    if (!firstEstablish && (NewWi != RenderWi || NewHt != RenderHt || NewDp != RenderDp) && NewWi != 1.0f) {
         RenderHt = NewHt;
         RenderWi = NewWi;
         RenderDp = NewDp;


### PR DESCRIPTION
You couldn't resize the moving heads on your layout.