### PR TITLE
Add models/controllers and xlDo API metadata

### DIFF
--- a/resources/controllersmetadata/Ethernet.json
+++ b/resources/controllersmetadata/Ethernet.json
@@ -1,0 +1,93 @@
+{
+    "schemaVersion": 1,
+    "objectType": "controller",
+    "description": "An Ethernet (network) controller: a <Controller Type=\"Ethernet\"> node in xlights_networks.xml. Adds IP/protocol level attributes on top of the shared controller attributes and owns one <network> child element per output (universe/port). Source of truth: src-core/outputs/ControllerEthernet.cpp constructor (@44, reader) and ControllerEthernet::Save (@90, writer), cross-checked against src-ui-wx/controllerproperties/ControllerEthernetPropertyAdapter.cpp AddProperties (@362) / UpdateProperties (@254) / ValidateProperties (@549) for labels, ranges and per-protocol gating.",
+    "extends": ["shared/Controller.json"],
+    "storage": { "file": "xlights_networks.xml", "node": "Controller" },
+    "properties": [
+        {
+            "xmlAttribute": "IP",
+            "label": "IP Address",
+            "gridKey": "IP",
+            "type": "string",
+            "default": "",
+            "description": "Controller IP address or hostname. The sentinel value \"MULTICAST\" (E131 protocol only) means multicast output; in the grid it is represented by a UI-only \"Multicast\" checkbox and the IP row is hidden (ControllerEthernetPropertyAdapter.cpp @271-291) - no separate XML attribute exists for multicast. Written unconditionally. Validation: must be a valid IP or hostname; for ZCPP and DDP it must also be unique across all controllers (ValidateProperties @568)."
+        },
+        {
+            "xmlAttribute": "Protocol",
+            "label": "Protocol",
+            "gridKey": "Protocol",
+            "type": "enum",
+            "enum": ["E131", "ZCPP", "ArtNet", "DDP", "OPC", "KINET", "xxx Ethernet", "Twinkly", "Player Only"],
+            "default": "E131",
+            "description": "Network output protocol; the discriminator the per-protocol documents in protocols/ key on, and it determines the attribute set of the <network> child elements. Exact stored strings verified against the OUTPUT_* constants in src-core/outputs/Output.h @30-49 (note the casings: \"ArtNet\", \"KINET\", \"Twinkly\", \"Player Only\"). \"xxx Ethernet\" is hidden from the grid choices unless the special option \"xxx\" is enabled or the file already uses it (ControllerEthernetPropertyAdapter.cpp @52-56, @82-86) but is a legitimately persisted value. Note: stored on the C++ side as ControllerEthernet::_type / GetProtocol(), distinct from the shared Type=\"Ethernet\" discriminator. Per-protocol relevance of sibling attributes: Priority applies to E131/ZCPP; Version to KINET; FPPProxy to the proxyable set (see each property's appliesWhen)."
+        },
+        {
+            "xmlAttribute": "FPPProxy",
+            "label": "FPP Proxy IP/Hostname",
+            "gridKey": "FPPProxy",
+            "type": "string",
+            "default": "",
+            "appliesWhen": { "attribute": "Protocol", "oneOf": ["E131", "DDP", "Twinkly", "Player Only"] },
+            "description": "IP/hostname of an FPP instance that bridges two networks (typically its WIFI IP); data for this controller is routed via the proxy. Written unconditionally, but only shown/meaningful for proxyable protocols: ControllerEthernet::IsFPPProxyable() is `E131 || DDP || Twinkly || Player Only` (ControllerEthernet.h @76 - Player Only is proxyable because the web UI is). Flagged red in the grid when equal to the controller's own IP or not a valid IP/hostname."
+        },
+        {
+            "xmlAttribute": "ForceLocalIP",
+            "label": "Force Local IP",
+            "gridKey": "ForceLocalIP",
+            "type": "string",
+            "default": "",
+            "appliesWhen": { "attribute": "Protocol", "notEquals": "Player Only" },
+            "description": "Local network-interface IP to send this controller's traffic from; empty means let the OS choose. The grid presents it as a dropdown of the machine's current local IPs plus a blank entry (ControllerEthernetPropertyAdapter.cpp @381-387, @443) but the stored value is a plain IP string, which may reference an interface that no longer exists. Written unconditionally; hidden in the grid for Player Only."
+        },
+        {
+            "xmlAttribute": "Priority",
+            "label": "Priority",
+            "gridKey": "Priority",
+            "type": "uint",
+            "default": 100,
+            "min": 0,
+            "max": 100,
+            "appliesWhen": { "attribute": "Protocol", "oneOf": ["E131", "ZCPP"] },
+            "description": "Data priority for controllers that can receive from more than one source and ignore the lower-priority one. Written unconditionally, but only shown/meaningful for E131 and ZCPP (ControllerEthernetPropertyAdapter.cpp @292-300). Propagated into each E131 <network> output on change."
+        },
+        {
+            "xmlAttribute": "Version",
+            "label": "Version",
+            "gridKey": "Version",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 2,
+            "appliesWhen": { "attribute": "Protocol", "equals": "KINET" },
+            "description": "KiNet protocol version (1 or 2). Written unconditionally for every ethernet controller, but the grid property only exists for the KINET protocol (KinetOutputPropertyAdapter::AddProperties, OutputPropertyAdapters.cpp @581, range 1-2); ControllerEthernet::SetVersion cascades the value into each KinetOutput <network> child (ControllerEthernet.cpp @458)."
+        },
+        {
+            "xmlAttribute": "Expanded",
+            "type": "bool",
+            "boolFormat": "TRUEFALSE",
+            "default": "FALSE",
+            "description": "UI-only state: whether this controller's row is expanded in the setup-tab controller list. Persisted with the uppercase literals \"TRUE\"/\"FALSE\", both values always written (ControllerEthernet.cpp @52 reader / @99 writer). No property-grid row; toggled via ControllerEthernetPropertyAdapter::HandleExpanded (@686). No effect on output data."
+        },
+        {
+            "xmlAttribute": "UPS",
+            "label": "Universe Per String",
+            "gridKey": "UniversePerString",
+            "type": "bool",
+            "boolFormat": "TRUEFALSE",
+            "default": "FALSE",
+            "capsGate": "SupportsUniversePerString",
+            "description": "Universe-per-string mode: when true and Auto Size is on, xLights sizes one universe (or run of universes) per physical model string instead of packing channels contiguously. Persisted with the uppercase literals \"TRUE\"/\"FALSE\", both values always written (ControllerEthernet.cpp @53 reader / @100 writer). Verified trap: xmlAttribute (\"UPS\") differs from its wxPropertyGrid key (\"UniversePerString\", label \"Universe Per String\", OutputPropertyAdapters.cpp @213); the grid row is only enabled when the controller is Auto Size and the caps support it."
+        }
+    ],
+    "childElements": [
+        {
+            "name": "network",
+            "description": "One child element per output (E131/ArtNet universe, KiNet port, or the single output of ZCPP/DDP/OPC/Twinkly/Player Only). Read by the base Controller constructor via Output::Create (Controller.cpp @97); each output writes its own attribute set in its Save(). The attribute set depends on this controller's Protocol; the per-protocol documents in protocols/ (e.g. protocols/E131.json) describe them - ref intentionally left unset until those documents exist (next task)."
+        }
+    ],
+    "notes": [
+        "The grid rows \"Multicast\" (checkbox writing IP=\"MULTICAST\"), \"Managed\" (read-only; runtime-derived from whether another controller shares the IP), \"Models\" (read-only model list) and the per-output rows (Universe/Universes/Channels/IndivSizes...) have no XML attribute on the <Controller> node: the first three are UI-only/derived, the rest persist inside the <network> children.",
+        "CORRECTION vs the brief's protocol list: the persisted Protocol vocabulary also includes \"xxx Ethernet\" (OUTPUT_xxxETHERNET, Output.h @45), included in the enum above since files containing it load and re-save it; it is merely hidden from the grid dropdown unless enabled via SpecialOptions \"xxx\"."
+    ]
+}

--- a/resources/controllersmetadata/Ethernet.json
+++ b/resources/controllersmetadata/Ethernet.json
@@ -83,7 +83,7 @@
     "childElements": [
         {
             "name": "network",
-            "description": "One child element per output (E131/ArtNet universe, KiNet port, or the single output of ZCPP/DDP/OPC/Twinkly/Player Only). Read by the base Controller constructor via Output::Create (Controller.cpp @97); each output writes its own attribute set in its Save(). The attribute set depends on this controller's Protocol; the per-protocol documents in protocols/ (e.g. protocols/E131.json) describe them - ref intentionally left unset until those documents exist (next task)."
+            "description": "One child element per output (E131/ArtNet universe, KiNet port, or the single output of ZCPP/DDP/OPC/Twinkly/Player Only). Read by the base Controller constructor via Output::Create (Controller.cpp @97); each output writes its own attribute set in its Save(). The attribute set depends on this controller's Protocol, so it is described by whichever sibling document in protocols/ matches (ArtNet.json, DDP.json, E131.json, KiNet.json, OPC.json, Twinkly.json, ZCPP.json) rather than a single fixed target - ref is intentionally left unset since this schema's ref field only holds one path, not a per-Protocol set."
         }
     ],
     "notes": [

--- a/resources/controllersmetadata/_schema.json
+++ b/resources/controllersmetadata/_schema.json
@@ -1,0 +1,97 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "xLights Controller Metadata",
+    "description": "XML-first description of ethernet controller and output attributes persisted to xlights_networks.xml. Canonical property ids are XML attribute names.",
+    "type": "object",
+    "required": ["schemaVersion", "description", "properties"],
+    "additionalProperties": false,
+    "properties": {
+        "schemaVersion": { "const": 1 },
+        "objectType": { "enum": ["model", "modelGroup", "controller", "output"] },
+        "displayAs": {
+            "oneOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+            ],
+            "description": "Exact DisplayAs XML value(s) this document describes. Array when several DisplayAs values share one property set (e.g. Horiz/Vert Matrix)."
+        },
+        "protocol": { "type": "string", "description": "Output protocol discriminator (controllersmetadata protocols/*.json only)" },
+        "description": { "type": "string", "minLength": 1 },
+        "extends": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Relative paths (from the tree root) of shared fragment files whose properties also apply. Composition is concatenation only."
+        },
+        "storage": { "$ref": "#/definitions/storage" },
+        "properties": { "type": "array", "items": { "$ref": "#/definitions/property" } },
+        "childElements": { "type": "array", "items": { "$ref": "#/definitions/childElement" } },
+        "notes": { "type": "array", "items": { "type": "string" } }
+    },
+    "definitions": {
+        "storage": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "file": { "enum": ["xlights_rgbeffects.xml", "xlights_networks.xml"] },
+                "node": { "type": "string", "description": "Node path under the document root, e.g. 'models/model' or 'Controller/network'" },
+                "element": { "type": "string", "description": "Document-level child-element override: all properties in this file live on this child element" }
+            }
+        },
+        "condition": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attribute": { "type": "string", "description": "XML attribute name (in the assembled object scope) this condition tests" },
+                "equals": {},
+                "notEquals": {},
+                "oneOf": { "type": "array" },
+                "notOneOf": { "type": "array" },
+                "greaterThan": { "type": "number" },
+                "startsWith": { "type": "string" },
+                "allOf": { "type": "array", "items": { "$ref": "#/definitions/condition" } }
+            }
+        },
+        "childElement": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "description"],
+            "properties": {
+                "name": { "type": "string", "description": "XML element name, e.g. 'faceInfo'" },
+                "ref": { "type": "string", "description": "Relative path of the fragment file describing this element's attributes" },
+                "description": { "type": "string" },
+                "encoding": { "type": "string", "description": "Format note for non-attribute content (text nodes, compressed blobs)" }
+            }
+        },
+        "property": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["xmlAttribute", "type", "description"],
+            "properties": {
+                "xmlAttribute": { "type": "string", "minLength": 1 },
+                "label": { "type": "string" },
+                "gridKey": { "type": "string" },
+                "type": { "enum": ["int", "uint", "float", "bool", "string", "enum", "color", "filepath"] },
+                "default": {},
+                "min": { "type": "number" },
+                "max": { "type": "number" },
+                "step": { "type": "number" },
+                "precision": { "type": "integer" },
+                "enum": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+                "labels": { "type": "object", "additionalProperties": { "type": "string" } },
+                "boolFormat": { "enum": ["01", "TRUEFALSE", "truefalse", "TrueFalse", "presentOnly"] },
+                "legacyAttributes": { "type": "array", "items": { "type": "string" } },
+                "storage": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["element"],
+                    "properties": { "element": { "type": "string" } }
+                },
+                "appliesWhen": { "$ref": "#/definitions/condition" },
+                "capsGate": { "type": "string" },
+                "relatedTo": { "type": "array", "items": { "type": "string" } },
+                "encoding": { "type": "string" },
+                "description": { "type": "string", "minLength": 1 }
+            }
+        }
+    }
+}

--- a/resources/controllersmetadata/protocols/ArtNet.json
+++ b/resources/controllersmetadata/protocols/ArtNet.json
@@ -1,0 +1,58 @@
+{
+    "schemaVersion": 1,
+    "objectType": "output",
+    "protocol": "ArtNet",
+    "description": "One <network> child node per Art-Net universe under an ethernet <Controller Protocol=\"ArtNet\">. Multi-universe controllers have one node per universe. Source of truth: src-core/outputs/Output.cpp Output::SaveAttr (@42, base writer) and IPOutput.cpp IPOutput::SaveAttr (@27, IP-output writer) for the attributes shared by every IP-based protocol document in this tree, plus ArtNetOutput.cpp constructor (@59, reader) / Save (@418, writer) for the Art-Net-specific extra. Cross-checked against OutputPropertyAdapters.cpp ArtNetOutputPropertyAdapter::AddProperties (@353) and ControllerEthernetPropertyAdapter::ValidateProperties (@601, ControllerEthernetPropertyAdapter.cpp) for grid labels, ranges and validation.",
+    "storage": { "file": "xlights_networks.xml", "node": "Controller/network" },
+    "properties": [
+        {
+            "xmlAttribute": "NetworkType",
+            "type": "string",
+            "default": "ArtNet",
+            "description": "Protocol discriminator for this <network> node; always the literal \"ArtNet\" (ArtNetOutput::GetType(), matching the OUTPUT_ARTNET constant in Output.h @33). Written unconditionally by Output::SaveAttr (Output.cpp @44). No property-grid row (fixed by the controller's Protocol selection)."
+        },
+        {
+            "xmlAttribute": "ComPort",
+            "type": "string",
+            "default": "",
+            "description": "IP address/hostname this universe's data is sent to. Verified trap: legacy attribute name \"ComPort\" holds an IP address, not a serial port (IPOutput::SaveAttr, IPOutput.cpp @29-31 writer / @40 reader). Only written when non-empty. No property-grid row of its own: mirrors the parent <Controller>'s IP attribute, cascaded to every output by ControllerEthernet::SetIP (ControllerEthernet.cpp @153-177)."
+        },
+        {
+            "xmlAttribute": "BaudRate",
+            "label": "Start Universe",
+            "gridKey": "Universe",
+            "type": "uint",
+            "min": 0,
+            "max": 32767,
+            "default": 1,
+            "description": "Art-Net universe number (the combined net/subnet/universe value packed by ArtNetOutput::GetArtNetCombinedUniverse, ArtNetOutput.h @70) carried in the legacy BaudRate attribute (IPOutput::SaveAttr, IPOutput.cpp @32 writer / @47 reader, default 1 if absent - though 0 is a valid Art-Net universe). Grid range 0-32767 (OutputPropertyAdapters.cpp @358-361); ValidateProperties flags the grid row red outside that range (ControllerEthernetPropertyAdapter.cpp @606-609). As with E1.31, the universe count is not a per-node attribute - it equals the number of <network> children."
+        },
+        {
+            "xmlAttribute": "MaxChannels",
+            "label": "Channels per Universe",
+            "gridKey": "Channels",
+            "type": "uint",
+            "min": 1,
+            "max": 512,
+            "description": "Channel count for this universe (Output::SaveAttr, Output.cpp @46 writer / @76 reader). Written unconditionally. Grid range 1-512 (ArtNetOutput::GetMaxChannels() is 512; OutputPropertyAdapters.cpp @377-379); also checked against the controller capability max via caps->GetMaxInputUniverseChannels() (ControllerEthernetPropertyAdapter.cpp @636-643). New Art-Net outputs default to 510 channels via ArtNetOutput's parameterless constructor (ArtNetOutput.cpp @73). When outputs are not all the same size the grid hides this row for the per-universe \"Sizes\" collection instead (OutputPropertyAdapters.cpp @300-329) - same underlying MaxChannels attribute on each <network> node."
+        },
+        {
+            "xmlAttribute": "FPPProxy",
+            "type": "string",
+            "default": "",
+            "description": "IP/hostname of an FPP proxy this universe's data is routed through. Written only when non-empty (Output::SaveAttr, Output.cpp @48-51). No property-grid row of its own: mirrors the parent <Controller>'s FPPProxy attribute, cascaded by ControllerEthernet::SetFPPProxy (ControllerEthernet.cpp @407-411)."
+        },
+        {
+            "xmlAttribute": "ForceSourcePort",
+            "gridKey": "ForceSourcePort",
+            "label": "Force source port",
+            "type": "bool",
+            "boolFormat": "presentOnly",
+            "description": "When true, binds the outgoing Art-Net socket to the standard Art-Net port 0x1936 instead of an ephemeral port (ArtNetOutput::OpenDatagram, ArtNetOutput.cpp @48). Verified trap: written as the literal \"TRUE\" only when true (ArtNetOutput::Save, ArtNetOutput.cpp @422-424: `if (_forceSourcePort) node.append_attribute(\"ForceSourcePort\") = \"TRUE\";`); absent means false. Read by comparing against \"TRUE\" with default \"FALSE\" (ArtNetOutput.cpp @68). Grid checkbox labelled \"Force source port\" (OutputPropertyAdapters.cpp @354-356): 'You should only set this option if your ArtNet device is not seeing the ArtNet packets because it strictly requires that packets come from port 0x1936.'"
+        }
+    ],
+    "notes": [
+        "The property-grid keys Universe, Universes, Channels, IndivSizes, UniversesDisplay and the Sizes/Channels/<universe> collection are NOT the persisted attribute names - Universe maps to BaudRate and Channels maps to MaxChannels (both above); Universes/UniversesDisplay/IndivSizes/Sizes have no XML attribute at all and are purely derived from the count and per-node MaxChannels of the controller's <network> children (OutputPropertyAdapters.cpp @353-403).",
+        "UniversePerString (grid key \"UniversePerString\") is a Controller-level attribute (xmlAttribute \"UPS\", see Ethernet.json), not a per-network attribute."
+    ]
+}

--- a/resources/controllersmetadata/protocols/ArtNet.json
+++ b/resources/controllersmetadata/protocols/ArtNet.json
@@ -47,7 +47,7 @@
             "gridKey": "ForceSourcePort",
             "label": "Force source port",
             "type": "bool",
-            "boolFormat": "presentOnly",
+            "boolFormat": "TRUEFALSE",
             "description": "When true, binds the outgoing Art-Net socket to the standard Art-Net port 0x1936 instead of an ephemeral port (ArtNetOutput::OpenDatagram, ArtNetOutput.cpp @48). Verified trap: written as the literal \"TRUE\" only when true (ArtNetOutput::Save, ArtNetOutput.cpp @422-424: `if (_forceSourcePort) node.append_attribute(\"ForceSourcePort\") = \"TRUE\";`); absent means false. Read by comparing against \"TRUE\" with default \"FALSE\" (ArtNetOutput.cpp @68). Grid checkbox labelled \"Force source port\" (OutputPropertyAdapters.cpp @354-356): 'You should only set this option if your ArtNet device is not seeing the ArtNet packets because it strictly requires that packets come from port 0x1936.'"
         }
     ],

--- a/resources/controllersmetadata/protocols/DDP.json
+++ b/resources/controllersmetadata/protocols/DDP.json
@@ -1,0 +1,63 @@
+{
+    "schemaVersion": 1,
+    "objectType": "output",
+    "protocol": "DDP",
+    "description": "The single <network> child node under an ethernet <Controller Protocol=\"DDP\">. DDP controllers are not universe-based - there is exactly one Output/one <network> node per controller, sized in raw channels and split into packets at send time. Source of truth: src-core/outputs/Output.cpp Output::SaveAttr (@42, base writer) and IPOutput.cpp IPOutput::SaveAttr (@27, IP-output writer) for the attributes shared by every IP-based protocol document in this tree, plus DDPOutput.cpp constructor (@58, reader) / Save (@97, writer) for the DDP-specific extras. Cross-checked against OutputPropertyAdapters.cpp DDPOutputPropertyAdapter::AddProperties (@429) for grid labels and ranges.",
+    "storage": { "file": "xlights_networks.xml", "node": "Controller/network" },
+    "properties": [
+        {
+            "xmlAttribute": "NetworkType",
+            "type": "string",
+            "default": "DDP",
+            "description": "Protocol discriminator for this <network> node; always the literal \"DDP\" (DDPOutput::GetType(), matching the OUTPUT_DDP constant in Output.h @34). Written unconditionally by Output::SaveAttr (Output.cpp @44). No property-grid row (fixed by the controller's Protocol selection)."
+        },
+        {
+            "xmlAttribute": "ComPort",
+            "type": "string",
+            "default": "",
+            "description": "IP address/hostname this controller's data is sent to. Verified trap: legacy attribute name \"ComPort\" holds an IP address, not a serial port (IPOutput::SaveAttr, IPOutput.cpp @29-31 writer / @40 reader). Only written when non-empty. No property-grid row of its own: mirrors the parent <Controller>'s IP attribute, cascaded by ControllerEthernet::SetIP (ControllerEthernet.cpp @153-177). DDP additionally requires this IP be unique across all controllers (ControllerEthernetPropertyAdapter::ValidateProperties, ControllerEthernetPropertyAdapter.cpp @573-591)."
+        },
+        {
+            "xmlAttribute": "BaudRate",
+            "type": "uint",
+            "default": 1,
+            "description": "Verified trap: for DDP this is NOT a universe or channel count - it is an internal unique id (DDPOutput::GetId()/SetId(), DDPOutput.h @92-93), used only to give the output a stable identity (e.g. when the protocol is switched to DDP, ControllerEthernet::SetProtocol assigns it OutputManager::UniqueId(), ControllerEthernet.cpp @251-259). There is no \"Universe\" property-grid row for DDP at all (DDPOutputPropertyAdapter::AddProperties has no Universe entry, OutputPropertyAdapters.cpp @429-445). New DDP outputs default this id to 64001 via DDPOutput's parameterless constructor (DDPOutput.cpp @70), distinct from the base IPOutput read-fallback of 1 used only when the attribute is missing from the file."
+        },
+        {
+            "xmlAttribute": "MaxChannels",
+            "label": "Channels",
+            "gridKey": "Channels",
+            "type": "uint",
+            "min": 1,
+            "max": 2000000,
+            "description": "Total channel count sent by this DDP output (Output::SaveAttr, Output.cpp @46 writer / @76 reader). Written unconditionally. Grid range 1 to DDPOutput::GetMaxChannels() = 2,000,000 (DDPOutput.h @105, OutputPropertyAdapters.cpp @442-444). New DDP outputs default to 512 channels via DDPOutput's parameterless constructor (DDPOutput.cpp @73)."
+        },
+        {
+            "xmlAttribute": "FPPProxy",
+            "type": "string",
+            "default": "",
+            "description": "IP/hostname of an FPP proxy this output's data is routed through. Written only when non-empty (Output::SaveAttr, Output.cpp @48-51). No property-grid row of its own: mirrors the parent <Controller>'s FPPProxy attribute, cascaded by ControllerEthernet::SetFPPProxy (ControllerEthernet.cpp @407-411). DDP is one of the protocols IsFPPProxyable() supports (ControllerEthernet.h @76, see Ethernet.json)."
+        },
+        {
+            "xmlAttribute": "ChannelsPerPacket",
+            "gridKey": "ChannelsPerPacket",
+            "label": "Channels Per Packet",
+            "type": "uint",
+            "min": 1,
+            "max": 1440,
+            "description": "Maximum channel payload per DDP UDP packet; larger outputs are split into multiple packets per frame (DDPOutput::EndFrame packet-splitting loop, DDPOutput.cpp @455-493). Written unconditionally, read with default 0 if absent (DDPOutput.cpp @61) though new outputs default to 1440 (the DDP protocol's own per-packet maximum, DDPOutput.h @24, DDPOutput.cpp @72). Grid help text: 'It would be very rare that you would ever want to change this from the default.' (OutputPropertyAdapters.cpp @430-434)."
+        },
+        {
+            "xmlAttribute": "KeepChannelNumbers",
+            "gridKey": "KeepChannelNumbers",
+            "label": "Keep Channel Numbers",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "description": "When true, the channel offset sent on the wire starts at this output's actual xLights start channel minus one instead of at 0 (DDPOutput::EndFrame, DDPOutput.cpp @456: `chan = _keepChannelNumbers ? (_startChannel - 1) : 0`). Written unconditionally as \"1\"/\"0\" (DDPOutput::Save, DDPOutput.cpp @102); read via as_int with default 0 (DDPOutput.cpp @62), though new outputs default it to true via DDPOutput's parameterless constructor (DDPOutput.cpp @76). Grid help text: 'When not selected DDP data arrives at each controller looking like it starts at channel 1. When selected it arrives with the xLights channel number.' Hidden from the grid entirely when the controller's Vendor is \"FPP\" (OutputPropertyAdapters.cpp @436-440: `if (c == nullptr || c->GetVendor() != \"FPP\")`). CapsGate interaction: when a controller's capability definition declares DDPStartsAtOne (ControllerCaps::DDPStartsAtOne, ControllerCaps.cpp @401, driven by a <DDPStartsAtOne/> marker in the vendor's capability XML, e.g. resources/controllers/wled.xcontroller), switching that controller's Protocol to DDP forces this attribute to false (ControllerEthernet::SetProtocol, ControllerEthernet.cpp @261-263: `if (c && c->DDPStartsAtOne()) ddpo->SetKeepChannelNumber(false);`) - i.e. DDPStartsAtOne is effectively the inverse default of KeepChannelNumbers for that controller model, applied only at protocol-switch time (not a live grid capsGate)."
+        }
+    ],
+    "notes": [
+        "Unlike E1.31/Art-Net/KiNet, DDP has exactly one <network> child per controller - there is no per-node universe concept, no Universes/UniversesDisplay/IndivSizes/Sizes rows, and BaudRate is repurposed as an internal id rather than a channel-addressing value."
+    ]
+}

--- a/resources/controllersmetadata/protocols/E131.json
+++ b/resources/controllersmetadata/protocols/E131.json
@@ -1,0 +1,58 @@
+{
+    "schemaVersion": 1,
+    "objectType": "output",
+    "protocol": "E131",
+    "description": "One <network> child node per E1.31 universe under an ethernet <Controller Protocol=\"E131\">. Multi-universe controllers have one node per universe (sequential universes starting at the Start Universe attribute), each an independent Output object. Source of truth: src-core/outputs/Output.cpp Output::SaveAttr (@42, base writer) and IPOutput.cpp IPOutput::SaveAttr (@27, IP-output writer) for the attributes shared by every IP-based protocol document in this tree, plus E131Output.cpp constructor (@89, reader) / Save (@142, writer) for the E1.31-specific extras. Cross-checked against OutputPropertyAdapters.cpp E131OutputPropertyAdapter::AddProperties (@203) and ControllerEthernetPropertyAdapter::ValidateProperties (@601, ControllerEthernetPropertyAdapter.cpp) for grid labels, ranges and validation.",
+    "storage": { "file": "xlights_networks.xml", "node": "Controller/network" },
+    "properties": [
+        {
+            "xmlAttribute": "NetworkType",
+            "type": "string",
+            "default": "E131",
+            "description": "Protocol discriminator for this <network> node; always the literal \"E131\" (E131Output::GetType(), matching the OUTPUT_E131 constant in Output.h @30). Written unconditionally by Output::SaveAttr (Output.cpp @44). Read by the base Output::Create dispatcher (Output.cpp @112) to decide which Output subclass to instantiate - independent of, but always equal to, the parent <Controller>'s Protocol attribute. No property-grid row (fixed by the controller's Protocol selection)."
+        },
+        {
+            "xmlAttribute": "ComPort",
+            "type": "string",
+            "default": "",
+            "description": "IP address/hostname this universe's data is sent to. Verified trap: legacy attribute name \"ComPort\" holds an IP address for every IP-based protocol, not a serial port (IPOutput::SaveAttr, IPOutput.cpp @29-31 writer / @40 reader). Only written when non-empty. No property-grid row of its own: mirrors the parent <Controller>'s IP attribute, cascaded to every output by ControllerEthernet::SetIP (ControllerEthernet.cpp @153-177) whenever the controller's IP changes, so it is normally identical across all of a controller's <network> children."
+        },
+        {
+            "xmlAttribute": "BaudRate",
+            "label": "Start Universe",
+            "gridKey": "Universe",
+            "type": "uint",
+            "min": 1,
+            "max": 64000,
+            "default": 1,
+            "description": "E1.31 universe number carried in the legacy BaudRate attribute (IPOutput::SaveAttr, IPOutput.cpp @32 writer / @47 reader, default 1 if absent). Verified trap: xmlAttribute \"BaudRate\" has nothing to do with serial baud rate for E1.31 - it stores the universe. Grid range 1-64000 (OutputPropertyAdapters.cpp @204-207); ValidateProperties flags the grid row red outside that range (ControllerEthernetPropertyAdapter.cpp @610-613). For a multi-universe controller each subsequent <network> node's BaudRate is this value plus its zero-based position among the controller's outputs; the universe count itself is not a per-node attribute - it equals the number of <network> children (grid-only \"Universes\"/\"UniversesDisplay\" rows, OutputPropertyAdapters.cpp @209, @216)."
+        },
+        {
+            "xmlAttribute": "MaxChannels",
+            "label": "Channels per Universe",
+            "gridKey": "Channels",
+            "type": "uint",
+            "min": 1,
+            "max": 512,
+            "description": "Channel count for this universe (Output::SaveAttr, Output.cpp @46 writer / @76 reader, default 0 if absent - in practice always written). Written unconditionally. Grid range 1-512 (E131Output::GetMaxChannels() is 512; OutputPropertyAdapters.cpp @223-225); also checked against the controller capability max via caps->GetMaxInputUniverseChannels() (ControllerEthernetPropertyAdapter.cpp @636-643). New E1.31 outputs default to 510 channels via E131Output's parameterless constructor (E131Output.cpp @105), distinct from the 0 fallback used only when reading a file with the attribute missing. When outputs are not all the same size, the grid hides this row and shows per-universe values instead under the UI-only \"Sizes\"/\"Channels/<universe>\" rows (OutputPropertyAdapters.cpp @150-179) - still each one is this same MaxChannels attribute on its own <network> node."
+        },
+        {
+            "xmlAttribute": "FPPProxy",
+            "type": "string",
+            "default": "",
+            "description": "IP/hostname of an FPP proxy this universe's data is routed through. Written only when non-empty: Output::SaveAttr unconditionally removes any existing FPPProxy attribute then re-adds it only if IsUsingFPPProxy() (Output.cpp @48-51). No property-grid row of its own: mirrors the parent <Controller>'s FPPProxy attribute (see Ethernet.json), cascaded to every output by ControllerEthernet::SetFPPProxy (ControllerEthernet.cpp @407-411) whenever the controller-level value changes."
+        },
+        {
+            "xmlAttribute": "Priority",
+            "type": "uint",
+            "min": 0,
+            "max": 100,
+            "default": 100,
+            "description": "E1.31 data priority (E131Output.h @24 E131_DEFAULT_PRIORITY=100). Read with default 100 (E131Output.cpp @94). Verified trap: written conditionally - only present when it differs from the default 100 (E131Output::Save, E131Output.cpp @147-149: `if (_priority != E131_DEFAULT_PRIORITY)`), unlike most other attributes on this node which are unconditional. No property-grid row on the output itself: set via the parent <Controller>'s Priority property (Ethernet.json, appliesWhen Protocol E131/ZCPP) and cascaded into every E1.31 <network> child by ControllerEthernet::SetPriority (ControllerEthernet.cpp @441-455)."
+        }
+    ],
+    "notes": [
+        "The property-grid keys Universe, Universes, Channels, IndivSizes, UniversesDisplay and the Sizes/Channels/<universe> collection are NOT the persisted attribute names - Universe maps to BaudRate and Channels maps to MaxChannels (both above); Universes/UniversesDisplay/IndivSizes/Sizes have no XML attribute at all and are purely derived from the count and per-node MaxChannels of the controller's <network> children (OutputPropertyAdapters.cpp @203-242).",
+        "UniversePerString (grid key \"UniversePerString\") is a Controller-level attribute (xmlAttribute \"UPS\", see Ethernet.json), not a per-network attribute, despite being edited alongside these rows in the property grid."
+    ]
+}

--- a/resources/controllersmetadata/protocols/KiNet.json
+++ b/resources/controllersmetadata/protocols/KiNet.json
@@ -1,0 +1,57 @@
+{
+    "schemaVersion": 1,
+    "objectType": "output",
+    "protocol": "KINET",
+    "description": "One <network> child node per KiNet port under an ethernet <Controller Protocol=\"KINET\">. Multi-port controllers have one node per port. Source of truth: src-core/outputs/Output.cpp Output::SaveAttr (@42, base writer) and IPOutput.cpp IPOutput::SaveAttr (@27, IP-output writer) for the attributes shared by every IP-based protocol document in this tree, plus KinetOutput.cpp constructor (@110, reader) / Save (@140, writer) for the KiNet-specific extra. Cross-checked against OutputPropertyAdapters.cpp KinetOutputPropertyAdapter::AddProperties (@580) and ControllerEthernetPropertyAdapter::ValidateProperties (@601, ControllerEthernetPropertyAdapter.cpp) for grid labels, ranges and validation. Note the stored protocol string is \"KINET\" (all caps, OUTPUT_KINET constant, Output.h @31) though the file is named KiNet.json per the brief's convention.",
+    "storage": { "file": "xlights_networks.xml", "node": "Controller/network" },
+    "properties": [
+        {
+            "xmlAttribute": "NetworkType",
+            "type": "string",
+            "default": "KINET",
+            "description": "Protocol discriminator for this <network> node; always the literal \"KINET\" (KinetOutput::GetType(), matching the OUTPUT_KINET constant in Output.h @31). Written unconditionally by Output::SaveAttr (Output.cpp @44). No property-grid row (fixed by the controller's Protocol selection)."
+        },
+        {
+            "xmlAttribute": "ComPort",
+            "type": "string",
+            "default": "",
+            "description": "IP address/hostname this port's data is sent to. Verified trap: legacy attribute name \"ComPort\" holds an IP address, not a serial port (IPOutput::SaveAttr, IPOutput.cpp @29-31 writer / @40 reader). Only written when non-empty. No property-grid row of its own: mirrors the parent <Controller>'s IP attribute, cascaded by ControllerEthernet::SetIP (ControllerEthernet.cpp @153-177)."
+        },
+        {
+            "xmlAttribute": "BaudRate",
+            "label": "Start Port",
+            "gridKey": "Universe",
+            "type": "uint",
+            "min": 0,
+            "max": 255,
+            "default": 1,
+            "description": "KiNet port number carried in the legacy BaudRate attribute (IPOutput::SaveAttr, IPOutput.cpp @32 writer / @47 reader, default 1 if absent). Grid range 0-255, labelled \"Start Port\" (OutputPropertyAdapters.cpp @587-590); ValidateProperties flags the grid row red outside 1-255 for KINET (ControllerEthernetPropertyAdapter.cpp @614-618 - note this differs from the grid's own 0 floor, so a value of 0 is enterable but shown as invalid). Verified trap: the value actually sent on the wire is this attribute minus 1, mod 256 - KinetOutput::PopulateHeader packs `(_universe - 1) & 0xFF` as the port byte for both KiNet v1 and v2 headers (KinetOutput.cpp @76, @96), so grid/XML port N corresponds to physical KiNet port N-1 (and port value 0 wraps to physical port 255). Port count is not a per-node attribute - it equals the number of <network> children."
+        },
+        {
+            "xmlAttribute": "MaxChannels",
+            "label": "Channels per Port",
+            "gridKey": "Channels",
+            "type": "uint",
+            "min": 1,
+            "max": 512,
+            "description": "Channel count for this port (Output::SaveAttr, Output.cpp @46 writer / @76 reader). Written unconditionally. Grid range 1-512 (KinetOutput::GetMaxChannels() is 512; OutputPropertyAdapters.cpp @603-605); also checked against the controller capability max via caps->GetMaxInputUniverseChannels() (ControllerEthernetPropertyAdapter.cpp @636-643). New KiNet outputs default to 512 channels via KinetOutput's parameterless constructor (KinetOutput.cpp @121). When ports are not all the same size the grid hides this row for the per-port \"Sizes\" collection instead (OutputPropertyAdapters.cpp @527-556) - same underlying MaxChannels attribute on each <network> node."
+        },
+        {
+            "xmlAttribute": "FPPProxy",
+            "type": "string",
+            "default": "",
+            "description": "IP/hostname of an FPP proxy this port's data is routed through. Written only when non-empty (Output::SaveAttr, Output.cpp @48-51). No property-grid row of its own: mirrors the parent <Controller>'s FPPProxy attribute, cascaded by ControllerEthernet::SetFPPProxy (ControllerEthernet.cpp @407-411). KiNet is not in ControllerEthernet::IsFPPProxyable()'s list (E131/DDP/Twinkly/Player Only only, ControllerEthernet.h @76), so this attribute is written but not meaningfully usable for KiNet."
+        },
+        {
+            "xmlAttribute": "Version",
+            "type": "uint",
+            "min": 1,
+            "max": 2,
+            "default": 2,
+            "description": "KiNet protocol version (1 or 2), selecting the v1 21-byte or v2 24-byte packet header (KinetOutput::GetHeaderPacketLength/PopulateHeader, KinetOutput.h @35-38, KinetOutput.cpp @47-106). Written unconditionally on every KiNet <network> node (KinetOutput::Save, KinetOutput.cpp @145); read with default 2 (KinetOutput.cpp @115). No property-grid row on the output itself: set via the parent <Controller>'s Version property (Ethernet.json, appliesWhen Protocol KINET, grid range 1-2) and cascaded into every KiNet <network> child by ControllerEthernet::SetVersion (ControllerEthernet.cpp @458)."
+        }
+    ],
+    "notes": [
+        "The property-grid keys Universe (labelled \"Start Port\"), Universes (labelled \"Port Count\"), Channels, IndivSizes, UniversesDisplay (labelled \"Ports\") and the Sizes/Channels/<port> collection are NOT the persisted attribute names one-for-one - Universe maps to BaudRate and Channels maps to MaxChannels (both above); Universes/UniversesDisplay/IndivSizes/Sizes have no XML attribute at all and are derived from the count and per-node MaxChannels of the controller's <network> children (OutputPropertyAdapters.cpp @580-618)."
+    ]
+}

--- a/resources/controllersmetadata/protocols/OPC.json
+++ b/resources/controllersmetadata/protocols/OPC.json
@@ -1,0 +1,49 @@
+{
+    "schemaVersion": 1,
+    "objectType": "output",
+    "protocol": "OPC",
+    "description": "The single <network> child node under an ethernet <Controller Protocol=\"OPC\">. OPC (Open Pixel Control, http://openpixelcontrol.org/) is a TCP protocol; there is exactly one Output/one <network> node per controller. OPC adds no attributes of its own beyond the shared IP-output base set - source of truth: src-core/outputs/Output.cpp Output::SaveAttr (@42, base writer) and IPOutput.cpp IPOutput::SaveAttr (@27, IP-output writer), plus OPCOutput.cpp constructor (@55, reader) / Save (@88, writer) which adds nothing further. Cross-checked against OutputPropertyAdapters.cpp OPCOutputPropertyAdapter::AddProperties (@792) and ControllerEthernetPropertyAdapter::ValidateProperties (@601, ControllerEthernetPropertyAdapter.cpp) for grid labels, ranges and validation.",
+    "storage": { "file": "xlights_networks.xml", "node": "Controller/network" },
+    "properties": [
+        {
+            "xmlAttribute": "NetworkType",
+            "type": "string",
+            "default": "OPC",
+            "description": "Protocol discriminator for this <network> node; always the literal \"OPC\" (OPCOutput::GetType(), matching the OUTPUT_OPC constant in Output.h @46). Written unconditionally by Output::SaveAttr (Output.cpp @44). No property-grid row (fixed by the controller's Protocol selection)."
+        },
+        {
+            "xmlAttribute": "ComPort",
+            "type": "string",
+            "default": "",
+            "description": "IP address/hostname this controller's OPC TCP connection is made to. Verified trap: legacy attribute name \"ComPort\" holds an IP address, not a serial port (IPOutput::SaveAttr, IPOutput.cpp @29-31 writer / @40 reader). Only written when non-empty. No property-grid row of its own: mirrors the parent <Controller>'s IP attribute, cascaded by ControllerEthernet::SetIP (ControllerEthernet.cpp @153-177)."
+        },
+        {
+            "xmlAttribute": "BaudRate",
+            "label": "OPC Channel",
+            "gridKey": "Universe",
+            "type": "uint",
+            "min": 1,
+            "max": 255,
+            "default": 1,
+            "description": "OPC channel number, sent as the single-byte channel id in the OPC packet header (OPCOutput::Open, OPCOutput.cpp @160: `_data[0] = (uint8_t)_universe;`). Carried in the legacy BaudRate attribute (IPOutput::SaveAttr, IPOutput.cpp @32 writer / @47 reader, default 1 if absent). Verified trap: the grid's SpinCtrl allows 0-255 (OutputPropertyAdapters.cpp @793-796), but ControllerEthernetPropertyAdapter::ValidateProperties flags the row red outside 1-255 for OPC (ControllerEthernetPropertyAdapter.cpp @614-618) - so 0, though enterable, is not a valid value."
+        },
+        {
+            "xmlAttribute": "MaxChannels",
+            "label": "Message Data Size",
+            "gridKey": "Channels",
+            "type": "uint",
+            "min": 1,
+            "max": 65535,
+            "description": "Channel count for this OPC output, sent as the 16-bit payload-length field in the OPC packet header (OPCOutput::Open, OPCOutput.cpp @162-163). Written unconditionally (Output::SaveAttr, Output.cpp @46 writer / @76 reader). Grid range 1 to OPCOutput::GetMaxChannels() = 65535 (OPCOutput.h @56, OutputPropertyAdapters.cpp @798-800). New OPC outputs default to 510 channels via OPCOutput's parameterless constructor (OPCOutput.cpp @65)."
+        },
+        {
+            "xmlAttribute": "FPPProxy",
+            "type": "string",
+            "default": "",
+            "description": "IP/hostname of an FPP proxy this output's data is routed through. Written only when non-empty (Output::SaveAttr, Output.cpp @48-51). No property-grid row of its own: mirrors the parent <Controller>'s FPPProxy attribute, cascaded by ControllerEthernet::SetFPPProxy (ControllerEthernet.cpp @407-411). OPC is not in ControllerEthernet::IsFPPProxyable()'s list (E131/DDP/Twinkly/Player Only only, ControllerEthernet.h @76), so this attribute is written but not meaningfully usable for OPC."
+        }
+    ],
+    "notes": [
+        "OPC has exactly one <network> child per controller (like DDP/ZCPP/Twinkly) - there is no per-node universe concept and no Universes/UniversesDisplay/IndivSizes/Sizes rows."
+    ]
+}

--- a/resources/controllersmetadata/protocols/Twinkly.json
+++ b/resources/controllersmetadata/protocols/Twinkly.json
@@ -1,0 +1,55 @@
+{
+    "schemaVersion": 1,
+    "objectType": "output",
+    "protocol": "Twinkly",
+    "description": "The single <network> child node under an ethernet <Controller Protocol=\"Twinkly\">. Twinkly controllers are addressed over HTTP (for auth/layout/mode control) and UDP (for realtime channel data); there is exactly one Output/one <network> node per controller. Source of truth: src-core/outputs/Output.cpp Output::SaveAttr (@42, base writer) and IPOutput.cpp IPOutput::SaveAttr (@27, IP-output writer) for the attributes shared by every IP-based protocol document in this tree, plus TwinklyOutput.cpp constructor (@32, reader) / Save (@54, writer) for the Twinkly-specific extra. Cross-checked against OutputPropertyAdapters.cpp TwinklyOutputPropertyAdapter::AddProperties (@732) for grid labels and ranges.",
+    "storage": { "file": "xlights_networks.xml", "node": "Controller/network" },
+    "properties": [
+        {
+            "xmlAttribute": "NetworkType",
+            "type": "string",
+            "default": "Twinkly",
+            "description": "Protocol discriminator for this <network> node; always the literal \"Twinkly\" (TwinklyOutput::GetType(), matching the OUTPUT_TWINKLY constant in Output.h @48). Written unconditionally by Output::SaveAttr (Output.cpp @44). No property-grid row (fixed by the controller's Protocol selection)."
+        },
+        {
+            "xmlAttribute": "ComPort",
+            "type": "string",
+            "default": "",
+            "description": "IP address/hostname of the Twinkly device: used for both the HTTP control calls (TwinklyOutput::MakeCall, TwinklyOutput.cpp @332,@350) and the realtime UDP data socket (TwinklyOutput::EndFrame, TwinklyOutput.cpp @262). Verified trap: legacy attribute name \"ComPort\" holds an IP address, not a serial port (IPOutput::SaveAttr, IPOutput.cpp @29-31 writer / @40 reader). Only written when non-empty. No property-grid row of its own: mirrors the parent <Controller>'s IP attribute, cascaded by ControllerEthernet::SetIP (ControllerEthernet.cpp @153-177)."
+        },
+        {
+            "xmlAttribute": "BaudRate",
+            "type": "uint",
+            "default": 1,
+            "description": "Verified trap: for Twinkly this is NOT a universe or channel count - it is an internal id (TwinklyOutput::GetId()/SetId(), TwinklyOutput.h @49-57), assigned OutputManager::UniqueId() when the protocol is switched to Twinkly (ControllerEthernet::SetProtocol, ControllerEthernet.cpp @268-277). There is no \"Universe\" property-grid row for Twinkly (TwinklyOutputPropertyAdapter::AddProperties has no Universe entry, OutputPropertyAdapters.cpp @732-742). Read with the base IPOutput fallback of 1 if the attribute is missing (IPOutput.cpp @47)."
+        },
+        {
+            "xmlAttribute": "MaxChannels",
+            "label": "Channels",
+            "gridKey": "Channels",
+            "type": "uint",
+            "min": 1,
+            "max": 8000,
+            "description": "Total channel count for this Twinkly output (Output::SaveAttr, Output.cpp @46 writer / @76 reader). Written unconditionally. Grid range 1 to TwinklyOutput::GetMaxChannels() = MAX_CHANNELS = 4*2000 = 8000 (TwinklyOutput.h @98, OutputPropertyAdapters.cpp @739-741) - a single Twinkly connection is documented in code as having 'unlimited channels' but the class caps it at 8000. Typically auto-sized from the device's reported pixel layout during discovery (TwinklyOutput::GetLayout, TwinklyOutput.cpp @845-847: `controller->SetChannelSize(pixels.size() * 3)`)."
+        },
+        {
+            "xmlAttribute": "FPPProxy",
+            "type": "string",
+            "default": "",
+            "description": "IP/hostname of an FPP proxy this output's data is routed through. Written only when non-empty (Output::SaveAttr, Output.cpp @48-51). No property-grid row of its own: mirrors the parent <Controller>'s FPPProxy attribute, cascaded by ControllerEthernet::SetFPPProxy (ControllerEthernet.cpp @407-411). Twinkly is one of the protocols IsFPPProxyable() supports (ControllerEthernet.h @76, see Ethernet.json)."
+        },
+        {
+            "xmlAttribute": "HTTPPort",
+            "gridKey": "HTTPPort",
+            "label": "HTTP Port",
+            "type": "uint",
+            "min": 1,
+            "max": 65535,
+            "default": 80,
+            "description": "TCP port for the Twinkly device's HTTP control API (login/verify/led-mode/layout calls, TwinklyOutput::MakeCall, TwinklyOutput.cpp @329-377). Written unconditionally (TwinklyOutput::Save, TwinklyOutput.cpp @58); read with default 80 (TwinklyOutput.cpp @35). Grid help text: 'Twinkly normally listens on port 80 but you may want to change the port if using Artnet To Twinkly.' (OutputPropertyAdapters.cpp @733-737). Note the realtime UDP data channel always uses the fixed port 7777 (TwinklyOutput.h UDP_PORT @102) regardless of this attribute - HTTPPort only affects the HTTP control calls."
+        }
+    ],
+    "notes": [
+        "Twinkly has exactly one <network> child per controller (like DDP/ZCPP/OPC) - there is no per-node universe concept and no Universes/UniversesDisplay/IndivSizes/Sizes rows, and BaudRate is repurposed as an internal id rather than a channel-addressing value."
+    ]
+}

--- a/resources/controllersmetadata/protocols/ZCPP.json
+++ b/resources/controllersmetadata/protocols/ZCPP.json
@@ -1,0 +1,107 @@
+{
+    "schemaVersion": 1,
+    "objectType": "output",
+    "protocol": "ZCPP",
+    "description": "The single <network> child node under an ethernet <Controller Protocol=\"ZCPP\">. ZCPP (Falcon's zero-configuration pixel protocol) controllers are not universe-based - there is exactly one Output/one <network> node per controller; per-port configuration lives in a separate .zcpp model-data file next to the show, not in xlights_networks.xml. Source of truth: src-core/outputs/Output.cpp Output::SaveAttr (@42, base writer) and IPOutput.cpp IPOutput::SaveAttr (@27, IP-output writer) for the attributes shared by every IP-based protocol document in this tree, plus ZCPPOutput.cpp constructor (@103, reader) / Save (@256, writer) for the ZCPP-specific extras. Cross-checked against OutputPropertyAdapters.cpp ZCPPOutputPropertyAdapter::AddProperties (@644) for grid labels and ranges.",
+    "storage": { "file": "xlights_networks.xml", "node": "Controller/network" },
+    "properties": [
+        {
+            "xmlAttribute": "NetworkType",
+            "type": "string",
+            "default": "ZCPP",
+            "description": "Protocol discriminator for this <network> node; always the literal \"ZCPP\" (ZCPPOutput::GetType(), matching the OUTPUT_ZCPP constant in Output.h @32). Written unconditionally by Output::SaveAttr (Output.cpp @44). No property-grid row (fixed by the controller's Protocol selection)."
+        },
+        {
+            "xmlAttribute": "ComPort",
+            "type": "string",
+            "default": "",
+            "description": "IP address/hostname this controller's data is sent to. Verified trap: legacy attribute name \"ComPort\" holds an IP address, not a serial port (IPOutput::SaveAttr, IPOutput.cpp @29-31 writer / @40 reader). Only written when non-empty. No property-grid row of its own: mirrors the parent <Controller>'s IP attribute, cascaded by ControllerEthernet::SetIP (ControllerEthernet.cpp @153-177). ZCPP additionally requires this IP be unique across all controllers (ControllerEthernetPropertyAdapter::ValidateProperties, ControllerEthernetPropertyAdapter.cpp @573-591). Also used, with '.' replaced by '_', to locate this controller's model-data file <ip>.zcpp in the show folder (ZCPPOutput constructor, ZCPPOutput.cpp @126-128)."
+        },
+        {
+            "xmlAttribute": "BaudRate",
+            "type": "int",
+            "default": 1,
+            "description": "Verified trap: for ZCPP this is NOT a universe or channel count - it is an internal id (ZCPPOutput::GetId()/SetId(), ZCPPOutput.h @98-99), assigned OutputManager::UniqueId() when the protocol is switched to ZCPP (ControllerEthernet::SetProtocol, ControllerEthernet.cpp @241-244). There is no \"Universe\" property-grid row for ZCPP (ZCPPOutputPropertyAdapter::AddProperties has no Universe entry, OutputPropertyAdapters.cpp @644-664). New ZCPP outputs default this id to -1 via ZCPPOutput's parameterless constructor (ZCPPOutput.cpp @208), distinct from the base IPOutput read-fallback of 1 used only when the attribute is missing from the file."
+        },
+        {
+            "xmlAttribute": "MaxChannels",
+            "label": "Channels",
+            "gridKey": "Channels",
+            "type": "uint",
+            "min": 1,
+            "max": 16384,
+            "description": "Total channel count for this ZCPP output (Output::SaveAttr, Output.cpp @46 writer / @76 reader). Written unconditionally. Grid range 1 to ZCPPOutput::GetMaxChannels() = ZCPP_MAXCHANNELS = 16*1024 = 16384 (ZCPPOutput.h @24,@94, OutputPropertyAdapters.cpp @661-663). Normally auto-sized from the controller's model-data file: ZCPPOutput::ExtractUsedChannelsFromModelData recomputes and overwrites this from the port configuration in the .zcpp file when the controller is set to Auto Size (ZCPPOutput.cpp @40-80). New outputs default to 1 channel via ZCPPOutput's parameterless constructor (ZCPPOutput.cpp @206)."
+        },
+        {
+            "xmlAttribute": "FPPProxy",
+            "type": "string",
+            "default": "",
+            "description": "IP/hostname of an FPP proxy this output's data is routed through. Written only when non-empty (Output::SaveAttr, Output.cpp @48-51). No property-grid row of its own: mirrors the parent <Controller>'s FPPProxy attribute, cascaded by ControllerEthernet::SetFPPProxy (ControllerEthernet.cpp @407-411). ZCPP is not in ControllerEthernet::IsFPPProxyable()'s list (E131/DDP/Twinkly/Player Only only, ControllerEthernet.h @76), so this attribute is written but not meaningfully usable for ZCPP."
+        },
+        {
+            "xmlAttribute": "Vendor",
+            "type": "int",
+            "default": 65535,
+            "description": "Encoded ZCPP vendor id (ZCPPOutput::EncodeVendor/DecodeVendor, ZCPPOutput.cpp @550-569; e.g. Falcon, FPP, ESP Pixel Stick, or 65535/ZCPP_VENDOR_UNKNOWN). Written unconditionally (ZCPPOutput::Save, ZCPPOutput.cpp @260); read with default 65535 (ZCPPOutput.cpp @116). No property-grid row - not populated by any current discovery or grid code path found; effectively round-trips whatever value was already in the file. Distinct from the parent <Controller>'s Vendor attribute (a plain string, see shared/Controller.json), which IS populated by discovery."
+        },
+        {
+            "xmlAttribute": "Model",
+            "type": "int",
+            "default": 65535,
+            "description": "Encoded ZCPP model id, paired with Vendor above. Written unconditionally (ZCPPOutput::Save, ZCPPOutput.cpp @261); read with default 65535 (ZCPPOutput.cpp @117). No property-grid row; same round-trip-only caveat as Vendor. Distinct from the parent <Controller>'s Model attribute (a plain string)."
+        },
+        {
+            "xmlAttribute": "Priority",
+            "type": "uint",
+            "min": 0,
+            "max": 100,
+            "default": 100,
+            "description": "ZCPP data priority. Written unconditionally (ZCPPOutput::Save, ZCPPOutput.cpp @262) - unlike E1.31's Priority, there is no default-value suppression here. Read with default 100 (ZCPPOutput.cpp @118). No property-grid row on the output itself: set via the parent <Controller>'s Priority property (Ethernet.json, appliesWhen Protocol E131/ZCPP) and cascaded into every ZCPP <network> child by ControllerEthernet::SetPriority (ControllerEthernet.cpp @441-455)."
+        },
+        {
+            "xmlAttribute": "SupportsVirtualStrings",
+            "gridKey": "SupportsVirtualStrings",
+            "label": "Supports Virtual Strings",
+            "type": "bool",
+            "boolFormat": "TRUEFALSE",
+            "default": "FALSE",
+            "description": "Whether this ZCPP controller supports splitting a physical output into multiple virtual strings. Written unconditionally as \"TRUE\"/\"FALSE\" (ZCPPOutput::Save, ZCPPOutput.cpp @263); read with default \"FALSE\" (ZCPPOutput.cpp @119). Auto-populated from a discovery-response flag bit (ZCPP_DISCOVERY_FLAG_SUPPORTS_VIRTUAL_STRINGS) when the controller is discovered (ZCPPOutput.cpp @496-498), also editable directly in the grid (OutputPropertyAdapters.cpp @649-650)."
+        },
+        {
+            "xmlAttribute": "SupportsSmartRemotes",
+            "gridKey": "SupportsSmartRemotes",
+            "label": "Supports Smart Remotes",
+            "type": "bool",
+            "boolFormat": "TRUEFALSE",
+            "default": "FALSE",
+            "description": "Whether this ZCPP controller supports smart remotes. Written unconditionally as \"TRUE\"/\"FALSE\" (ZCPPOutput::Save, ZCPPOutput.cpp @264); read with default \"FALSE\" (ZCPPOutput.cpp @120). Auto-populated from a discovery-response flag bit (ZCPP_DISCOVERY_FLAG_SUPPORTS_SMART_REMOTES, ZCPPOutput.cpp @500-502), also editable directly in the grid (OutputPropertyAdapters.cpp @652-653)."
+        },
+        {
+            "xmlAttribute": "DontConfigure",
+            "gridKey": "DontSendConfig",
+            "label": "Suppress Sending Configuration",
+            "type": "bool",
+            "boolFormat": "presentOnly",
+            "description": "Verified trap: the property-grid key is \"DontSendConfig\" but the persisted xmlAttribute is \"DontConfigure\". When true, xLights does not push its model-data configuration to this controller (it also skips reading any local .zcpp model-data file at all, ZCPPOutput constructor, ZCPPOutput.cpp @125,@199-201). Written as the literal \"TRUE\" only when true (ZCPPOutput::Save, ZCPPOutput.cpp @265: `if (_dontConfigure) node.append_attribute(\"DontConfigure\") = \"TRUE\";`); absent means false. Read by comparing against \"TRUE\" with default \"FALSE\" (ZCPPOutput.cpp @122). Auto-populated from a discovery-response flag bit (ZCPP_DISCOVERY_FLAG_CONFIGURATION_LOCKED, ZCPPOutput.cpp @504-506)."
+        },
+        {
+            "xmlAttribute": "Multicast",
+            "gridKey": "SendDataMulticast",
+            "label": "Send Data Multicast",
+            "type": "bool",
+            "boolFormat": "presentOnly",
+            "description": "Verified trap: the property-grid key is \"SendDataMulticast\" but the persisted xmlAttribute is \"Multicast\" (distinct from the E1.31/DDP concept of a controller-level \"MULTICAST\" IP sentinel - this is a ZCPP-only per-output flag). When true, pixel data is sent to a multicast address (ZCPP_GetDataMulticastAddress(ip), displayed read-only in the grid as \"Multicast Address\"/\"MulticastAddressDisplay\", OutputPropertyAdapters.cpp @645-647) instead of unicast to ComPort. Written as the literal \"TRUE\" only when true (ZCPPOutput::Save, ZCPPOutput.cpp @266); absent means false. Read by comparing against \"TRUE\" with default \"FALSE\" (ZCPPOutput.cpp @121). Auto-populated from a discovery-response flag bit (ZCPP_DISCOVERY_FLAG_SEND_DATA_AS_MULTICAST, ZCPPOutput.cpp @508-510)."
+        },
+        {
+            "xmlAttribute": "Protocols",
+            "type": "string",
+            "default": "",
+            "encoding": "Pipe-delimited ('|') list of lower-cased protocol names this ZCPP controller advertises support for (ZCPPOutput::SerialiseProtocols/DeserialiseProtocols, ZCPPOutput.cpp @82-99), e.g. \"ws2811|tm18xx\".",
+            "description": "Set of pixel protocols this ZCPP controller supports, used to populate protocol choice lists elsewhere in the UI. Written unconditionally (ZCPPOutput::Save, ZCPPOutput.cpp @267); read via DeserialiseProtocols with default \"\" (ZCPPOutput.cpp @123). Auto-populated bit-by-bit from a discovery response (ZCPPOutput.cpp @514-522). No property-grid row."
+        }
+    ],
+    "notes": [
+        "ZCPP has exactly one <network> child per controller (like DDP/OPC/Twinkly) - there is no per-node universe/port concept, no Universes/UniversesDisplay/IndivSizes/Sizes rows, and BaudRate is repurposed as an internal id rather than a channel-addressing value.",
+        "Per-port configuration (string counts, pixel types, colour order, smart remotes, etc.) lives in a separate <ip>.zcpp binary model-data file in the show folder, not as XML attributes on this <network> node; that file's format is out of scope for this metadata tree."
+    ]
+}

--- a/resources/controllersmetadata/protocols/ZCPP.json
+++ b/resources/controllersmetadata/protocols/ZCPP.json
@@ -81,7 +81,7 @@
             "gridKey": "DontSendConfig",
             "label": "Suppress Sending Configuration",
             "type": "bool",
-            "boolFormat": "presentOnly",
+            "boolFormat": "TRUEFALSE",
             "description": "Verified trap: the property-grid key is \"DontSendConfig\" but the persisted xmlAttribute is \"DontConfigure\". When true, xLights does not push its model-data configuration to this controller (it also skips reading any local .zcpp model-data file at all, ZCPPOutput constructor, ZCPPOutput.cpp @125,@199-201). Written as the literal \"TRUE\" only when true (ZCPPOutput::Save, ZCPPOutput.cpp @265: `if (_dontConfigure) node.append_attribute(\"DontConfigure\") = \"TRUE\";`); absent means false. Read by comparing against \"TRUE\" with default \"FALSE\" (ZCPPOutput.cpp @122). Auto-populated from a discovery-response flag bit (ZCPP_DISCOVERY_FLAG_CONFIGURATION_LOCKED, ZCPPOutput.cpp @504-506)."
         },
         {
@@ -89,7 +89,7 @@
             "gridKey": "SendDataMulticast",
             "label": "Send Data Multicast",
             "type": "bool",
-            "boolFormat": "presentOnly",
+            "boolFormat": "TRUEFALSE",
             "description": "Verified trap: the property-grid key is \"SendDataMulticast\" but the persisted xmlAttribute is \"Multicast\" (distinct from the E1.31/DDP concept of a controller-level \"MULTICAST\" IP sentinel - this is a ZCPP-only per-output flag). When true, pixel data is sent to a multicast address (ZCPP_GetDataMulticastAddress(ip), displayed read-only in the grid as \"Multicast Address\"/\"MulticastAddressDisplay\", OutputPropertyAdapters.cpp @645-647) instead of unicast to ComPort. Written as the literal \"TRUE\" only when true (ZCPPOutput::Save, ZCPPOutput.cpp @266); absent means false. Read by comparing against \"TRUE\" with default \"FALSE\" (ZCPPOutput.cpp @121). Auto-populated from a discovery-response flag bit (ZCPP_DISCOVERY_FLAG_SEND_DATA_AS_MULTICAST, ZCPPOutput.cpp @508-510)."
         },
         {

--- a/resources/controllersmetadata/shared/Controller.json
+++ b/resources/controllersmetadata/shared/Controller.json
@@ -93,7 +93,7 @@
             "label": "Full xLights Control",
             "gridKey": "FullxLightsControl",
             "type": "bool",
-            "boolFormat": "presentOnly",
+            "boolFormat": "TRUEFALSE",
             "capsGate": "SupportsFullxLightsControl",
             "description": "When set, uploading erases the configuration of all unused ports on the controller. Written as the literal \"TRUE\" and only when true (Controller::Save @180: `if (_fullxLightsControl) ... = \"TRUE\"`); absent means false. The reader compares the value against \"TRUE\" with default \"FALSE\" (Controller.cpp @116), so presence with any other value also reads as false. Besides the caps gate, ControllerEthernet::SupportsFullxLightsControl hard-returns false for the ZCPP protocol (ControllerEthernet.cpp @588)."
         },

--- a/resources/controllersmetadata/shared/Controller.json
+++ b/resources/controllersmetadata/shared/Controller.json
@@ -1,0 +1,172 @@
+{
+    "schemaVersion": 1,
+    "description": "Attributes common to every <Controller> node in xlights_networks.xml, regardless of Type. Extended by every top-level controller document in this tree. Source of truth: src-core/outputs/Controller.cpp constructor (@84, reader) and Controller::Save (@166, writer), cross-checked against src-ui-wx/controllerproperties/ControllerPropertyAdapter.cpp AddProperties (@187) / UpdateProperties (@115) / ValidateProperties (@444) for labels, ranges and grid gating.",
+    "storage": { "file": "xlights_networks.xml", "node": "Controller" },
+    "properties": [
+        {
+            "xmlAttribute": "Name",
+            "label": "Name",
+            "gridKey": "ControllerName",
+            "type": "string",
+            "description": "Unique controller name. Trimmed on read/set; must be unique across all controllers, non-blank, must not contain ':' (used as a separator in \"!ControllerName:N\" model start-channel references) and must not equal the NO_CONTROLLER sentinel \"No Controller\" (ControllerPropertyAdapter::HandlePropertyEvent / ValidateProperties). Written unconditionally; on read a missing Name gets a generated unique default."
+        },
+        {
+            "xmlAttribute": "Description",
+            "label": "Description",
+            "gridKey": "ControllerDescription",
+            "type": "string",
+            "default": "",
+            "description": "Free-text user note about the controller. Trimmed. Written unconditionally, including when empty (Controller::Save)."
+        },
+        {
+            "xmlAttribute": "Type",
+            "label": "Type",
+            "type": "enum",
+            "enum": ["Null", "Ethernet", "Serial"],
+            "description": "Controller sub-type discriminator (CONTROLLER_NULL/CONTROLLER_ETHERNET/CONTROLLER_SERIAL constants in src-core/outputs/Controller.h @31-33). Fixed at creation time; selects the concrete class in Controller::Create and therefore which top-level document in this tree applies. Only \"Ethernet\" (Ethernet.json) is covered by this metadata tree so far; \"Null\" and \"Serial\" documents are a known coverage gap. Not editable in the property grid."
+        },
+        {
+            "xmlAttribute": "Vendor",
+            "label": "Vendor",
+            "gridKey": "Vendor",
+            "type": "string",
+            "default": "",
+            "description": "Controller vendor name. Not a fixed enum: the property grid offers the vendor list from ControllerCaps::GetVendors(type), sourced from the controller capability XML files shipped in resources/controllers. Empty means a generic/unknown controller (no ControllerCaps). Legacy vendor/model spellings are migrated on load by Controller::SearchForNewVendor (__controllerNameMap, Controller.cpp @45)."
+        },
+        {
+            "xmlAttribute": "Model",
+            "label": "Model/Category",
+            "gridKey": "Model",
+            "type": "string",
+            "default": "",
+            "description": "Controller model within the selected Vendor. Choices come from ControllerCaps::GetModels(type, vendor); empty when no vendor/model selected. Together with Vendor and Variant this keys the ControllerCaps capability definition that gates several other properties (see capsGate fields)."
+        },
+        {
+            "xmlAttribute": "Variant",
+            "label": "Variant",
+            "gridKey": "Variant",
+            "type": "string",
+            "default": "",
+            "description": "Controller variant within the selected Vendor/Model (e.g. firmware generation or expansion configuration). Choices from ControllerCaps::GetVariants(type, vendor, model); empty when the model has no variants."
+        },
+        {
+            "xmlAttribute": "Id",
+            "label": "Id",
+            "gridKey": "ControllerId",
+            "type": "uint",
+            "default": 64001,
+            "min": 1,
+            "max": 65335,
+            "description": "Controller id, used with some start-channel addressing modes for controllers that do not support universes. Read default is 64001 (Controller.cpp @109); new controllers get OutputManager::UniqueId(). Should be unique across controllers (ValidateProperties flags duplicates red but does not block saving). The grid hides it when Controller::IsNeedsId() is false. Note the grid max really is 65335, not 65535 (ControllerPropertyAdapter.cpp @212)."
+        },
+        {
+            "xmlAttribute": "AutoLayout",
+            "label": "Auto Layout Models",
+            "gridKey": "AutoLayout",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "capsGate": "SupportsAutoLayout",
+            "description": "When true xLights may move models around within the controller's channel range to optimise them, and models can be moved between controllers in the visualiser. Written unconditionally. On read, disabling AutoLayout also forces AutoSize off (Controller.cpp @120)."
+        },
+        {
+            "xmlAttribute": "AutoUpload",
+            "label": "Auto Upload Configuration",
+            "gridKey": "AutoUpload",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "capsGate": "SupportsAutoUpload",
+            "description": "When true the controller configuration is uploaded to the controller when output-to-lights is turned on. Written unconditionally, but the writer coerces the value to \"0\" when the controller does not support auto upload (Controller::Save @186: `_autoUpload && SupportsAutoUpload()`). Controller::SupportsAutoUpload additionally hard-returns false for the ZCPP protocol regardless of caps (Controller.cpp @586)."
+        },
+        {
+            "xmlAttribute": "AutoSize",
+            "label": "Auto Size",
+            "gridKey": "AutoSize",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "description": "When true xLights dynamically resizes the controller's channel/universe count to exactly fit the models assigned to it. Written unconditionally. Gating is NOT a ControllerCaps method (no capsGate): Controller::SupportsAutoSize() is a C++ virtual, false in the base class and overridden by ControllerEthernet to `managed && AutoLayout && Protocol != \"Player Only\"` (ControllerEthernet.h @137). On read it is forced off when AutoLayout is off (Controller.cpp @120)."
+        },
+        {
+            "xmlAttribute": "FullxLightsControl",
+            "label": "Full xLights Control",
+            "gridKey": "FullxLightsControl",
+            "type": "bool",
+            "boolFormat": "presentOnly",
+            "capsGate": "SupportsFullxLightsControl",
+            "description": "When set, uploading erases the configuration of all unused ports on the controller. Written as the literal \"TRUE\" and only when true (Controller::Save @180: `if (_fullxLightsControl) ... = \"TRUE\"`); absent means false. The reader compares the value against \"TRUE\" with default \"FALSE\" (Controller.cpp @116), so presence with any other value also reads as false. Besides the caps gate, ControllerEthernet::SupportsFullxLightsControl hard-returns false for the ZCPP protocol (ControllerEthernet.cpp @588)."
+        },
+        {
+            "xmlAttribute": "DefaultBrightnessUnderFullControl",
+            "label": "Default Port Brightness",
+            "gridKey": "DefaultBrightnessUnderFullxLightsControl",
+            "type": "uint",
+            "default": 100,
+            "min": 5,
+            "max": 100,
+            "capsGate": "SupportsDefaultBrightness",
+            "appliesWhen": { "attribute": "FullxLightsControl", "equals": "TRUE" },
+            "description": "Brightness percentage applied to all ports during Full xLights Control upload unless overridden per model. Verified trap: xmlAttribute (\"DefaultBrightnessUnderFullControl\") differs from its wxPropertyGrid key (\"DefaultBrightnessUnderFullxLightsControl\"). Written unconditionally even when FullxLightsControl is off; only shown/meaningful when Full xLights Control is enabled and the caps support a default brightness."
+        },
+        {
+            "xmlAttribute": "DefaultGammaUnderFullControl",
+            "label": "Default Port Gamma",
+            "gridKey": "DefaultGammaUnderFullxLightsControl",
+            "type": "float",
+            "default": 1.0,
+            "min": 0.1,
+            "max": 5.0,
+            "capsGate": "SupportsDefaultGamma",
+            "appliesWhen": { "attribute": "FullxLightsControl", "equals": "TRUE" },
+            "description": "Gamma applied to all ports during Full xLights Control upload unless overridden per model. Same xmlAttribute-vs-gridKey trap as DefaultBrightnessUnderFullControl. Written unconditionally; only shown/meaningful when Full xLights Control is enabled and the caps support a default gamma."
+        },
+        {
+            "xmlAttribute": "ActiveState",
+            "label": "Active",
+            "gridKey": "Active",
+            "type": "enum",
+            "enum": ["Active", "Inactive", "xLights Only"],
+            "default": "Active",
+            "legacyAttributes": ["Active"],
+            "description": "Whether this controller outputs data. \"Inactive\" outputs nothing (and uploads to FPP/xSchedule will not output either); \"xLights Only\" outputs only when played from xLights. Stored strings verified in Controller::DecodeActiveState (Controller.cpp @322). Verified trap: xmlAttribute is \"ActiveState\" while the wxPropertyGrid key is \"Active\". The legacy attribute \"Active\" (\"0\"/\"1\") is read as a fallback when ActiveState is absent (Controller.cpp @86-95) and never written by the current version. ValidateProperties flags \"Active\" red for Player-Only caps controllers (they should be \"xLights Only\" or \"Inactive\")."
+        },
+        {
+            "xmlAttribute": "Monitor",
+            "label": "Monitor",
+            "gridKey": "Monitor",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "description": "When true the show player monitors connectivity to the controller (ping packets or other network traffic). Disabling reduces network traffic and controller load. Written unconditionally."
+        },
+        {
+            "xmlAttribute": "SuppressDuplicates",
+            "label": "Suppress Duplicate Frames",
+            "gridKey": "SuppressDuplicates",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "description": "When true, frames whose data is identical to the previous frame are not re-sent, trusting the controller to reuse the previous data. Written unconditionally. Gating is NOT a ControllerCaps method (no capsGate): Controller::SupportsSuppressDuplicateFrames() is a C++ virtual, true in the base class, overridden by ControllerEthernet to `Protocol != \"Player Only\"` (ControllerEthernet.h @141)."
+        },
+        {
+            "xmlAttribute": "FromBase",
+            "label": "From Base Show Folder",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "description": "Read-only provenance flag: true when this controller's definition was merged in from a linked base show folder rather than defined locally. Set programmatically during base-folder merge, not user-editable in the property grid. Written unconditionally (both \"0\" and \"1\" appear in files, Controller::Save @179)."
+        }
+    ],
+    "childElements": [
+        {
+            "name": "ExtraProperty",
+            "description": "Vendor-capability extra properties: zero or more <ExtraProperty name=\"...\" value=\"...\"/> children, written only when at least one exists (Controller::Save @192). The set of meaningful names, labels, types (String or Enum) and allowed values comes from the controller's ControllerCaps::GetExtraPropertyDefs() capability definition; unknown pairs round-trip verbatim. In the property grid each appears with key \"Controller\" + name (ControllerPropertyAdapter.cpp @262).",
+            "encoding": "One element per key/value pair; lowercase attribute names \"name\" and \"value\", both plain strings (Controller.cpp @104 reader)."
+        }
+    ],
+    "notes": [
+        "capsGate values name ControllerCaps methods (src-core/controllers/ControllerCaps.h) driven by the vendor capability XML; a property with a capsGate is hidden in the grid when the method returns false but its attribute is still persisted. CORRECTION vs the brief: ControllerCaps has no SupportsAutoSize or SupportsSuppressDuplicateFrames methods - those two gates are Controller C++ virtuals (see the AutoSize and SuppressDuplicates descriptions), so those properties intentionally carry no capsGate.",
+        "The <network> child elements (one per output/universe) are read by the base Controller constructor (Controller.cpp @97) but are documented in the concrete controller documents (see Ethernet.json childElements) because their attribute set depends on Protocol."
+    ]
+}

--- a/resources/modelsmetadata/Arches.json
+++ b/resources/modelsmetadata/Arches.json
@@ -1,0 +1,152 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Arches",
+    "description": "A row of curved arch segments, typically along a walkway or roofline. Nodes run along each arch; an optional layered mode instead nests concentric arch layers of independently-sized node counts sharing one arc/tilt.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumArches",
+            "label": "# Arches",
+            "gridKey": "ArchesCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 100,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "appliesWhen": {
+                "attribute": "LayerSizes",
+                "equals": ""
+            },
+            "description": "Number of arches in the model (ArchesModel::_numArches). Always written (BaseSerializingVisitor::Visit(const ArchesModel&)), but only user-editable in non-layered mode: when Layered Arches is enabled (LayerSizes non-empty) the \"Layered Arches\" checkbox handler forces this to 1 (ArchesPropertyAdapter::OnPropertyGridChange \"LayeredArches\") and the property is hidden from the grid."
+        },
+        {
+            "xmlAttribute": "NodesPerArch",
+            "label": "Nodes Per Arch",
+            "gridKey": "ArchesNodes",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 10000,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Light nodes along each arch (ArchesModel::_nodesPerArch). Applies in both modes. The property grid caps entry at 1000 in non-layered mode and 10000 in layered mode (ArchesPropertyAdapter::AddTypeProperties); the XML attribute itself has no mode-specific ceiling, so this document uses the wider (layered) bound. In layered mode this must equal the sum of LayerSizes (see LayerSizes encoding INVARIANT)."
+        },
+        {
+            "xmlAttribute": "LightsPerNode",
+            "label": "Lights Per Node",
+            "gridKey": "ArchesLights",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 250,
+            "legacyAttributes": [
+                "parm3"
+            ],
+            "description": "Number of physical lights represented by each node (e.g. for RGB pixel clusters or superstring wiring)."
+        },
+        {
+            "xmlAttribute": "Arc",
+            "label": "Arc Degrees",
+            "gridKey": "ArchesArc",
+            "type": "uint",
+            "default": 180,
+            "min": 1,
+            "max": 180,
+            "legacyAttributes": [
+                "arc"
+            ],
+            "description": "Total angular sweep of the arch, in degrees (ArchesModel::_arc). CORRECTION vs the brief's survey guess of a lowercase xmlAttribute: the canonical, currently-written attribute is \"Arc\" (XmlNodeKeys::ArcAttribute), verified in both BaseSerializingVisitor::Visit(const ArchesModel&) and XmlDeserializingModelFactory::DeserializeArches; lowercase \"arc\" (XmlNodeKeys::CArcAttribute) is a read-only legacy fallback name for older files (HasAttrOrLegacy/GetAttrWithLegacyFallback), never written by the current serializer - modeled here via legacyAttributes."
+        },
+        {
+            "xmlAttribute": "Gap",
+            "label": "Gap Between Arches",
+            "gridKey": "ArchesGap",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 500,
+            "appliesWhen": {
+                "attribute": "LayerSizes",
+                "equals": ""
+            },
+            "description": "Extra screen-space gap inserted between successive arches, in preview pixels (ArchesModel::_gap; ArchesModel::SetArchCoord). Only written when non-zero. Only shown/editable in the property grid in non-layered mode; layered mode has no equivalent control (it uses Hollow instead)."
+        },
+        {
+            "xmlAttribute": "Hollow",
+            "label": "Hollow %",
+            "gridKey": "Hollow",
+            "type": "uint",
+            "default": 70,
+            "min": 0,
+            "max": 95,
+            "appliesWhen": {
+                "attribute": "LayerSizes",
+                "notEquals": ""
+            },
+            "description": "Percentage the inner layers are pulled in toward the arc's centre in layered mode (ArchesModel::_hollow; ArchesModel::SetLayerdArchCoord). Always written regardless of mode (BaseSerializingVisitor::Visit unconditionally adds it), but only shown/editable in the property grid when Layered Arches is enabled."
+        },
+        {
+            "xmlAttribute": "ZigZag",
+            "label": "Zig-Zag Layers",
+            "gridKey": "ZigZag",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "appliesWhen": {
+                "attribute": "LayerSizes",
+                "notEquals": ""
+            },
+            "description": "When \"true\", each successive layer alternates its start direction (zig-zag) instead of every layer starting from the same side (ArchesModel::_zigzag). Persisted as the lowercase literal true/false (XmlNodeKeys::ZigZagAttribute). Only ever written when true (BaseSerializingVisitor::Visit(const ArchesModel&): `if (model.GetZigZag()) attrs.Add(ZigZagAttribute, \"true\")`), so absence on read means false. Only meaningful in layered mode."
+        },
+        {
+            "xmlAttribute": "LayerSizes",
+            "gridKey": "Layers",
+            "type": "string",
+            "default": "",
+            "encoding": "Comma-separated list of per-layer node counts, first-entry-first (Model::SerialiseLayerSizes/DeserializeLayerSizes; Model.h member comment \"inside to outside\"). A non-empty value switches the model into layered mode (concentric arch layers sharing one Arc/Hollow/ZigZag) in place of the flat NumArches x NodesPerArch grid; an empty/absent value means non-layered mode. The property grid exposes this as a \"Layers\" count spinner (gridKey \"Layers\", range 1-100) plus one \"Layer{n}\" row per entry (0-based n, range 1-1000 each; row 0 labelled \"Inside\", the last row labelled \"Outside\") - see ModelPropertyAdapter::AddLayerSizeProperty - but only this ONE xmlAttribute is ever persisted. INVARIANT for writers: xLights keeps the total-node attribute equal to the SUM of this list (NodesPerArch = sum(LayerSizes), enforced by ArchesModel::OnLayerSizesChange whenever layer sizes change in the UI); an external writer (e.g. an MCP) must set both consistently or the model will allocate the wrong node count (node allocation uses the total attribute, not this list - ArchesModel::InitModel SetNodeCount(1, _nodesPerArch, ...)).",
+            "description": "Per-layer node-count list for layered-arches mode; see encoding for the exact format. Enabling/disabling layered mode is itself UI-only bookkeeping (the \"Layered Arches\" checkbox, gridKey \"LayeredArches\") with no XML attribute of its own - its checked state is exactly \"is LayerSizes non-empty\" (ArchesPropertyAdapter::AddTypeProperties: `_arches.GetLayerSizeCount() != 0`)."
+        }
+    ],
+    "notes": [
+        "Starting Location: the \"ArchesStart\" property-grid enum (ArchesPropertyAdapter, gridKey \"ArchesStart\") decodes into the shared Dir/StartSide attributes (shared/Common.json), not a dedicated Arches attribute - so no property object for it appears above. In non-layered mode it is a 2-value Green Square/Blue Square picker that sets only Dir (StartSide is left untouched and unused - ArchesModel::IsNodeFirst ignores StartSide when LayerSizeCount()==0). In layered mode it becomes a 4-value Inside/Outside x Green/Blue Square picker that sets both Dir and StartSide together (ArchesPropertyAdapter::OnPropertyGridChange \"ArchesStart\").",
+        "Legacy read-only alias for Angle: XmlNodeKeys::ArchesSkewAttribute (\"ArchesSkew\") is a legacy fallback attribute name for the ThreePoint \"Angle\" attribute documented in shared/ScreenLocation.json (XmlDeserializingModelFactory::DeserializeArches overrides the deserialized angle from it, if present, after DeserializeThreePointScreenLocationAttributes has already read \"Angle\"). The current serializer never writes \"ArchesSkew\", only \"Angle\" (AddThreePointScreenLocationAttributes). Not modeled as a property in this file because Angle is owned by shared/ScreenLocation.json (extended, not redefined here) to avoid a duplicate-xmlAttribute validation error; flagged here for an MCP reader that needs to accept legacy files."
+    ]
+}

--- a/resources/modelsmetadata/CandyCanes.json
+++ b/resources/modelsmetadata/CandyCanes.json
@@ -1,0 +1,127 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Candy Canes",
+    "description": "A row of candy-cane shaped light strings: a straight upright section topped by a curved hook. Nodes run up each cane and around its hook.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumCanes",
+            "label": "# Canes",
+            "gridKey": "CandyCaneCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 20,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Number of candy canes in the model (CandyCaneModel::_numCanes)."
+        },
+        {
+            "xmlAttribute": "NodesPerCane",
+            "label": "Nodes Per Cane",
+            "gridKey": "CandyCaneNodes",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 250,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Node count per cane for traditional (multi-node) string types (CandyCaneModel::_nodesPerCane). SingleNode quirk: for SingleNode string types this is instead normalized to and persisted as 1, and the real per-cane light count is held in LightsPerNode - see CandyCaneModel::InitModel() (\"When a SingleNode model is saved, _nodesPerCane is stored as 1 and _lightsPerNode holds lights per cane\") and the LightsPerNode property below. The property grid reuses this same gridKey (\"CandyCaneNodes\") for both cases, only swapping its label between \"Nodes Per Cane\" and \"Lights Per Cane\" (CandyCanePropertyAdapter::AddTypeProperties/OnPropertyGridChange \"ModelStringType\")."
+        },
+        {
+            "xmlAttribute": "LightsPerNode",
+            "label": "Lights Per Node",
+            "gridKey": "CandyCaneLights",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 250,
+            "legacyAttributes": [
+                "parm3"
+            ],
+            "description": "Lights represented by each node, for RGB pixel-cluster wiring (CandyCaneModel::_lightsPerNode). Hidden in the property grid (but still persisted) for SingleNode string types, where this attribute instead holds the real per-cane light count - see the NodesPerCane property's SingleNode quirk note."
+        },
+        {
+            "xmlAttribute": "CandyCaneHeight",
+            "label": "Height",
+            "gridKey": "CandyCaneHeight",
+            "type": "float",
+            "default": 1.0,
+            "step": 0.1,
+            "precision": 2,
+            "description": "Relative vertical scale of the upright section when Sticks is enabled (CandyCaneModel::_caneheight; CandyCaneModel::SetCaneCoord). Distinct from the generic ThreePoint \"Height\"/gridKey \"ModelHeight\" attribute documented in shared/ScreenLocation.json - this is a separate, CandyCane-specific xmlAttribute (XmlNodeKeys::CCHeightAttribute = \"CandyCaneHeight\") with its own value, not an alias."
+        },
+        {
+            "xmlAttribute": "CandyCaneReverse",
+            "label": "Reverse",
+            "gridKey": "CandyCaneReverse",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "appliesWhen": {
+                "attribute": "CandyCaneSticks",
+                "equals": "false"
+            },
+            "description": "When \"true\", the hook curves to the opposite side (CandyCaneModel::_reverse; CandyCaneModel::SetCaneCoord). Persisted as the lowercase literal true/false. Always written (unconditional, both values). Only enabled in the property grid when Sticks is false (CandyCanePropertyAdapter::AddTypeProperties/UpdateTypeProperties: `p->Enable(!_candyCane.IsSticks())`); still persisted regardless of Sticks."
+        },
+        {
+            "xmlAttribute": "CandyCaneSticks",
+            "label": "Sticks",
+            "gridKey": "CandyCaneSticks",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "description": "When \"true\", renders each cane as a plain straight stick (no curved hook), scaled by CandyCaneHeight, instead of the default upright-plus-hook shape (CandyCaneModel::_sticks; CandyCaneModel::SetCaneCoord). Persisted as the lowercase literal true/false. Always written (unconditional, both values)."
+        },
+        {
+            "xmlAttribute": "AlternateNodes",
+            "label": "Alternate Nodes",
+            "gridKey": "AlternateNodes",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "description": "When \"true\", interleaves node buffer positions along the cane (used for staggered/zig-zag physical wiring) instead of assigning them in simple sequential order (CandyCaneModel::_alternateNodes; CandyCaneModel::InitModel). Persisted as the lowercase literal true/false. Always written (unconditional, both values). Disabled (but still persisted) in the property grid for SingleNode string types (CandyCanePropertyAdapter::UpdateTypeProperties)."
+        }
+    ],
+    "notes": [
+        "Starting Location: the \"CandyCaneStart\" property-grid enum (gridKey \"CandyCaneStart\") is a 2-value Green Square/Blue Square picker that sets only the shared Dir attribute (shared/Common.json); StartSide is not involved for this model type (CandyCanePropertyAdapter::OnPropertyGridChange \"CandyCaneStart\" only calls SetDirection/SetIsLtoR). No property object for it appears above since Dir itself is owned by shared/Common.json.",
+        "Legacy read-only alias for Angle: XmlNodeKeys::CCSkewAttribute (\"CandyCaneSkew\") is a legacy fallback attribute name for the ThreePoint \"Angle\" attribute documented in shared/ScreenLocation.json (XmlDeserializingModelFactory::DeserializeCandyCane overrides the deserialized angle from it, if present). The current serializer never writes \"CandyCaneSkew\", only \"Angle\". Not modeled as a property in this file for the same reason as Arches.json's equivalent note (Angle is owned by shared/ScreenLocation.json)."
+    ]
+}

--- a/resources/modelsmetadata/ChannelBlock.json
+++ b/resources/modelsmetadata/ChannelBlock.json
@@ -1,0 +1,69 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Channel Block",
+    "description": "A row of independently-coloured single-channel blocks (e.g. a bank of floods or a DMX dimmer bank), each rendered as one solid colour swatch rather than an RGB pixel. Not exportable as Custom and has no wiring-view support (ChannelBlockModel::SupportsExportAsCustom()/SupportsWiringView() both false).",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumChannels",
+            "label": "# Channels",
+            "gridKey": "ChannelBlockCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 128,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Number of channel blocks in the model (ChannelBlockModel::_numChannels; MAX_CB_CHANNELS = 128). Always forced to StringType \"Single Color Custom\" and SingleNode = true internally (ChannelBlockModel::InitModel), regardless of the model's own StringType/CustomColor attributes (shared/Common.json) - the property grid disables ModelStringType/ModelStringColor for this model type (ChannelBlockPropertyAdapter::DisableUnusedProperties)."
+        },
+        {
+            "xmlAttribute": "ChannelProperties.ChannelColor{n}",
+            "label": "Colour {n}",
+            "gridKey": "ChannelColor{n}",
+            "type": "color",
+            "default": "white",
+            "encoding": "Family of independently-named attributes ChannelProperties.ChannelColor1 .. ChannelProperties.ChannelColor{NumChannels} (1-based index n; XmlNodeKeys::ChannelColorAttribute = \"ChannelProperties.ChannelColor\" concatenated with the index, verified in both BaseSerializingVisitor::Visit(const ChannelBlockModel&) and XmlDeserializingModelFactory::DeserializeChannelBlock). CORRECTION vs the brief's survey guess of a bare \"ChannelColor{n}\" xmlAttribute: the persisted attribute carries the literal \"ChannelProperties.\" prefix; only the wxPropertyGrid child-property name (nested under the disabled placeholder property \"Indiv Colors\"/gridKey \"ChannelProperties\") is the shorter \"ChannelColor{n}\" form.",
+            "description": "Per-channel display colour for channel n (1-based), one attribute per configured channel (count = NumChannels). Value is either a CSS-style colour name (default \"white\" - ChannelBlockModel::InitChannelBlock seeds any missing/empty slot to the literal string \"white\") or a #RRGGBB hex string once picked via the colour-swatch editor (xlColor::operator std::string()); not restricted to hex-only."
+        }
+    ],
+    "notes": [
+        "ChannelBlock has no Starting Location / Dir / StartSide UI at all - its property grid only exposes # Channels and the per-channel colour swatches (ChannelBlockPropertyAdapter::AddTypeProperties); the shared Dir/StartSide attributes (shared/Common.json) are still written/read like every model but have no visible effect on this model's single-row TwoPoint layout.",
+        "TwoPoint screen-location style (shared/ScreenLocation.json): ChannelBlock is one of the two model types using TwoPoint (X2/Y2/Z2, no ScaleX/Y/Z, no Angle/Shear/Height) rather than Boxed or ThreePoint."
+    ]
+}

--- a/resources/modelsmetadata/Circle.json
+++ b/resources/modelsmetadata/Circle.json
@@ -1,0 +1,109 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Circle",
+    "description": "One or more concentric rings of nodes. Supports the same inside-to-outside layer-size mechanism as Arches, always active (a Circle with no explicit layers still has one implicit layer holding all its nodes).",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumStrings",
+            "label": "# Strings",
+            "gridKey": "CircleStringCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 100,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Number of physical connections/strings from the prop to the controller (CircleModel::_numStrings; CirclePropertyAdapter help text: \"typically the number of connections from the prop to your controller\")."
+        },
+        {
+            "xmlAttribute": "NodesPerString",
+            "label": "Nodes/String",
+            "gridKey": "CircleLightCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 2000,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Nodes per string (CircleModel::_nodesPerString; total lights = NumStrings x NodesPerString, redistributed across the layer(s) defined by LayerSizes). Grid label is \"Lights/String\" for SingleNode string types, \"Nodes/String\" otherwise; same xmlAttribute/gridKey either way."
+        },
+        {
+            "xmlAttribute": "centerPercent",
+            "label": "Center %",
+            "gridKey": "CircleCenterPercent",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 100,
+            "legacyAttributes": [
+                "parm3"
+            ],
+            "description": "Radius of the innermost layer, as a percentage of the outer radius (CircleModel::_centerPercent; 0 = a filled disc, 100 = all layers on the same ring). CORRECTION vs the brief's survey (which did not list a parm fallback for this attribute): XmlDeserializingModelFactory::DeserializeCircle reads it via ReadAttrWithParmFallback(..., CenterPercentAttribute, Parm3Attribute, \"0\") - i.e. it DOES fall back to legacy parm3, like NumStrings/NodesPerString do to parm1/parm2."
+        },
+        {
+            "xmlAttribute": "InsideOut",
+            "gridKey": "CircleStart",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "relatedTo": [
+                "Dir",
+                "StartSide"
+            ],
+            "description": "When true, layer 0 (\"Inside\" in the generic Layers UI) is drawn as the innermost ring and the last layer as the outermost; when false (default), layer 0 is drawn as the OUTERMOST ring instead (CircleModel::_insideOut; CircleModel::SetCircleCoord radius formula) - see this file's notes for the resulting label/visual mismatch. Always written unconditionally (unlike Locked/Active which are conditionally written elsewhere). Folded together with the shared Dir/StartSide attributes (shared/Common.json) into the single 8-value \"CircleStart\"/\"Starting Location\" property-grid enum (Top/Bottom x Outer/Inner x CW/CCW; CirclePropertyAdapter::OnPropertyGridChange \"CircleStart\")."
+        },
+        {
+            "xmlAttribute": "LayerSizes",
+            "gridKey": "Layers",
+            "type": "string",
+            "default": "",
+            "legacyAttributes": [
+                "circleSizes"
+            ],
+            "encoding": "Comma-separated list of per-layer node counts (Model::SerialiseLayerSizes/DeserializeLayerSizes). The property grid exposes this as a \"Layers\" count spinner (gridKey \"Layers\", range 1-100) plus one \"Layer{n}\" row per entry (0-based n, range 1-1000 each) - see ModelPropertyAdapter::AddLayerSizeProperty - but only this ONE xmlAttribute is ever currently written. INVARIANT for writers: xLights keeps the total-node attribute equal to the SUM of this list (parm2 (nodes per string) = sum(LayerSizes), enforced by CircleModel::OnLayerSizesChange whenever layer sizes change in the UI); an external writer (e.g. an MCP) must set both consistently or the model will allocate the wrong node count (node allocation uses the total attribute, not this list - CircleModel::InitModel).",
+            "description": "Per-layer node-count list (CircleModel::InitCircle/InitModel always ensures at least one layer summing to NumStrings x NodesPerString). CORRECTION vs the brief's survey guess that \"circleSizes\" is the current attribute: XmlDeserializingModelFactory::DeserializeCircle shows the CURRENT xmlAttribute is the generic \"LayerSizes\" (same name Arches.json uses, in this separate document so no collision); lowercase \"circleSizes\" (XmlNodeKeys::CircleSizesAttribute) is a legacy READ-ONLY attribute that, unusually, is preferred over LayerSizes when BOTH are present in a file, and its comma values are reversed (ReverseCSV) before use, because the legacy format stored sizes outside-to-inside while the current LayerSizes convention stores inside-to-outside. This is the opposite precedence of the parm1/2/3 fallback pattern used elsewhere (there, the NEW name always wins over the legacy one)."
+        }
+    ],
+    "notes": [
+        "Layer 0 visual meaning depends on InsideOut: CircleModel::SetCircleCoord's radius formula makes layer 0 the OUTERMOST ring when InsideOut=false (the default) and the INNERMOST ring when InsideOut=true. The generic Layers property-grid labels (\"Inside\" for row 0, \"Outside\" for the last row - shared ModelPropertyAdapter::AddLayerSizeProperty, written from the Arches convention) are therefore only accurate for Circle when InsideOut=true; with the default InsideOut=false they are visually reversed. Flagged as an observed inconsistency, not something this metadata task changes.",
+        "StartSide default override: XmlDeserializingModelFactory::DeserializeCircle contains `if (node.attribute(\"StartSide\").empty()) model->SetIsBtoT(false);` - i.e. for a legacy/partial file that omits StartSide entirely, Circle defaults StartSide to \"T\" (top-to-bottom), overriding the generic default of \"B\" documented in shared/Common.json. Only relevant to reading old/hand-edited files missing the attribute; every model unconditionally writes StartSide on save (shared/Common.json), so this never matters for round-tripping a file this version of xLights wrote."
+    ]
+}

--- a/resources/modelsmetadata/Cube.json
+++ b/resources/modelsmetadata/Cube.json
@@ -1,0 +1,204 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Cube",
+    "description": "A 3D grid of nodes forming a solid cube or a cylinder, wired as a stack of 2D panels (front/back or left/right facing) in one of several zig-zag/stacked strand patterns.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "CubeWidth",
+            "label": "Width",
+            "gridKey": "CubeWidth",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 100,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Grid width, in nodes (CubeModel::_cubeWidth, GetCubeWidth()/SetCubeWidth()). Property-grid label becomes \"Circumference\" when CubeShape is Cylinder (CubePropertyAdapter::AddTypeProperties); same xmlAttribute either way."
+        },
+        {
+            "xmlAttribute": "CubeHeight",
+            "label": "Height",
+            "gridKey": "CubeHeight",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 100,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Grid height, in nodes (CubeModel::_cubeHeight, GetCubeHeight()/SetCubeHeight()). Label is always \"Height\" regardless of CubeShape."
+        },
+        {
+            "xmlAttribute": "CubeDepth",
+            "label": "Depth",
+            "gridKey": "CubeDepth",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 100,
+            "legacyAttributes": [
+                "parm3"
+            ],
+            "description": "Grid depth, in nodes/panels (CubeModel::_cubeDepth, GetCubeDepth()/SetCubeDepth()). Property-grid label becomes \"Layers\" when CubeShape is Cylinder (CubePropertyAdapter::AddTypeProperties); same xmlAttribute either way."
+        },
+        {
+            "xmlAttribute": "CubeShape",
+            "label": "Shape",
+            "gridKey": "CubeShape",
+            "type": "enum",
+            "enum": [
+                "0",
+                "1"
+            ],
+            "labels": {
+                "0": "Cube",
+                "1": "Cylinder"
+            },
+            "default": "0",
+            "description": "Overall form: a rectilinear Cube or a round Cylinder (CubeModel::CubeShape enum class, GetCubeShape()/SetCubeShape(), persisted as its underlying int value via std::to_string - same int-as-string-with-differing-labels pattern as shared/Common.json's Antialias/ModelPixelStyle). Governs which of CubeHollow (Cylinder) or CubeRowOffset (Cube) applies, and relabels CubeWidth/CubeDepth (see those properties)."
+        },
+        {
+            "xmlAttribute": "Start",
+            "label": "Starting Location",
+            "gridKey": "CubeStart",
+            "type": "enum",
+            "enum": [
+                "Front Bottom Left",
+                "Front Bottom Right",
+                "Front Top Left",
+                "Front Top Right",
+                "Back Bottom Left",
+                "Back Bottom Right",
+                "Back Top Left",
+                "Back Top Right"
+            ],
+            "default": "Front Bottom Left",
+            "description": "Which corner of the cube the first node starts from (CubeModel::GetCubeStart()/SetCubeStart(), persisted as the literal enum text itself, not an index - the index used internally/in the grid, GetCubeStartIndex()/SetCubeStartIndex(), is a separate in-memory-only concept). This is Cube's own composite starting-location picker; it does not use the shared Dir/StartSide attributes at all (CubeModel::GetStartLocation() override)."
+        },
+        {
+            "xmlAttribute": "Style",
+            "label": "Direction",
+            "gridKey": "CubeStyle",
+            "type": "enum",
+            "enum": [
+                "Vertical Front/Back",
+                "Vertical Left/Right",
+                "Horizontal Front/Back",
+                "Horizontal Left/Right",
+                "Stacked Front/Back",
+                "Stacked Left/Right"
+            ],
+            "default": "Vertical Front/Back",
+            "description": "Wiring direction/face pattern across the cube's panels (CubeModel::GetCubeStyle()/SetCubeStyle(), persisted as the literal enum text - same pattern as Start). Used by CubeModel::CalcTransformationIndex() (string-matched via Contains() for \"Left\"/\"Horizontal\"/\"Stacked\" substrings) to determine per-panel coordinate transforms."
+        },
+        {
+            "xmlAttribute": "StrandPerLine",
+            "label": "Strand Style",
+            "gridKey": "StrandPerLine",
+            "type": "enum",
+            "enum": [
+                "Zig Zag",
+                "No Zig Zag",
+                "Aternate Pixel"
+            ],
+            "default": "Zig Zag",
+            "description": "Per-panel strand wiring pattern (CubeModel::GetStrandStyle()/SetStrandStyle(), persisted as the literal enum text). Recorded exactly as stored, including the source typo \"Aternate Pixel\" (missing 'l') - CubePropertyAdapter.cpp's STRAND_STYLES_VALUES array, which SetStrandStyle() string-matches against, so this exact misspelling is what ends up on disk when that option is chosen."
+        },
+        {
+            "xmlAttribute": "StrandPerLayer",
+            "label": "Layers All Start in Same Place",
+            "gridKey": "StrandPerLayer",
+            "type": "bool",
+            "boolFormat": "TRUEFALSE",
+            "default": "FALSE",
+            "description": "When \"TRUE\", every depth layer's strand starts from the same physical corner instead of alternating (CubeModel::IsStrandPerLayer()/SetStrandPerLayer()). Persisted as the UPPERCASE literal TRUE/FALSE; always written."
+        },
+        {
+            "xmlAttribute": "CubeHollow",
+            "label": "Hollow %",
+            "gridKey": "CubeHollow",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 99,
+            "appliesWhen": {
+                "attribute": "CubeShape",
+                "equals": "1"
+            },
+            "description": "Inner hollow radius as a percentage of the outer radius for a Cylinder (0 = solid, 99 = thin shell) (CubeModel::GetHollowPct()/SetHollowPct(), which clamps to [0,99] in the setter itself). Always written regardless of shape, but only shown/editable in the property grid when CubeShape is Cylinder (CubePropertyAdapter::AddTypeProperties)."
+        },
+        {
+            "xmlAttribute": "CubeRowOffset",
+            "label": "Row Offset",
+            "gridKey": "CubeRowOffset",
+            "type": "enum",
+            "enum": [
+                "0",
+                "1",
+                "2"
+            ],
+            "labels": {
+                "0": "None",
+                "1": "Positive",
+                "2": "Negative"
+            },
+            "default": "0",
+            "appliesWhen": {
+                "attribute": "CubeShape",
+                "equals": "0"
+            },
+            "description": "Alternating-row horizontal offset applied when CubeShape is Cube, for a brick-like stagger (CubeModel::RowOffset enum class, GetRowOffset()/SetRowOffset(), persisted as its underlying int value). Always written regardless of shape, but only shown/editable in the property grid when CubeShape is Cube (mutually exclusive with CubeHollow in the UI, which shows instead for Cylinder)."
+        },
+        {
+            "xmlAttribute": "Strings",
+            "label": "# Strings",
+            "gridKey": "CubeStrings",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 1000,
+            "description": "Number of physical connections/strings from the prop to the controller (CubeModel::_cubeStrings, GetCubeStrings()/SetCubeStrings()); CubePropertyAdapter help text: \"typically the number of connections from the prop to your controller.\" Distinct from CubeModel::GetNumStrings(), which is hard-coded to always return 1 (Cube is one of the models where Model::HasOneString() is true, alongside Window Frame) - this Strings attribute is a separate wiring-connection count, not the model's internal string count."
+        }
+    ],
+    "notes": [
+        "CubeWidth/CubeHeight/CubeDepth are Cube-specific grid-dimension attributes (XmlNodeKeys::CubeWidthAttribute etc.), unrelated to the generic Width/Height/Depth constants used elsewhere (e.g. view-object Mesh elements) - no collision since Cube does not extend any fragment that defines those.",
+        "Enum-valued attributes here (CubeShape, Start, Style, StrandPerLine, CubeRowOffset) are recorded with their exact stored forms per the brief's instruction, including the verbatim source typo in StrandPerLine's third option."
+    ]
+}

--- a/resources/modelsmetadata/Custom.json
+++ b/resources/modelsmetadata/Custom.json
@@ -1,0 +1,134 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Custom",
+    "description": "A model whose node layout is an arbitrary hand-placed grid (width x height x depth), authored via the dedicated Custom Model editor dialog rather than a parametric shape. Node positions are stored as a dense grid blob (CustomModel or CustomModelCompressed), not as individual attributes.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "CustomWidth",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Grid width, in node columns (CustomModel::_customWidth, GetCustomWidth()/SetCustomWidth(), stored as a C++ long). Set via the Custom Model editor dialog (not the main property grid), which also holds the corresponding Height/Depth."
+        },
+        {
+            "xmlAttribute": "CustomHeight",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Grid height, in node rows (CustomModel::_customHeight, GetCustomHeight()/SetCustomHeight()). Set via the Custom Model editor dialog."
+        },
+        {
+            "xmlAttribute": "Depth",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "description": "Grid depth, in node layers - 1 for a flat 2D custom model, >1 for a 3D one (CustomModel::_depth, GetCustomDepth()/SetCustomDepth(), XmlNodeKeys::CMDepthAttribute = \"Depth\"). Verify-note: this reuses the bare xmlAttribute name \"Depth\" also used generically elsewhere in the codebase (e.g. view-object Width/Height/Depth attributes) - no collision here since Custom does not extend any fragment that defines a model-level \"Depth\", but the shared name is coincidental, not an alias. Set via the Custom Model editor dialog; no legacy parm fallback (unlike CustomWidth/CustomHeight)."
+        },
+        {
+            "xmlAttribute": "CustomStrings",
+            "label": "# Strings",
+            "gridKey": "CustomModelStrings",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 100,
+            "description": "Number of physical connections/strings from the prop to the controller (derived from CustomModel::GetNumStrings()/SetNumStrings(), written as the count read back on load); CustomPropertyAdapter help text: \"typically the number of connections from the prop to your controller.\""
+        },
+        {
+            "xmlAttribute": "CustomBkgImage",
+            "label": "Background Image",
+            "gridKey": "CustomBkgImage",
+            "type": "filepath",
+            "default": "",
+            "description": "Path to a reference image displayed behind the node grid in the Custom Model editor dialog (CustomModel::GetCustomBackground()/SetCustomBackground()). Only written when non-empty (BaseSerializingVisitor::Visit(const CustomModel&): the whole CustomBkgImage/CustomBkgLightness/CustomBkgScale/CustomBkgBrightness group is written only if the background path is set)."
+        },
+        {
+            "xmlAttribute": "CustomBkgLightness",
+            "label": "Background Lightness",
+            "type": "int",
+            "default": 0,
+            "min": 0,
+            "max": 100,
+            "appliesWhen": {
+                "attribute": "CustomBkgImage",
+                "notEquals": ""
+            },
+            "description": "Background image lightness adjustment (CustomModel::GetCustomLightness()/SetCustomLightness(), stored as a C++ long). Edited via a slider in the Custom Model editor dialog (CustomModelDialog::SliderCustomLightness), not the main property grid. Only written alongside CustomBkgImage when a background is set."
+        },
+        {
+            "xmlAttribute": "CustomBkgScale",
+            "label": "Background Image Scale %",
+            "gridKey": "CustomBkgScale",
+            "type": "uint",
+            "default": 100,
+            "min": 10,
+            "max": 500,
+            "appliesWhen": {
+                "attribute": "CustomBkgImage",
+                "notEquals": ""
+            },
+            "description": "Scale of the background image as a percentage of the model size (100 = fit model bounds) (CustomModel::GetCustomBkgScale()/SetCustomBkgScale()). Only written alongside CustomBkgImage when a background is set."
+        },
+        {
+            "xmlAttribute": "CustomBkgBrightness",
+            "label": "Background Image Brightness %",
+            "gridKey": "CustomBkgBrightness",
+            "type": "uint",
+            "default": 20,
+            "min": 0,
+            "max": 100,
+            "appliesWhen": {
+                "attribute": "CustomBkgImage",
+                "notEquals": ""
+            },
+            "description": "Brightness of the background image (0 = black, 100 = full brightness) (CustomModel::GetCustomBkgBrightness()/SetCustomBkgBrightness()). Only written alongside CustomBkgImage when a background is set."
+        }
+    ],
+    "notes": [
+        "Node grid data: exactly one of \"CustomModel\" or \"CustomModelCompressed\" is written per model (BaseSerializingVisitor::Visit(const CustomModel&) writes CustomModelCompressed when GetCompressedData() is non-empty, else falls back to CustomModel/GetCustomData()); both are read via the same XmlSerialize::ParseCustomModelDataFromXml (checks CustomModelCompressed first, then CustomModel). Uncompressed \"CustomModel\" encoding: layers separated by '|', rows within a layer separated by ';', node values within a row separated by ',' - each cell is either empty (no node at that grid position) or a positive 1-based node index (XmlSerialize::ParseCustomModel). Compressed \"CustomModelCompressed\" encoding: a ';'-separated list of per-node entries, each a ','-separated tuple \"node,row,col\" (2D) or \"node,row,col,layer\" (3D) - only actual nodes are listed, so this format is compact for sparse/large grids (XmlSerialize::ParseCompressed). Not modeled as individual properties per the brief's guidance for non-scalar blob data. GRID ORIENTATION (verified against CustomModel::InitCustomMatrix, src-core/models/CustomModel.cpp: `Nodes.back()->AddBufCoord(layer*width + col, height - row - 1)`): row 0 (the FIRST ';'-separated group) is the TOP row of the model as displayed in the layout; row increases downward. Column 0 (the first value in a row's ','-separated list) is the LEFT column; column increases rightward. So the data string reads exactly like a normal top-to-bottom, left-to-right image/matrix dump - confirmed 2026-07-18 by converting a real native Matrix model to Custom and round-tripping the result through a live xLights instance via the automation API (getModel), which parsed the generated grid back into the expected layout with no distortion.",
+        "Per-string start-node overrides: when CustomStrings > 1, one attribute per string named \"NodeStart1\", \"NodeStart2\", ... \"NodeStart{CustomStrings}\" (1-based; CustomModel::StartNodeAttrName(idx) = \"NodeStart\" + (idx+1)) holds that string's starting node index. Note the different family name from PolyLine's \"PolyNode{n}\" pattern (models/PolyLine.json) - each model type defines its own StartNodeAttrName() override. Unlike PolyLine, HasIndivStartNodes() is unconditionally set true whenever CustomStrings > 1 on read (XmlDeserializingModelFactory::DeserializeCustom), not inferred from attribute presence.",
+        "widthmm/heightmm/depthmm are export-only attributes (written only when the forExport flag is set and a RulerObject is configured, giving the model's real-world physical size in millimeters) - not modeled here as they never appear in a saved xlights_rgbeffects.xml, only in exported custom-model files."
+    ]
+}

--- a/resources/modelsmetadata/DmxFloodArea.json
+++ b/resources/modelsmetadata/DmxFloodArea.json
@@ -1,0 +1,47 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "DmxFloodArea",
+    "description": "A C++ subclass of DmxFloodlight (src-core/models/DMX/DmxFloodArea.{h,cpp}: `class DmxFloodArea : public DmxFloodlight`) that renders its beam as a flat rectangular wash area instead of a cone, but is otherwise identical: same DisplayAs discriminator swap (DisplayAsType::DmxFloodArea), same InitModel() (calls straight through to DmxFloodlight::InitModel()), same property-grid adapter (ModelPropertyManager::CreateAdapter maps both DisplayAsType::DmxFloodArea and DisplayAsType::DmxFloodlight to DmxFloodlightPropertyAdapter), and the identical Visit(const DmxFloodArea&) serializer path (CommonVisitSteps + AddDmxModelAttributes only, no type-specific attributes). Every attribute this model type persists is already covered by shared/DmxAbilities.json - this document adds none of its own, so `properties` is intentionally empty.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json",
+        "shared/DmxAbilities.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions. Round-tripped but disabled in DmxFloodArea's property grid - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions. Deliberately left enabled for DMX models."
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions. Not disabled for DMX models."
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve. Round-tripped but disabled in DmxFloodArea's property grid - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [],
+    "notes": [
+        "No motor/servo/mesh/image child elements: DmxFloodArea has no moving parts.",
+        "See DmxFloodlight.json for the identical attribute set, PWM/pixel-property-disable behavior, and the DmxColorType/beam-orient/beam-yoffset caveats - both documents describe the same persisted XML shape; only DisplayAs and the rendered beam geometry differ."
+    ]
+}

--- a/resources/modelsmetadata/DmxFloodlight.json
+++ b/resources/modelsmetadata/DmxFloodlight.json
@@ -1,0 +1,49 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "DmxFloodlight",
+    "description": "A fixed-position DMX floodlight/wash fixture: channel count, RGBW color ability, shutter ability and beam ability, rendered in the layout preview as a cone of light. Source: src-core/models/DMX/DmxFloodlight.{h,cpp} (DisplayAs = DisplayAsType::DmxFloodlight; constructor attaches `color_ability = DmxColorAbilityRGB`, `shutter_ability = DmxShutterAbility`, `beam_ability = DmxBeamAbility` - no dimmer ability). Every attribute this model type persists is already covered by shared/DmxAbilities.json (DmxChannelCount, the color/shutter/beam ability blocks, and the DmxPreset* family) - this document adds none of its own, so `properties` is intentionally empty. See DmxFloodArea.json for the visually-different but XML-identical sibling type.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json",
+        "shared/DmxAbilities.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions. Round-tripped but disabled in DmxFloodlight's property grid - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions. Deliberately left enabled for DMX models."
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions. Not disabled for DMX models."
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve. Round-tripped but disabled in DmxFloodlight's property grid - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [],
+    "notes": [
+        "No motor/servo/mesh/image child elements: DmxFloodlight has no moving parts.",
+        "DmxFloodlightPropertyAdapter additionally disables shared/Common.json's PixelSize (\"ModelPixelSize\") and Antialias (\"ModelPixelStyle\") properties, on top of the base DmxPropertyAdapter disables (ModelStringType/ModelStringColor/ModelFaces/ModelDimmingCurves) - a DMX-family-wide behavior that only Floodlight/FloodArea opt into, since their preview is a beam cone rather than discrete pixels.",
+        "DmxColorType is written (always \"0\"/RGBW) but inert on read for this document - the color ability is fixed at construction and never switched at runtime, per shared/DmxAbilities.json's DmxColorType note.",
+        "DmxBeamOrient/DmxBeamYOffset are never written for this document: DmxFloodlight's constructor never calls SetSupportsOrient(true)/SetSupportsYOffset(true), unlike DmxMovingHeadAdv."
+    ]
+}

--- a/resources/modelsmetadata/DmxGeneral.json
+++ b/resources/modelsmetadata/DmxGeneral.json
@@ -1,0 +1,48 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "DmxGeneral",
+    "description": "A generic single-color/RGBW DMX fixture with no moving parts: just a channel count, the optional preset-channel ability, and (usually) an RGBW color ability. Source: src-core/models/DMX/DmxGeneral.{h,cpp} (DisplayAs = DisplayAsType::DmxGeneral; constructor attaches only `color_ability = std::make_unique<DmxColorAbilityRGB>()`, no beam/shutter/dimmer ability). Every attribute this model type persists is already covered by shared/DmxAbilities.json (DmxChannelCount, the DmxColorType/DmxRed-Green-Blue-White-Channel color-ability block, and the DmxPreset* family) - this document adds none of its own, so `properties` is intentionally empty.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json",
+        "shared/DmxAbilities.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions. Round-tripped but disabled in DmxGeneral's property grid (DmxPropertyAdapter::DisableUnusedProperties) - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions. Deliberately left enabled for DMX models (can drive a value range to a color/behaviour)."
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions. Not disabled for DMX models."
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve. Round-tripped but disabled in DmxGeneral's property grid - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [],
+    "notes": [
+        "No motor/servo/mesh/image child elements: DmxGeneral has no moving parts and no DmxMovingHeadComm-derived channel (no PanMotor/TiltMotor, no Servo, no Mesh, no DmxImage children).",
+        "Color ability is fixed to RGBW at construction (DmxGeneral::DmxGeneral: `color_ability = std::make_unique<DmxColorAbilityRGB>();`) and never switched at runtime - DmxColorType is written (always \"0\") but inert on read for this document, per shared/DmxAbilities.json's DmxColorType note.",
+        "DmxGeneralPropertyAdapter does not attach a shutter, dimmer or beam ability, and does not add DmxStyle/DmxFixture/HideBody - those are DmxMovingHead(Adv)-only, documented in DmxMovingHead.json."
+    ]
+}

--- a/resources/modelsmetadata/DmxMovingHead.json
+++ b/resources/modelsmetadata/DmxMovingHead.json
@@ -1,0 +1,83 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "DmxMovingHead",
+    "description": "A 2D-rendered moving-head fixture with pan/tilt motors, a switchable color ability (RGBW/ColorWheel/CMYW), dimmer, shutter and beam abilities, plus a fixed body-style silhouette (DmxStyle) drawn in the layout preview. Source: src-core/models/DMX/DmxMovingHead.{h,cpp} (DisplayAs = DisplayAsType::DmxMovingHead; derives from DmxMovingHeadComm for the shared Pan/Tilt motors + DmxFixture attribute). Compare DmxMovingHeadAdv.json for the 3D-mesh-rendered sibling, which shares the motor/color/dimmer/shutter/beam abilities but has no DmxStyle/HideBody and instead adds Base/Yoke/Head mesh children and position zones.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json",
+        "shared/DmxAbilities.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions. Round-tripped but disabled in DmxMovingHead's property grid - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions. Deliberately left enabled for DMX models."
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions. Not disabled for DMX models."
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve. Round-tripped but disabled in DmxMovingHead's property grid - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        },
+        {
+            "name": "PanMotor",
+            "description": "Pan-axis motor child element. Instantiates the {base}Motor pattern documented in shared/DmxAbilities.json notes (ChannelCoarse/ChannelFine/MinLimit/MaxLimit/RangeOfMotion/OrientZero/OrientHome/SlewLimit/Reverse/UpsideDown). Always present (DmxMovingHead::GetPanMotor(), written unconditionally by Visit(const DmxMovingHead&))."
+        },
+        {
+            "name": "TiltMotor",
+            "description": "Tilt-axis motor child element. Same attribute set as PanMotor - see shared/DmxAbilities.json notes. Always present (DmxMovingHead::GetTiltMotor())."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "DmxStyle",
+            "label": "DMX Style",
+            "gridKey": "DmxStyle",
+            "type": "enum",
+            "enum": ["Moving Head Top", "Moving Head Side", "Moving Head Bars", "Moving Head TopBars", "Moving Head SideBars", "Moving Head 3D"],
+            "labels": {
+                "Moving Head Top": "Moving Head Top",
+                "Moving Head Side": "Moving Head Side",
+                "Moving Head Bars": "Moving Head Bars",
+                "Moving Head TopBars": "Moving Head Top Bars",
+                "Moving Head SideBars": "Moving Head Side Bars",
+                "Moving Head 3D": "Moving Head 3D"
+            },
+            "default": "Moving Head Top",
+            "description": "Body-silhouette style drawn for this fixture in the 2D layout preview (DmxMovingHead::GetDMXStyle()/SetDmxStyle()). CORRECTION/trap: the property grid's displayed choice labels (DmxMovingHeadPropertyAdapter.cpp DMX_STYLE_VALUES: \"Moving Head Top Bars\", \"Moving Head Side Bars\" - WITH a space) differ from the two literal strings actually written to XML for those same two choices (DMX_STYLE_NAMES: \"Moving Head TopBars\", \"Moving Head SideBars\" - NO space); the other four choices are spelled identically in both arrays. `enum` above lists the persisted (no-space) forms; `labels` maps them to the UI's displayed (spaced) text where it differs. Only present on DmxMovingHead - DmxMovingHeadAdv has no DmxStyle attribute at all (its silhouette is the 3D mesh children instead)."
+        },
+        {
+            "xmlAttribute": "HideBody",
+            "label": "Hide Body",
+            "gridKey": "HideBody",
+            "type": "bool",
+            "boolFormat": "TrueFalse",
+            "default": "False",
+            "description": "When \"True\", suppresses drawing the DmxStyle body silhouette, showing only the beam (DmxMovingHead::GetHideBody()/SetHideBody()). Persisted as the Title-case literal True/False (`model.GetHideBody() ? \"True\" : \"False\"`, XmlDeserializingModelFactory default \"False\" compared against \"True\") - unlike most bool attributes elsewhere in this tree which use lowercase true/false. Only present on DmxMovingHead."
+        }
+    ],
+    "notes": [
+        "DmxFixture, DmxColorType + color-ability channels, MhDimmerChannel, shutter-ability and beam-ability attributes are all documented once in shared/DmxAbilities.json - DmxMovingHead genuinely shares them with DmxMovingHeadAdv (DmxFixture, color, dimmer, shutter, beam) rather than owning them uniquely, correcting the task brief's survey which attributed DmxFixture/DmxColorType to DmxMovingHead alone.",
+        "In-memory constructor starting values (only relevant for a brand-new, unsaved model, not for reading an existing file - see shared/DmxAbilities.json's DmxRedChannel/DmxBeamLength/DmxBeamWidth notes for the general caveat): DmxMovingHead's constructor seeds DmxRedChannel/DmxGreenChannel/DmxBlueChannel to 1/2/3 (matching the shared read-fallback default) and DmxBeamLength/DmxBeamWidth to 4.0/30.0.",
+        "DmxMovingHead supports neither DmxBeamOrient nor DmxBeamYOffset (its beam_ability never calls SetSupportsOrient/SetSupportsYOffset) - only DmxMovingHeadAdv writes those two."
+    ]
+}

--- a/resources/modelsmetadata/DmxMovingHeadAdv.json
+++ b/resources/modelsmetadata/DmxMovingHeadAdv.json
@@ -1,0 +1,74 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "DmxMovingHeadAdv",
+    "description": "A 3D-mesh-rendered moving-head fixture: pan/tilt motors plus three OBJ mesh children (base/yoke/head) forming its 3D body, a switchable color ability (RGBW/ColorWheel/CMYW), dimmer, shutter and beam abilities (with beam orient + Y-offset support, unlike the plain DmxMovingHead), and an optional list of pan/tilt \"position zones\" that force a fixed DMX value on another channel while the beam is aimed within a given pan/tilt window. Source: src-core/models/DMX/DmxMovingHeadAdv.{h,cpp} (DisplayAs = DisplayAsType::DmxMovingHeadAdv; derives from DmxMovingHeadComm). Compare DmxMovingHead.json for the simpler 2D-silhouette sibling (which has DmxStyle/HideBody instead of mesh children/position zones).",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json",
+        "shared/DmxAbilities.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions. Round-tripped but disabled in DmxMovingHeadAdv's property grid - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions. Deliberately left enabled for DMX models."
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions. Not disabled for DMX models."
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve. Round-tripped but disabled in DmxMovingHeadAdv's property grid - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        },
+        {
+            "name": "PanMotor",
+            "description": "Pan-axis motor child element. Instantiates the {base}Motor pattern documented in shared/DmxAbilities.json notes. Always present (DmxMovingHeadAdv::GetPanMotor())."
+        },
+        {
+            "name": "TiltMotor",
+            "description": "Tilt-axis motor child element. Same attribute set as PanMotor. Always present (DmxMovingHeadAdv::GetTiltMotor())."
+        },
+        {
+            "name": "BaseMesh",
+            "description": "Fixed base 3D mesh child element. Instantiates the {base}Mesh pattern documented in shared/DmxAbilities.json notes (ObjFile/MeshOnly/Brightness/Width/Height/Depth/ScaleX-Y-Z/RotateX-Y-Z/OffsetX-Y-Z). Always present (DmxMovingHeadAdv::GetBaseMesh()/CreateBaseMesh())."
+        },
+        {
+            "name": "YokeMesh",
+            "description": "Pan/tilt yoke 3D mesh child element. Same attribute set as BaseMesh. Always present (GetYokeMesh()/CreateYokeMesh()). Its RotateZ property (\"YokeMeshRotateZ\") is hidden in the property grid (DmxMovingHeadAdvPropertyAdapter::DisableUnusedProperties: Z-axis rotation on the yoke/head conflicts with the pan/tilt rotation already being applied) but the attribute is still read/written normally."
+        },
+        {
+            "name": "HeadMesh",
+            "description": "Head 3D mesh child element. Same attribute set as BaseMesh. Always present (GetHeadMesh()/CreateHeadMesh()). Its RotateZ property (\"HeadMeshRotateZ\") is likewise hidden in the property grid for the same reason as YokeMesh's."
+        },
+        {
+            "name": "PositionZone",
+            "encoding": "Zero or more repeated PositionZone child elements, one per configured zone (DmxMovingHeadAdv::GetPositionZones()/AddPositionZone()); order is significant only for last-match-wins evaluation, not indexed by attribute name.",
+            "description": "A pan/tilt window that forces a fixed value onto another DMX channel while the beam is aimed inside it (struct PositionZone). Attributes: PanMin (uint, default 0, 0-255), PanMax (uint, default 255, 0-255), TiltMin (uint, default 0, 0-255), TiltMax (uint, default 255, 0-255), Channel (uint, default 1, min clamped to 1 on read), Value (uint, default 0, 0-255, stored/read as uint8_t)."
+        }
+    ],
+    "properties": [],
+    "notes": [
+        "All of this document's own attributes (Fixture, DmxColorType + color channels, MhDimmerChannel, shutter, beam - including DmxBeamOrient/DmxBeamYOffset, which ARE written here, unlike DmxMovingHead) are documented once in shared/DmxAbilities.json; `properties` is intentionally empty.",
+        "DmxMovingHeadAdv is the only one of the four beam-ability DMX documents whose constructor enables SetSupportsOrient(true)/SetSupportsYOffset(true) - so it is the only document that actually writes DmxBeamOrient/DmxBeamYOffset (default beam length/width/y-offset overridden to 4.0/4.0/17.0 in its constructor).",
+        "Has no DmxStyle or HideBody attribute (those belong to DmxMovingHead only) - its visual style is entirely the BaseMesh/YokeMesh/HeadMesh OBJ geometry.",
+        "PivotAxes-style caveat does not apply here (that is a DmxServo3d-only UI element); DmxMovingHeadAdv has no non-persisted UI-only properties beyond the PositionZoneConfig popup button itself, which is a UI convenience for editing the PositionZone list above rather than an attribute."
+    ]
+}

--- a/resources/modelsmetadata/DmxServo.json
+++ b/resources/modelsmetadata/DmxServo.json
@@ -1,0 +1,92 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "DmxServo",
+    "description": "A bank of independent 2D servo-driven axes, each optionally rendered via a pair of static/motion 2D images that swap based on the servo's live position (e.g. an animated prop with several image-swapped moving parts). No color/shutter/dimmer/beam ability of its own. Source: src-core/models/DMX/DmxServo.{h,cpp} (DisplayAs = DisplayAsType::DmxServo). Compare DmxServo3d.json for the 3D-mesh equivalent (which uses Mesh children instead of DmxImage children, plus a servo-to-mesh motion-linkage system).",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json",
+        "shared/DmxAbilities.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions. Round-tripped but disabled in DmxServo's property grid - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions. Deliberately left enabled for DMX models."
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions. Not disabled for DMX models."
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve. Round-tripped but disabled in DmxServo's property grid - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        },
+        {
+            "name": "Servo{n}",
+            "encoding": "1-based numbered family Servo1, Servo2, ... ServoN, where N = NumServos (up to 24, DmxServo::CreateServo(\"Servo\" + std::to_string(i+1), i)).",
+            "description": "One servo axis. Instantiates the Servo pattern documented in shared/DmxAbilities.json notes (Channel/MinLimit/MaxLimit/RangeOfMotion/PivotOffsetX-Y-Z/ServoStyle/ControllerMin-Max-Reverse-ZeroBehavior-DataType)."
+        },
+        {
+            "name": "StaticImage{n}",
+            "encoding": "1-based numbered family StaticImage1, StaticImage2, ... StaticImageN paired index-for-index with Servo{n} (N = NumServos). A legacy unnumbered \"StaticImage\" element (no digit) is accepted on read and treated as StaticImage1 (XmlDeserializingModelFactory::DeserializeDmxServo).",
+            "description": "2D image shown while the paired servo is at/near its resting position. Instantiates the DmxImage pattern documented in shared/DmxAbilities.json notes (Image/ScaleX-Y-Z/RotateX-Y-Z/OffsetX-Y-Z)."
+        },
+        {
+            "name": "MotionImage{n}",
+            "encoding": "1-based numbered family MotionImage1, MotionImage2, ... MotionImageN paired index-for-index with Servo{n}. A legacy unnumbered \"MotionImage\" element is likewise accepted on read as MotionImage1 - CORRECTION/trap: XmlDeserializingModelFactory::DeserializeDmxServo's legacy-name branch for \"MotionImage\" actually calls `model->CreateStaticImage(\"MotionImage1\", 0)` (re-using the static-image constructor, not a motion-image one) - an apparent copy/paste artifact in that one legacy-compatibility code path; the numbered MotionImage{n} branch (n >= 1) correctly calls CreateMotionImage.",
+            "description": "2D image shown while the paired servo is in motion, swapped in based on the servo's live channel value. Same attribute set as StaticImage{n}."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumServos",
+            "label": "Num Servos",
+            "gridKey": "NumServos",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 24,
+            "description": "Number of independent servo axes (DmxServo::GetNumServos()/SetNumServos()); also the count of Servo{n}/StaticImage{n}/MotionImage{n} child-element families. Grid max of 24 matches the internal SUPPORTED_SERVOS cap used by the property-grid adapter."
+        },
+        {
+            "xmlAttribute": "Bits16",
+            "label": "16 Bit",
+            "gridKey": "Bits16",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "description": "When \"1\", each servo channel is treated as a 16-bit (coarse+fine) pair instead of a single 8-bit channel (DmxServo::Is16Bit()/SetIs16Bit()); affects the minimum required DmxChannelCount (NumServos * 2 vs * 1, enforced by the property grid) and each Servo's channel numbering."
+        },
+        {
+            "xmlAttribute": "Brightness",
+            "label": "Brightness",
+            "gridKey": "Brightness",
+            "type": "uint",
+            "default": 100,
+            "min": 0,
+            "max": 100,
+            "description": "Overall image-rendering brightness percentage for this model's static/motion images (DmxServo::GetBrightness()/SetBrightness(); stored as a float member but always an integer percentage in the property grid). Note: this is a different xmlAttribute scope than shared/ControllerConnection.json's own \"Brightness\" property - that one lives on the nested <ControllerConnection> child element, this one is a direct attribute of the <model> node itself, so there is no collision."
+        }
+    ],
+    "notes": [
+        "No color/shutter/dimmer/beam ability: DmxServo attaches none of the five DmxModel abilities beyond the always-present preset ability (no `color_ability =`/`shutter_ability =`/etc. in DmxServo::DmxServo()), so none of shared/DmxAbilities.json's color/shutter/dimmer/beam properties ever appear for this document - only DmxChannelCount and the DmxPreset* family from that fragment apply.",
+        "AMBIGUITY (flagged rather than modeled as a properties[] entry to avoid a duplicate-xmlAttribute validator error): DmxServo also persists an XML attribute literally named \"Transparency\" (XmlNodeKeys::TransparencyAttribute, DmxServo::GetTransparency()/SetTransparency(), written unconditionally by Visit(const DmxServo&) and read by XmlDeserializingModelFactory::DeserializeDmxServo) meaning per-image transparency (0-100, default 0) for this model's static/motion images - exposed in DmxServoPropertyAdapter as its own \"Transparency\" grid row. This is the EXACT SAME xmlAttribute name already owned by shared/Common.json's generic pixel \"Transparency\" property (gridKey \"ModelPixelTransparency\", default 0, description \"how opaque the element is in the layout preview\"). Neither DmxServoPropertyAdapter nor the base DmxPropertyAdapter disables/hides the inherited generic ModelPixelTransparency property for DmxServo, so in principle both the generic pixel-transparency control and DmxServo's own per-image-transparency control could appear in the same property grid, both writing the identical <model Transparency=\"...\"> attribute - an apparent unintentional attribute-name reuse in the C++ (verified: XmlNodeKeys::TransparencyAttribute is the one and only constant for the literal string \"Transparency\", used by both call sites). Per this metadata tree's rule that no attribute may be redefined once inherited from an extended fragment, this document does NOT add a second \"Transparency\" property - shared/Common.json's existing entry is authoritative for the xmlAttribute/type/bounds, and an MCP reader should treat a DmxServo file's \"Transparency\" value as DmxServo's own per-image transparency (DmxServo::GetTransparency()), not generic pixel transparency, since DmxServo has no per-pixel rendering to speak of."
+    ]
+}

--- a/resources/modelsmetadata/DmxServo3d.json
+++ b/resources/modelsmetadata/DmxServo3d.json
@@ -1,0 +1,130 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "DmxServo3d",
+    "description": "A bank of independent 3D servo-driven axes, each optionally linked to one of a separate pool of static/motion 3D OBJ meshes whose visibility/transform is driven by the servo's live position - e.g. a 3D-rendered animatronic prop. No color/shutter/dimmer/beam ability of its own. Source: src-core/models/DMX/DmxServo3D.{h,cpp} (DisplayAs = DisplayAsType::DmxServo3d; legacy DisplayAs alias \"DmxServo3Axis\" is accepted read-only). Compare DmxServo.json for the simpler 2D-image equivalent (no independent mesh pool or linkage system - each servo has exactly one fixed static+motion image pair).",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json",
+        "shared/DmxAbilities.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions. Round-tripped but disabled in DmxServo3d's property grid - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions. Deliberately left enabled for DMX models."
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions. Not disabled for DMX models."
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve. Round-tripped but disabled in DmxServo3d's property grid - see shared/DmxAbilities.json notes."
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        },
+        {
+            "name": "Servo{n}",
+            "encoding": "1-based numbered family Servo1, Servo2, ... ServoN, where N = NumServos (up to 24, DmxServo3d::CreateServo(\"Servo\" + std::to_string(i+1), i)).",
+            "description": "One servo axis. Instantiates the Servo pattern documented in shared/DmxAbilities.json notes (Channel/MinLimit/MaxLimit/RangeOfMotion/PivotOffsetX-Y-Z/ServoStyle/ControllerMin-Max-Reverse-ZeroBehavior-DataType)."
+        },
+        {
+            "name": "StaticMesh{n}",
+            "encoding": "1-based numbered family StaticMesh1, StaticMesh2, ... StaticMeshN, where N = NumStatic (up to 24, DmxServo3d::CreateStaticMesh). A legacy unnumbered \"StaticMesh\" element (no digit) is accepted on read and treated as StaticMesh1 (XmlDeserializingModelFactory::DeserializeDmxServo3d). Independent of the Servo{n} family in count and index - linked via the Servo{n}Linkage attribute below, not by matching array position.",
+            "description": "A 3D OBJ mesh from the static-mesh pool. Instantiates the Mesh pattern documented in shared/DmxAbilities.json notes (ObjFile/MeshOnly/Brightness/Width/Height/Depth/ScaleX-Y-Z/RotateX-Y-Z/OffsetX-Y-Z)."
+        },
+        {
+            "name": "MotionMesh{n}",
+            "encoding": "1-based numbered family MotionMesh1, MotionMesh2, ... MotionMeshN, where N = NumMotion (up to 24). A legacy unnumbered \"MotionMesh\" element is likewise accepted on read as MotionMesh1. Independent of Servo{n} in count and index - linked via Mesh{n}Linkage.",
+            "description": "A 3D OBJ mesh from the motion-mesh pool, swapped in based on the linked servo's live position. Same attribute set as StaticMesh{n}."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumServos",
+            "label": "Num Servos",
+            "gridKey": "NumServos",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 24,
+            "description": "Number of independent servo axes (DmxServo3d::GetNumServos()/SetNumServos()); edited via the \"Servo Config\" popup dialog (ServoConfigDialog), not a direct top-level grid row. Grid max of 24 (ServoConfigDialog.wxs SpinCtrl_NumServos) matches SUPPORTED_SERVOS."
+        },
+        {
+            "xmlAttribute": "NumStatic",
+            "label": "Num Static Meshes",
+            "gridKey": "NumStatic",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 24,
+            "description": "Size of the static-mesh pool (DmxServo3d::GetNumStatic()/SetNumStatic()), independent of NumServos. Edited via the same Servo Config dialog."
+        },
+        {
+            "xmlAttribute": "NumMotion",
+            "label": "Num Motion Meshes",
+            "gridKey": "NumMotion",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 24,
+            "description": "Size of the motion-mesh pool (DmxServo3d::GetNumMotion()/SetNumMotion()), independent of NumServos. Its dialog spinner range is dynamically capped to [1, NumServos] at dialog-open time (ServoConfigDialogAdapter::DoShowDialog: `SpinCtrl_NumMotion->SetRange(1, m_model->GetNumServos())`), but the persisted attribute itself has no such constraint enforced on load."
+        },
+        {
+            "xmlAttribute": "Bits16",
+            "label": "16 Bit",
+            "gridKey": "Bits16",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "description": "When \"1\", each servo channel is a 16-bit (coarse+fine) pair instead of 8-bit (DmxServo3d::Is16Bit()/SetIs16Bit()). Edited via the Servo Config dialog's \"16 bits\" checkbox, not a direct top-level grid row."
+        },
+        {
+            "xmlAttribute": "Brightness",
+            "label": "Brightness",
+            "type": "uint",
+            "default": 100,
+            "min": 0,
+            "max": 100,
+            "description": "Overall mesh-rendering brightness percentage (DmxServo3d::GetBrightness()/SetBrightness()). Always written (Visit(const DmxServo3d&) unconditionally adds it), but AMBIGUITY: unlike DmxServo, DmxServo3dPropertyAdapter::AddTypeProperties has no corresponding wxUIntProperty row for it at all - there is currently no way to edit this attribute from DmxServo3d's property grid; it round-trips whatever value a file already has (default 100 for a brand-new model). No gridKey is listed because none exists."
+        },
+        {
+            "xmlAttribute": "Servo{n}Linkage",
+            "label": "Servo {n} Linkage",
+            "gridKey": "Servo{n}Linkage",
+            "type": "string",
+            "encoding": "1-based numbered family Servo1Linkage, Servo2Linkage, ... ServoNLinkage (n = 1..NumServos). Stored value is the literal string \"Mesh \" + (1-based static-mesh-pool index), e.g. \"Mesh 1\", \"Mesh 2\" - NOT the plain integer. On read, a value with fewer than 5 characters (i.e. not matching \"Mesh N\") falls back to \"Mesh 1\" (XmlDeserializingModelFactory::DeserializeDmxServo3d); a valid value maps to DmxServo3d::SetServoLink(i, link_id - 1).",
+            "default": "Mesh {n}",
+            "description": "Which entry in the static-mesh pool servo {n}'s motion visually drives/is associated with (DmxServo3d::GetServoLink(i)/SetServoLink(i); in-memory sentinel -1 means \"defaults to its own index\", serialized as \"Mesh {n}\" either way). Edited via the \"Servo Linkage\" category's per-servo enum dropdowns (DmxServo3dPropertyAdapter.cpp), populated from a shared MOTION_LINKS choice list sized to NumServos."
+        },
+        {
+            "xmlAttribute": "Mesh{n}Linkage",
+            "label": "Mesh {n} Linkage",
+            "gridKey": "Mesh{n}Linkage",
+            "type": "string",
+            "encoding": "Same family/index/value convention as Servo{n}Linkage above, but governs DmxServo3d::GetMeshLink(i)/SetMeshLink(i) instead.",
+            "default": "Mesh {n}",
+            "description": "Which entry in the static-mesh pool is associated with motion-mesh slot {n} (DmxServo3d::GetMeshLink(i)/SetMeshLink(i)). Edited via the \"Mesh Linkage\" category's per-slot enum dropdowns."
+        }
+    ],
+    "notes": [
+        "No color/shutter/dimmer/beam ability: DmxServo3d attaches none of the five DmxModel abilities beyond the always-present preset ability, so only DmxChannelCount and the DmxPreset* family from shared/DmxAbilities.json apply.",
+        "CORRECTION vs the task brief's suggestion that DmxServo3d adds a persisted \"PivotAxes\" attribute: \"PivotAxes\" (grid label \"Show Pivot Axes\", DmxServo3d::GetShowPivot()/SetShowPivot()) is NOT written anywhere in Visit(const DmxServo3d&) and NOT read anywhere in XmlDeserializingModelFactory::DeserializeDmxServo3d - it is purely transient, in-memory, per-session UI display state (whether pivot-axis gizmos are drawn in the 3D preview) with no corresponding xmlAttribute at all. It is intentionally excluded from `properties` here.",
+        "The task brief's \"motion-link enums\" refers to the Servo{n}Linkage/Mesh{n}Linkage attributes above; they are persisted as descriptive \"Mesh N\" strings rather than as small integers or a fixed enum list, because the valid choice set (\"Mesh 1\".. \"Mesh NumServos\") is sized dynamically to the current NumServos and therefore cannot be expressed as this schema's static `enum` array - modeled as `type: string` with the value format documented in `encoding` instead, matching this metadata tree's convention for dynamically-bounded value sets (see e.g. shared/Common.json's LayoutGroup)."
+    ]
+}

--- a/resources/modelsmetadata/DmxSkull.json
+++ b/resources/modelsmetadata/DmxSkull.json
@@ -1,0 +1,222 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "DmxSkull",
+    "description": "A talking/animatronic skull prop: up to six independently-toggleable servo axes (jaw, pan, tilt, nod, eye up/down, eye left/right), four 3D OBJ meshes (head, jaw, left eye, right eye), a fixed per-axis orientation offset for each enabled axis, and an optional RGBW color ability for eye lighting. Source: src-core/models/DMX/DmxSkull.{h,cpp} (DisplayAs = DisplayAsType::DmxSkull; constructor attaches `color_ability = std::make_unique<DmxColorAbilityRGB>()` unconditionally, but its use is further gated by the HasColor flag below). No shutter/dimmer/beam ability.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json",
+        "shared/DmxAbilities.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions. CORRECTION vs the other seven DMX documents: DmxSkullPropertyAdapter::DisableUnusedProperties disables ModelStringType, ModelStringColor and ModelDimmingCurves, but - unlike the base DmxPropertyAdapter::DisableUnusedProperties (inherited by every other Dmx*PropertyAdapter) - it does NOT disable ModelFaces. faceInfo therefore remains fully enabled/editable in DmxSkull's property grid, unlike every other DMX document in this family."
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions. Deliberately left enabled for DMX models."
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions. Not disabled for DMX models."
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve. Round-tripped but disabled in DmxSkull's property grid (ModelDimmingCurves is disabled the same as every other DMX document)."
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        },
+        {
+            "name": "JawServo",
+            "description": "Jaw axis servo child element (fixed, axis-named - NOT part of the {n}-numbered Servo1/Servo2/... family used by DmxServo/DmxServo3d). Instantiates the Servo pattern documented in shared/DmxAbilities.json notes. Only created/present when HasJaw() is true (DmxSkull::CreateServo(\"JawServo\"))."
+        },
+        {
+            "name": "PanServo",
+            "description": "Pan axis servo child element. Same attribute set as JawServo. Only present when HasPan() is true."
+        },
+        {
+            "name": "TiltServo",
+            "description": "Tilt axis servo child element. Same attribute set as JawServo. Only present when HasTilt() is true."
+        },
+        {
+            "name": "NodServo",
+            "description": "Nod axis servo child element. Same attribute set as JawServo. Only present when HasNod() is true."
+        },
+        {
+            "name": "EyeUpDownServo",
+            "description": "Eye up/down axis servo child element. CORRECTION vs the task brief's shorthand \"EyeUD\": the actual literal element/base name is \"EyeUpDownServo\" (DmxSkull::CreateServo(\"EyeUpDownServo\"), XmlDeserializingModelFactory::DeserializeDmxSkull `if (\"EyeUpDownServo\" == name)`), not \"EyeUD\" or \"EyeUDServo\". Same attribute set as JawServo. Only present when HasEyeUD() is true."
+        },
+        {
+            "name": "EyeLeftRightServo",
+            "description": "Eye left/right axis servo child element. CORRECTION vs the task brief's shorthand \"EyeLR\": the actual literal element/base name is \"EyeLeftRightServo\", not \"EyeLR\" or \"EyeLRServo\". Same attribute set as JawServo. Only present when HasEyeLR() is true."
+        },
+        {
+            "name": "HeadMesh",
+            "description": "Head 3D mesh child element (fixed, axis-named). Instantiates the Mesh pattern documented in shared/DmxAbilities.json notes. Always created (DmxSkull::CreateMesh(\"HeadMesh\"))."
+        },
+        {
+            "name": "JawMesh",
+            "description": "Jaw 3D mesh child element. Same attribute set as HeadMesh. Always created."
+        },
+        {
+            "name": "EyeMeshL",
+            "description": "Left eye 3D mesh child element. Same attribute set as HeadMesh. Always created."
+        },
+        {
+            "name": "EyeMeshR",
+            "description": "Right eye 3D mesh child element. Same attribute set as HeadMesh. Always created."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "HasJaw",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "description": "Whether this skull has a jaw servo axis at all (DmxSkull::HasJaw()/SetHasJaw()). Configured via the \"Skull Config\" popup dialog (SkullConfigDialog checkboxes), not a direct top-level grid row; gates whether the JawServo child element and its DmxJawOrient property exist/are shown."
+        },
+        {
+            "xmlAttribute": "HasPan",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "description": "Whether this skull has a pan servo axis (DmxSkull::HasPan()/SetHasPan()). Configured via the Skull Config dialog; gates PanServo/DmxPanOrient."
+        },
+        {
+            "xmlAttribute": "HasTilt",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "description": "Whether this skull has a tilt servo axis (DmxSkull::HasTilt()/SetHasTilt()). Configured via the Skull Config dialog; gates TiltServo/DmxTiltOrient."
+        },
+        {
+            "xmlAttribute": "HasNod",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "description": "Whether this skull has a nod servo axis (DmxSkull::HasNod()/SetHasNod()). Configured via the Skull Config dialog; gates NodServo/DmxNodOrient."
+        },
+        {
+            "xmlAttribute": "HasEyeUD",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "description": "Whether this skull has an eye up/down servo axis (DmxSkull::HasEyeUD()/SetHasEyeUD()). Configured via the Skull Config dialog; gates EyeUpDownServo/DmxEyeUDOrient."
+        },
+        {
+            "xmlAttribute": "HasEyeLR",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "description": "Whether this skull has an eye left/right servo axis (DmxSkull::HasEyeLR()/SetHasEyeLR()). Configured via the Skull Config dialog; gates EyeLeftRightServo/DmxEyeLROrient."
+        },
+        {
+            "xmlAttribute": "HasColor",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "description": "Whether this skull's eyes have an RGBW color ability at all (DmxSkull::HasColor()/SetHasColor()). Configured via the Skull Config dialog; gates whether the \"Color Properties\" category (DmxEyeBrtChannel + shared/DmxAbilities.json's color-ability properties) is shown/used at all - note this is a coarser, DmxSkull-specific on/off switch layered on top of (and independent from) DmxModel::HasColorAbility(), which is always true for DmxSkull since its constructor always creates the color_ability object regardless of this flag."
+        },
+        {
+            "xmlAttribute": "Bits16",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "description": "When \"1\", servo channels are treated as 16-bit (coarse+fine) pairs (DmxSkull::Is16Bit()/SetIs16Bit()). Configured via the Skull Config dialog's \"16 bits\" checkbox."
+        },
+        {
+            "xmlAttribute": "MeshOnly",
+            "gridKey": "MeshOnly",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "description": "When \"1\", renders only the OBJ meshes without the servo/orientation gizmo overlays (DmxSkull::IsMeshOnly()/SetMeshOnly()). Has its own direct top-level grid checkbox (unlike the Has*/Bits16 flags above, which are all Skull-Config-dialog-only)."
+        },
+        {
+            "xmlAttribute": "DmxEyeBrtChannel",
+            "gridKey": "DmxEyeBrtChannel",
+            "type": "uint",
+            "default": 15,
+            "min": 0,
+            "max": 512,
+            "description": "DMX channel controlling eye brightness/dimming (DmxSkull::GetEyeBrightnessChannel()/SetEyeBrightnessChannel()). Only shown in the property grid when HasColor() is true."
+        },
+        {
+            "xmlAttribute": "DmxJawOrient",
+            "gridKey": "DmxJawOrient",
+            "type": "int",
+            "default": 0,
+            "min": -360,
+            "max": 360,
+            "appliesWhen": { "attribute": "HasJaw", "equals": "1" },
+            "description": "Fixed orientation offset (degrees) applied to the jaw servo's rendered position (DmxSkull::GetJawOrient()/SetJawOrient()). Default is DmxSkull::default_orient[JAW] = 0, used as the read-fallback via GetDefaultOrient(SERVO_TYPE::JAW). Only present/shown when HasJaw() is true."
+        },
+        {
+            "xmlAttribute": "DmxPanOrient",
+            "gridKey": "DmxPanOrient",
+            "type": "int",
+            "default": 90,
+            "min": -360,
+            "max": 360,
+            "appliesWhen": { "attribute": "HasPan", "equals": "1" },
+            "description": "Fixed orientation offset (degrees) for the pan servo (DmxSkull::GetPanOrient()/SetPanOrient()). Default is default_orient[PAN] = 90. Only present/shown when HasPan() is true."
+        },
+        {
+            "xmlAttribute": "DmxTiltOrient",
+            "gridKey": "DmxTiltOrient",
+            "type": "int",
+            "default": -20,
+            "min": -360,
+            "max": 360,
+            "appliesWhen": { "attribute": "HasTilt", "equals": "1" },
+            "description": "Fixed orientation offset (degrees) for the tilt servo (DmxSkull::GetTiltOrient()/SetTiltOrient()). Default is default_orient[TILT] = -20. Only present/shown when HasTilt() is true."
+        },
+        {
+            "xmlAttribute": "DmxNodOrient",
+            "gridKey": "DmxNodOrient",
+            "type": "int",
+            "default": 29,
+            "min": -360,
+            "max": 360,
+            "appliesWhen": { "attribute": "HasNod", "equals": "1" },
+            "description": "Fixed orientation offset (degrees) for the nod servo (DmxSkull::GetNodOrient()/SetNodOrient()). Default is default_orient[NOD] = 29. Only present/shown when HasNod() is true."
+        },
+        {
+            "xmlAttribute": "DmxEyeUDOrient",
+            "gridKey": "DmxEyeUDOrient",
+            "type": "int",
+            "default": 35,
+            "min": -360,
+            "max": 360,
+            "appliesWhen": { "attribute": "HasEyeUD", "equals": "1" },
+            "description": "Fixed orientation offset (degrees) for the eye up/down servo (DmxSkull::GetEyeUDOrient()/SetEyeUDOrient()). Default is default_orient[EYE_UD] = 35. Only present/shown when HasEyeUD() is true."
+        },
+        {
+            "xmlAttribute": "DmxEyeLROrient",
+            "gridKey": "DmxEyeLROrient",
+            "type": "int",
+            "default": -35,
+            "min": -360,
+            "max": 360,
+            "appliesWhen": { "attribute": "HasEyeLR", "equals": "1" },
+            "description": "Fixed orientation offset (degrees) for the eye left/right servo (DmxSkull::GetEyeLROrient()/SetEyeLROrient()). Default is default_orient[EYE_LR] = -35. Only present/shown when HasEyeLR() is true."
+        }
+    ],
+    "notes": [
+        "No shutter/dimmer/beam ability: DmxSkull attaches only a color_ability (unconditionally, RGBW) plus the always-present preset ability - no shutter_ability/dimmer_ability/beam_ability - so only DmxChannelCount, DmxColorType and the RGBW-channel properties from shared/DmxAbilities.json apply beyond this document's own properties (color type is fixed at RGBW like DmxGeneral/DmxFloodlight/DmxFloodArea - never switched dynamically).",
+        "gridKey omitted for HasPan/HasTilt/HasNod/HasEyeUD/HasEyeLR/HasColor/Bits16/HasJaw above: none of the Has*/Bits16 flags have a direct property-grid row of their own - they are only editable through the \"Skull Config\" popup-dialog checkboxes (SkullConfigDialog), which read/write the model directly rather than going through a named wxPGProperty/gridKey.",
+        "Servo child-element base names use full descriptive names (JawServo/PanServo/TiltServo/NodServo/EyeUpDownServo/EyeLeftRightServo), not the short axis labels (Jaw/Pan/Tilt/Nod/EyeUD/EyeLR) the task brief's survey shorthand suggested - see the childElements entries above for the verified literal names."
+    ]
+}

--- a/resources/modelsmetadata/Icicles.json
+++ b/resources/modelsmetadata/Icicles.json
@@ -72,7 +72,7 @@
             "type": "bool",
             "boolFormat": "truefalse",
             "default": "false",
-            "description": "When \"true\", interleaves buffer Y-positions within each drop (staggered wiring) instead of assigning them top-to-bottom in simple sequential order (IciclesModel::_alternateNodes; IciclesModel::InitModel). Persisted as the lowercase literal true/false. json - see Arches.json's matching note for the full rationale (same pattern recurs on CandyCanes.json's Reverse/Sticks/AlternateNodes). Always written (unconditional, both values)."
+            "description": "When \"true\", interleaves buffer Y-positions within each drop (staggered wiring) instead of assigning them top-to-bottom in simple sequential order (IciclesModel::_alternateNodes; IciclesModel::InitModel). Persisted as the lowercase literal true/false. See Arches.json's matching note for the full rationale (same pattern recurs on CandyCanes.json's Reverse/Sticks/AlternateNodes). Always written (unconditional, both values)."
         },
         {
             "xmlAttribute": "DropPattern",

--- a/resources/modelsmetadata/Icicles.json
+++ b/resources/modelsmetadata/Icicles.json
@@ -1,0 +1,91 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Icicles",
+    "description": "A row of hanging icicle drops of varying lengths, repeating a configurable drop-length pattern across the row. Does not support the ThreePoint Angle/tilt control (always 0) but does support Shear.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumStrings",
+            "label": "# Strings",
+            "gridKey": "IciclesStrings",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 100,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Number of physical connections/strings from the prop to the controller (IciclesModel::_numStrings; IciclesPropertyAdapter help text: \"typically the number of connections from the prop to your controller\")."
+        },
+        {
+            "xmlAttribute": "NodesPerString",
+            "label": "Nodes/String",
+            "gridKey": "IciclesLights",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 2000,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Nodes per string (IciclesModel::_lightsPerString, despite the generic xmlAttribute name NodesPerString shared with Circle/SingleLine/Wreath in their own separate documents). Grid label is \"Lights/String\" for SingleNode string types, \"Nodes/String\" otherwise; same xmlAttribute/gridKey either way."
+        },
+        {
+            "xmlAttribute": "AlternateNodes",
+            "label": "Alternate Nodes",
+            "gridKey": "AlternateNodes",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "description": "When \"true\", interleaves buffer Y-positions within each drop (staggered wiring) instead of assigning them top-to-bottom in simple sequential order (IciclesModel::_alternateNodes; IciclesModel::InitModel). Persisted as the lowercase literal true/false. json - see Arches.json's matching note for the full rationale (same pattern recurs on CandyCanes.json's Reverse/Sticks/AlternateNodes). Always written (unconditional, both values)."
+        },
+        {
+            "xmlAttribute": "DropPattern",
+            "label": "Drop Pattern",
+            "gridKey": "IciclesDrops",
+            "type": "string",
+            "default": "3,4,5,4",
+            "encoding": "Comma-separated list of non-negative integers, one per drop position, cycled repeatedly across the row's NodesPerString x NumStrings total lights (IciclesModel::ParseDropSizes/SetDropPattern; ModelFaceDialog-style custom editor wxDropPatternProperty, IciclesPropertyAdapter::AddTypeProperties). Each value is the node/light count of that drop; an all-invalid or empty pattern falls back in-memory to a single drop of length 5 (IciclesModel::ParseDropSizes), though the on-disk default when the attribute is absent is \"3,4,5,4\".",
+            "description": "Repeating pattern of icicle drop lengths, longest-to-shortest as authored by the user (e.g. the default \"3,4,5,4\" draws a short-long-longest-long repeating icicle shape)."
+        }
+    ],
+    "notes": [
+        "Starting Location: the \"IciclesStart\" property-grid enum (gridKey \"IciclesStart\") is a 2-value Green Square/Blue Square picker that sets only the shared Dir attribute (shared/Common.json); StartSide is not involved for this model type (IciclesPropertyAdapter::OnPropertyGridChange \"IciclesStart\" only calls SetDirection/SetIsLtoR). No property object for it appears above since Dir itself is owned by shared/Common.json.",
+        "Angle (shared/ScreenLocation.json) is always written (AddThreePointScreenLocationAttributes runs unconditionally for every ThreePoint model) but Icicles never calls SetSupportsAngle(true) in its constructor, so its value is always 0 and there is no \"Arch Tilt\"-style property-grid control for it (IciclesModel::IciclesModel; contrast with Arches/CandyCanes, which do expose it). Icicles does call SetSupportsShear(true) and SetMHeight(-0.5), so Shear is meaningful/adjustable for this model type even though Angle is not."
+    ]
+}

--- a/resources/modelsmetadata/Image.json
+++ b/resources/modelsmetadata/Image.json
@@ -1,0 +1,74 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Image",
+    "description": "A single static image file mapped onto the model's bounding box and treated as one block of pixel/channel data (brightness-modulated, optionally alpha-keyed off its white channel). Keeps the full shared extends list below (Faces/States/SubModels/DimmingCurve/pixel-rendering attributes all still persist if present in the file) but most of them are non-functional for Image and hidden from its property grid - see notes.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "Image",
+            "label": "Image",
+            "gridKey": "Image",
+            "type": "filepath",
+            "default": "",
+            "description": "Path to the image file rendered by this model (ImageModel::GetImageFile()/SetImageFile()). Supported formats per the property grid's file-picker wildcard: png, bmp, jpg, gif, jpeg, webp."
+        },
+        {
+            "xmlAttribute": "OffBrightness",
+            "label": "Off Brightness",
+            "gridKey": "OffBrightness",
+            "type": "uint",
+            "default": 80,
+            "min": 0,
+            "max": 200,
+            "description": "Brightness percentage applied to the image when it is considered \"off\"/inactive (ImageModel::GetOffBrightness()/SetOffBrightness()). Range extends to 200 (not just 100), allowing an over-bright \"off\" state."
+        },
+        {
+            "xmlAttribute": "WhiteAsAlpha",
+            "label": "Read White As Alpha",
+            "gridKey": "WhiteAsAlpha",
+            "type": "bool",
+            "boolFormat": "TrueFalse",
+            "default": "False",
+            "description": "When \"True\", the image's white channel/value is treated as an alpha (transparency) mask instead of being rendered as opaque white (ImageModel::IsWhiteAsAlpha()/SetWhiteAsAlpha()). Persisted as the Title-case literal True/False (XmlNodeKeys::WhiteAsAlphaAttribute), unlike every boolean attribute elsewhere in this tree which uses lowercase true/false - verified via both BaseSerializingVisitor::Visit(const ImageModel&) (`? \"True\" : \"False\"`) and XmlDeserializingModelFactory::DeserializeImage (default \"False\", compared against \"True\")."
+        }
+    ],
+    "notes": [
+        "Properties from the shared fragments that do NOT apply to Image, and are explicitly disabled (greyed out) in its property grid by ImagePropertyAdapter::DisableUnusedProperties: faceInfo (\"ModelFaces\"), dimmingCurve (\"ModelDimmingCurves\"), stateInfo (\"ModelStates\"), StrandNames/NodeNames (\"ModelStrandNodeNames\"), subModel (\"SubModels\"), PixelSize (\"ModelPixelSize\"), Antialias/Pixel Style (\"ModelPixelStyle\"), and BlackTransparency (\"ModelPixelBlackTransparency\", all from shared/Common.json). These attributes may still be present/round-tripped if an existing file already has them (e.g. from converting another model type to Image), but the current UI provides no way to set them on an Image model.",
+        "ImageModel::GetNumPhysicalStrings() is hard-coded to 1 and SupportsWiringView()/SupportsExportAsCustom() both return false - Image has no wiring-view or export-as-custom-model concept, consistent with it not exposing the usual per-string/per-node configuration attributes that Matrix/Star/etc. do."
+    ]
+}

--- a/resources/modelsmetadata/Matrix.json
+++ b/resources/modelsmetadata/Matrix.json
@@ -1,0 +1,115 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Matrix",
+    "description": "A rectangular grid of nodes, wired either row-major (Horizontal) or column-major (Vertical). Orientation is carried by the \"Vertical\" attribute, not by DisplayAs: the current serializer always writes the single literal DisplayAs value \"Matrix\" (MatrixModel::MatrixModel sets DisplayAs = DisplayAsType::Matrix; DisplayAsTypeToString(DisplayAsType::Matrix) always returns \"Matrix\", src-core/models/DisplayAsType.cpp). The compound values \"Horiz Matrix\"/\"Vert Matrix\" seen in older files are legacy read-only aliases (DisplayAsTypeFromString's lookup map, plus XmlDeserializingModelFactory::DeserializeMatrix's own `if (type == \"Vert Matrix\") SetVertical(true)` check) that are never produced by this version's writer - see the Vertical property below for the resolution of this vs. the brief's alternate survey guess.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumStrings",
+            "label": "# Strings",
+            "gridKey": "MatrixStringCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 10000,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Number of physical connections/strings from the prop to the controller (MatrixModel::_numStrings, GetNumMatrixStrings/SetNumMatrixStrings). MatrixPropertyAdapter help text: \"typically the number of connections from the prop to your controller. This would also be the 'Height' of a Horizontal Virtual Matrix.\""
+        },
+        {
+            "xmlAttribute": "NodesPerString",
+            "label": "Nodes/String",
+            "gridKey": "MatrixLightCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 10000,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Nodes per string (MatrixModel::_nodesPerString). Grid label is \"Lights/String\" for SingleNode string types, \"Nodes/String\" otherwise (MatrixPropertyAdapter::AddTypeProperties), with help text noting this would also be the 'Width' of a Horizontal Virtual Matrix; same xmlAttribute/gridKey either way."
+        },
+        {
+            "xmlAttribute": "StrandsPerString",
+            "label": "Strands/String",
+            "gridKey": "MatrixStrandCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 2500,
+            "legacyAttributes": [
+                "parm3"
+            ],
+            "description": "How many times each #String ZigZags (MatrixModel::_strandsPerString). Must divide evenly into NodesPerString - the property grid flags the row red and adds a help string when it does not (MatrixPropertyAdapter::AddTypeProperties), but the value is still persisted regardless."
+        },
+        {
+            "xmlAttribute": "Vertical",
+            "label": "Direction",
+            "gridKey": "MatrixStyle",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "description": "When \"true\", nodes are wired column-major (Vertical); when \"false\" (default), row-major (Horizontal) (MatrixModel::_vMatrix, isVerticalMatrix()/SetVertical()). This IS the currently-written orientation attribute (XmlNodeKeys::VertMatrixAttribute = \"Vertical\"), confirming the brief survey's alternate hypothesis (grid enum \"MatrixStyle\" maps to attribute \"Vertical\") over its primary DisplayAs-array guess - see the description above for why DisplayAs itself no longer varies. Presented in the property grid as a 2-value enum (\"Horizontal\"/\"Vertical\", gridKey \"MatrixStyle\", MatrixPropertyAdapter::AddStyleProperties) rather than a checkbox, but persisted as the lowercase literal true/false. On read, a legacy DisplayAs value of exactly \"Vert Matrix\" forces Vertical=true even if this attribute says otherwise (XmlDeserializingModelFactory::DeserializeMatrix); the current writer never produces that legacy DisplayAs value, so this only matters for old files."
+        },
+        {
+            "xmlAttribute": "AlternateNodes",
+            "label": "Alternate Nodes",
+            "gridKey": "AlternateNodes",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "description": "When \"true\", interleaves node buffer positions (staggered/zig-zag physical wiring) instead of simple sequential order (MatrixModel::_alternateNodes). Persisted as the lowercase literal true/false; always written (unconditional, both values). Mutually-enabling in the property grid with NoZig (each is disabled while the other is checked, MatrixPropertyAdapter::OnPropertyGridChange), but both attributes are always persisted regardless of the other's value."
+        },
+        {
+            "xmlAttribute": "NoZig",
+            "label": "Don't Zig Zag",
+            "gridKey": "NoZig",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "description": "When \"true\", suppresses the zig-zag strand pattern within each string (MatrixModel::_noZigZag, IsNoZigZag()/SetNoZigZag()). Persisted as the lowercase literal true/false; always written. See AlternateNodes for the mutual UI enable/disable relationship."
+        }
+    ],
+    "notes": [
+        "Starting Location: the \"MatrixStart\" property-grid enum (gridKey \"MatrixStart\") is a 4-value Top Left/Top Right/Bottom Left/Bottom Right picker that sets the shared Dir and StartSide attributes (shared/Common.json) together (MatrixPropertyAdapter::OnPropertyGridChange \"MatrixStart\") - no property object for it appears above since Dir/StartSide are owned by shared/Common.json.",
+        "LowDefinition (shared/Common.json) is inherited unchanged: its appliesWhen already restricts it to DisplayAs Matrix/Sphere, and MatrixModel supports it whenever the model is not SingleNode (SupportsLowDefinitionRender() override) - no Matrix-specific redefinition needed here.",
+        "TreeModel is a C++ subclass of MatrixModel and reuses NumStrings/NodesPerString/StrandsPerString/AlternateNodes/NoZig with identical xmlAttribute names, but per this metadata tree's house style (sibling documents never extend each other) they are repeated in Tree.json rather than referenced from here. Tree does NOT reuse this file's \"Vertical\" attribute - it has its own \"StrandDir\" string attribute instead (see Tree.json).",
+        "CONVERTING TO A CUSTOM MODEL (models/Custom.json): to replicate this model's native pixel layout as a Custom model's grid (e.g. to allow arbitrary per-port pixel counts instead of the whole-NodesPerString port granularity - see shared/ControllerConnection.json's Port note), the buffer/channel math is (verified against MatrixModel::InitHMatrix, src-core/models/MatrixModel.cpp, for the default AlternateNodes=false/NoZig=false zigzag mode, Vertical=false horizontal orientation): let PixelsPerStrand = NodesPerString / StrandsPerString (must divide evenly), y = a physical strand index 0..(NumStrings*StrandsPerString-1) where stringnum=y div StrandsPerString and segmentnum=y mod StrandsPerString, x = 0..(PixelsPerStrand-1). The node's sequential channel-order index (1-based, i.e. the value to place in the Custom model's grid) is idx = y*PixelsPerStrand + x + 1 - this ordering is STRICTLY SEQUENTIAL per string+strand (segment-major, x-minor) regardless of zigzag; the 'back and forth' wiring pattern is purely a BUFFER/VISUAL concern; it does not reorder channels. Grid placement (row/col in models/Custom.json's row0-is-top/col0-is-left convention): row = y if StartSide='T' (top-to-bottom wiring start), or (NumStrings*StrandsPerString-1-y) if StartSide='B' (bottom-to-top); within a row, col = x if (Dir='L') != (segmentnum is odd), else (PixelsPerStrand-1-x) - i.e. every other physical strand reverses direction (classic boustrophedon/serpentine), producing the exact 'N, N-1, ..., N-PixelsPerStrand+1' reversed-row pattern per strand. CAVEAT (verified only for the even case): this per-string-reset segmentnum formula is mathematically identical to one continuous top-to-bottom serpentine across ALL rows only when StrandsPerString is EVEN (so each string's last strand and the next string's first strand end up on the same visual side, keeping the snake unbroken); this has NOT been verified for odd StrandsPerString and may produce a visual discontinuity between strings that the simple 'ignore string boundaries' shortcut would get wrong - re-derive from MatrixModel::InitHMatrix directly if StrandsPerString is odd."
+    ]
+}

--- a/resources/modelsmetadata/ModelGroup.json
+++ b/resources/modelsmetadata/ModelGroup.json
@@ -1,0 +1,144 @@
+{
+    "schemaVersion": 1,
+    "objectType": "modelGroup",
+    "description": "A <modelGroup> node: a named collection of other models (and/or nested groups) that can be selected, sequenced and previewed as a single unit, without owning any pixels of its own - it renders by delegating to its member models' own buffers, referencing them purely by name. Standalone document: does not extend shared/Common.json, because ModelGroup is built from BaseObject's minimal AddBaseObjectAttributes rather than Model's fuller AddCommonModelAttributes (see notes). Source of truth: src-core/models/ModelGroup.h/.cpp, src-core/XmlSerializer/BaseSerializingVisitor.cpp BaseSerializingVisitor::Visit(const ModelGroup&) (writer) and src-core/XmlSerializer/XmlDeserializingModelFactory.cpp DeserializeModelGroup (reader); editing UI is src-ui-wx/layout/ModelGroupPanel.cpp.",
+    "storage": { "file": "xlights_rgbeffects.xml", "node": "modelGroups/modelGroup" },
+    "properties": [
+        {
+            "xmlAttribute": "name",
+            "type": "string",
+            "description": "Unique group name (BaseObject::GetName(), the same base-object attribute mechanism used by a <model>'s \"name\"). Members reference their containing group, and groups reference members, purely by name (see \"models\" below)."
+        },
+        {
+            "xmlAttribute": "DisplayAs",
+            "type": "enum",
+            "enum": ["ModelGroup"],
+            "default": "ModelGroup",
+            "description": "Always the fixed literal \"ModelGroup\" (XmlNodeKeys::ModelGroupType) - this is how the loader tells a <modelGroup> element apart from a <model> element, and how ModelManager recognises a group among the flat model list (Model::GetDisplayAs() == DisplayAsType::ModelGroup). Not read back from the XML on the ModelGroup load path (DeserializeModelGroup never inspects it) and not user-editable; written unconditionally. Distinct from the DisplayAs enum documented in shared/Common.json, which only covers <model> nodes."
+        },
+        {
+            "xmlAttribute": "LayoutGroup",
+            "type": "string",
+            "default": "Unassigned",
+            "description": "Name of the layout group / preview this group is assigned to - same semantics as a model's LayoutGroup (shared/Common.json), written/read via the same AddBaseObjectAttributes/DeserializeBaseObjectAttributes helpers used for <model>."
+        },
+        {
+            "xmlAttribute": "Active",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "description": "When false, the group is not rendered/shown. Default (attribute absent) is true; only \"0\" is ever written (BaseSerializingVisitor::AddBaseObjectAttributes), matching the <model> Active attribute."
+        },
+        {
+            "xmlAttribute": "FromBase",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "description": "Read-only provenance flag: true when this group was merged in from a linked base show folder. Only \"1\" is ever written, matching the <model> FromBase attribute."
+        },
+        {
+            "xmlAttribute": "GridSize",
+            "type": "uint",
+            "default": 400,
+            "min": 10,
+            "max": 4000,
+            "description": "Maximum grid cell size (in preview pixels) used by the grid-style layouts when auto-arranging member models (ModelGroup::GetGridSize()/SetGridSize(); the \"Max Grid Size\" spinner in ModelGroupPanel.cpp, range 10-4000). Always written unconditionally, unlike most of the other group attributes below."
+        },
+        {
+            "xmlAttribute": "layout",
+            "type": "string",
+            "default": "minimalGrid",
+            "description": "How member models are arranged for the group's own default render buffer (ModelGroup::SetLayout(), which also derives the internal defaultBufferStyle from this same value). Modeled as a free-form string rather than an enum because its on-disk values are inconsistent - see notes. Always written unconditionally."
+        },
+        {
+            "xmlAttribute": "DefaultCamera",
+            "type": "string",
+            "default": "2D",
+            "description": "Name of the camera/perspective this group renders under by default: the fixed sentinel \"2D\", or the name of one of the user's configured 3D viewpoints (viewpoint_mgr.GetCamera3D(); ModelGroupPanel.cpp Choice_DefaultCamera). Free-form string because 3D camera names are user-defined, not a fixed enum. Always written unconditionally."
+        },
+        {
+            "xmlAttribute": "XCentreOffset",
+            "type": "int",
+            "default": 0,
+            "min": -5000,
+            "max": 5000,
+            "description": "Horizontal pixel offset applied to the group's custom rotate/scale centre point (ModelGroup::GetXCentreOffset()/SetXCentreOffset(); range -5000..5000 per its ModelGroupPanel.cpp spin control). CORRECTION vs the brief's guessed spelling (\"xCentreOffset\"): the persisted xmlAttribute is capitalised \"XCentreOffset\", verified in both the writer (BaseSerializingVisitor::Visit(const ModelGroup&)) and the reader (XmlDeserializingModelFactory::DeserializeModelGroup). Only written when non-zero."
+        },
+        {
+            "xmlAttribute": "YCentreOffset",
+            "type": "int",
+            "default": 0,
+            "min": -5000,
+            "max": 5000,
+            "description": "Vertical pixel offset, matching XCentreOffset (ModelGroup::GetYCentreOffset()/SetYCentreOffset()). Same capitalisation correction applies. Only written when non-zero."
+        },
+        {
+            "xmlAttribute": "models",
+            "type": "string",
+            "encoding": "Comma-separated list of member names, in group order, with no escaping of embedded commas (a member name containing a comma is not supported). Each entry is either a plain model/group name, or \"<Model>/<SubModel>\" for a specific sub-model member, or - transiently, only inside an export/import snapshot, never in a saved show file - an \"EXPORTEDMODEL/<SubModel>\" placeholder that ModelManager::AddModelGroups resolves against the newly-imported model's own name.",
+            "description": "The group's membership list (ModelGroup::ModelNames()/AddModel()/SetModels()). A member that does not currently exist in the model manager is kept in the list (so re-adding the model later restores membership) but excluded from ActiveModels()/rendering. Always written unconditionally (may be an empty string)."
+        },
+        {
+            "xmlAttribute": "centreDefined",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "description": "True when the user has set a custom rotate/scale pivot point for this group in the layout preview (ModelGroup::GetCentreDefined()/SetCentreDefined(); ModelPreview.cpp group-centre drag handling), rather than using the group's auto-computed bounding-box centre. Not exposed in ModelGroupPanel - only ever set interactively in the layout preview. Only written (and only then are centrex/centrey/centreMinx/centreMiny/centreMaxx/centreMaxy present) when true."
+        },
+        {
+            "xmlAttribute": "centrex",
+            "type": "float",
+            "appliesWhen": { "attribute": "centreDefined", "equals": "1" },
+            "description": "Custom pivot point X, in preview pixels (ModelGroup::GetCentreX()/SetCentreX())."
+        },
+        {
+            "xmlAttribute": "centrey",
+            "type": "float",
+            "appliesWhen": { "attribute": "centreDefined", "equals": "1" },
+            "description": "Custom pivot point Y, in preview pixels (ModelGroup::GetCentreY()/SetCentreY())."
+        },
+        {
+            "xmlAttribute": "centreMinx",
+            "type": "int",
+            "appliesWhen": { "attribute": "centreDefined", "equals": "1" },
+            "description": "Left edge of the member models' combined bounding box at the time the custom pivot was set (ModelGroup::GetCentreMinx()/SetCentreMinx()); used to detect when membership/positions have since changed enough to invalidate the custom pivot. The writer always emits centreMinx/centreMiny/centreMaxx/centreMaxy together whenever centreDefined is true, but the reader treats each of the four independently-optional (defaults to 0 if individually absent)."
+        },
+        {
+            "xmlAttribute": "centreMiny",
+            "type": "int",
+            "appliesWhen": { "attribute": "centreDefined", "equals": "1" },
+            "description": "Top edge of the same bounding box, matching centreMinx."
+        },
+        {
+            "xmlAttribute": "centreMaxx",
+            "type": "int",
+            "appliesWhen": { "attribute": "centreDefined", "equals": "1" },
+            "description": "Right edge of the same bounding box, matching centreMinx."
+        },
+        {
+            "xmlAttribute": "centreMaxy",
+            "type": "int",
+            "appliesWhen": { "attribute": "centreDefined", "equals": "1" },
+            "description": "Bottom edge of the same bounding box, matching centreMinx."
+        },
+        {
+            "xmlAttribute": "TagColour",
+            "type": "color",
+            "default": "#000000",
+            "description": "Visual colour tag shown next to the group in the model list, in #RRGGBB - same attribute/semantics as a <model>'s TagColour (shared/Common.json). Only written when different from the default."
+        }
+    ],
+    "childElements": [
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this group (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Same shape as the <Aliases> element written for a <model> or <subModel>; not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "notes": [
+        "CORRECTION vs the brief (which suggested groups live inside <models> alongside <model>, storage.node \"models/modelGroup\"): <modelGroup> elements actually live under their OWN sibling top-level element, <modelGroups> (XmlNodeKeys::GroupsNodeName = \"modelGroups\"), written and read as a completely separate block from <models>. See src-core/XmlSerializer/XmlSerializer.h XmlSerializer::SerializeAllModels, which writes a whole <models>...</models> block for non-group models and then a separate <modelGroups>...</modelGroups> block for models whose DisplayAs is ModelGroup; and, on the read side, e.g. src-ui-wx/app-shell/TabSequence.cpp (modelGroupsNode = root.child(\"modelGroups\")). storage.node here is corrected to \"modelGroups/modelGroup\" accordingly.",
+        "ModelGroup does not extend shared/Common.json: it is built from BaseObject's minimal AddBaseObjectAttributes (name/DisplayAs/LayoutGroup/Active/FromBase) rather than Model's fuller AddCommonModelAttributes, so it has none of Common.json's model-only attributes (Description, StartChannel, Controller, StringType, PixelSize, ...) and no ScreenLocation/ControllerConnection child data of its own.",
+        "CORRECTION vs the brief's attribute list: \"selected\" is NOT part of the canonical modelGroups/modelGroup element - BaseSerializingVisitor::Visit(const ModelGroup&) never writes it and XmlDeserializingModelFactory::DeserializeModelGroup never reads it. ModelGroup::selected (IsSelected()) is hard-coded false in the constructor (ModelGroup.cpp:385) with no setter anywhere in the class, so it is always false at runtime. The literal attribute name \"selected\" (XmlNodeKeys::mgSelectedAttribute) does appear, always written as \"0\", in a completely different, secondary serialization path used only when embedding a group definition inside a <model>'s <shadowmodels>/<associatedmodels> export snapshot (src-core/XmlSerializer/XmlSerializeFunctions.cpp, ~line 501); that embedded snapshot is reconstructed via a different, narrower code path and \"selected\" is never read back from it either. Omitted from properties above as dead/vestigial for the modelGroups/modelGroup element this document describes.",
+        "The \"layout\" attribute's on-disk values are inconsistent, and its own UI round-trip has an apparent mismatch: of the 16 choices in ModelGroupPanel's layout dropdown, 5 persist as short codes (\"grid\", \"minimalGrid\", \"horizontal\", \"vertical\", \"perModelDefault\") while the other 11 persist as the exact display-label text verbatim (e.g. \"Horizontal Stack - Scaled\", \"Overlay - Centered\", \"Single Line Model As A Pixel\"). Additionally, the write path (ModelGroupPanel::SaveGroupChanges, ~lines 817-840) maps choice indices 6/7 (\"Horizontal Per Model\"/\"Vertical Per Model\") to \"horizontal\"/\"vertical\", while the read path (~lines 557-582) maps those same two short codes back to choice indices 2/3 (\"Horizontal Stack\"/\"Vertical Stack\") instead. Documented here as observed behaviour, not corrected, since changing UI round-trip behaviour is outside this metadata task's scope.",
+        "GridSize/layout/DefaultCamera/models are always written unconditionally by the visitor, in that order, immediately after the shared base-object attributes; XCentreOffset/YCentreOffset, the whole centreDefined/centre* group, and TagColour are only written when non-default."
+    ]
+}

--- a/resources/modelsmetadata/ModelGroup.json
+++ b/resources/modelsmetadata/ModelGroup.json
@@ -1,6 +1,7 @@
 {
     "schemaVersion": 1,
     "objectType": "modelGroup",
+    "displayAs": "ModelGroup",
     "description": "A <modelGroup> node: a named collection of other models (and/or nested groups) that can be selected, sequenced and previewed as a single unit, without owning any pixels of its own - it renders by delegating to its member models' own buffers, referencing them purely by name. Standalone document: does not extend shared/Common.json, because ModelGroup is built from BaseObject's minimal AddBaseObjectAttributes rather than Model's fuller AddCommonModelAttributes (see notes). Source of truth: src-core/models/ModelGroup.h/.cpp, src-core/XmlSerializer/BaseSerializingVisitor.cpp BaseSerializingVisitor::Visit(const ModelGroup&) (writer) and src-core/XmlSerializer/XmlDeserializingModelFactory.cpp DeserializeModelGroup (reader); editing UI is src-ui-wx/layout/ModelGroupPanel.cpp.",
     "storage": { "file": "xlights_rgbeffects.xml", "node": "modelGroups/modelGroup" },
     "properties": [

--- a/resources/modelsmetadata/PolyLine.json
+++ b/resources/modelsmetadata/PolyLine.json
@@ -1,0 +1,125 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Poly Line",
+    "description": "A chain of straight or curved segments defined by an arbitrary number of user-placed vertices, with nodes distributed along its total length and optional per-segment/per-point overrides. Uses the PolyPoint ScreenLocation style (shared/ScreenLocation.json), which already documents NumPoints, PointData, cPointData and ScaleX/Y/Z for this model - not repeated here. This file covers PolyLine's own attributes: node/light counts, drop pattern, and the dynamically-indexed per-point/per-segment/per-corner families that live directly on the <model> element.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NodesPerString",
+            "label": "# Nodes",
+            "gridKey": "PolyLineNodes",
+            "type": "uint",
+            "min": 1,
+            "max": 10000,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Total light/node count distributed along the whole poly-line (PolyLineModel::GetTotalLightCount()/SetTotalLightCount()) - despite the generic xmlAttribute name NodesPerString shared with Matrix/Sphere/Icicles/etc. in their own separate documents, this is a TOTAL count, not a per-string count. Grid label is \"# Lights\" for SingleNode string types, \"# Nodes\" otherwise (PolyLinePropertyAdapter::AddTypeProperties); same xmlAttribute/gridKey either way. No JSON \"default\" is given: the reader's fallback when both this attribute and legacy parm2 are absent is the out-of-range sentinel 0 (XmlDeserializingModelFactory::DeserializePolyLine), below the property grid's Min of 1."
+        },
+        {
+            "xmlAttribute": "LightsPerNode",
+            "label": "Lights/Node",
+            "gridKey": "PolyLineLights",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 300,
+            "legacyAttributes": [
+                "parm3"
+            ],
+            "appliesWhen": {
+                "attribute": "StringType",
+                "notEquals": "SingleNode"
+            },
+            "description": "Physical lights represented by each node (PolyLineModel::GetLightsPerNode()/SetLightsPerNode()). Only shown in the property grid for non-SingleNode string types, but the attribute itself is unconditional."
+        },
+        {
+            "xmlAttribute": "PolyStrings",
+            "label": "Strings",
+            "gridKey": "PolyLineStrings",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 48,
+            "description": "Number of physical connections/strings from the prop to the controller (PolyLineModel::GetNumStrings()/SetNumStrings()); PolyLinePropertyAdapter help text: \"typically the number of connections from the prop to your controller.\""
+        },
+        {
+            "xmlAttribute": "AlternateNodes",
+            "label": "Alternate Drop Nodes",
+            "gridKey": "AlternateNodes",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "description": "When \"true\", interleaves buffer positions within each drop (staggered wiring) instead of simple sequential order (PolyLineModel::HasAlternateNodes()/SetAlternateNodes()). Persisted as the lowercase literal true/false; always written."
+        },
+        {
+            "xmlAttribute": "DropPattern",
+            "label": "Drop Pattern",
+            "gridKey": "IciclesDrops",
+            "type": "string",
+            "default": "1",
+            "encoding": "Comma-separated list of non-negative integers, one per drop position, cycled repeatedly along the poly-line (PolyLineModel::ParseDropSizes/SetDropPattern; reuses the same wxDropPatternProperty editor and gridKey \"IciclesDrops\" as Icicles.json's DropPattern, though PolyLineModel has its own separate _dropPatternString member/implementation, not a shared one). Each value is the node/light count of that drop.",
+            "description": "Repeating pattern of drop lengths along the poly-line, analogous to Icicles' DropPattern but with a different on-disk default (\"1\" here vs. \"3,4,5,4\" for Icicles - PolyLineModel::_dropPatternString's initializer)."
+        },
+        {
+            "xmlAttribute": "ModelHeight",
+            "label": "Height",
+            "gridKey": "ModelHeight",
+            "type": "float",
+            "default": 1.0,
+            "step": 0.1,
+            "precision": 2,
+            "description": "Cross-sectional height/thickness of the poly-line ribbon (PolyLineModel::GetModelHeight()/SetModelHeight()). No min/max is enforced by the property grid itself, but OnPropertyGridChange clamps the magnitude to at least 0.01 (preserving sign) and vetoes edits entirely while the ScreenLocation is locked or the model is from a linked base show folder. CAUTION: this shares its gridKey \"ModelHeight\" with shared/ScreenLocation.json's unrelated ThreePoint \"Height\" property (xmlAttribute \"Height\", used by Arches/CandyCanes/Icicles) - the two are different xmlAttributes (\"ModelHeight\" vs \"Height\") on different ScreenLocation styles, not an alias."
+        },
+        {
+            "xmlAttribute": "SegsExpanded",
+            "gridKey": "ModelIndividualSegments",
+            "type": "bool",
+            "boolFormat": "TRUEFALSE",
+            "default": "FALSE",
+            "description": "UI bookkeeping: whether the \"Segments\"/\"Corner Settings\" property-grid sub-trees are expanded or collapsed (PolyLineModel::AreSegsExpanded(), toggled via OnPropertyGridItemCollapsed/Expanded). Persisted as the UPPERCASE literal TRUE/FALSE; always written."
+        }
+    ],
+    "notes": [
+        "Per-point start-node overrides: when PolyStrings > 1, one attribute per string named \"PolyNode1\", \"PolyNode2\", ... \"PolyNode{PolyStrings}\" (1-based; PolyLineModel::StartNodeAttrName(idx) = \"PolyNode\" + (idx+1)) holds that string's starting node index (1-based, within GetNodeCount()). Presence of \"PolyNode1\" on read is what sets HasIndivStartNodes() (not a separate boolean attribute). Not enumerated as individual properties per the brief's guidance for patterned/dynamically-indexed attributes.",
+        "Per-segment length overrides: one attribute per segment named \"Seg1\", \"Seg2\", ... \"Seg{N}\" (1-based; PolyLineModel::SegAttrName(idx) = \"Seg\" + (idx+1), N = NumPoints-1) holds that segment's node count. CORRECTION vs. the brief's survey guess of \"SegExpanded\"/\"Seg{n}\": the boolean UI-expansion flag is \"SegsExpanded\" (plural \"Segs\", see the SegsExpanded property above), not \"SegExpanded\"; only written at all when AutoDistribute is off (PolyLineModel::GetAutoDistribute() == false), which itself is inferred purely from whether \"Seg1\" is present on read, not from any persisted boolean attribute.",
+        "Per-corner style: one attribute per point named \"Corner1\", \"Corner2\", ... \"Corner{N+1}\" (1-based; PolyLineModel::CornerAttrName(idx) = \"Corner\" + (idx+1), N = number of segments) holds one of the literal enum strings \"Leading Segment\", \"Trailing Segment\" or \"Neither\" (default \"Neither\" when absent) - PolyLinePropertyAdapter's POLY_CORNER_VALUES. Governs how the poly-line's rendered width tapers in/out at that vertex.",
+        "Starting Location: the \"PolyLineStart\" property-grid enum (gridKey \"PolyLineStart\") is a 2-value Green Square/Blue Square picker that sets only the shared Dir attribute (shared/Common.json); StartSide is not involved (PolyLinePropertyAdapter::OnPropertyGridChange \"PolyLineStart\" only calls SetIsLtoR/SetDirection). No property object for it appears above since Dir itself is owned by shared/Common.json.",
+        "NumPoints, PointData and cPointData (the vertex/curve data) plus ScaleX/Y/Z are all already documented in shared/ScreenLocation.json under the PolyPoint style and are not redefined here to avoid a duplicate-xmlAttribute validation error."
+    ]
+}

--- a/resources/modelsmetadata/SingleLine.json
+++ b/resources/modelsmetadata/SingleLine.json
@@ -1,0 +1,86 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Single Line",
+    "description": "A single straight row of nodes, the simplest pixel model shape (a single strand of lights strung in a line). Also used internally as the per-string/per-strand representation created on the fly for other model types' \"Single Line\" buffer style (ArchesModel/CandyCaneModel::GetBufferSize).",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumStrings",
+            "label": "# Strings",
+            "gridKey": "SingleLineCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 100,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Number of physical connections/strings from the prop to the controller (SingleLineModel::_numStrings; SingleLinePropertyAdapter help text: \"typically the number of connections from the prop to your controller\")."
+        },
+        {
+            "xmlAttribute": "NodesPerString",
+            "label": "Nodes/String",
+            "gridKey": "SingleLineNodes",
+            "type": "uint",
+            "default": 50,
+            "min": 1,
+            "max": 10000,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Nodes per string (SingleLineModel::_nodesPerString). Note the read-time default is 50, not 1 (XmlDeserializingModelFactory::DeserializeSingleLine: `ReadAttrWithParmFallback(node, NodesPerStringAttribute, Parm2Attribute, \"50\")`), unlike the analogous NodesPerString attribute on Circle/Icicles/Wreath which defaults to 1. Grid label is \"Lights/String\" for SingleNode string types, \"Nodes/String\" otherwise; same xmlAttribute/gridKey either way."
+        },
+        {
+            "xmlAttribute": "LightsPerNode",
+            "label": "Lights/Node",
+            "gridKey": "SingleLineLights",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 300,
+            "legacyAttributes": [
+                "parm3"
+            ],
+            "description": "Lights represented by each node, for RGB pixel-cluster wiring (SingleLineModel::_lightsPerNode). Only shown in the property grid for non-SingleNode string types (SingleLinePropertyAdapter::AddTypeProperties), but always written/read regardless of StringType."
+        }
+    ],
+    "notes": [
+        "Starting Location: the \"SingleLineStart\" property-grid enum (gridKey \"SingleLineStart\") is a 2-value Green Square/Blue Square picker that sets only the shared Dir attribute (shared/Common.json); StartSide is not involved (SingleLinePropertyAdapter::OnPropertyGridChange \"SingleLineStart\" only calls SetDirection/SetIsLtoR). No property object for it appears above since Dir itself is owned by shared/Common.json.",
+        "TwoPoint screen-location style (shared/ScreenLocation.json): SingleLine is one of the two model types using TwoPoint (X2/Y2/Z2, no ScaleX/Y/Z, no Angle/Shear/Height) rather than Boxed or ThreePoint. It additionally supports swapping its two endpoints (SupportsSwapStartEnd/SwapStartEnd), a screen-location-only operation with no dedicated XML attribute of its own (it just swaps the already-documented WorldPos/X2Y2Z2 values in place)."
+    ]
+}

--- a/resources/modelsmetadata/Sphere.json
+++ b/resources/modelsmetadata/Sphere.json
@@ -1,0 +1,135 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Sphere",
+    "description": "A sphere/globe of nodes wound around a configurable latitude band, built from vertical matrix strands. Like Tree, SphereModel reuses MatrixModel's core string/strand attributes verbatim (repeated below, not inherited - sibling documents never extend each other), but has no orientation attribute of its own (no Vertical/StrandDir equivalent).",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumStrings",
+            "label": "# Strings",
+            "gridKey": "MatrixStringCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 10000,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Number of physical connections/strings from the prop to the controller (SphereModel::GetNumMatrixStrings()/SetNumMatrixStrings(), inherited storage from MatrixModel). Identical attribute/semantics to Matrix.json's NumStrings; repeated here because sibling documents do not extend each other."
+        },
+        {
+            "xmlAttribute": "NodesPerString",
+            "label": "Nodes/String",
+            "gridKey": "MatrixLightCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 10000,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Nodes per string. Identical attribute/semantics to Matrix.json's NodesPerString."
+        },
+        {
+            "xmlAttribute": "StrandsPerString",
+            "label": "Strands/String",
+            "gridKey": "MatrixStrandCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 2500,
+            "legacyAttributes": [
+                "parm3"
+            ],
+            "description": "How many times each #String ZigZags. Identical attribute/semantics to Matrix.json's StrandsPerString."
+        },
+        {
+            "xmlAttribute": "Degrees",
+            "label": "Degrees",
+            "gridKey": "Degrees",
+            "type": "int",
+            "default": 360,
+            "min": 45,
+            "max": 360,
+            "description": "Total longitude sweep of the sphere, in degrees (SphereModel::GetSphereDegrees()/SetDegrees()); 360 is a complete globe, smaller values render a partial wedge. Confirms the brief's survey range exactly (SpherePropertyAdapter::AddStyleProperties: Min 45, Max 360)."
+        },
+        {
+            "xmlAttribute": "StartLatitude",
+            "label": "Southern Latitude",
+            "gridKey": "StartLatitude",
+            "type": "int",
+            "default": -86,
+            "min": -89,
+            "max": -1,
+            "description": "Southernmost latitude rendered, in degrees (SphereModel::GetStartLatitude()/SetStartLatitude()); always negative (southern hemisphere). Confirms the brief's survey range exactly (SpherePropertyAdapter::AddStyleProperties: Min -89, Max -1)."
+        },
+        {
+            "xmlAttribute": "EndLatitude",
+            "label": "Northern Latitude",
+            "gridKey": "EndLatitude",
+            "type": "uint",
+            "default": 86,
+            "min": 1,
+            "max": 89,
+            "description": "Northernmost latitude rendered, in degrees (SphereModel::GetEndLatitude()/SetEndLatitude()); always positive (northern hemisphere). Confirms the brief's survey range exactly (SpherePropertyAdapter::AddStyleProperties: Min 1, Max 89)."
+        },
+        {
+            "xmlAttribute": "AlternateNodes",
+            "label": "Alternate Nodes",
+            "gridKey": "AlternateNodes",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "description": "When \"true\", interleaves node buffer positions instead of simple sequential order (SphereModel::HasAlternateNodes()/SetAlternateNodes()). Persisted as the lowercase literal true/false; always written. Mutually-enabling in the grid with NoZig."
+        },
+        {
+            "xmlAttribute": "NoZig",
+            "label": "Don't Zig Zag",
+            "gridKey": "NoZig",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "description": "When \"true\", suppresses the zig-zag strand pattern (SphereModel::IsNoZigZag()/SetNoZigZag()). Persisted as the lowercase literal true/false; always written."
+        }
+    ],
+    "notes": [
+        "LowDefinition (shared/Common.json) applies to Sphere: its appliesWhen already includes DisplayAs \"Sphere\", and BaseSerializingVisitor::Visit(const SphereModel&) writes it unconditionally, same as Matrix. No Sphere-specific redefinition was needed.",
+        "versionNumber-gated migration (informational, not a property): XmlDeserializingModelFactory::DeserializeSphere applies a one-off scale correction on load for files with versionNumber < 8 (or absent), compensating for an old non-uniform sphere-scaling formula that has since been fixed to be truly round. This mutates ScaleX/Y/Z (shared/ScreenLocation.json) at load time rather than any Sphere-specific attribute, and only for old files.",
+        "Starting Location: the \"MatrixStart\" property-grid enum inherited from MatrixPropertyAdapter (SpherePropertyAdapter extends it) sets the shared Dir/StartSide attributes (shared/Common.json); no property object for it appears above."
+    ]
+}

--- a/resources/modelsmetadata/Spinner.json
+++ b/resources/modelsmetadata/Spinner.json
@@ -1,0 +1,136 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Spinner",
+    "description": "A pinwheel of radiating arms, each carrying a run of nodes outward from (or with a hollow gap around) a shared center, spanning a configurable arc.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumStrings",
+            "label": "# Strings",
+            "gridKey": "SpinnerStringCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 640,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Number of physical connections/strings from the prop to the controller (SpinnerModel::_numStrings, GetNumSpinnerStrings()/SetNumSpinnerStrings()); SpinnerPropertyAdapter help text: \"typically the number of connections from the prop to your controller.\""
+        },
+        {
+            "xmlAttribute": "NodesPerArm",
+            "label": "Lights/Arm",
+            "gridKey": "SpinnerArmNodeCount",
+            "type": "uint",
+            "default": 1,
+            "min": 0,
+            "max": 200,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Nodes per arm (SpinnerModel::_nodesPerArm, GetNodesPerArm()/SetNodesPerArm()). Min is 0 (an arm can be entirely hollow/empty, distinct from the separate Hollow % gap around the center)."
+        },
+        {
+            "xmlAttribute": "ArmsPerString",
+            "label": "Arms/String",
+            "gridKey": "FoldCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 250,
+            "legacyAttributes": [
+                "parm3"
+            ],
+            "description": "Number of arms per string (SpinnerModel::_armsPerString, GetArmsPerString()/SetArmsPerString()). Verified trap: xmlAttribute \"ArmsPerString\" differs from its wxPropertyGrid key \"FoldCount\"."
+        },
+        {
+            "xmlAttribute": "Hollow",
+            "label": "Hollow %",
+            "gridKey": "Hollow",
+            "type": "uint",
+            "default": 20,
+            "min": 0,
+            "max": 80,
+            "description": "Percentage of each arm's length left empty around the center hub (SpinnerModel::_hollow, GetHollowPercent()/SetHollow())."
+        },
+        {
+            "xmlAttribute": "StartAngle",
+            "label": "Start Angle",
+            "gridKey": "StartAngle",
+            "type": "int",
+            "default": 0,
+            "min": -360,
+            "max": 360,
+            "description": "Rotational offset of the first arm from its default position, in degrees, positive or negative (SpinnerModel::_startAngle, GetStartAngle()/SetStartAngle())."
+        },
+        {
+            "xmlAttribute": "Arc",
+            "label": "Arc",
+            "gridKey": "Arc",
+            "type": "uint",
+            "default": 360,
+            "min": 1,
+            "max": 360,
+            "description": "Total angular sweep across which the arms are distributed, in degrees; 360 spaces arms evenly around a full circle (SpinnerModel::_arc, GetArcAngle()/SetArc())."
+        },
+        {
+            "xmlAttribute": "Alternate",
+            "label": "Alternate",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "description": "When \"true\", alternate arms are wired in the opposite rotational direction (SpinnerModel::_alternate, HasAlternateNodes()/SetAlternate()). Persisted as the lowercase literal true/false; always written. No dedicated 1:1 property-grid control - set as part of the composite 6-value \"Starting Location\" enum picker (gridKey \"MatrixStart\": Center/End x Clockwise/Counter-Clockwise, plus two \"Alternate\" variants) alongside the shared Dir/StartSide attributes (shared/Common.json) via SpinnerModel::EncodeStartLocation()/DecodeStartLocation()."
+        },
+        {
+            "xmlAttribute": "ZigZag",
+            "label": "Zig-Zag Start",
+            "gridKey": "ZigZag",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "appliesWhen": {
+                "attribute": "Alternate",
+                "equals": "false"
+            },
+            "description": "When \"true\", successive arms alternate their start direction (SpinnerModel::_zigzag, HasZigZag()/SetZigZag()). Persisted as the lowercase literal true/false; always written. Only enabled in the property grid when Alternate is false (SpinnerPropertyAdapter::UpdateTypeProperties); DecodeStartLocation() also forces this to false internally when an \"Alternate\" starting-location option is chosen."
+        }
+    ],
+    "notes": [
+        "Starting Location is a single composite picker (gridKey \"MatrixStart\", reusing Matrix's gridKey name coincidentally) covering three underlying attributes at once: the shared Dir/StartSide (shared/Common.json) plus this file's own Alternate. See SpinnerModel::EncodeStartLocation()/DecodeStartLocation() for the 6-way mapping (Center/End x CW/CCW, plus Center-Alternate CW/CCW)."
+    ]
+}

--- a/resources/modelsmetadata/Star.json
+++ b/resources/modelsmetadata/Star.json
@@ -126,9 +126,10 @@
             "label": "Inner Layer %",
             "gridKey": "StarCenterPercent",
             "type": "int",
-            "min": 0,
+            "default": -1,
+            "min": -1,
             "max": 100,
-            "description": "For a layered (multi-strand) star, how far in toward the center the innermost layer's points reach, as a percentage (StarModel::_innerPercent, GetInnerPercent()/SetInnerPercent()). No JSON \"default\" is given because the true on-disk default when the attribute is absent is the out-of-range sentinel -1 (\"not set\"/auto), which falls outside the 0-100 range the property grid enforces once shown. Only shown/editable in the property grid when the star has more than one layer (StarModel::GetNumStrands() > 1, i.e. LayerSizes describes 2+ layers), but always written regardless of layer count."
+            "description": "For a layered (multi-strand) star, how far in toward the center the innermost layer's points reach, as a percentage (StarModel::_innerPercent, GetInnerPercent()/SetInnerPercent()). Default/on-disk value when never configured is the sentinel -1 (\"not set\"/auto; StarModel::_innerPercent's initializer, and the fallback XmlDeserializingModelFactory::DeserializeStar reads when the attribute is absent). The property grid only exposes 0-100 (\"not set\" is not user-selectable once the control is shown), and only shows/allows editing when the star has more than one layer (StarModel::GetNumStrands() > 1, i.e. LayerSizes describes 2+ layers), but the attribute is always written regardless of layer count."
         }
     ],
     "notes": [

--- a/resources/modelsmetadata/Star.json
+++ b/resources/modelsmetadata/Star.json
@@ -1,0 +1,138 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Star",
+    "description": "A multi-pointed star of nodes, optionally built from several concentric star-shaped layers of independently-sized node counts sharing one outer/inner ratio.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumStrings",
+            "label": "# Strings",
+            "gridKey": "StarStringCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 640,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Number of physical connections/strings from the prop to the controller (StarModel::_numStrings, GetNumStarStrings()/SetNumStarStrings()); StarPropertyAdapter help text: \"typically the number of connections from the prop to your controller.\""
+        },
+        {
+            "xmlAttribute": "NodesPerString",
+            "label": "Nodes/String",
+            "gridKey": "StarLightCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 10000,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Nodes per string (StarModel::_nodesPerString, GetNodesPerString()/SetStarNodesPerString()). Grid label is \"Lights/String\" for SingleNode string types, \"Nodes/String\" otherwise (StarPropertyAdapter::AddTypeProperties); same xmlAttribute/gridKey either way."
+        },
+        {
+            "xmlAttribute": "StarPoints",
+            "label": "# Points",
+            "gridKey": "StarStrandCount",
+            "type": "uint",
+            "default": 5,
+            "min": 1,
+            "max": 250,
+            "legacyAttributes": [
+                "parm3"
+            ],
+            "description": "Number of points on the star (StarModel::_starPoints, GetStarPoints()/SetStarPoints()). Verified trap: xmlAttribute \"StarPoints\" differs from its wxPropertyGrid key \"StarStrandCount\"."
+        },
+        {
+            "xmlAttribute": "LayerSizes",
+            "gridKey": "Layers",
+            "type": "string",
+            "default": "",
+            "legacyAttributes": [
+                "starSizes"
+            ],
+            "encoding": "Comma-separated list of per-layer node counts (Model::SerialiseLayerSizes/DeserializeLayerSizes), identical wire format to Arches.json's LayerSizes. The property grid exposes this as a \"Layers\" count spinner (gridKey \"Layers\", range 1-100) plus one \"Layer{n}\" row per entry (0-based n, range 1-1000 each; row 0 labelled \"Inside\", the last labelled \"Outside\") via the shared ModelPropertyAdapter::AddLayerSizeProperty helper (StarPropertyAdapter::AddTypeProperties calls it directly, unconditionally, unlike Arches where it is gated by a layered-mode toggle) - but only this ONE xmlAttribute is ever persisted. INVARIANT for writers: xLights keeps the total-node attribute equal to the SUM of this list (parm2 (nodes per string) = sum(LayerSizes), enforced by StarModel::OnLayerSizesChange whenever layer sizes change in the UI); an external writer (e.g. an MCP) must set both consistently or the model will allocate the wrong node count (node allocation uses the total attribute, not this list - StarModel::InitModel).",
+            "description": "Per-layer node-count list for concentric star layers; see encoding for the exact format. Legacy files may instead use the attribute \"starSizes\" (XmlNodeKeys::StarSizesAttribute), checked first by XmlDeserializingModelFactory::DeserializeStar and, if present, used in place of \"LayerSizes\"; the current writer only ever writes \"LayerSizes\" (StarModel::SerialiseLayerSizes())."
+        },
+        {
+            "xmlAttribute": "StarStartLocation",
+            "label": "Starting Location",
+            "gridKey": "StarStart",
+            "type": "enum",
+            "enum": [
+                "Top Ctr-CCW",
+                "Top Ctr-CW",
+                "Top Ctr-CCW Inside",
+                "Top Ctr-CW Inside",
+                "Bottom Ctr-CW",
+                "Bottom Ctr-CCW",
+                "Bottom Ctr-CW Inside",
+                "Bottom Ctr-CCW Inside",
+                "Left Bottom-CW",
+                "Left Bottom-CCW",
+                "Right Bottom-CW",
+                "Right Bottom-CCW"
+            ],
+            "default": "Bottom Ctr-CW",
+            "description": "Which point the first node starts from and its winding direction (StarModel::_starStartLocation, GetStartLocation()/SetStarStartLocation(), persisted as the literal enum text). This is Star's own composite starting-location picker; it does not use the shared Dir/StartSide attributes directly. If the xmlAttribute is absent on read, XmlDeserializingModelFactory::DeserializeStar falls back to StarModel::ConvertFromDirStartSide() (deriving a value from the shared Dir/StartSide attributes instead) rather than this default."
+        },
+        {
+            "xmlAttribute": "starRatio",
+            "label": "Outer to Inner Ratio",
+            "gridKey": "StarRatio",
+            "type": "float",
+            "default": 2.618034,
+            "precision": 2,
+            "step": 0.1,
+            "description": "Ratio between the star's outer point radius and its inner valley radius (StarModel::_starRatio, GetStarRatio()/SetStarRatio()); default is the golden ratio, 2.618034. No min/max is enforced by the property grid (StarPropertyAdapter::AddTypeProperties sets only Precision/Step on the wxFloatProperty)."
+        },
+        {
+            "xmlAttribute": "starCenterPercent",
+            "label": "Inner Layer %",
+            "gridKey": "StarCenterPercent",
+            "type": "int",
+            "min": 0,
+            "max": 100,
+            "description": "For a layered (multi-strand) star, how far in toward the center the innermost layer's points reach, as a percentage (StarModel::_innerPercent, GetInnerPercent()/SetInnerPercent()). No JSON \"default\" is given because the true on-disk default when the attribute is absent is the out-of-range sentinel -1 (\"not set\"/auto), which falls outside the 0-100 range the property grid enforces once shown. Only shown/editable in the property grid when the star has more than one layer (StarModel::GetNumStrands() > 1, i.e. LayerSizes describes 2+ layers), but always written regardless of layer count."
+        }
+    ],
+    "notes": [
+        "starRatio and starCenterPercent are recorded exactly as they appear on disk: lowercase-initial xmlAttribute names (XmlNodeKeys::StarRatioAttribute = \"starRatio\", StarCenterPercentAttribute = \"starCenterPercent\"), unlike every other Star attribute which is PascalCase.",
+        "This file's LayerSizes property duplicates Arches.json's LayerSizes property (same xmlAttribute, same wire encoding) but is not shared via extends, per this tree's house style that sibling model documents never extend each other; only shared/ fragments are extended."
+    ]
+}

--- a/resources/modelsmetadata/Tree.json
+++ b/resources/modelsmetadata/Tree.json
@@ -1,0 +1,219 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Tree",
+    "description": "A tree built from vertical matrix strands: either wrapped around a round/conical trunk over a configurable degree sweep (\"Round\"), splayed flat (\"Flat\"), or splayed flat with an extra width-defining ribbon edge (\"Ribbon\"). C++ implementation-wise, TreeModel is a subclass of MatrixModel and reuses its NumStrings/NodesPerString/StrandsPerString/AlternateNodes/NoZig attributes verbatim (repeated below, not inherited, per this tree's house style: sibling documents never extend each other) - but Tree does NOT reuse Matrix's \"Vertical\" orientation attribute; it has its own \"StrandDir\" string attribute instead. Style is carried by the TreeType/TreeDegrees attributes, not by DisplayAs: the current serializer always writes the single literal DisplayAs value \"Tree\" (TreeModel::TreeModel sets DisplayAs = DisplayAsType::Tree; DisplayAsTypeToString always returns \"Tree\"). The compound legacy values \"Tree 360\"/\"Tree Flat\"/\"Tree Ribbon\" (and other \"Tree {degrees}\" forms) are read-only: XmlDeserializingModelFactory::DeserializeTree only parses them when the DisplayAs attribute is present and not exactly \"Tree\", converting them into TreeType/TreeDegrees; the current writer never produces them.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumStrings",
+            "label": "# Strings",
+            "gridKey": "MatrixStringCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 10000,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Number of physical connections/strings from the prop to the controller (inherited MatrixModel::_numStrings via GetNumMatrixStrings/SetNumMatrixStrings). Identical attribute/semantics to Matrix.json's NumStrings; repeated here because sibling documents do not extend each other."
+        },
+        {
+            "xmlAttribute": "NodesPerString",
+            "label": "Nodes/String",
+            "gridKey": "MatrixLightCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 10000,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Nodes per string (inherited MatrixModel::_nodesPerString). Identical attribute/semantics to Matrix.json's NodesPerString."
+        },
+        {
+            "xmlAttribute": "StrandsPerString",
+            "label": "Strands/String",
+            "gridKey": "MatrixStrandCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 2500,
+            "legacyAttributes": [
+                "parm3"
+            ],
+            "description": "How many times each #String ZigZags (inherited MatrixModel::_strandsPerString). Identical attribute/semantics to Matrix.json's StrandsPerString."
+        },
+        {
+            "xmlAttribute": "AlternateNodes",
+            "label": "Alternate Nodes",
+            "gridKey": "AlternateNodes",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "description": "When \"true\", interleaves node buffer positions instead of simple sequential order (inherited MatrixModel::_alternateNodes). Persisted as the lowercase literal true/false; always written. Mutually-enabling in the grid with NoZig, same pattern as Matrix.json."
+        },
+        {
+            "xmlAttribute": "NoZig",
+            "label": "Don't Zig Zag",
+            "gridKey": "NoZig",
+            "type": "bool",
+            "boolFormat": "truefalse",
+            "default": "false",
+            "description": "When \"true\", suppresses the zig-zag strand pattern (inherited MatrixModel::_noZigZag). Persisted as the lowercase literal true/false; always written."
+        },
+        {
+            "xmlAttribute": "StrandDir",
+            "label": "Strand Direction",
+            "gridKey": "StrandDir",
+            "type": "enum",
+            "enum": [
+                "Horizontal",
+                "Vertical"
+            ],
+            "default": "Vertical",
+            "description": "Strand wiring orientation (TreeModel::isVerticalMatrix()/SetVertical(), read back via TreePropertyAdapter's \"Strand Direction\" enum). CORRECTION vs. treating Tree as a plain Matrix: Tree does NOT write Matrix's boolean \"Vertical\" attribute at all (TreeModel's own BaseSerializingVisitor::Visit override has no VertMatrixAttribute call); orientation is instead carried by this separate string-valued attribute, read with XmlDeserializingModelFactory::DeserializeTree comparing it to the literal \"Vertical\" (default when absent)."
+        },
+        {
+            "xmlAttribute": "exportFirstStrand",
+            "label": "First Strand",
+            "type": "int",
+            "default": 1,
+            "min": 1,
+            "description": "1-based index of the first strand used when exporting/rendering (TreeModel::GetFirstStrand()+1 is written; TreeModel::_firstStrand, 0-based internally). No dedicated property-grid control was found in TreePropertyAdapter for this attribute. Reader quirk: if absent, XmlDeserializingModelFactory::DeserializeTree computes GetFirstStrand() = as_int(0) - 1 = -1, but TreeModel::InitModel() immediately clamps any negative _firstStrand back to 0 before use."
+        },
+        {
+            "xmlAttribute": "TreeType",
+            "label": "Type",
+            "gridKey": "TreeStyle",
+            "type": "enum",
+            "enum": [
+                "0",
+                "1",
+                "2"
+            ],
+            "labels": {
+                "0": "Round",
+                "1": "Flat",
+                "2": "Ribbon"
+            },
+            "default": "0",
+            "description": "Tree style discriminator (TreeModel::_treeType, GetTreeType()/SetTreeType()), persisted as its underlying int value via std::to_string. Verified trap: xmlAttribute \"TreeType\" differs from its wxPropertyGrid key \"TreeStyle\" (TreePropertyAdapter::AddStyleProperties). \"Round\" renders a full 3D wrap using TreeDegrees/TreeRotation/TreeSpiralRotations/TreeBottomTopRatio/TreePerspective (TreeModel::SetTreeCoord branches on TreeDegrees > 0); \"Flat\"/\"Ribbon\" render a flat splayed shape driven directly by the raw TreeDegrees value being 0 or -1 respectively (see TreeDegrees)."
+        },
+        {
+            "xmlAttribute": "TreeDegrees",
+            "label": "Degrees",
+            "gridKey": "TreeDegrees",
+            "type": "uint",
+            "default": 360,
+            "min": 1,
+            "max": 360,
+            "appliesWhen": {
+                "attribute": "TreeType",
+                "equals": "0"
+            },
+            "description": "Angular sweep of the round tree's trunk wrap, in degrees (TreeModel::_degrees, GetTreeDegrees()/SetTreeDegrees(), stored as a C++ long but written/read as a plain integer). Only shown/editable in the property grid when TreeType == \"0\" (Round; TreePropertyAdapter::AddStyleProperties shows a fixed display of 180 and disables the control otherwise), but the underlying TreeModel::SetTreeCoord() branches directly on this raw value for ALL styles: values > 0 render the round-wrap formula; legacy Flat/Ribbon conversions (see displayAs description) set this to the sentinels 0 (Flat) or -1 (Ribbon) respectively, which TreeModel::SetTreeCoord treats as flat-splay render paths distinguished by degrees == -1 vs. not."
+        },
+        {
+            "xmlAttribute": "TreeRotation",
+            "label": "Rotation",
+            "gridKey": "TreeRotation",
+            "type": "float",
+            "default": 3.0,
+            "min": -360,
+            "max": 360,
+            "step": 0.1,
+            "precision": 2,
+            "appliesWhen": {
+                "attribute": "TreeType",
+                "equals": "0"
+            },
+            "description": "Starting angular offset of the trunk wrap, in degrees (TreeModel::_rotation, GetTreeRotation()/SetTreeRotation()); shifts strands so they don't line up exactly front-to-back. Only shown/editable when TreeType == \"0\" (Round), but always written."
+        },
+        {
+            "xmlAttribute": "TreeSpiralRotations",
+            "label": "Spiral Wraps",
+            "gridKey": "TreeSpiralRotations",
+            "type": "float",
+            "default": 0.0,
+            "min": -200,
+            "max": 200,
+            "precision": 2,
+            "appliesWhen": {
+                "attribute": "TreeType",
+                "equals": "0"
+            },
+            "description": "Number of extra spiral wraps to twist the strands through over the trunk height, 0 = straight vertical strands (TreeModel::_spiralRotations, GetSpiralRotations()/SetTreeSpiralRotations()). Only shown/editable when TreeType == \"0\" (Round), but always written."
+        },
+        {
+            "xmlAttribute": "TreeBottomTopRatio",
+            "label": "Bottom/Top Ratio",
+            "gridKey": "TreeBottomTopRatio",
+            "type": "float",
+            "default": 6.0,
+            "min": -50,
+            "max": 50,
+            "step": 0.5,
+            "precision": 2,
+            "appliesWhen": {
+                "attribute": "TreeType",
+                "equals": "0"
+            },
+            "description": "Ratio of the trunk's bottom radius to its top radius (TreeModel::_botTopRatio, GetBottomTopRatio()/SetTreeBottomTopRatio()); a negative value swaps which end is wider (TreeModel::SetTreeCoord). Only shown/editable when TreeType == \"0\" (Round), but always written."
+        },
+        {
+            "xmlAttribute": "TreePerspective",
+            "label": "Perspective",
+            "gridKey": "TreePerspective",
+            "type": "float",
+            "default": 0.2,
+            "min": 0,
+            "max": 1,
+            "precision": 2,
+            "encoding": "Persisted value = displayed property-grid value / 10. The \"Perspective\" spinner shown in the grid ranges 0-10 (step 0.1, precision 2) and is only shown/editable when TreeType == \"0\"; TreePropertyAdapter::AddStyleProperties multiplies the stored value by 10 for display, and OnPropertyGridChange divides the entered value by 10.0 before calling TreeModel::SetPerspective(). So an on-screen \"2\" is stored/written as \"0.2\".",
+            "appliesWhen": {
+                "attribute": "TreeType",
+                "equals": "0"
+            },
+            "description": "2D perspective foreshortening factor applied to the trunk render (TreeModel::_perspective, GetTreePerspective()/SetPerspective(), ModelScreenLocation::SetPerspective2D). See encoding for the x10 UI/storage relationship called out in the brief."
+        }
+    ],
+    "notes": [
+        "LowDefinition (shared/Common.json) does NOT apply to Tree despite Tree being a MatrixModel subclass in C++: TreeModel explicitly overrides SupportsLowDefinitionRender() to return false (\"we cant do low def on single node matrices\" / TreeModel.h comment), and its own Visit() override never writes the LowDefinition attribute (only MatrixModel's and SphereModel's Visit() do). Common.json's appliesWhen already restricts the property to DisplayAs Matrix/Sphere, so no Tree-specific action was needed, but this is flagged since a naive reading of the C++ class hierarchy could suggest otherwise.",
+        "Starting Location: the \"MatrixStart\" property-grid enum inherited from MatrixPropertyAdapter (TreePropertyAdapter extends it) sets the shared Dir/StartSide attributes (shared/Common.json); no property object for it appears above."
+    ]
+}

--- a/resources/modelsmetadata/Tree.json
+++ b/resources/modelsmetadata/Tree.json
@@ -138,9 +138,9 @@
             "xmlAttribute": "TreeDegrees",
             "label": "Degrees",
             "gridKey": "TreeDegrees",
-            "type": "uint",
+            "type": "int",
             "default": 360,
-            "min": 1,
+            "min": -1,
             "max": 360,
             "appliesWhen": {
                 "attribute": "TreeType",

--- a/resources/modelsmetadata/WindowFrame.json
+++ b/resources/modelsmetadata/WindowFrame.json
@@ -1,0 +1,98 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Window Frame",
+    "description": "A rectangular frame of nodes running along the top, both sides, and bottom of a window (or similar opening), with independently-sized top/side/bottom runs traced clockwise or counter-clockwise from one corner.",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "TopNodes",
+            "label": "# Lights Top",
+            "gridKey": "WFTopCount",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 1000,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Node count along the top run of the frame (WindowFrameModel::_topNodes). May be 0 (a frame need not have a top run)."
+        },
+        {
+            "xmlAttribute": "SideNodes",
+            "label": "# Lights Left/Right",
+            "gridKey": "WFLeftRightCount",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 1000,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Node count along EACH side run (left and right use the same count; WindowFrameModel::_sideNodes). Also determines the model's buffer height (WindowFrameModel::InitFrame: `SetBufferSize(height=_sideNodes, ...)`)."
+        },
+        {
+            "xmlAttribute": "BottomNodes",
+            "label": "# Lights Bottom",
+            "gridKey": "WFBottomCount",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 1000,
+            "legacyAttributes": [
+                "parm3"
+            ],
+            "description": "Node count along the bottom run of the frame (WindowFrameModel::_bottomNodes). May be 0 (a frame need not have a bottom run)."
+        },
+        {
+            "xmlAttribute": "Rotation",
+            "label": "Direction",
+            "gridKey": "WFDirection",
+            "type": "enum",
+            "enum": [
+                "Clockwise",
+                "Counter Clockwise"
+            ],
+            "default": "Clockwise",
+            "description": "Winding direction of the frame trace, combined with the corner set by WFStartLocation (WindowFrameModel::_rotation, stored in-memory as 0=Clockwise/1=Counter Clockwise; WindowFramePropertyAdapter gridKey \"WFDirection\"). Legacy files may spell the clockwise value as the short form \"CW\" instead of \"Clockwise\" (XmlDeserializingModelFactory::DeserializeWindow: `(rotation == \"Clockwise\" || rotation == \"CW\") ? 0 : 1`); any other value (including a hypothetical \"CCW\") is treated as Counter Clockwise. The current serializer only ever writes the two full-word enum values listed here."
+        }
+    ],
+    "notes": [
+        "Starting Location: the \"WFStartLocation\" property-grid enum (gridKey \"WFStartLocation\", 4 values: Top Left/Top Right/Bottom Left/Bottom Right) decodes into the shared Dir/StartSide attributes (shared/Common.json), not a dedicated WindowFrame attribute - so no property object for it appears above. Top Left/Top Right set StartSide=T, Bottom Left/Bottom Right set StartSide=B; Top/Bottom-Left set Dir=L, Top/Bottom-Right set Dir=R (WindowFramePropertyAdapter::OnPropertyGridChange \"WFStartLocation\"). This is independent of the Rotation property above (which only controls trace winding direction, not the starting corner).",
+        "Boxed screen-location style (shared/ScreenLocation.json): Window Frame is one of the Boxed-style model types (full ScaleX/Y/Z, RotateX/Y/Z; no Angle/Shear/ThreePoint Height, no TwoPoint X2/Y2/Z2)."
+    ]
+}

--- a/resources/modelsmetadata/Wreath.json
+++ b/resources/modelsmetadata/Wreath.json
@@ -1,0 +1,73 @@
+{
+    "schemaVersion": 1,
+    "objectType": "model",
+    "displayAs": "Wreath",
+    "description": "A single ring of nodes arranged in a circle, distributed evenly across one or more physical strings (unlike Circle, Wreath has no multi-layer/concentric-ring support).",
+    "extends": [
+        "shared/Common.json",
+        "shared/ScreenLocation.json",
+        "shared/ControllerConnection.json"
+    ],
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "childElements": [
+        {
+            "name": "faceInfo",
+            "ref": "shared/Faces.json",
+            "description": "Singing face definitions"
+        },
+        {
+            "name": "stateInfo",
+            "ref": "shared/States.json",
+            "description": "State definitions"
+        },
+        {
+            "name": "subModel",
+            "ref": "shared/SubModels.json",
+            "description": "Submodel definitions"
+        },
+        {
+            "name": "dimmingCurve",
+            "ref": "shared/DimmingCurves.json",
+            "description": "Dimming curve"
+        },
+        {
+            "name": "Aliases",
+            "description": "Optional wrapper containing one or more <alias name=\"...\"/> children: alternate historical names for this model, used to match renamed models on import/mapping (BaseSerializingVisitor::WriteAliases / XmlDeserializingModelFactory::DeserializeAliases). Not yet described by a dedicated shared fragment in this metadata tree."
+        }
+    ],
+    "properties": [
+        {
+            "xmlAttribute": "NumStrings",
+            "label": "# Strings",
+            "gridKey": "WreathStringCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 640,
+            "legacyAttributes": [
+                "parm1"
+            ],
+            "description": "Number of physical connections/strings from the prop to the controller (WreathModel::_numStrings; WreathPropertyAdapter help text: \"typically the number of connections from the prop to your controller\")."
+        },
+        {
+            "xmlAttribute": "NodesPerString",
+            "label": "Nodes/String",
+            "gridKey": "WreathLightCount",
+            "type": "uint",
+            "default": 50,
+            "min": 1,
+            "max": 640,
+            "legacyAttributes": [
+                "parm2"
+            ],
+            "description": "Nodes per string (WreathModel::_nodesPerString; total ring lights = NumStrings x NodesPerString). Note the read-time default is 50, not 1 (XmlDeserializingModelFactory::DeserializeWreath: `ReadAttrWithParmFallback(node, NodesPerStringAttribute, Parm2Attribute, \"50\")`), matching SingleLine's NodesPerString default rather than Circle/Icicles' default of 1. Grid label is \"Lights/String\" for SingleNode string types, \"Nodes/String\" otherwise; same xmlAttribute/gridKey either way."
+        }
+    ],
+    "notes": [
+        "Starting Location: the \"WreathStart\" property-grid enum (gridKey \"WreathStart\", 4 values: Top Ctr-CCW/Top Ctr-CW/Bottom Ctr-CW/Bottom Ctr-CCW) decodes into the shared Dir/StartSide attributes (shared/Common.json), not a dedicated Wreath attribute - so no property object for it appears above (WreathPropertyAdapter::OnPropertyGridChange \"WreathStart\" only calls SetDirection/SetStartSide/SetIsLtoR/SetIsBtoT). Unlike Circle's equivalent 8-value picker, Wreath has no InsideOut-style third dimension - it is purely Dir x StartSide.",
+        "Boxed screen-location style (shared/ScreenLocation.json): Wreath is one of the Boxed-style model types (full ScaleX/Y/Z, RotateX/Y/Z; no Angle/Shear/ThreePoint Height, no TwoPoint X2/Y2/Z2)."
+    ]
+}

--- a/resources/modelsmetadata/_schema.json
+++ b/resources/modelsmetadata/_schema.json
@@ -1,0 +1,97 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "xLights Model Metadata",
+    "description": "XML-first description of model/group object attributes persisted to xlights_rgbeffects.xml. Canonical property ids are XML attribute names.",
+    "type": "object",
+    "required": ["schemaVersion", "description", "properties"],
+    "additionalProperties": false,
+    "properties": {
+        "schemaVersion": { "const": 1 },
+        "objectType": { "enum": ["model", "modelGroup", "controller", "output"] },
+        "displayAs": {
+            "oneOf": [
+                { "type": "string" },
+                { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+            ],
+            "description": "Exact DisplayAs XML value(s) this document describes. Array when several DisplayAs values share one property set (e.g. Horiz/Vert Matrix)."
+        },
+        "protocol": { "type": "string", "description": "Output protocol discriminator (controllersmetadata protocols/*.json only)" },
+        "description": { "type": "string", "minLength": 1 },
+        "extends": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Relative paths (from the tree root) of shared fragment files whose properties also apply. Composition is concatenation only."
+        },
+        "storage": { "$ref": "#/definitions/storage" },
+        "properties": { "type": "array", "items": { "$ref": "#/definitions/property" } },
+        "childElements": { "type": "array", "items": { "$ref": "#/definitions/childElement" } },
+        "notes": { "type": "array", "items": { "type": "string" } }
+    },
+    "definitions": {
+        "storage": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "file": { "enum": ["xlights_rgbeffects.xml", "xlights_networks.xml"] },
+                "node": { "type": "string", "description": "Node path under the document root, e.g. 'models/model' or 'Controller/network'" },
+                "element": { "type": "string", "description": "Document-level child-element override: all properties in this file live on this child element" }
+            }
+        },
+        "condition": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "attribute": { "type": "string", "description": "XML attribute name (in the assembled object scope) this condition tests" },
+                "equals": {},
+                "notEquals": {},
+                "oneOf": { "type": "array" },
+                "notOneOf": { "type": "array" },
+                "greaterThan": { "type": "number" },
+                "startsWith": { "type": "string" },
+                "allOf": { "type": "array", "items": { "$ref": "#/definitions/condition" } }
+            }
+        },
+        "childElement": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "description"],
+            "properties": {
+                "name": { "type": "string", "description": "XML element name, e.g. 'faceInfo'" },
+                "ref": { "type": "string", "description": "Relative path of the fragment file describing this element's attributes" },
+                "description": { "type": "string" },
+                "encoding": { "type": "string", "description": "Format note for non-attribute content (text nodes, compressed blobs)" }
+            }
+        },
+        "property": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["xmlAttribute", "type", "description"],
+            "properties": {
+                "xmlAttribute": { "type": "string", "minLength": 1 },
+                "label": { "type": "string" },
+                "gridKey": { "type": "string" },
+                "type": { "enum": ["int", "uint", "float", "bool", "string", "enum", "color", "filepath"] },
+                "default": {},
+                "min": { "type": "number" },
+                "max": { "type": "number" },
+                "step": { "type": "number" },
+                "precision": { "type": "integer" },
+                "enum": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+                "labels": { "type": "object", "additionalProperties": { "type": "string" } },
+                "boolFormat": { "enum": ["01", "TRUEFALSE", "truefalse", "TrueFalse", "presentOnly"] },
+                "legacyAttributes": { "type": "array", "items": { "type": "string" } },
+                "storage": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["element"],
+                    "properties": { "element": { "type": "string" } }
+                },
+                "appliesWhen": { "$ref": "#/definitions/condition" },
+                "capsGate": { "type": "string" },
+                "relatedTo": { "type": "array", "items": { "type": "string" } },
+                "encoding": { "type": "string" },
+                "description": { "type": "string", "minLength": 1 }
+            }
+        }
+    }
+}

--- a/resources/modelsmetadata/shared/Common.json
+++ b/resources/modelsmetadata/shared/Common.json
@@ -1,0 +1,359 @@
+{
+    "schemaVersion": 1,
+    "description": "Attributes common to every <model> node in xlights_rgbeffects.xml, regardless of DisplayAs. Extended by every models/*.json top-level document. Screen-location and controller-connection attributes are documented separately in shared/ScreenLocation.json and shared/ControllerConnection.json.",
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model"
+    },
+    "properties": [
+        {
+            "xmlAttribute": "name",
+            "label": "Name",
+            "type": "string",
+            "description": "Unique model name (source: BaseObject::GetName(), written via XmlNodeKeys::NameAttribute = \"name\"). Renames must also update groups, submodel references, effects and the ModelChain of any downstream model. Not editable through the generic property grid (renamed via the layout tree / Rename dialog)."
+        },
+        {
+            "xmlAttribute": "DisplayAs",
+            "label": "Model Type",
+            "type": "enum",
+            "enum": [
+                "Arches",
+                "Candy Canes",
+                "Channel Block",
+                "Circle",
+                "Cube",
+                "Custom",
+                "DmxFloodArea",
+                "DmxFloodlight",
+                "DmxGeneral",
+                "DmxMovingHead",
+                "DmxMovingHeadAdv",
+                "DmxServo",
+                "DmxServo3d",
+                "DmxSkull",
+                "Icicles",
+                "Image",
+                "Label",
+                "Matrix",
+                "MultiPoint",
+                "Poly Line",
+                "Single Line",
+                "Sphere",
+                "Spinner",
+                "Star",
+                "Tree",
+                "Window Frame",
+                "Wreath"
+            ],
+            "description": "Model sub-type discriminator. Fixed at creation time; determines which additional per-type property fragment (e.g. Arches.json) and which ScreenLocation style (Boxed/TwoPoint/ThreePoint/PolyPoint) applies. Source: DisplayAsType enum in src-core/models/DisplayAsType.h/.cpp (DisplayAsTypeToString/DisplayAsTypeFromString); written unconditionally by BaseSerializingVisitor::AddBaseObjectAttributes. Not settable via the generic property grid. NOTE: ModelGroup also writes a DisplayAs=\"ModelGroup\" attribute but on a separate <modelGroup> element (see BaseSerializingVisitor::Visit(const ModelGroup&)), not on <model>; ModelGroup therefore does not extend this fragment and \"ModelGroup\" is intentionally excluded from this enum. DisplayAsTypeFromString also accepts legacy aliases on read (\"Vert Matrix\"/\"Horiz Matrix\" -> Matrix, \"DmxServo3Axis\" -> DmxServo3d, \"Tree ...\" compound values -> Tree) which are never written by the current version."
+        },
+        {
+            "xmlAttribute": "Description",
+            "label": "Description",
+            "gridKey": "Description",
+            "type": "string",
+            "default": "",
+            "description": "Free-text user note about the model. Only written when non-empty (Model::GetDescription())."
+        },
+        {
+            "xmlAttribute": "LayoutGroup",
+            "label": "Preview",
+            "gridKey": "ModelLayoutGroup",
+            "type": "string",
+            "default": "Unassigned",
+            "description": "Name of the layout group / preview this model is assigned to. Value is one of the user-defined layout group names (Model::GetLayoutGroups()) or the sentinel \"Unassigned\", \"All Previews\" or \"Default\" depending on configuration; not a fixed enum because layout groups are user-created."
+        },
+        {
+            "xmlAttribute": "StartChannel",
+            "label": "Start Channel",
+            "gridKey": "ModelStartChannel",
+            "type": "string",
+            "default": "1",
+            "encoding": "Free-form channel-reference string parsed by Model::GetNumberFromChannelString(). Forms: a bare integer N = absolute channel N (only meaningful when Controller is empty/StartChannel-driven); \"@ModelName:N\" = N channels after the FIRST channel of ModelName; \">ModelName:N\" = N channels after the LAST channel of ModelName, requires ModelName to have a controller assigned (used for same-controller model chaining); \"<ModelName:N\" = N channels after the LAST channel of ModelName, without the controller requirement; \"!ControllerName:N\" = N channels after ControllerName's own start channel; \"#ip:universe:channel\" or \"#universe:channel\" = absolute address resolved via OutputManager::GetAbsoluteChannel(). Written unconditionally via XmlNodeKeys::StartChannelAttribute.",
+            "description": "This model's (or its first string's) start channel, in one of several encodings (see encoding). Cleared/recomputed when a Controller is assigned. See ModelChain for controller-port-relative chaining of an already-controller-assigned model. CREATION SEMANTICS for external writers (e.g. an MCP): OMIT this attribute when creating a new model - xLights assigns/recomputes the real start channel at load time or when the model is placed on a controller port (auto-layout); the JSON default of \"1\" is only the read-side fallback. Only write an explicit value for deliberate manual channel addressing with no Controller assigned."
+        },
+        {
+            "xmlAttribute": "Advanced",
+            "label": "Indiv Start Chans",
+            "gridKey": "ModelIndividualStartChannels",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "description": "Enables per-string individual start channels instead of one auto-computed StartChannel for the whole model. NOTE: xmlAttribute (\"Advanced\") differs from its wxPropertyGrid key (\"ModelIndividualStartChannels\") - verified trap, analogous to the Antialias/ModelPixelStyle case. When enabled, one additional attribute per physical string is written, named \"String1\", \"String2\", ... \"StringN\" (1-based; see Model::StartChanAttrName), each holding the same channel-reference encoding as StartChannel. Only present/meaningful when the model has more than one string and no Controller is assigned."
+        },
+        {
+            "xmlAttribute": "ModelChain",
+            "label": "Model Chain",
+            "gridKey": "ModelChain",
+            "type": "string",
+            "default": "",
+            "description": "For controller-port-assigned models: the name of the model this one is chained after on the same controller/port (or the literal \"Beginning\" in the UI meaning first-on-port), or empty when not chained. Only written when non-empty. Only relevant/editable when Controller, protocol and port are all set (see shared/ControllerConnection.json)."
+        },
+        {
+            "xmlAttribute": "ShadowModelFor",
+            "label": "Shadow Model For",
+            "gridKey": "ShadowModelFor",
+            "type": "string",
+            "default": "",
+            "description": "Name of another model whose node/pixel layout this model mirrors for rendering purposes (\"shadowing\"), or empty for a normal model. Only written when non-empty."
+        },
+        {
+            "xmlAttribute": "Controller",
+            "label": "Controller",
+            "gridKey": "Controller",
+            "type": "string",
+            "default": "",
+            "description": "Name of the Controller (from xlights_networks.xml) this model's output is assigned to. Empty string means the model uses StartChannel directly with no controller/port assignment (\"Use Start Channel\" in the UI). The literal value \"No Controller\" (NO_CONTROLLER sentinel, src-core/models/Model.h) is a distinct third state meaning the user explicitly excluded this model from controller auto-layout/upload. See shared/ControllerConnection.json for the associated port/protocol child element."
+        },
+        {
+            "xmlAttribute": "LowDefinition",
+            "label": "Low Definition Factor",
+            "gridKey": "LowDefinition",
+            "type": "uint",
+            "default": 100,
+            "min": 1,
+            "max": 100,
+            "appliesWhen": {
+                "attribute": "DisplayAs",
+                "oneOf": [
+                    "Matrix",
+                    "Sphere"
+                ]
+            },
+            "description": "Percentage of full node/pixel definition to render at (100 = full detail). Read into every model on load with default 100 (XmlDeserializingModelFactory::DeserializeCommonModelAttributes), but only ever written back by Matrix and Sphere models (BaseSerializingVisitor::Visit(const MatrixModel&) and Visit(const SphereModel&)); Sphere inherits Matrix's support for low-definition rendering, while TreeModel opts out via SupportsLowDefinitionRender() == false. The property grid only exposes this attribute when Model::SupportsLowDefinitionRender() is true."
+        },
+        {
+            "xmlAttribute": "Active",
+            "label": "Active",
+            "gridKey": "Active",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "1",
+            "description": "When false, the model is not rendered/shown in the layout preview. Default (attribute absent) is true; only the value \"0\" is ever written (BaseSerializingVisitor::AddBaseObjectAttributes writes Active=\"0\" only when inactive, never writes \"1\")."
+        },
+        {
+            "xmlAttribute": "FromBase",
+            "label": "From Base Show Folder",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "description": "Read-only provenance flag: true when this model's definition was merged in from a linked base show folder rather than defined locally in this show folder. Set programmatically during base-folder merge, not user-editable in the property grid. Only the value \"1\" is ever written (written only when true)."
+        },
+        {
+            "xmlAttribute": "StartSide",
+            "label": "Start Side",
+            "type": "enum",
+            "enum": [
+                "B",
+                "T"
+            ],
+            "default": "B",
+            "description": "Vertical starting corner for the model's default node layout: \"B\" = bottom-to-top, \"T\" = top-to-bottom. Written/read unconditionally for every model (Model::GetStartSide/SetIsBtoT) but has no single generic property-grid control; specific model types combine it with Dir into their own composite picker (e.g. ArchesPropertyAdapter's \"Starting Location\" combining Green/Blue Square with Inside/Outside)."
+        },
+        {
+            "xmlAttribute": "Dir",
+            "label": "Direction",
+            "type": "enum",
+            "enum": [
+                "L",
+                "R"
+            ],
+            "default": "L",
+            "description": "Horizontal starting direction for the model's default node layout: \"L\" = left-to-right, \"R\" = right-to-left. Written/read unconditionally for every model (Model::GetDirection/SetIsLtoR); see StartSide for the paired attribute and its per-model composite UI."
+        },
+        {
+            "xmlAttribute": "StringType",
+            "label": "String Type",
+            "gridKey": "ModelStringType",
+            "type": "enum",
+            "default": "RGB Nodes",
+            "enum": [
+                "RGB Nodes",
+                "RBG Nodes",
+                "GBR Nodes",
+                "GRB Nodes",
+                "BRG Nodes",
+                "BGR Nodes",
+                "Node Single Color",
+                "3 Channel RGB",
+                "4 Channel RGBW",
+                "4 Channel WRGB",
+                "Strobes",
+                "Single Color Red",
+                "Single Color Green",
+                "Single Color Blue",
+                "Single Color White",
+                "Single Color Custom",
+                "Single Color Intensity",
+                "Superstring",
+                "WRGB Nodes",
+                "WRBG Nodes",
+                "WGBR Nodes",
+                "WGRB Nodes",
+                "WBRG Nodes",
+                "WBGR Nodes",
+                "RGBW Nodes",
+                "RBGW Nodes",
+                "GBRW Nodes",
+                "GRBW Nodes",
+                "BRGW Nodes",
+                "BGRW Nodes",
+                "RGBWW Nodes"
+            ],
+            "description": "Node color-channel layout for this model's pixels. Source list: NODE_TYPES / NODE_TYPE_VALUES in src-ui-wx/modelproperties/PropertyGridHelpers.cpp (27 grid choices), passed straight through by Model::GetStringType()/SetStringType(). CORRECTION vs the generic 27-value grid list: the grid's generic \"Single Color\" choice is never itself persisted - once a color is picked it is written back as one of the five concrete values Single Color Red/Green/Blue/White/Custom (see ModelPropertyAdapter.cpp OnPropertyGridChange \"ModelStringType\"/GetColorString), so this enum lists those 5 concrete forms instead of the generic one (31 total values here vs 27 grid choices)."
+        },
+        {
+            "xmlAttribute": "CustomColor",
+            "label": "Color",
+            "gridKey": "ModelStringColor",
+            "type": "color",
+            "default": "#000000",
+            "appliesWhen": {
+                "attribute": "StringType",
+                "oneOf": [
+                    "Single Color Custom",
+                    "Single Color Intensity",
+                    "Node Single Color"
+                ]
+            },
+            "description": "Custom single-node/single-string color, in #RRGGBB. Only meaningful (and only written, since Model::GetCustomColor() != xlBLACK is required) when StringType is one of the custom/intensity/node-single-color variants; for Single Color Red/Green/Blue/White the color is implied by StringType itself and this attribute is not used."
+        },
+        {
+            "xmlAttribute": "RGBWHandling",
+            "label": "RGBW Color Handling",
+            "gridKey": "ModelRGBWHandling",
+            "type": "enum",
+            "default": "R=G=B -> W",
+            "enum": [
+                "R=G=B -> W",
+                "RGB Only",
+                "White Only",
+                "Advanced",
+                "White On All"
+            ],
+            "description": "How the white channel is derived/handled for 4+ channel-per-node string types. Only written when the string type's channel count per node exceeds 3 (Model::GetChanCountPerNode() > 3, e.g. 4 Channel RGBW/WRGB, RGBW*/WRGB* Nodes, RGBWW Nodes, or Superstring); absent/ignored for 3-channel and single-color types."
+        },
+        {
+            "xmlAttribute": "SuperStringColour{n}",
+            "label": "Colour {n+1}",
+            "gridKey": "SuperStringColour{n}",
+            "type": "color",
+            "encoding": "Family of independently-named attributes SuperStringColour0, SuperStringColour1, ... SuperStringColour{count-1} (0-based index n), one per configured superstring colour slot. Count is Model::GetNumSuperStringColours() (UI range 1-32, see \"SuperStringColours\" wxIntProperty).",
+            "appliesWhen": {
+                "attribute": "StringType",
+                "equals": "Superstring"
+            },
+            "description": "One #RRGGBB color per physical color position for a Superstring-type string (each node cycles through this many distinct wired colors). Only present when StringType == \"Superstring\"."
+        },
+        {
+            "xmlAttribute": "PixelSize",
+            "label": "Pixel Size",
+            "gridKey": "ModelPixelSize",
+            "type": "uint",
+            "default": 2,
+            "min": 1,
+            "max": 300,
+            "description": "Rendered pixel diameter in the layout/house preview (visual only, no effect on channel data)."
+        },
+        {
+            "xmlAttribute": "Antialias",
+            "label": "Pixel Style",
+            "gridKey": "ModelPixelStyle",
+            "type": "enum",
+            "default": "1",
+            "enum": [
+                "0",
+                "1",
+                "2",
+                "3"
+            ],
+            "labels": {
+                "0": "Square",
+                "1": "Smooth",
+                "2": "Solid Circle",
+                "3": "Blended Circle"
+            },
+            "description": "Verified trap: xmlAttribute is \"Antialias\", fully different from its wxPropertyGrid key \"ModelPixelStyle\". Stores Model::PIXEL_STYLE as its underlying int value (src-core/models/Model.h enum class PIXEL_STYLE). Purely a preview rendering style, no effect on channel data."
+        },
+        {
+            "xmlAttribute": "Transparency",
+            "label": "Transparency",
+            "gridKey": "ModelPixelTransparency",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 100,
+            "description": "Adjusts how opaque the element is in the layout preview (0 = opaque, 100 = fully transparent). Preview-only."
+        },
+        {
+            "xmlAttribute": "BlackTransparency",
+            "label": "Black Transparency",
+            "gridKey": "ModelPixelBlackTransparency",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 100,
+            "description": "Adjusts how transparent black/off pixels are rendered in the layout preview. Only written when non-zero (BaseSerializingVisitor::AddCommonModelAttributes)."
+        },
+        {
+            "xmlAttribute": "TagColour",
+            "label": "Tag Color",
+            "gridKey": "ModelTagColour",
+            "type": "color",
+            "default": "#000000",
+            "description": "Visual color tag shown next to the model in the model list, in #RRGGBB. Only written when different from the default #000000."
+        },
+        {
+            "xmlAttribute": "NodeNames",
+            "type": "string",
+            "default": "",
+            "description": "Opaque, semicolon-delimited per-node display name overrides (Model::GetNodeNames/SetNodeNames). Only written when non-empty; passed through verbatim on load/save. No property-grid editor currently sets this attribute in the codebase - it round-trips whatever a file already contains (e.g. from an external tool or an older xLights UI)."
+        },
+        {
+            "xmlAttribute": "StrandNames",
+            "type": "string",
+            "default": "",
+            "description": "Opaque, semicolon-delimited per-strand display name overrides (Model::GetStrandNames/SetStrandNames). Only written when non-empty; same no-active-editor caveat as NodeNames."
+        },
+        {
+            "xmlAttribute": "PixelSpacing",
+            "type": "string",
+            "default": "",
+            "description": "Opaque physical pixel-spacing descriptor (Model::GetPixelSpacing/SetPixelSpacing). Only written when non-empty. No property-grid editor currently sets this attribute; format is not otherwise documented in the C++ - treat as pass-through data."
+        },
+        {
+            "xmlAttribute": "PixelCount",
+            "type": "string",
+            "default": "",
+            "description": "Opaque physical pixel-count descriptor (Model::GetPixelCount/SetPixelCount). Only written when non-empty. No property-grid editor currently sets this attribute; treat as pass-through data."
+        },
+        {
+            "xmlAttribute": "PixelType",
+            "type": "string",
+            "default": "",
+            "description": "Opaque physical pixel/product-type descriptor (Model::GetPixelType/SetPixelType). Only written when non-empty. No property-grid editor currently sets this attribute; treat as pass-through data."
+        },
+        {
+            "xmlAttribute": "versionNumber",
+            "type": "uint",
+            "default": 0,
+            "description": "Read-only provenance: model position/attribute schema version written by the exporting xLights build (CUR_MODEL_POS_VER), used internally by the deserializer to trigger one-off migrations for specific model types (e.g. Sphere scale-correction for version < 8, XmlDeserializingModelFactory::DeserializeSphere). Always written; not user-editable. Current value written by this codebase: 8 (CUR_MODEL_POS_VER, src-core/models/ModelScreenLocation.h). External writers creating NEW models should write the current value, not the JSON default of 0 - old values trigger one-off migrations on load."
+        },
+        {
+            "xmlAttribute": "SourceVersion",
+            "type": "string",
+            "default": "",
+            "description": "Read-only provenance: the xLights version string that last saved this model (xlights_version_string). Always written; never read back by the deserializer (informational only)."
+        },
+        {
+            "xmlAttribute": "ModelBrightness",
+            "type": "int",
+            "description": "Legacy/import-only attribute from older xLights versions that stored per-model brightness directly. On load, if present and no dimmingCurve child element already exists, its value seeds a synthesized dimmingCurve entry (gamma 1.0, brightness = this value) instead - see XmlDeserializingModelFactory::DeserializeCommonModelAttributes and shared/DimmingCurves.json. Never written by the current serializer (no corresponding attrs.Add call in BaseSerializingVisitor); current files persist brightness only via the dimmingCurve child element."
+        }
+    ],
+    "notes": [
+        "DisplayAs enum scope: this list covers only values written on a <model> node. ModelGroup writes DisplayAs=\"ModelGroup\" on a separate <modelGroup> element (different storage.node) and does not extend this fragment; ViewObject types (Gridlines, Terrain, Mesh, Ruler) and the in-memory-only SubModel/ObjectGroup values never appear as a <model> DisplayAs value.",
+        "Two DisplayAsType model values present in the enum here (Label, MultiPoint) do not yet have a corresponding models/*.json top-level document in this metadata tree's coverage list; they are included here because the C++ demonstrably supports and persists them (BaseSerializingVisitor::Visit(const LabelModel&) / Visit(const MultiPointModel&)). Treat their absence from the coverage list as an existing gap outside this task's scope, not a contradiction of this fragment.",
+        "parm1/parm2/parm3 (XmlNodeKeys::Parm1Attribute etc.) are legacy, read-only fallback attributes used by individual model types when their own named attribute is absent; they are not modeled here since Common.json has no parm-aliased attribute of its own (see legacyAttributes on the specific per-model properties that alias them in other files)."
+    ]
+}

--- a/resources/modelsmetadata/shared/ControllerConnection.json
+++ b/resources/modelsmetadata/shared/ControllerConnection.json
@@ -1,0 +1,217 @@
+{
+    "schemaVersion": 1,
+    "description": "Attributes of the <ControllerConnection> child element of a <model> node in xlights_rgbeffects.xml. Present only when the model has a non-zero port (Model::GetConstCtrlConn().GetCtrlPort() != 0, see BaseSerializingVisitor::WriteControllerConnectionElement); a model with no controller/port assignment has no <ControllerConnection> element at all. Source of truth: src-core/models/ControllerConnection.h/.cpp, BaseSerializingVisitor::Visit(const ControllerConnection&) (writer) and XmlDeserializingModelFactory::DeserializeControllerConnection (reader), cross-checked against ModelPropertyAdapter::AddControllerProperties/UpdateControllerProperties (@630/@877) for property-grid ranges and ControllerCaps capsGate names.",
+    "storage": {
+        "file": "xlights_rgbeffects.xml",
+        "node": "models/model",
+        "element": "ControllerConnection"
+    },
+    "properties": [
+        {
+            "xmlAttribute": "Port",
+            "gridKey": "ModelControllerConnectionPort",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 128,
+            "description": "Controller port/output number this model is wired to (1-based; 0 = not connected, in which case the whole <ControllerConnection> element is omitted). Default max shown here (128, MOST_CONTROLLER_PORTS_WE_EXPECT) applies when no controller/protocol is assigned; once assigned, the effective max is protocol-dependent via the controller's ControllerCaps: GetMaxSerialPort() for serial protocols, GetMaxPixelPort() for pixel protocols, GetMaxLEDPanelMatrixPort()/GetMaxVirtualMatrixPort() for matrix protocols, GetMaxPWMPort() for PWM. MULTI-STRING MAPPING: this is only the port for physical string 1. When the model has N physical strings (e.g. a Matrix model's NumStrings), strings 2..N are NOT separately addressable in XML - they automatically occupy the N-1 controller ports immediately following this one, one string per port (ControllerConnection::GetCtrlPort(string) = this Port plus a same-SmartRemote-group offset derived from string index; see ControllerConnection.cpp GetPortSR). A writer cannot place a multi-string model's strings on non-consecutive or arbitrarily-sized ports - each physical string is exactly one whole port. This is precisely the limitation that forces native multi-string models (e.g. Matrix) to be converted to a Custom model (see models/Custom.json) when arbitrary per-port pixel counts are needed."
+        },
+        {
+            "xmlAttribute": "Protocol",
+            "gridKey": "ModelControllerConnectionProtocol",
+            "type": "string",
+            "default": "",
+            "description": "Output protocol identifier for this port (e.g. \"ws2811\", \"E1.31\", \"DMX\", \"LOR\", \"LED Panel Matrix\", \"Virtual Matrix\", \"PWM\", ...). Deliberately modeled as a free-form string rather than a fixed enum: the valid set is the union of Model::GetControllerProtocols() (pixel + serial + matrix + PWM protocol names), which is assembled from the large, actively-maintained tables in src-core/models/Pixels.cpp (GetAllPixelTypes()/GetAllSerialTypes()) plus the literal names \"LED Panel Matrix\", \"Virtual Matrix\", \"PWM\" (see Pixels.cpp IsMatrixProtocol/IsPWMProtocol) - reproducing that list here would drift out of sync with the C++. This value determines which of channel/Speed (serial) vs the pixel-port properties below actually apply; see Model::IsSerialProtocol()/IsPixelProtocol()/IsMatrixProtocol()/IsPWMProtocol() (all also require Port != 0)."
+        },
+        {
+            "xmlAttribute": "channel",
+            "gridKey": "ModelControllerConnectionDMXChannel",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 512,
+            "description": "DMX/serial channel-within-port offset. Only written/relevant when Protocol is a serial protocol (Model::IsSerialProtocol()). Default max (512) applies when no controller assigned; otherwise ControllerCaps::GetMaxSerialPortChannels() governs the effective max."
+        },
+        {
+            "xmlAttribute": "Speed",
+            "gridKey": "ModelControllerConnectionSpeed",
+            "type": "uint",
+            "default": 25000,
+            "description": "Serial protocol link speed/baud (CONTROLLER_CONNECTION_DEFAULTS::DEFAULT_PROTOCOL_SPEED = 25000). Only written/relevant for serial protocols. Modeled as a plain integer rather than an enum because the property grid's valid choice list is protocol-specific (Model::GetSerialProtocolSpeeds(protocol)) and varies per selected Protocol value; 0 is never persisted (ControllerConnection::SetSerialProtocolSpeed ignores an incoming 0 and keeps the previous value)."
+        },
+        {
+            "xmlAttribute": "SmartRemote",
+            "gridKey": "SmartRemote",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "capsGate": "SupportsSmartRemotes",
+            "description": "1-based smart-remote index this port cascades through (0 = smart remote not in use). Displayed in the UI as a letter (A=1, B=2, ...; Model::GetSmartRemoteLetter()). Only written when non-zero AND the USE_SMART_REMOTE toggle is active (ControllerConnection::IsPropertySet(CtrlProps::USE_SMART_REMOTE)); the toggle itself (\"Use Smart Remote\" / gridKey \"UseSmartRemote\") is UI-only - its state is exactly \"is SmartRemote present and non-zero\", there is no separate persisted flag. Upper bound is dynamic: ControllerCaps::GetSmartRemoteCount() for the assigned controller (commonly up to 15)."
+        },
+        {
+            "xmlAttribute": "SmartRemoteType",
+            "gridKey": "SmartRemoteType",
+            "type": "string",
+            "default": "",
+            "capsGate": "SupportsSmartRemotes",
+            "description": "Smart-remote hardware sub-type name for this port, chosen from the assigned controller's ControllerCaps::GetSmartRemoteTypes() (a data-driven, controller-model-specific list - not a fixed enum). Only present inside the same SmartRemote-active block described above."
+        },
+        {
+            "xmlAttribute": "SRMaxCascade",
+            "gridKey": "MaxCascadeRemotes",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "capsGate": "SupportsSmartRemotes",
+            "relatedTo": [
+                "SmartRemote",
+                "SRCascadeOnPort"
+            ],
+            "description": "Number of consecutive smart remotes to cascade across for this model's strings (e.g. 2 = use remotes B and C starting from SmartRemote). Upper bound is ControllerCaps::GetSmartRemoteCount() for the assigned controller. Only present/relevant when the model has more than one physical string and smart remote is active."
+        },
+        {
+            "xmlAttribute": "SRCascadeOnPort",
+            "gridKey": "CascadeOnPort",
+            "type": "bool",
+            "boolFormat": "TRUEFALSE",
+            "default": "FALSE",
+            "capsGate": "SupportsSmartRemotes",
+            "relatedTo": [
+                "SmartRemote",
+                "SRMaxCascade"
+            ],
+            "description": "When TRUE, string order is 1A,1B,1C,... (cascade within a port before advancing port); when FALSE (default), order is 1A,2A,3A,4A,1B,... (cascade across ports at the same remote letter first). Only present inside the smart-remote-active block."
+        },
+        {
+            "xmlAttribute": "ts",
+            "gridKey": "ModelControllerConnectionPixelTs",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 20,
+            "capsGate": "SupportsTs",
+            "description": "Smart-remote \"Ts\" timing parameter. Only written when BOTH Smart Remote is active (SmartRemote != 0 and USE_SMART_REMOTE is set) AND the TS_ACTIVE toggle (\"Set Smart Ts\" / gridKey \"ModelControllerConnectionPixelSetTs\") is enabled; that toggle is UI-only (its state is exactly \"is ts present\"). Absent means the controller/port default applies. Nested inside the SmartRemote-active block, so persists only under the dual preconditions."
+        },
+        {
+            "xmlAttribute": "nullNodes",
+            "gridKey": "ModelControllerConnectionPixelNullNodes",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 100,
+            "capsGate": "SupportsPixelPortNullPixels",
+            "description": "Number of extra \"null\" (unlit/dummy) pixels sent before the model's real pixel data on this port. Only written when the START_NULLS_ACTIVE toggle (\"Set Start Null Pixels\" / gridKey \"ModelControllerConnectionPixelSetNullNodes\") is enabled; that toggle is UI-only - presence of this attribute IS the toggle. capsGate name corrects the brief's survey guess of \"SupportsPixelNullPixels\" to the actual ControllerCaps method \"SupportsPixelPortNullPixels\"."
+        },
+        {
+            "xmlAttribute": "endNullNodes",
+            "gridKey": "ModelControllerConnectionPixelEndNullNodes",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 100,
+            "capsGate": "SupportsPixelPortEndNullPixels",
+            "description": "Number of extra null pixels sent after the model's real pixel data on this port. Only written when END_NULLS_ACTIVE (\"Set End Null Pixels\") is enabled; UI-only toggle, same pattern as nullNodes. capsGate name corrects the brief's survey guess of \"SupportsPixelEndNullPixels\" to the actual ControllerCaps method \"SupportsPixelPortEndNullPixels\"."
+        },
+        {
+            "xmlAttribute": "Brightness",
+            "gridKey": "ModelControllerConnectionPixelBrightness",
+            "type": "uint",
+            "default": 100,
+            "min": 0,
+            "max": 100,
+            "capsGate": "SupportsPixelPortBrightness",
+            "legacyAttributes": [
+                "brightness"
+            ],
+            "description": "Per-port pixel brightness percentage override. Only written when BRIGHTNESS_ACTIVE (\"Set Brightness\") is enabled; UI-only toggle, presence of this attribute IS the toggle (ControllerConnection::_brightnessIsSet mirrors this). Also read for PWM protocol ports unconditionally under the same gridKey (no separate toggle in that branch of ModelPropertyAdapter::AddControllerProperties). Legacy files may instead use the lowercase attribute \"brightness\" (XmlNodeKeys::DCBrightnessAttribute); the reader falls back to it via ReadIntAttrWithLegacyFallback when \"Brightness\" is absent."
+        },
+        {
+            "xmlAttribute": "gamma",
+            "gridKey": "ModelControllerConnectionPixelGamma",
+            "type": "float",
+            "default": 1.0,
+            "min": 0.1,
+            "max": 5.0,
+            "step": 0.1,
+            "precision": 1,
+            "capsGate": "SupportsPixelPortGamma",
+            "description": "Per-port gamma correction factor. Only written when GAMMA_ACTIVE (\"Set Gamma\") is enabled for pixel protocols; UI-only toggle. Also read for PWM protocol ports unconditionally under the same gridKey/xmlAttribute (no separate toggle in that branch)."
+        },
+        {
+            "xmlAttribute": "colorOrder",
+            "gridKey": "ModelControllerConnectionPixelColorOrder",
+            "type": "enum",
+            "default": "RGB",
+            "enum": [
+                "RGB",
+                "RBG",
+                "GBR",
+                "GRB",
+                "BRG",
+                "BGR",
+                "RGBW",
+                "RBGW",
+                "GBRW",
+                "GRBW",
+                "BRGW",
+                "BGRW",
+                "WRGB",
+                "WRBG",
+                "WGBR",
+                "WGRB",
+                "WBRG",
+                "WBGR"
+            ],
+            "capsGate": "SupportsPixelPortColourOrder",
+            "description": "Per-port pixel color channel order override, from the fixed 18-value list Model::CONTROLLER_COLORORDER (src-core/models/Model.cpp). Only written when COLOR_ORDER_ACTIVE (\"Set Color Order\") is enabled; UI-only toggle."
+        },
+        {
+            "xmlAttribute": "Reverse",
+            "gridKey": "ModelControllerConnectionPixelDirection",
+            "type": "enum",
+            "default": "0",
+            "enum": [
+                "0",
+                "1"
+            ],
+            "labels": {
+                "0": "Forward",
+                "1": "Reverse"
+            },
+            "legacyAttributes": [
+                "reverse"
+            ],
+            "capsGate": "SupportsPixelPortDirection",
+            "description": "Per-port pixel direction override, from CONTROLLER_DIRECTION (src-ui-wx/modelproperties/PropertyGridHelpers.cpp: \"Forward\"=0, \"Reverse\"=1). Only written when REVERSE_ACTIVE (\"Set Pixel Direction\") is enabled; UI-only toggle. CORRECTION vs the brief's survey question: the canonical xmlAttribute is \"Reverse\" (capital R, XmlNodeKeys::ReverseAttribute), verified in both BaseSerializingVisitor::Visit(const ControllerConnection&) and XmlDeserializingModelFactory::DeserializeControllerConnection; lowercase \"reverse\" (XmlNodeKeys::CReverseAttribute) is a read-only legacy fallback name for older files, never written by the current serializer."
+        },
+        {
+            "xmlAttribute": "groupCount",
+            "gridKey": "ModelControllerConnectionPixelGroupCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 500,
+            "capsGate": "SupportsPixelPortGrouping",
+            "description": "Number of physical pixels grouped together as one logical/effect pixel on this port. Only written when GROUP_COUNT_ACTIVE (\"Set Group Count\") is enabled; UI-only toggle. Note: the underlying C++ default constant (CONTROLLER_CONNECTION_DEFAULTS::DEFAULT_GROUP_COUNT) is 0, but 0 is never exposed/written in practice - the property is only ever serialized while its toggle is active, and the property grid enforces Min=1 whenever it is shown; \"default\": 1 here documents that active/visible semantic (grouping of 1 = no grouping) rather than the internal not-yet-activated sentinel of 0."
+        },
+        {
+            "xmlAttribute": "ZigZag",
+            "gridKey": "ModelControllerConnectionPixelZigZag",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 1000,
+            "capsGate": "SupportsPixelZigZag",
+            "legacyAttributes": [
+                "zigZag"
+            ],
+            "description": "Per-port zig-zag pixel count (re-routes every N pixels back-and-forth across sub-strands on this port). Only written when ZIG_ZAG_ACTIVE (\"Set Zig Zag\") is enabled; UI-only toggle. Legacy files may instead use \"zigZag\" (XmlNodeKeys::CZigZagAttribute); the reader falls back to it via ReadIntAttrWithLegacyFallback. Distinct from the per-model boolean \"ZigZag\" attribute some model types (e.g. Arches, Spinner) write directly on the <model> element itself (\"true\"/\"false\") for a different, model-specific zig-zag-layers concept - no collision since they live on different XML elements (<model> vs <model><ControllerConnection>)."
+        }
+    ],
+    "notes": [
+        "The whole <ControllerConnection> element is written only when GetCtrlPort() != 0 (BaseSerializingVisitor::WriteControllerConnectionElement); a model using plain StartChannel with no controller assignment has no such element at all.",
+        "Every property gated by an 'ACTIVE' flag above (nullNodes, endNullNodes, Brightness, gamma, colorOrder, Reverse, groupCount, ZigZag, ts) follows the same pattern per the brief's instruction: the 'Set X' checkbox seen in the property grid is UI-only bookkeeping (ControllerConnection::CTRL_PROPS / active_props map) with no attribute of its own - the presence of the value attribute in the XML IS the toggle. They are modeled here as ordinary optional properties, not as separate boolean properties.",
+        "SmartRemote/SmartRemoteType/SRMaxCascade/SRCascadeOnPort/ts are additionally gated as a group by GetSmartRemote() != 0 AND CtrlProps::USE_SMART_REMOTE being set (ControllerConnection::LoadSmartRemote/UpdateProperty(USE_SMART_REMOTE, ...)); there is no separate persisted 'UseSmartRemote' attribute either - it mirrors GetSmartRemote() != 0 on load. For ts specifically, the TS_ACTIVE toggle adds a second layer of gating: ts persists only when SmartRemote is active AND TS_ACTIVE is set.",
+        "capsGate names were verified directly against src-core/controllers/ControllerCaps.h method signatures, not just the brief's survey guesses; two were corrected (SupportsPixelNullPixels -> SupportsPixelPortNullPixels, SupportsPixelEndNullPixels -> SupportsPixelPortEndNullPixels)."
+    ]
+}

--- a/resources/modelsmetadata/shared/DimmingCurves.json
+++ b/resources/modelsmetadata/shared/DimmingCurves.json
@@ -1,0 +1,34 @@
+{
+    "schemaVersion": 1,
+    "description": "The <dimmingCurve> child element of a <model> node in xlights_rgbeffects.xml: an optional per-model brightness/gamma correction curve applied before effect data reaches the model's pixels. <dimmingCurve> itself carries no attributes of its own - it is purely a wrapper around one or more per-channel child elements (see notes). Source of truth: src-core/XmlSerializer/BaseSerializingVisitor.cpp BaseSerializingVisitor::WriteDimmingCurve (writer) and src-core/XmlSerializer/XmlDeserializingModelFactory.cpp DeserializeDimmingCurve (reader); curve math is src-core/render/DimmingCurve.h/.cpp (DimmingCurve::createFromInfo); editing UI is src-ui-wx/model/ModelDimmingCurveDialog.cpp.",
+    "storage": { "file": "xlights_rgbeffects.xml", "node": "models/model", "element": "dimmingCurve" },
+    "properties": [
+        {
+            "xmlAttribute": "filename",
+            "type": "filepath",
+            "description": "Path to an external dimming-curve calibration file: a plain-text file with one 0-255 output value per line, indexed by input brightness (FileDimmingCurve, src-core/render/DimmingCurve.cpp). When present on a channel element it takes precedence over that element's brightness/gamma attributes, which are then ignored."
+        },
+        {
+            "xmlAttribute": "brightness",
+            "type": "int",
+            "default": 100,
+            "min": -100,
+            "max": 100,
+            "description": "Brightness adjustment percentage for this channel (-100..100). A value of 0 combined with gamma=1.0 yields an identity curve with no effect (BasicDimmingCurve::isIdentity()); ignored when the channel element also has a filename attribute. Range from ModelDimmingCurveDialog.cpp brightnessValidator.SetRange(-100, 100). See notes for why \"default\" here is 100, not the UI's own empty-field fallback of 0."
+        },
+        {
+            "xmlAttribute": "gamma",
+            "type": "float",
+            "default": 1.0,
+            "min": 0.0,
+            "max": 50.0,
+            "step": 0.1,
+            "description": "Gamma correction factor for this channel (1.0 = linear/no correction). A curve with gamma exactly 0.0 blanks the model entirely and is flagged as a settings error (Model::CheckModelSettings). Range from ModelDimmingCurveDialog.cpp gammaValidator.SetRange(0.0, 50.0)."
+        }
+    ],
+    "notes": [
+        "Two-level nesting that this fragment's single storage.element cannot fully express: the attributes above do not live on <dimmingCurve> itself, but on 1-3 further child elements nested one level inside it, each named literally \"all\" (one overall curve applied to every channel) OR \"red\"+\"green\"+\"blue\" together (independent per-channel curves) - never a mix of \"all\" with a colour name (DimmingCurve::createFromInfo, src-core/render/DimmingCurve.cpp, and ModelDimmingCurveDialog.cpp which reads/writes dimmingInfo[\"all\"]/[\"red\"]/[\"green\"]/[\"blue\"] literally). For example, a single-curve model writes exactly one child: <dimmingCurve><all brightness=\"20\" gamma=\"1.0\"/></dimmingCurve>; an RGB model writes up to three: <dimmingCurve><red .../><green .../><blue .../></dimmingCurve>.",
+        "brightness has two different observed defaults depending on context: XmlDeserializingModelFactory::DeserializeDimmingCurve seeds a missing brightness attribute to \"100\" whenever a channel child element already exists in the file but the attribute itself is absent, while the curve math (DimmingCurve::createCurve) separately falls back to \"0\" only if the whole key were missing from the in-memory map, which cannot happen once a model has been loaded through the normal reader. \"default\": 100 above reflects the reader's on-disk-read behaviour, the one relevant to interpreting a file.",
+        "The whole <dimmingCurve> element is only written when at least one channel entry exists (Model::dimmingInfo non-empty); a model with no dimming curve configured has no <dimmingCurve> element at all. A legacy <model ModelBrightness=\"N\"> attribute (see shared/Common.json) is converted into a synthesized <dimmingCurve><all gamma=\"1.0\" brightness=\"N\"/></dimmingCurve> on load if no real dimmingCurve element is present and N != 0."
+    ]
+}

--- a/resources/modelsmetadata/shared/DmxAbilities.json
+++ b/resources/modelsmetadata/shared/DmxAbilities.json
@@ -1,0 +1,382 @@
+{
+    "schemaVersion": 1,
+    "description": "Ability/component attributes shared by 2+ of the eight DMX model documents (DmxGeneral, DmxFloodlight, DmxFloodArea, DmxMovingHead, DmxMovingHeadAdv, DmxServo, DmxServo3d, DmxSkull). Each DMX document lists this fragment in its own `extends` alongside shared/Common.json, shared/ScreenLocation.json and shared/ControllerConnection.json. Source of truth: src-core/models/DMX/DmxModel.{h,cpp} (DmxChannelCount + preset ability, unconditionally present on every DmxModel subclass), DmxColorAbility*.{h,cpp}, DmxShutterAbility.h, DmxDimmerAbility.h, DmxBeamAbility.h, DmxMovingHeadComm.h (fixture), plus BaseSerializingVisitor.cpp's AddDmxModelAttributes/AddColorAbility*Attributes/AddShutterAbilityAttributes/AddDimmerAbilityAttributes/AddBeamAbilityAttributes/AddPresetAbilityAttributes and XmlDeserializingModelFactory.cpp's matching Deserialize* functions. Type-specific attributes that belong to only one DMX document (DmxStyle/HideBody on DmxMovingHead; NumServos/Bits16/Brightness/Transparency on DmxServo; PivotAxes-is-NOT-persisted/motion-link attributes on DmxServo3d; per-axis Has*/orient ints on DmxSkull; etc.) are documented in that document instead, never here.",
+    "storage": { "file": "xlights_rgbeffects.xml", "node": "models/model" },
+    "properties": [
+        {
+            "xmlAttribute": "DmxChannelCount",
+            "label": "# Channels",
+            "gridKey": "DmxChannelCount",
+            "type": "uint",
+            "default": 1,
+            "min": 1,
+            "max": 512,
+            "description": "Total DMX channel count for this fixture (DmxModel::_dmxChannelCount, GetDmxChannelCount()/SetDmxChannelCount()); also drives Model::GetNumStrings() for a DMX model. Always written by every one of the eight DMX documents (BaseSerializingVisitor::AddDmxModelAttributes, called from every Dmx*::Visit()). legacyAttributes note: read via ReadAttrWithParmFallback(node, DmxChannelCountAttribute, Parm1Attribute, \"1\") - falls back to legacy parm1 only when DmxChannelCount itself is absent.",
+            "legacyAttributes": ["parm1"]
+        },
+        {
+            "xmlAttribute": "DmxColorType",
+            "label": "Color Type",
+            "gridKey": "DmxColorType",
+            "type": "enum",
+            "enum": ["0", "1", "2", "3"],
+            "labels": { "0": "RGBW", "1": "ColorWheel", "2": "CMYW", "3": "Unused" },
+            "default": "0",
+            "description": "Discriminator for which DmxColorAbility subclass this model's color_ability is (DmxColorAbility::DMX_COLOR_TYPE, stored as the underlying int; DMX_COLOR_TYPES_VALUES label order RGBW/ColorWheel/CMYW/Unused matches the enum's int order 0-3). Written whenever HasColorAbility() (BaseSerializingVisitor::AddColorAbilityAttributes) - true for DmxFloodArea, DmxFloodlight, DmxGeneral, DmxMovingHead, DmxMovingHeadAdv and DmxSkull (6 of 8; DmxServo/DmxServo3d have no color ability at all). CORRECTION vs a per-document read: only DmxMovingHead and DmxMovingHeadAdv actually read this attribute back into a live color-type switch on load (XmlDeserializingModelFactory::DeserializeDynamicColorAbility -> Model::InitColorAbility(color_type), called only from DeserializeDmxMovingHead/DeserializeDmxMovingHeadAdv). For FloodArea/Floodlight/General/Skull the color ability's concrete subclass is fixed at construction time to DmxColorAbilityRGB (their constructors call `color_ability = std::make_unique<DmxColorAbilityRGB>()` directly) and DeserializeDmxModel -> DeserializeColorAbility never consults this attribute - so for those four documents DmxColorType is always written as \"0\" and is inert on read."
+        },
+        {
+            "xmlAttribute": "DmxRedChannel",
+            "label": "Red Channel",
+            "gridKey": "DmxRedChannel",
+            "type": "uint",
+            "default": 1,
+            "min": 0,
+            "max": 512,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "0" },
+            "description": "Red channel offset for an RGBW color ability (DmxColorAbilityRGB::red_channel, GetRedChannel()/SetRedChannel()). Default shown is the deserializer's read-fallback (XmlDeserializingModelFactory::DeserializeColorAbilityRGBAttributes: `.as_int(1)`); brand-new in-memory models seed different starting values per document (e.g. DmxMovingHead ctor sets 1, DmxMovingHeadAdv ctor sets 5) but those are just first-save starting points, not read-time defaults."
+        },
+        {
+            "xmlAttribute": "DmxGreenChannel",
+            "label": "Green Channel",
+            "gridKey": "DmxGreenChannel",
+            "type": "uint",
+            "default": 2,
+            "min": 0,
+            "max": 512,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "0" },
+            "description": "Green channel offset for an RGBW color ability (DmxColorAbilityRGB::green_channel). Default is the deserializer read-fallback (`.as_int(2)`)."
+        },
+        {
+            "xmlAttribute": "DmxBlueChannel",
+            "label": "Blue Channel",
+            "gridKey": "DmxBlueChannel",
+            "type": "uint",
+            "default": 3,
+            "min": 0,
+            "max": 512,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "0" },
+            "description": "Blue channel offset for an RGBW color ability (DmxColorAbilityRGB::blue_channel). Default is the deserializer read-fallback (`.as_int(3)`)."
+        },
+        {
+            "xmlAttribute": "DmxWhiteChannel",
+            "label": "White Channel",
+            "gridKey": "DmxWhiteChannel",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 512,
+            "appliesWhen": { "attribute": "DmxColorType", "oneOf": ["0", "2"] },
+            "description": "White channel offset, shared by both the RGBW ability (DmxColorAbilityRGB::white_channel) and the CMYW ability (DmxColorAbilityCMY::white_channel) - same literal xmlAttribute name in both, only one of which is ever active per model (mutually exclusive on DmxColorType), so it is modeled once here rather than as two properties. Default 0 (unused) is the deserializer read-fallback for both abilities."
+        },
+        {
+            "xmlAttribute": "DmxRedBrightness",
+            "label": "PWM Red Brightness",
+            "gridKey": "DmxRedBrightness",
+            "type": "uint",
+            "default": 100,
+            "min": 0,
+            "max": 200,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "0" },
+            "description": "PWM brightness percentage for the red channel (DmxColorAbilityRGB::red_brightness). Only written when non-default (BaseSerializingVisitor::AddColorAbilityRGBAttributes: `if (colors->GetRedBrightness() != 100) attrs.Add(...)`); only shown in the property grid when the model's assigned controller reports PWM support (`pwm` flag), but the attribute itself has no such gate on read."
+        },
+        {
+            "xmlAttribute": "DmxGreenBrightness",
+            "label": "PWM Green Brightness",
+            "gridKey": "DmxGreenBrightness",
+            "type": "uint",
+            "default": 100,
+            "min": 0,
+            "max": 200,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "0" },
+            "description": "PWM brightness percentage for the green channel (DmxColorAbilityRGB::green_brightness). Only written when non-default (100)."
+        },
+        {
+            "xmlAttribute": "DmxBlueBrightness",
+            "label": "PWM Blue Brightness",
+            "gridKey": "DmxBlueBrightness",
+            "type": "uint",
+            "default": 100,
+            "min": 0,
+            "max": 200,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "0" },
+            "description": "PWM brightness percentage for the blue channel (DmxColorAbilityRGB::blue_brightness). Only written when non-default (100)."
+        },
+        {
+            "xmlAttribute": "DmxWhiteBrightness",
+            "label": "PWM White Brightness",
+            "gridKey": "DmxWhiteBrightness",
+            "type": "uint",
+            "default": 100,
+            "min": 0,
+            "max": 200,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "0" },
+            "description": "PWM brightness percentage for the white channel (DmxColorAbilityRGB::white_brightness). Only written when non-default (100). CMYW has no per-channel brightness/gamma attributes (DmxColorAbilityCMY has no such members)."
+        },
+        {
+            "xmlAttribute": "DmxRedGamma",
+            "label": "PWM Red Gamma",
+            "gridKey": "DmxRedGamma",
+            "type": "float",
+            "default": 1.0,
+            "min": 0.1,
+            "max": 5.0,
+            "precision": 2,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "0" },
+            "description": "PWM gamma correction for the red channel (DmxColorAbilityRGB::red_gamma). Only written when non-default (BaseSerializingVisitor: `if (colors->GetRedGamma() != 1.0f) ...`, serialized via FloatToString)."
+        },
+        {
+            "xmlAttribute": "DmxGreenGamma",
+            "label": "PWM Green Gamma",
+            "gridKey": "DmxGreenGamma",
+            "type": "float",
+            "default": 1.0,
+            "min": 0.1,
+            "max": 5.0,
+            "precision": 2,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "0" },
+            "description": "PWM gamma correction for the green channel (DmxColorAbilityRGB::green_gamma). Only written when non-default (1.0)."
+        },
+        {
+            "xmlAttribute": "DmxBlueGamma",
+            "label": "PWM Blue Gamma",
+            "gridKey": "DmxBlueGamma",
+            "type": "float",
+            "default": 1.0,
+            "min": 0.1,
+            "max": 5.0,
+            "precision": 2,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "0" },
+            "description": "PWM gamma correction for the blue channel (DmxColorAbilityRGB::blue_gamma). Only written when non-default (1.0)."
+        },
+        {
+            "xmlAttribute": "DmxWhiteGamma",
+            "label": "PWM White Gamma",
+            "gridKey": "DmxWhiteGamma",
+            "type": "float",
+            "default": 1.0,
+            "min": 0.1,
+            "max": 5.0,
+            "precision": 2,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "0" },
+            "description": "PWM gamma correction for the white channel (DmxColorAbilityRGB::white_gamma). Only written when non-default (1.0)."
+        },
+        {
+            "xmlAttribute": "DmxCyanChannel",
+            "label": "Cyan Channel",
+            "gridKey": "DmxCyanChannel",
+            "type": "uint",
+            "default": 1,
+            "min": 0,
+            "max": 512,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "2" },
+            "description": "Cyan channel offset for a CMYW color ability (DmxColorAbilityCMY::cyan_channel). Default is the deserializer read-fallback (`.as_int(1)`)."
+        },
+        {
+            "xmlAttribute": "DmxMagentaChannel",
+            "label": "Magenta Channel",
+            "gridKey": "DmxMagentaChannel",
+            "type": "uint",
+            "default": 2,
+            "min": 0,
+            "max": 512,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "2" },
+            "description": "Magenta channel offset for a CMYW color ability (DmxColorAbilityCMY::magenta_channel). Default is the deserializer read-fallback (`.as_int(2)`)."
+        },
+        {
+            "xmlAttribute": "DmxYellowChannel",
+            "label": "Yellow Channel",
+            "gridKey": "DmxYellowChannel",
+            "type": "uint",
+            "default": 3,
+            "min": 0,
+            "max": 512,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "2" },
+            "description": "Yellow channel offset for a CMYW color ability (DmxColorAbilityCMY::yellow_channel). Default is the deserializer read-fallback (`.as_int(3)`)."
+        },
+        {
+            "xmlAttribute": "DmxColorWheelChannel",
+            "label": "Color Wheel Channel",
+            "gridKey": "DmxColorWheelChannel",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 512,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "1" },
+            "description": "Color-wheel position channel for a ColorWheel color ability (DmxColorAbilityWheel::wheel_channel)."
+        },
+        {
+            "xmlAttribute": "DmxDimmerChannel",
+            "label": "Dimmer Channel",
+            "gridKey": "DmxDimmerChannel",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 512,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "1" },
+            "description": "Dimmer channel belonging to the ColorWheel color ability itself (DmxColorAbilityWheel::dimmer_channel) - distinct from the separate MhDimmerChannel dimmer ability documented below, which some of the same models also carry independently of their color type."
+        },
+        {
+            "xmlAttribute": "DmxColorWheelDelay",
+            "label": "Color Wheel Delay(ms)",
+            "gridKey": "DmxColorWheelDelay",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 10000,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "1" },
+            "description": "Milliseconds the wheel takes to physically rotate to a new color (DmxColorAbilityWheel::wheel_delay); used to delay-render the beam color after a wheel change."
+        },
+        {
+            "xmlAttribute": "DmxColorWheelColor{n}",
+            "label": "Color {n+1}",
+            "gridKey": "DmxColorWheelColor{n}",
+            "type": "color",
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "1" },
+            "encoding": "Family of independently-named attributes DmxColorWheelColor0, DmxColorWheelColor1, ... one per configured wheel-color slot (0-based index n, up to DmxColorAbilityWheel::MAX_COLORS = 25). Paired index-for-index with DmxColorWheelDMX{n}. Only as many slots are written as the ability currently holds (GetWheelColorSettings()); reading stops at the first missing pair (XmlDeserializingModelFactory::DeserializeColorWheelAttributes breaks when either half of a pair is absent). Freshly-constructed wheel abilities seed 4 built-in entries (white/red/green/blue at DMX 10/30/50/70, DmxColorAbilityWheel::InitColor()) which only get persisted once the model's color type is actually switched to ColorWheel and saved.",
+            "description": "#RRGGBB color swatch for one color-wheel position (WheelColor::color)."
+        },
+        {
+            "xmlAttribute": "DmxColorWheelDMX{n}",
+            "label": "Color {n+1} DMX",
+            "gridKey": "DmxColorWheelDMX{n}",
+            "type": "uint",
+            "min": 0,
+            "max": 255,
+            "appliesWhen": { "attribute": "DmxColorType", "equals": "1" },
+            "encoding": "Same family/index convention as DmxColorWheelColor{n} above.",
+            "description": "DMX value (0-255) that selects this color-wheel position (WheelColor::dmxValue)."
+        },
+        {
+            "xmlAttribute": "DmxShutterChannel",
+            "label": "Shutter Channel",
+            "gridKey": "DmxShutterChannel",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 512,
+            "description": "Shutter/strobe channel (DmxShutterAbility::shutter_channel). Present on DmxFloodArea, DmxFloodlight, DmxMovingHead and DmxMovingHeadAdv (DmxModel::HasShutterAbility(); absent on DmxGeneral/DmxServo/DmxServo3d/DmxSkull, none of which construct a shutter_ability)."
+        },
+        {
+            "xmlAttribute": "DmxShutterOpen",
+            "label": "Shutter Open Threshold",
+            "gridKey": "DmxShutterOpen",
+            "type": "int",
+            "default": 1,
+            "min": -255,
+            "max": 255,
+            "description": "Threshold the shutter channel's value is compared against to decide open/closed (DmxShutterAbility::shutter_threshold). Sign convention: a positive threshold means \"value >= threshold is open\"; a negative threshold means \"abs(value) <= |threshold| is open\" (see IsShutterOpen())."
+        },
+        {
+            "xmlAttribute": "DmxShutterOnValue",
+            "label": "Shutter On Value",
+            "gridKey": "DmxShutterOnValue",
+            "type": "int",
+            "default": 0,
+            "min": 0,
+            "max": 255,
+            "description": "Fixed DMX value written to the shutter channel while shutter is enabled/on (DmxShutterAbility::shutter_on_value); only applied by EnableFixedChannels when non-zero."
+        },
+        {
+            "xmlAttribute": "MhDimmerChannel",
+            "label": "Dimmer Channel",
+            "gridKey": "MhDimmerChannel",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 512,
+            "description": "Overall fixture dimmer channel (DmxDimmerAbility::dimmer_channel). Present only on DmxMovingHead and DmxMovingHeadAdv (DmxModel::HasDimmerAbility()); distinct from the color-wheel-scoped DmxDimmerChannel attribute above."
+        },
+        {
+            "xmlAttribute": "DmxBeamLength",
+            "label": "Beam Display Length",
+            "gridKey": "DmxBeamLength",
+            "type": "float",
+            "default": 1.0,
+            "min": 0,
+            "max": 100,
+            "precision": 2,
+            "step": 0.1,
+            "description": "Visual beam-cone length in the layout preview (DmxBeamAbility::beam_length; preview-only, no channel-data effect). Present on DmxFloodArea, DmxFloodlight, DmxMovingHead and DmxMovingHeadAdv. Default shown (1.0) is the DmxBeamAbility base-class default used by FloodArea/Floodlight; DmxMovingHead and DmxMovingHeadAdv both override their in-memory default to 4.0 in their constructors (SetDefaultBeamLength(4.0)), which becomes the effective read-fallback for those two documents specifically."
+        },
+        {
+            "xmlAttribute": "DmxBeamWidth",
+            "label": "Beam Display Width",
+            "gridKey": "DmxBeamWidth",
+            "type": "float",
+            "default": 1.0,
+            "min": 0.01,
+            "max": 150,
+            "precision": 2,
+            "step": 0.1,
+            "description": "Visual beam-cone width in the layout preview (DmxBeamAbility::beam_width; preview-only). Default shown (1.0) is the base-class default (FloodArea/Floodlight); DmxMovingHead overrides its default to 30.0 and DmxMovingHeadAdv overrides its default to 4.0 (both via SetDefaultBeamWidth in their constructors)."
+        },
+        {
+            "xmlAttribute": "DmxBeamOrient",
+            "label": "Beam Orientation",
+            "gridKey": "DmxBeamOrient",
+            "type": "uint",
+            "default": 0,
+            "min": 0,
+            "max": 360,
+            "description": "Fixed rotational offset added to the rendered beam (DmxBeamAbility::beam_orient). Only ever written when the ability's SupportsOrient() flag is true (BaseSerializingVisitor::AddBeamAbilityAttributes), which only DmxMovingHeadAdv's constructor enables (SetSupportsOrient(true)) - so in practice this attribute is FloodArea/Floodlight/MovingHead-absent, MovingHeadAdv-only. SupportsOrient itself is a runtime capability flag, not a persisted attribute, so this cannot be expressed as an appliesWhen condition here."
+        },
+        {
+            "xmlAttribute": "DmxBeamYOffset",
+            "label": "Beam Y Offset",
+            "gridKey": "DmxBeamYOffset",
+            "type": "float",
+            "default": 0,
+            "min": 0,
+            "max": 500,
+            "precision": 1,
+            "step": 1,
+            "description": "Vertical offset applied to the rendered beam's origin (DmxBeamAbility::beam_y_offset). Only written when SupportsYOffset() is true - again only DmxMovingHeadAdv enables this (SetSupportsYOffset(true), SetDefaultBeamYOffset(17.0)); absent for FloodArea/Floodlight/MovingHead."
+        },
+        {
+            "xmlAttribute": "DmxPresetChannel{n}",
+            "label": "Fixed Channel {n+1} DMX Channel",
+            "gridKey": "DmxPresetChannel{n}",
+            "type": "uint",
+            "min": 0,
+            "max": 255,
+            "encoding": "Family of independently-named attributes DmxPresetChannel0, DmxPresetChannel1, ... (0-based index n, up to DmxPresetAbility::MAX_PRESETS = 25). Paired index-for-index with DmxPresetValue{n} and DmxPresetDesc{n}. Present on ALL eight DMX documents - DmxModel's constructor unconditionally creates a preset_ability (DmxModel::DmxModel(): `preset_ability = std::make_unique<DmxPresetAbility>();`). The property grid's \"DmxPresetSize\" spinner (DmxAbilityPropertyHelpers::AddPresetProperties) controls how many indexed slots exist but is itself derived from GetPresetsCount(), not a persisted attribute. Reading stops at the first index missing either DmxPresetChannel{n} or DmxPresetValue{n} (XmlDeserializingModelFactory::DeserializePresetAbility).",
+            "description": "DMX channel number for one \"fixed/preset\" channel-value override (PresetSetting::DMXChannel, stored as uint8_t - values above 255 are not representable even though a model may have up to 512 DMX channels)."
+        },
+        {
+            "xmlAttribute": "DmxPresetValue{n}",
+            "label": "Fixed Channel {n+1} DMX Value",
+            "gridKey": "DmxPresetValue{n}",
+            "type": "uint",
+            "min": 0,
+            "max": 255,
+            "encoding": "Same family/index convention as DmxPresetChannel{n} above.",
+            "description": "Fixed DMX value (0-255) always written to the paired preset channel (PresetSetting::DMXValue)."
+        },
+        {
+            "xmlAttribute": "DmxPresetDesc{n}",
+            "label": "Fixed Channel {n+1} Description",
+            "gridKey": "DmxPresetDesc{n}",
+            "type": "string",
+            "default": "",
+            "encoding": "Same family/index convention as DmxPresetChannel{n} above.",
+            "description": "Free-text label for this preset channel override (PresetSetting::Description)."
+        },
+        {
+            "xmlAttribute": "DmxFixture",
+            "label": "Fixture",
+            "gridKey": "DmxFixture",
+            "type": "enum",
+            "enum": ["MH1", "MH2", "MH3", "MH4", "MH5", "MH6", "MH7", "MH8"],
+            "default": "MH1",
+            "description": "Logical fixture-instance slot (1-8) this moving-head model occupies, used by MhFeature-based effects to target a specific physical head when several are chained (DmxMovingHeadComm::dmx_fixture / GetFixture() / FixtureIDtoString() - stored form is the literal \"MH1\"..\"MH8\" string, not the 0-based fixture_val int). Present on DmxMovingHead and DmxMovingHeadAdv only (both derive from DmxMovingHeadComm, whose AddDmxMovingHeadCommAttributes always writes it)."
+        }
+    ],
+    "notes": [
+        "Motor child elements (pattern {base}Motor, e.g. PanMotor/TiltMotor): written as a CHILD ELEMENT of the model node (BaseSerializingVisitor::WriteDmxMotorElement: `WriteOpenTag(motor->GetName(), attrs, true)`), NOT as flat {base}-prefixed attributes on the model itself - this corrects the task brief's survey guess of flat `{base}ChannelCoarse` etc. Each {base}Motor element carries these literal attributes (DmxMotor getters in parentheses): ChannelCoarse (uint 0-512, GetChannelCoarse), ChannelFine (uint 0-512, GetChannelFine), MinLimit (int, default -180, GetMinLimit), MaxLimit (int, default 180, GetMaxLimit), RangeOfMotion (float 0-65535, default 180.0, GetRangeOfMotion), OrientZero (int 0-360, default 0, GetOrientZero), OrientHome (int 0-360, default 0, GetOrientHome; grid label is \"Orient Forward (deg)\" for PanMotor, \"Orient Up (deg)\" for TiltMotor - same attribute either way), SlewLimit (float 0-500, default 0.0, GetSlewLimit), Reverse (bool \"0\"/\"1\", GetReverse), UpsideDown (bool \"0\"/\"1\", GetUpsideDown). Concrete base names instantiated: DmxMovingHead and DmxMovingHeadAdv both use PanMotor + TiltMotor (see DmxMovingHeadComm::GetPanMotor/GetTiltMotor). DmxSkull uses Servo elements instead of Motor elements for its equivalent axes (see next note) - it has no {base}Motor children.",
+        "Servo child elements (pattern varies by document - either axis-named like PanServo/JawServo, or 1-based numbered like Servo1/Servo2/...): also a CHILD ELEMENT, not flat attributes (BaseSerializingVisitor::WriteServoElement: `WriteOpenTag(servo->GetName(), attrs, true)`). Literal attributes on every Servo element (Servo.h getters in parentheses): Channel (uint 0-512, default 0, GetChannel), MinLimit (uint, default 1, GetMinLimit), MaxLimit (uint, default 65535, GetMaxLimit), RangeOfMotion (float, default 180.0, GetRangeOfMotion), PivotOffsetX/PivotOffsetY/PivotOffsetZ (float, default 0 - persisted as the RAW unscaled pivot_offset_x/y/z members; the GetScaledPivotOffsetX()-style accessors used by the property grid divide/multiply by a 2D-only offset_scale of 100 and are never what gets written), ServoStyle (string, default \"Translate X\", one of \"Translate X\"/\"Translate Y\"/\"Translate Z\"/\"Rotate X\"/\"Rotate Y\"/\"Rotate Z\"), ControllerMin (int, default 1000, GetControllerMin), ControllerMax (int, default 2000, GetControllerMax), ControllerReverse (bool \"0\"/\"1\", default 0, GetControllerReverse), ControllerZeroBehavior (string, default \"Hold\", one of \"Hold\"/\"Min\"/\"Max\"/\"Center\"/\"Stop PWM\"), ControllerDataType (string, default \"Scaled\", one of \"Scaled\"/\"Absolute\"/\"1/2 Absolute\"/\"2x Absolute\"). All Controller* attributes are always written regardless of whether the assigned controller actually supports PWM (that only gates their property-grid visibility). Concrete base names instantiated: DmxSkull uses JawServo/PanServo/TiltServo/NodServo/EyeUpDownServo/EyeLeftRightServo (fixed, axis-named - note EyeUpDownServo/EyeLeftRightServo are the literal element names, not \"EyeUD\"/\"EyeLR\" as the task brief's shorthand suggested); DmxServo and DmxServo3d both use a 1-based numbered family Servo1, Servo2, ... ServoN (N = NumServos, up to 24) via CreateServo(\"Servo\" + std::to_string(i+1), i).",
+        "Mesh child elements (pattern varies - BaseMesh/YokeMesh/HeadMesh, HeadMesh/JawMesh/EyeMeshL/EyeMeshR, or numbered StaticMesh{n}/MotionMesh{n}): also a CHILD ELEMENT (BaseSerializingVisitor::WriteMeshElement). Literal attributes on every Mesh element (Mesh.h getters in parentheses): ObjFile (filepath, default \"\", GetObjFile), MeshOnly (bool \"0\"/\"1\", default 0, GetMeshOnly), Brightness (float 0-100, default 100.0, GetBrightness), Width/Height/Depth (float, default 1.0 each - the OBJ's own computed bounding-box dimensions, GetWidth/GetHeight/GetDepth; persisted so the size is known before the OBJ is (re)loaded, and restored into a separate RenderWidth/RenderHeight/RenderDepth on read via SetRenderWidth/Height/Depth - not directly user-editable in the property grid), ScaleX/ScaleY/ScaleZ (float, default 1.0, precision 3), RotateX/RotateY/RotateZ (float, default 0.0, range -180..180, precision 8), OffsetX/OffsetY/OffsetZ (float, default 0.0, precision 2). Concrete base names instantiated: DmxMovingHeadAdv uses BaseMesh + YokeMesh + HeadMesh (GetBaseMesh/GetYokeMesh/GetHeadMesh); DmxSkull uses HeadMesh + JawMesh + EyeMeshL + EyeMeshR (fixed, axis-named); DmxServo3d uses a 1-based numbered family StaticMesh{n} (n = 1..NumStatic) and MotionMesh{n} (n = 1..NumMotion), up to 24 each.",
+        "DmxImage child elements (pattern StaticImage{n}/MotionImage{n}, 1-based numbered, n = 1..NumServos up to 24): also a CHILD ELEMENT (BaseSerializingVisitor::WriteDmxImageElement), used only by DmxServo (one static + one motion image per servo). Literal attributes (DmxImage.h getters in parentheses): Image (filepath, default \"\", GetImageFile), ScaleX/ScaleY/ScaleZ (float, default 1.0), RotateX/RotateY/RotateZ (float, default 0.0, range -180..180), OffsetX/OffsetY/OffsetZ (float, default 0.0 - persisted as the RAW value already divided by DmxImage::OFFSET_SCALE = 100; the property grid multiplies by 100 for display only).",
+        "DisplayAs enum scope: DmxGeneral/DmxFloodlight/DmxFloodArea/DmxMovingHead/DmxMovingHeadAdv/DmxServo/DmxServo3d/DmxSkull are all confirmed as the exact, sole, currently-written DisplayAs literals for their respective types (src-core/models/DisplayAsType.cpp DisplayAsTypeToString/XmlNodeKeys::Dmx*Type) - there is no separate \"DmxMovingHead3D\" DisplayAs value; \"DmxServo3Axis\" is a read-only legacy alias accepted only on load for DmxServo3d (DisplayAsType.cpp's alias map / XmlDeserializingModelFactory.cpp's `type == \"DmxServo3Axis\"` check).",
+        "Property-grid applicability shared by ALL eight DMX documents (DmxPropertyAdapter::DisableUnusedProperties, inherited by every Dmx*PropertyAdapter except DmxSkullPropertyAdapter which reimplements its own subset - see DmxSkull.json): the shared/Common.json ModelStringType and ModelStringColor properties are disabled/greyed out (DMX models are hard-coded to StringType \"Single Color White\" by DmxModel::InitModel() and never expose a color picker for it), and the shared/Faces.json faceInfo and shared/DimmingCurves.json dimmingCurve child elements are likewise disabled - all three remain structurally round-tripped (BaseSerializingVisitor::WriteOtherElements is called unconditionally for every DMX Visit()) if already present in a file, just not settable from the DMX property grids. shared/States.json stateInfo and shared/SubModels.json subModel are deliberately left enabled for every DMX type (DmxPropertyAdapter.cpp comment: \"these can be used for DMX devices that use a value range to set a colour or behaviour\")."
+    ]
+}

--- a/resources/modelsmetadata/shared/Faces.json
+++ b/resources/modelsmetadata/shared/Faces.json
@@ -1,0 +1,41 @@
+{
+    "schemaVersion": 1,
+    "description": "The <faceInfo> child elements of a <model> node in xlights_rgbeffects.xml: singing-face definitions consumed by the Faces effect. A model may define any number of named faces (Model::faceInfo, a map of face name -> attribute map). Source of truth: src-core/models/Model.cpp Model::WriteFaceInfo (writer, prepends one <faceInfo> per entry) and src-core/XmlSerializer/XmlSerializeFunctions.cpp DeserializeFaceInfo (reader); the SingleNode/NodeRange/Matrix editing UI is src-ui-wx/model/ModelFaceDialog.cpp; consumed at render time by src-core/effects/FacesEffect.cpp.",
+    "storage": { "file": "xlights_rgbeffects.xml", "node": "models/model", "element": "faceInfo" },
+    "properties": [
+        {
+            "xmlAttribute": "Name",
+            "type": "string",
+            "description": "Face definition name, unique within the model (map key in Model::faceInfo). Read via XmlNodeKeys::StateNameAttribute (\"Name\" - the same attribute key used by stateInfo). Defaults to the literal string \"SingleNode\" if the attribute is missing entirely; if present but empty, falls back to the Type value instead (DeserializeFaceInfo)."
+        },
+        {
+            "xmlAttribute": "Type",
+            "type": "enum",
+            "enum": ["SingleNode", "NodeRange", "Matrix"],
+            "default": "SingleNode",
+            "description": "How this face's parts map onto the model: named single nodes, node-range lists, or whole-matrix overlay images. Defaults to \"SingleNode\" when the attribute is absent; a legacy/unrecognized Type value is normalized on read to SingleNode (if the raw value was \"Coro\") or otherwise Matrix (DeserializeFaceInfo)."
+        },
+        {
+            "xmlAttribute": "CustomColors",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "appliesWhen": { "attribute": "Type", "oneOf": ["SingleNode", "NodeRange"] },
+            "description": "When \"1\", per-part colours (the <Part>-Color attributes) and the alternate \"...2\"/\"...3\" alternate-region rows are active in the face editor; when \"0\" all parts render using the sequence's own colour and the -Color attributes are ignored. Only meaningful for SingleNode/NodeRange faces - the Matrix editor tab has no CustomColors control (ModelFaceDialog.cpp SetGrid()/OnCheckBox handlers)."
+        },
+        {
+            "xmlAttribute": "ImagePlacement",
+            "type": "enum",
+            "enum": ["Centered", "Scaled", "Scale Keep Aspect Ratio", "Scale Keep Aspect Ratio Crop"],
+            "default": "Scaled",
+            "appliesWhen": { "attribute": "Type", "equals": "Matrix" },
+            "description": "How each phoneme/eye image is fitted into the model's render buffer for a Matrix face (MatrixImagePlacementChoice, ModelFaceDialog.cpp). Only present/meaningful for Type=\"Matrix\"; only ever set by the Matrix tab's placement dropdown (OnMatricImagePlacementChoiceSelect)."
+        }
+    ],
+    "notes": [
+        "Part names are an open-ended attribute vocabulary, not enumerated here: \"FaceOutline\" (plus an alternate region \"FaceOutline2\"), \"Eyes-Open\"/\"Eyes-Closed\" (plus alternates \"Eyes-Open2\"/\"Eyes-Open3\"/\"Eyes-Closed2\"/\"Eyes-Closed3\"), and \"Mouth-<Phoneme>\" for the 10 fixed phoneme codes AI, E, etc, FV, L, MBP, O, rest, U, WQ (plus each mouth phoneme's alternate \"Mouth-<Phoneme>2\" region) - see src-core/effects/FacesEffect.cpp for the canonical phoneme list and src-ui-wx/model/ModelFaceDialog.cpp SingleNodeGrid/NodeRangeGrid row labels.",
+        "For Type=SingleNode/NodeRange, each part attribute's value is either a single node name (SingleNode) or a compressed node-range list such as \"1-50,60\" (NodeRange; NodeUtils::CompressNodes). For Type=Matrix, each part instead has TWO attributes named \"<Part>-EyesOpen\" and \"<Part>-EyesClosed\" (e.g. \"Mouth-AI-EyesOpen\") each holding an image file path (SelectMatrixImage/GenerateKey, ModelFaceDialog.cpp) - Matrix faces never use the bare \"<Part>\" attribute name.",
+        "Optional per-part colour attributes use the suffix \"-Color\" with #RRGGBB values (e.g. \"Mouth-AI-Color\", \"FaceOutline-Color\"), only meaningful when CustomColors=\"1\"; unset/blank is treated as white (#FFFFFF) by the editor.",
+        "CORRECTION vs a naive reading of the brief: faceInfo's Type enum has 3 values (SingleNode/NodeRange/Matrix); stateInfo's Type enum (see shared/States.json) has only 2 (SingleNode/NodeRange) - there is no Matrix state type."
+    ]
+}

--- a/resources/modelsmetadata/shared/ScreenLocation.json
+++ b/resources/modelsmetadata/shared/ScreenLocation.json
@@ -1,0 +1,166 @@
+{
+    "schemaVersion": 1,
+    "description": "Position/size/rotation attributes on every <model> node in xlights_rgbeffects.xml. Every model uses exactly one of four ModelScreenLocation subclasses (Boxed / TwoPoint / ThreePoint / PolyPoint) selected by its DisplayAs (see shared/Common.json for the DisplayAs enum and notes below for the style mapping); which attributes are actually written depends on that style, not on any attribute defined in this fragment itself.",
+    "storage": { "file": "xlights_rgbeffects.xml", "node": "models/model" },
+    "properties": [
+        {
+            "xmlAttribute": "WorldPosX",
+            "type": "float",
+            "default": 0,
+            "relatedTo": ["WorldPosY", "WorldPosZ"],
+            "description": "World-space X position of the model's reference point (glm::vec3 GetWorldPosition().x), in layout units. Written/read for every style via BaseSerializingVisitor::AddModelScreenLocationAttributes / XmlSerialize::DeserializeModelScreenLocationAttributes. Property-grid key/label differ by style: Boxed exposes it as float property \"X\"/gridKey \"ModelX\"; TwoPoint/ThreePoint expose it as \"WorldX\"/gridKey \"WorldX\" (plus a redundant \"X1\"/gridKey \"ModelX1\" showing the same value, see notes); PolyPoint does not expose WorldPos directly (only per-point X1/Y1/Z1..XN/YN/ZN, each already offset by world position)."
+        },
+        {
+            "xmlAttribute": "WorldPosY",
+            "type": "float",
+            "default": 0,
+            "relatedTo": ["WorldPosX", "WorldPosZ"],
+            "description": "World-space Y position, matching WorldPosX (gridKey \"ModelY\" for Boxed, \"WorldY\"/\"ModelY1\" for TwoPoint/ThreePoint)."
+        },
+        {
+            "xmlAttribute": "WorldPosZ",
+            "type": "float",
+            "default": 0,
+            "relatedTo": ["WorldPosX", "WorldPosY"],
+            "description": "World-space Z position, matching WorldPosX (gridKey \"ModelZ\" for Boxed, \"WorldZ\"/\"ModelZ1\" for TwoPoint/ThreePoint)."
+        },
+        {
+            "xmlAttribute": "Locked",
+            "gridKey": "Locked",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "description": "When true, the model's position/size handles are locked against accidental drag/resize in the layout preview. Only the value \"1\" is ever written (BaseSerializingVisitor::AddModelScreenLocationAttributes writes it only when IsLocked() is true); absence means unlocked. Applies to all four location styles identically."
+        },
+        {
+            "xmlAttribute": "ScaleX",
+            "gridKey": "ScaleX",
+            "type": "float",
+            "default": 1.0,
+            "relatedTo": ["ScaleY", "ScaleZ"],
+            "description": "Bounding-box scale factor on X. Written for Boxed style (all Boxed-using DisplayAs types, plus every Dmx* model) and for PolyLine's PolyPoint style (AddPolyPointScreenLocationAttributes); NOT written for TwoPoint or ThreePoint styles (ChannelBlock, SingleLine, Arches, CandyCanes, Icicles) even though it is still read on load with default 1.0 for every style (XmlSerialize::DeserializeModelScreenLocationAttributes runs unconditionally). PolyLine's UI does not expose ScaleX/Y/Z directly (no property-grid entry); only Boxed models expose it as the \"ScaleX\" float property."
+        },
+        {
+            "xmlAttribute": "ScaleY",
+            "gridKey": "ScaleY",
+            "type": "float",
+            "default": 1.0,
+            "relatedTo": ["ScaleX", "ScaleZ"],
+            "description": "Bounding-box scale factor on Y; see ScaleX for which styles write/read/expose it."
+        },
+        {
+            "xmlAttribute": "ScaleZ",
+            "gridKey": "ScaleZ",
+            "type": "float",
+            "default": 1.0,
+            "relatedTo": ["ScaleX", "ScaleY"],
+            "description": "Bounding-box scale factor on Z; see ScaleX for which styles write/read/expose it. Boxed style only shows this property when the location supports Z scaling (BoxedScreenLocation::GetSupportsZScaling())."
+        },
+        {
+            "xmlAttribute": "RotateX",
+            "gridKey": "RotateX",
+            "type": "float",
+            "default": 0,
+            "min": -180,
+            "max": 180,
+            "relatedTo": ["RotateY", "RotateZ"],
+            "description": "Rotation around X, in degrees. Written for Boxed style (all 3 axes) and for ThreePoint style (X axis only - see BaseSerializingVisitor::AddThreePointScreenLocationAttributes, which writes RotateX but not RotateY/RotateZ); not written for TwoPoint or PolyPoint styles. Read unconditionally for every style with default 0."
+        },
+        {
+            "xmlAttribute": "RotateY",
+            "gridKey": "RotateY",
+            "type": "float",
+            "default": 0,
+            "min": -180,
+            "max": 180,
+            "relatedTo": ["RotateX", "RotateZ"],
+            "description": "Rotation around Y, in degrees. Written only for Boxed style; ThreePoint/TwoPoint/PolyPoint do not write this axis (ThreePoint models still rotate visually via RotateX + Angle + Shear)."
+        },
+        {
+            "xmlAttribute": "RotateZ",
+            "gridKey": "RotateZ",
+            "type": "float",
+            "default": 0,
+            "min": -180,
+            "max": 180,
+            "relatedTo": ["RotateX", "RotateY"],
+            "description": "Rotation around Z, in degrees. Written only for Boxed style; see RotateY."
+        },
+        {
+            "xmlAttribute": "X2",
+            "gridKey": "ModelX2",
+            "type": "float",
+            "default": 0,
+            "relatedTo": ["Y2", "Z2"],
+            "description": "TwoPoint/ThreePoint style only (ChannelBlock, SingleLine, Arches, CandyCanes, Icicles): X offset of the model's second point from WorldPosX (TwoPointScreenLocation::GetX2()/SetX2()). Verified trap: property-grid key \"ModelX2\" differs from the xmlAttribute \"X2\"; the grid additionally shows an absolute \"X2\" display value (GetX2() + GetWorldPos_X()) under the same key. Not present for Boxed or PolyPoint styles."
+        },
+        {
+            "xmlAttribute": "Y2",
+            "gridKey": "ModelY2",
+            "type": "float",
+            "default": 0,
+            "relatedTo": ["X2", "Z2"],
+            "description": "TwoPoint/ThreePoint style only: Y offset of the second point from WorldPosY; see X2."
+        },
+        {
+            "xmlAttribute": "Z2",
+            "gridKey": "ModelZ2",
+            "type": "float",
+            "default": 0,
+            "relatedTo": ["X2", "Y2"],
+            "description": "TwoPoint/ThreePoint style only: Z offset of the second point from WorldPosZ; see X2."
+        },
+        {
+            "xmlAttribute": "Angle",
+            "type": "int",
+            "default": 0,
+            "min": -180,
+            "max": 180,
+            "relatedTo": ["Shear", "Height"],
+            "description": "ThreePoint style only (Arches, CandyCanes, Icicles): integer tilt/skew angle in degrees around the model's own axis (ThreePointScreenLocation::GetAngle()/SetAngle(), gated by SetSupportsAngle(true) in each of those three model constructors). CORRECTION vs a naive reading of the C++: this is a distinct attribute from Shear, not an alias for it - both are always written together by AddThreePointScreenLocationAttributes. There is no single generic property-grid entry for it; each model type exposes it with its own label/gridKey over the SAME xmlAttribute and underlying value: ArchesPropertyAdapter exposes it as \"Arch Tilt\"/gridKey \"ArchesSkew\" (min/max -180..180), CandyCanePropertyAdapter as \"Cane Rotation\"/gridKey \"CandyCaneSkew\". Icicles does not expose a UI control for it (always 0)."
+        },
+        {
+            "xmlAttribute": "Shear",
+            "gridKey": "ModelShear",
+            "type": "float",
+            "default": 0.0,
+            "relatedTo": ["Angle", "Height"],
+            "description": "ThreePoint style only: Y-shear factor (ThreePointScreenLocation::GetYShear()/SetYShear(), backed by member GetShear()/SetShear()). Effective only when the model's screen location was constructed with SetSupportsShear(true) (GetYShear() forces 0.0 otherwise), but the attribute is always written regardless. Exposed as a \"Shear\" float property only when ScreenLocationPropertyHelper detects GetSupportsShear()."
+        },
+        {
+            "xmlAttribute": "Height",
+            "gridKey": "ModelHeight",
+            "type": "float",
+            "default": 1.0,
+            "relatedTo": ["Angle", "Shear"],
+            "description": "ThreePoint style only: relative model height factor (ThreePointScreenLocation::GetMHeight()/SetMHeight(), aliased by GetHeight()/SetHeight()). NOTE: this shares the generic xmlAttribute name \"Height\" (XmlNodeKeys::HeightAttribute) also used for unrelated Width/Height/Depth-style attributes elsewhere (e.g. the Mesh view-object child element) - those live on different XML elements so there is no collision, but do not confuse this ThreePoint Height with a Boxed model's rendered dimensions (which are NOT persisted directly - see notes)."
+        },
+        {
+            "xmlAttribute": "NumPoints",
+            "type": "uint",
+            "default": 2,
+            "min": 2,
+            "description": "PolyPoint style only (PolyLine; also used more sparingly by MultiPoint via the lighter AddMultiPointScreenLocationAttributes): number of vertices in PointData (PolyPointScreenLocation::GetNumPoints()/SetNumPoints()). Drives how many comma-separated triples PointData/cPointData contain."
+        },
+        {
+            "xmlAttribute": "PointData",
+            "type": "string",
+            "default": "0.0, 0.0, 0.0, 0.0, 0.0, 0.0",
+            "encoding": "Comma-separated flat list of floats, 3 per point (x,y,z), NumPoints triples total, in point order: \"x0,y0,z0,x1,y1,z1,...,x{N-1},y{N-1},z{N-1}\". Coordinates are relative to the model's world position/scale. Produced/parsed by PolyPointScreenLocation::GetPointDataAsString()/SetDataFromString().",
+            "description": "PolyPoint style only: the raw vertex coordinates of every point in the poly-line/multi-point path."
+        },
+        {
+            "xmlAttribute": "cPointData",
+            "type": "string",
+            "default": "",
+            "encoding": "Comma-separated repeating groups of 7 fields, one group per curved segment: \"segIndex,cp0x,cp0y,cp0z,cp1x,cp1y,cp1z,\" (trailing comma after each group; segments without a curve are omitted entirely, not zero-filled). segIndex is the 0-based index of the segment's start point; cp0/cp1 are the cubic Bezier control points for that segment. Produced/parsed by PolyPointScreenLocation::GetCurveDataAsString()/SetCurveDataFromString().",
+            "description": "PolyPoint style only, PolyLine specifically (not written by MultiPoint's lighter AddMultiPointScreenLocationAttributes): optional per-segment cubic-Bezier curve data overlaid on top of the straight-line PointData path. Empty string / absent means no segments are curved."
+        }
+    ],
+    "notes": [
+        "Style-to-DisplayAs mapping (verified against BaseSerializingVisitor.cpp Visit() overloads): Boxed = Circle, Cube, Custom, Image, Label, Matrix, Sphere, Spinner, Star, Tree, Window Frame, Wreath, and every Dmx* type (DmxFloodArea, DmxFloodlight, DmxGeneral, DmxMovingHead, DmxMovingHeadAdv, DmxServo, DmxServo3d, DmxSkull) via AddDmxModelAttributes. TwoPoint = Channel Block, Single Line. ThreePoint = Arches, Candy Canes, Icicles (all three call SetSupportsAngle(true) in their constructors; only CandyCanes/Arches expose Angle in their property grid). PolyPoint (full, with ScaleX/Y/Z + cPointData) = Poly Line. PolyPoint (light, NumPoints + PointData only, no scale/curve) = MultiPoint.",
+        "RealWidth, RealHeight, RealDepth and RealLength are NOT persisted XML attributes - they are derived, on-the-fly computed property-grid display values (BoxedScreenLocation::GetRealWidth/GetRealHeight/GetRealDepth for Boxed; RulerObject::Measure(point1, point2) for TwoPoint/ThreePoint/PolyPoint) shown in real-world units via ScreenLocationPropertyHelper::AddDimensionProperties. Editing them in the UI back-solves ScaleX/Y/Z (Boxed) or the X2/Y2/Z2 offsets (TwoPoint) - it does not add a new XML attribute. This corrects the survey's open question about whether they persist: they do not.",
+        "A separate, unrelated <dimensions> child element (XmlNodeKeys::DimNodeName, attributes units/width/height/depth) is written only during export (forExport flag, BaseSerializingVisitor::WriteDimensionsElement) from the same Real* getters, in the ruler's configured display units (mm/inches/feet/yards/cm/m). It is informational/export-only and is not modeled in this fragment; see childElements in a future task if needed.",
+        "PolyLine additionally persists auxiliary per-point/per-segment data on the <model> element itself (outside ScreenLocation): dynamic-indexed \"CornerN\", \"SegN\" and per-node \"StartNodeN\" attributes (see PolyLineModel::CornerAttrName/SegAttrName/StartNodeAttrName) plus \"SegsExpanded\" (bool, TRUE/FALSE). These are PolyLine-specific, not shared ScreenLocation concepts, and are left to models/PolyLine.json."
+    ]
+}

--- a/resources/modelsmetadata/shared/ScreenLocation.json
+++ b/resources/modelsmetadata/shared/ScreenLocation.json
@@ -28,7 +28,7 @@
             "xmlAttribute": "Locked",
             "gridKey": "Locked",
             "type": "bool",
-            "boolFormat": "01",
+            "boolFormat": "presentOnly",
             "default": "0",
             "description": "When true, the model's position/size handles are locked against accidental drag/resize in the layout preview. Only the value \"1\" is ever written (BaseSerializingVisitor::AddModelScreenLocationAttributes writes it only when IsLocked() is true); absence means unlocked. Applies to all four location styles identically."
         },

--- a/resources/modelsmetadata/shared/States.json
+++ b/resources/modelsmetadata/shared/States.json
@@ -1,0 +1,30 @@
+{
+    "schemaVersion": 1,
+    "description": "The <stateInfo> child elements of a <model> node in xlights_rgbeffects.xml: named custom-state definitions consumed by the State effect. A model may define any number of named states (Model::stateInfo, a map of state name -> attribute map). Source of truth: src-core/models/Model.cpp (Model::stateInfo/GetStateInfo/SetStateInfo) with the shared faceInfo/stateInfo writer BaseSerializingVisitor::WriteFacesAndStates, and src-core/XmlSerializer/XmlSerializeFunctions.cpp DeserializeStateInfo (reader); editing UI is src-ui-wx/model/ModelStateDialog.cpp; consumed at render time by src-core/effects/StateEffect.cpp.",
+    "storage": { "file": "xlights_rgbeffects.xml", "node": "models/model", "element": "stateInfo" },
+    "properties": [
+        {
+            "xmlAttribute": "Name",
+            "type": "string",
+            "description": "State definition name, unique within the model. Read via the same XmlNodeKeys::StateNameAttribute (\"Name\") key faceInfo uses. Defaults to the literal string \"SingleNode\" if the attribute is missing entirely; if present but empty, falls back to the Type value instead (DeserializeStateInfo)."
+        },
+        {
+            "xmlAttribute": "Type",
+            "type": "enum",
+            "enum": ["SingleNode", "NodeRange"],
+            "default": "SingleNode",
+            "description": "How this state's rows map onto the model: named single nodes or node-range lists. CORRECTION vs a naive reading of the C++/brief: unlike faceInfo, stateInfo has no \"Matrix\" Type value - src-core/XmlSerializer/XmlSerializeFunctions.cpp DeserializeStateInfo and src-ui-wx/model/ModelStateDialog.cpp only ever construct/recognize SingleNode or NodeRange. A legacy \"Coro\" value is normalized on read to SingleNode."
+        },
+        {
+            "xmlAttribute": "CustomColors",
+            "type": "bool",
+            "boolFormat": "01",
+            "default": "0",
+            "description": "When \"1\", each defined row's custom colour (the sNNN-Color attribute) is honoured; when \"0\" states render using the sequence's own colour and sNNN-Color attributes are ignored (ModelStateDialog.cpp SetGrid(); src-core/effects/StateEffect.cpp findKey(...,\"CustomColors\"))."
+        }
+    ],
+    "notes": [
+        "Row attributes are an open-ended, zero-padded attribute family - NOT the \"s1\"/\"s1-Name\"/\"s1-Color\" pattern a naive reading of the property-grid row numbers might suggest. CORRECTION (verified file:line): the persisted key is always \"s\" plus a 3-digit zero-padded row number, e.g. \"s001\", \"s002\", ... up to \"s200\" (SingleNodeGrid/NodeRangeGrid both CreateGrid(200, 3), src-ui-wx/model/ModelStateDialog.cpp). See ModelStateDialog.cpp lines 496, 640, 1009, 1490-1526 and 2309 (all wxString::Format(\"s%03d\", ...)) for the write/UI side, and src-core/XmlSerializer/XmlSerializeFunctions.cpp DeserializeStateInfo lines 250-258, which actively RE-NORMALIZES any legacy unpadded key (e.g. an old file's bare \"s1\") to \"s001\" while loading - so an unpadded form never round-trips through a save.",
+        "Each row is really up to three attributes sharing the same \"sNNN\" prefix: \"sNNN\" itself holds the node name (Type=SingleNode) or a compressed node-range list (Type=NodeRange); \"sNNN-Name\" holds the user-assigned state label, matched case-insensitively against sequence effect tokens (StateEffect.cpp); \"sNNN-Color\" holds an optional #RRGGBB override, only meaningful when CustomColors=\"1\". A row with no value is simply absent from the XML - DeserializeStateInfo only stores non-empty attribute values to keep the file small."
+    ]
+}

--- a/resources/modelsmetadata/shared/SubModels.json
+++ b/resources/modelsmetadata/shared/SubModels.json
@@ -1,0 +1,45 @@
+{
+    "schemaVersion": 1,
+    "description": "The <subModel> child elements of a <model> node in xlights_rgbeffects.xml: user-defined sub-regions of a model's nodes (e.g. individual arches within an arch set, or windows within a window-frame prop) that can be sequenced independently of the parent model. Source of truth: src-core/XmlSerializer/BaseSerializingVisitor.cpp BaseSerializingVisitor::WriteSubmodels (writer) and src-core/XmlSerializer/XmlSerializeFunctions.cpp ParseSubModelNode plus src-core/XmlSerializer/XmlDeserializingModelFactory.cpp DeserializeSubModel (readers); backing class is src-core/models/SubModel.h/.cpp; editing UI is src-ui-wx/model/SubModelsDialog.cpp.",
+    "storage": { "file": "xlights_rgbeffects.xml", "node": "models/model", "element": "subModel" },
+    "properties": [
+        {
+            "xmlAttribute": "name",
+            "type": "string",
+            "description": "Sub-model name, unique within the parent model (XmlNodeKeys::NameAttribute = \"name\", lowercase - a distinct attribute key from the model-level \"name\" or the faceInfo/stateInfo \"Name\"). Elsewhere in the file (group membership, effects) the sub-model is referenced by its qualified name \"<ParentModel>/<name>\"."
+        },
+        {
+            "xmlAttribute": "layout",
+            "type": "enum",
+            "enum": ["vertical", "horizontal"],
+            "default": "vertical",
+            "description": "Orientation used when laying out this sub-model's default render buffer (SubModel::IsVertical(); XmlNodeKeys::LayoutAttribute). Always written; defaults to \"vertical\" on read if absent."
+        },
+        {
+            "xmlAttribute": "type",
+            "type": "enum",
+            "enum": ["ranges", "subbuffer"],
+            "default": "ranges",
+            "description": "Whether the sub-model is defined by explicit per-row node-range lists (\"ranges\": see line0/line1/... in notes) or by a single rectangular crop of the parent's default buffer (\"subbuffer\": see the subBuffer attribute). XmlNodeKeys::SMTypeAttribute; always written; defaults to \"ranges\" on read if absent."
+        },
+        {
+            "xmlAttribute": "bufferstyle",
+            "type": "enum",
+            "enum": ["Default", "Keep XY", "Stacked Strands"],
+            "default": "Default",
+            "description": "How the sub-model's node rows are packed into its own render buffer (SubModel::BUFFER_STYLES/GetSubModelBufferStyle()): \"Default\" packs each line0/line1/... row into its own buffer row; \"Keep XY\" (SubModel::IsXYBufferStyle()) preserves each node's original X/Y position from the parent's buffer; \"Stacked Strands\" overlays every row onto the same buffer row. XmlNodeKeys::BufferStyleAttribute (lowercase). Always written regardless of the \"type\" attribute (BaseSerializingVisitor::WriteSubmodels adds it unconditionally), though it is only functionally meaningful for type=\"ranges\" sub-models; defaults to \"Default\" on read if absent."
+        },
+        {
+            "xmlAttribute": "subBuffer",
+            "type": "string",
+            "appliesWhen": { "attribute": "type", "equals": "subbuffer" },
+            "encoding": "Four percentages (0-100) joined by literal 'x' characters: \"x1xy1xx2xy2\", e.g. \"0x0x100x100\" for the whole buffer or \"25x25x75x75\" for the centre quadrant (SubModel::initSubbufferRange, split on 'x'). Missing trailing values default to x1=0,y1=0,x2=100,y2=100; x1/x2 and y1/y2 are swapped if given in reverse order.",
+            "description": "Rectangular crop of the parent model's default render buffer, expressed as percentages of its width/height. Only present when type=\"subbuffer\"; mutually exclusive with the line0/line1/... rows described in notes."
+        }
+    ],
+    "notes": [
+        "Node-range rows are an open-ended, positionally-named attribute family, not enumerated here: \"line0\", \"line1\", ... \"lineN\" (0-based, contiguous - both ParseSubModelNode and Model::CreateBufferAsSubmodel read/write them by probing line0, line1, ... until one is missing). Only present when type=\"ranges\"; each value is a compressed node-number/range list in the parent model's own node numbering, e.g. \"1-50,60\" (NodeUtils::CompressNodes), one row per buffer line.",
+        "A subModel may contain a nested <Aliases> child element (zero or more <alias name=\"...\"/> children) for alternate historical names, exactly like a top-level <model> - written by the shared BaseSerializingVisitor::WriteAliases helper only when the sub-model has aliases. Legacy files may instead use the lowercase element name \"aliases\"; both spellings are accepted on read (XmlDeserializingModelFactory::DeserializeSubModel).",
+        "The specially-named sub-model \"DefaultRenderBuffer\" (Model::CreateBufferAsSubmodel) is a synthesized ranges-type subModel representing the model's own default buffer layout, generated on demand (e.g. for export) rather than user-authored; it uses the same attribute shape described here."
+    ]
+}

--- a/xlDo/xldo_metadata.json
+++ b/xlDo/xldo_metadata.json
@@ -1,0 +1,434 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "xLights xlDo Automation API Metadata",
+    "description": "Specification of the HTTP Automation API server built into xLights and accessed via xlDo or raw HTTP requests.",
+    "server": {
+        "ports": {
+            "defaultA": 49913,
+            "defaultB": 49914,
+            "description": "Enabled by launching xLights with '-a' (Port 49913) or '-b' (Port 49914) command-line flags, or by setting xFadePort preference in settings."
+        },
+        "endpoints": {
+            "version": {
+                "path": "/getVersion",
+                "method": "GET",
+                "description": "Returns the active xLights version string."
+            },
+            "automation": {
+                "path": "/xlDoAutomation",
+                "method": "POST",
+                "contentType": "application/json",
+                "description": "Primary endpoint for executing JSON-formatted automation commands.",
+                "requestFormat": "The POST body is a single FLAT JSON object: {\"cmd\": \"<commandName>\", ...params}. Every command's own parameters (e.g. \"folder\", \"force\") must be TOP-LEVEL keys sibling to \"cmd\" - do NOT nest them under a \"parameters\"/\"params\" wrapper object. Verified 2026-07-18 against xLightsFrame::ProcessxlDoAutomation (src-ui-wx/automation/xLightsAutomations.cpp): it parses the body, requires a top-level \"cmd\" string, and for every OTHER key copies string/int/float/bool/array values into a flat parameter map - an object-typed value (e.g. a nested \"parameters\": {...}) matches none of those branches and is SILENTLY DROPPED, so the command receives that parameter as empty/missing with no error. A misshapen changeShowFolder call with folder nested under \"parameters\" produced 'Folder does not exist.' instead of a shape/validation error, because the handler just saw an empty folder string. Correct example: {\"cmd\":\"changeShowFolder\",\"folder\":\"/path/to/showfolder\",\"force\":true}. Success/failure is signaled by the HTTP status code (200 = success; 503 = command-specific rejection, e.g. unsaved changes; 504 = missing \"cmd\"), with a small JSON body such as {\"msg\":\"...\"} or command-specific fields - curl callers should check the status code (e.g. `curl -i` or `-w '%{http_code}'`), not just whether a body came back, since some successful responses can be entirely absent (e.g. changeShowFolder on success)."
+            }
+        }
+    },
+    "commands": [
+        {
+            "name": "saveLayout",
+            "description": "Saves layout changes (xlights_rgbeffects.xml) and setup network/controller changes (xlights_networks.xml) to disk.",
+            "parameters": []
+        },
+        {
+            "name": "changeShowFolder",
+            "description": "Changes the active show folder and reloads all layout/network configurations from disk.",
+            "parameters": [
+                {
+                    "name": "folder",
+                    "type": "string",
+                    "required": true,
+                    "description": "Absolute path to the new show folder."
+                },
+                {
+                    "name": "force",
+                    "type": "boolean",
+                    "required": false,
+                    "default": false,
+                    "description": "Force change folder even if there are unsaved changes."
+                }
+            ]
+        },
+        {
+            "name": "getShowFolder",
+            "description": "Retrieves the active show folder path.",
+            "parameters": []
+        },
+        {
+            "name": "listSequences",
+            "description": "Lists all sequence files (.xsq, .xsqz, .zip, .piz) in a given folder.",
+            "parameters": [
+                {
+                    "name": "folder",
+                    "type": "string",
+                    "required": true,
+                    "description": "Absolute path to the target folder."
+                }
+            ]
+        },
+        {
+            "name": "getSequenceInfo",
+            "description": "Returns metadata about a sequence file.",
+            "parameters": [
+                {
+                    "name": "filename",
+                    "type": "string",
+                    "required": true,
+                    "description": "Path to the sequence file."
+                }
+            ]
+        },
+        {
+            "name": "openSequence",
+            "description": "Opens a sequence in the sequencer.",
+            "parameters": [
+                {
+                    "name": "seq",
+                    "type": "string",
+                    "required": true,
+                    "description": "Path to the sequence file."
+                },
+                {
+                    "name": "promptIssues",
+                    "type": "boolean",
+                    "required": false,
+                    "default": false,
+                    "description": "If true, prompts for warnings/issues on load."
+                },
+                {
+                    "name": "force",
+                    "type": "boolean",
+                    "required": false,
+                    "default": false,
+                    "description": "Forces opening even if another sequence has unsaved changes."
+                }
+            ]
+        },
+        {
+            "name": "closeSequence",
+            "description": "Closes the active sequence.",
+            "parameters": [
+                {
+                    "name": "force",
+                    "type": "boolean",
+                    "required": false,
+                    "default": false,
+                    "description": "Closes even if there are unsaved changes."
+                },
+                {
+                    "name": "quiet",
+                    "type": "boolean",
+                    "required": false,
+                    "default": false,
+                    "description": "Suppress warning if no sequence is open."
+                }
+            ]
+        },
+        {
+            "name": "newSequence",
+            "description": "Creates a new sequence.",
+            "parameters": [
+                {
+                    "name": "mediaFile",
+                    "type": "string",
+                    "required": false,
+                    "description": "Path to the audio/video media file."
+                },
+                {
+                    "name": "durationSecs",
+                    "type": "integer",
+                    "required": false,
+                    "description": "Duration in seconds (required if no media file)."
+                },
+                {
+                    "name": "frameMS",
+                    "type": "integer",
+                    "required": false,
+                    "default": 50,
+                    "description": "Timing interval in milliseconds."
+                },
+                {
+                    "name": "view",
+                    "type": "string",
+                    "required": false,
+                    "description": "Name of the starting grid view."
+                },
+                {
+                    "name": "force",
+                    "type": "boolean",
+                    "required": false,
+                    "default": false,
+                    "description": "Forces new creation even if active sequence has unsaved changes."
+                }
+            ]
+        },
+        {
+            "name": "saveSequence",
+            "description": "Saves the open sequence.",
+            "parameters": [
+                {
+                    "name": "seq",
+                    "type": "string",
+                    "required": false,
+                    "description": "Save-as path (optional; overrides active file name)."
+                }
+            ]
+        },
+        {
+            "name": "renderAll",
+            "description": "Renders all effects in the active sequence.",
+            "parameters": [
+                {
+                    "name": "highdef",
+                    "type": "boolean",
+                    "required": false,
+                    "default": false,
+                    "description": "Forces high-definition rendering mode."
+                }
+            ]
+        },
+        {
+            "name": "batchRender",
+            "description": "Renders multiple sequences in batch mode.",
+            "parameters": [
+                {
+                    "name": "files",
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "required": true,
+                    "description": "List of sequence file paths to render."
+                },
+                {
+                    "name": "lowdef",
+                    "type": "boolean",
+                    "required": false,
+                    "default": false,
+                    "description": "Render in low definition to speed up rendering."
+                }
+            ]
+        },
+        {
+            "name": "uploadController",
+            "description": "Uploads configuration to a controller.",
+            "parameters": [
+                {
+                    "name": "controller",
+                    "type": "string",
+                    "required": true,
+                    "description": "Name of the controller to upload to."
+                },
+                {
+                    "name": "force",
+                    "type": "boolean",
+                    "required": false,
+                    "default": false,
+                    "description": "Forces upload regardless of state."
+                }
+            ]
+        },
+        {
+            "name": "uploadFPPConfig",
+            "description": "Uploads network and layout configuration to FPP.",
+            "parameters": []
+        },
+        {
+            "name": "uploadSequence",
+            "description": "Uploads the sequence and media to the controller.",
+            "parameters": [
+                {
+                    "name": "controller",
+                    "type": "string",
+                    "required": true,
+                    "description": "Name of the target controller."
+                }
+            ]
+        },
+        {
+            "name": "checkSequence",
+            "description": "Runs validation checks on a sequence and returns the output log.",
+            "parameters": [
+                {
+                    "name": "seq",
+                    "type": "string",
+                    "required": true,
+                    "description": "Path to the sequence file to check."
+                }
+            ]
+        },
+        {
+            "name": "openController",
+            "description": "Opens the configuration page of a controller in the default browser.",
+            "parameters": [
+                {
+                    "name": "ip",
+                    "type": "string",
+                    "required": true,
+                    "description": "IP address of the controller."
+                }
+            ]
+        },
+        {
+            "name": "exportModelsCSV",
+            "description": "Exports layout models configuration to a CSV file.",
+            "parameters": [
+                {
+                    "name": "filename",
+                    "type": "string",
+                    "required": true,
+                    "description": "Output path of the CSV."
+                }
+            ]
+        },
+        {
+            "name": "exportModel",
+            "description": "Exports a specific model layout to a file.",
+            "parameters": [
+                {
+                    "name": "model",
+                    "type": "string",
+                    "required": true,
+                    "description": "Name of the model."
+                },
+                {
+                    "name": "filename",
+                    "type": "string",
+                    "required": true,
+                    "description": "Target filename."
+                }
+            ]
+        },
+        {
+            "name": "closexLights",
+            "description": "Shuts down the xLights application instance.",
+            "parameters": [
+                {
+                    "name": "force",
+                    "type": "boolean",
+                    "required": false,
+                    "default": false,
+                    "description": "Force shutdown even with unsaved changes."
+                }
+            ]
+        },
+        {
+            "name": "lightsOn",
+            "description": "Enables output to lights.",
+            "parameters": []
+        },
+        {
+            "name": "lightsOff",
+            "description": "Disables output to lights.",
+            "parameters": []
+        },
+        {
+            "name": "playJukebox",
+            "description": "Plays Jukebox item.",
+            "parameters": [
+                {
+                    "name": "index",
+                    "type": "integer",
+                    "required": true,
+                    "description": "0-based index of the jukebox item to trigger."
+                }
+            ]
+        },
+        {
+            "name": "getModels",
+            "description": "Lists all configured models in the active layout.",
+            "parameters": []
+        },
+        {
+            "name": "getModel",
+            "description": "Retrieves configuration details of a specific model.",
+            "parameters": [
+                {
+                    "name": "model",
+                    "type": "string",
+                    "required": true,
+                    "description": "Name of the model."
+                }
+            ]
+        },
+        {
+            "name": "getControllers",
+            "description": "Lists all configured controllers.",
+            "parameters": []
+        },
+        {
+            "name": "getControllerIPs",
+            "description": "Lists IP addresses of all configured controllers.",
+            "parameters": []
+        },
+        {
+            "name": "addEffect",
+            "description": "Adds an effect to the sequence timeline.",
+            "parameters": [
+                {
+                    "name": "model",
+                    "type": "string",
+                    "required": true,
+                    "description": "Name of the target model or group."
+                },
+                {
+                    "name": "layer",
+                    "type": "integer",
+                    "required": true,
+                    "description": "Target layer index."
+                },
+                {
+                    "name": "effectType",
+                    "type": "string",
+                    "required": true,
+                    "description": "Type/name of the effect to add (e.g. 'Fire', 'Bars')."
+                },
+                {
+                    "name": "startMS",
+                    "type": "integer",
+                    "required": true,
+                    "description": "Start time in milliseconds."
+                },
+                {
+                    "name": "endMS",
+                    "type": "integer",
+                    "required": true,
+                    "description": "End time in milliseconds."
+                }
+            ]
+        },
+        {
+            "name": "setModelProperty",
+            "description": "Modifies a setting on a layout model.",
+            "parameters": [
+                {
+                    "name": "model",
+                    "type": "string",
+                    "required": true,
+                    "description": "Name of the model."
+                },
+                {
+                    "name": "property",
+                    "type": "string",
+                    "required": true,
+                    "description": "XML attribute/property key to change."
+                },
+                {
+                    "name": "value",
+                    "type": "string",
+                    "required": true,
+                    "description": "New value."
+                }
+            ]
+        },
+        {
+            "name": "runScript",
+            "description": "Runs a custom script (e.g., Python/Lua).",
+            "parameters": [
+                {
+                    "name": "script",
+                    "type": "string",
+                    "required": true,
+                    "description": "Path to the script file."
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This allows agents to manage show folder items, create and edit models.

Can you add five 3-layer Stars to my show layout (xLights_Testing/Playground), with the layers being 50 inside, 60 middle, and 70 outside?
Please convert the matrix in my current show folder to a custom matrix so I can have individual star channels and set them to 250 per port, except the last one at 200.
Please create a group of the two matrices, called 'All Matrices'

<img width="342" height="309" alt="image" src="https://github.com/user-attachments/assets/529e52f2-d943-46b4-9137-5ea7ec79e14c" />

And the crazy part is that it used this info to add a DMX model and test the last fix by actually creating a sequence and validating channel data values.