### PR TITLE
Fix Servo 3D preview: pivot offsets, mesh linkage, and Zero Behavior accuracy

### DIFF
--- a/plans/ipad-parity/06-layout-models-preview.md
+++ b/plans/ipad-parity/06-layout-models-preview.md
@@ -155,7 +155,7 @@
 | Mesh object file picker (.obj/.3ds/.stl/.ply) | dialog | ✅ | ✅ | parity | P2 | medium | feasible | iPad mesh-file picker w/ UTType filter. |
 | Terrain object height-map / editing | dialog | ✅ | 🟡 | ipad-missing | P3 | hard | feasible | iPad terrain edit target flow; full height-map paint scope narrower than desktop TerrainObjectPropertyAdapter. |
 | DMX MovingHead / MovingHeadAdv create + props | menu/panel | ✅ | ✅ | parity | P2 | hard | feasible | iPad AddModelSheet + descriptor (fixture/mode), MovingHeadFixtureRowView. |
-| DMX Servo / Servo3D create + props | menu/panel | ✅ | ✅ | parity | P2 | hard | feasible | iPad add types + descriptor. |
+| DMX Servo / Servo3D create + props | menu/panel | ✅ | ✅ | parity | P2 | hard | feasible | iPad add types + descriptor. Shared-core fixes (auto-applied, no iPad work needed): dynamically-added Servo3D servos now get Pivot Offset Z + correct pivot scale (`Servo.h`/`DmxServo3D.cpp`), Mesh Linkage now resolves a parented mesh's driving servo via `servo_links` instead of assuming servo index == mesh index (`DmxServo3D.cpp` `applyMeshServos`), and the preview now honors each servo's Controller Zero Behavior using pixel-alpha to detect an undriven channel instead of the ambiguous `value == 0` (`DmxModel::IsChannelDriven`, `Servo::GetPosition`). |
 | DMX Skull create + props | menu/panel | ✅ | ✅ | parity | P2 | hard | feasible | iPad add types + descriptor (Skulltronix preset). |
 | DMX Floodlight create + props | menu/panel | ✅ | ✅ | parity | P2 | hard | feasible | iPad add types + descriptor. |
 | DMX General create + props | menu/panel | ✅ | ✅ | parity | P2 | hard | feasible | iPad add types + descriptor. |

--- a/src-core/models/DMX/DmxModel.cpp
+++ b/src-core/models/DMX/DmxModel.cpp
@@ -131,6 +131,31 @@ int DmxModel::GetChannelValue(int channel, bool bits16)
     return ret_val;
 }
 
+// RenderBuffer pixels are cleared to alpha=0 each frame and only effects that
+// actually paint a channel raise it (ServoEffect writes opaque, alpha=255)
+// -- so alpha, not the value itself, is the reliable "was this channel
+// actually driven this frame" signal. A raw value of 0 is legitimate real
+// data (e.g. a value curve sweeping through the bottom of its range) and
+// must not be treated as "no effect present".
+bool DmxModel::IsChannelDriven(int channel, bool bits16) const
+{
+    xlColor color_angle;
+    if (bits16) {
+        if ((int)Nodes.size() > channel + 1) {
+            Nodes[channel]->GetColor(color_angle);
+            if (color_angle.alpha != 0) return true;
+            Nodes[channel + 1]->GetColor(color_angle);
+            return color_angle.alpha != 0;
+        }
+    } else {
+        if ((int)Nodes.size() > channel) {
+            Nodes[channel]->GetColor(color_angle);
+            return color_angle.alpha != 0;
+        }
+    }
+    return false;
+}
+
 // support for moving heads or devices where coarse and fine channels are not contiguous
 int DmxModel::GetChannelValue(int channel_coarse, int channel_fine)
 {

--- a/src-core/models/DMX/DmxModel.cpp
+++ b/src-core/models/DMX/DmxModel.cpp
@@ -106,19 +106,29 @@ void DmxModel::InitModel()
     SetBufferSize(1, _dmxChannelCount);
 }
 
-int DmxModel::GetChannelValue(int channel, bool bits16)
+// RenderBuffer pixels are cleared to alpha=0 each frame and only effects that
+// actually paint a channel raise it (ServoEffect writes opaque, alpha=255)
+// -- so alpha, not the value itself, is the reliable "was this channel
+// actually driven this frame" signal. A raw value of 0 is legitimate real
+// data (e.g. a value curve sweeping through the bottom of its range) and
+// must not be treated as "no effect present". `driven`, if non-null, is set
+// to that signal so callers don't need a second Nodes[] lookup for it.
+int DmxModel::GetChannelValue(int channel, bool bits16, bool* driven)
 {
     xlColor color_angle;
     int lsb = 0;
     int msb = 0;
     int ret_val = 0;
+    bool isDriven = false;
 
     if (bits16) {
         if ((int)Nodes.size() > channel + 1) {
             Nodes[channel]->GetColor(color_angle);
             msb = color_angle.red;
+            isDriven = color_angle.alpha != 0;
             Nodes[channel + 1]->GetColor(color_angle);
             lsb = color_angle.red;
+            isDriven = isDriven || color_angle.alpha != 0;
             ret_val = ((msb << 8) | lsb);
         }
     }
@@ -126,34 +136,11 @@ int DmxModel::GetChannelValue(int channel, bool bits16)
         if ((int)Nodes.size() > channel) {
             Nodes[channel]->GetColor(color_angle);
             ret_val = color_angle.red;
+            isDriven = color_angle.alpha != 0;
         }
     }
+    if (driven) *driven = isDriven;
     return ret_val;
-}
-
-// RenderBuffer pixels are cleared to alpha=0 each frame and only effects that
-// actually paint a channel raise it (ServoEffect writes opaque, alpha=255)
-// -- so alpha, not the value itself, is the reliable "was this channel
-// actually driven this frame" signal. A raw value of 0 is legitimate real
-// data (e.g. a value curve sweeping through the bottom of its range) and
-// must not be treated as "no effect present".
-bool DmxModel::IsChannelDriven(int channel, bool bits16) const
-{
-    xlColor color_angle;
-    if (bits16) {
-        if ((int)Nodes.size() > channel + 1) {
-            Nodes[channel]->GetColor(color_angle);
-            if (color_angle.alpha != 0) return true;
-            Nodes[channel + 1]->GetColor(color_angle);
-            return color_angle.alpha != 0;
-        }
-    } else {
-        if ((int)Nodes.size() > channel) {
-            Nodes[channel]->GetColor(color_angle);
-            return color_angle.alpha != 0;
-        }
-    }
-    return false;
 }
 
 // support for moving heads or devices where coarse and fine channels are not contiguous

--- a/src-core/models/DMX/DmxModel.h
+++ b/src-core/models/DMX/DmxModel.h
@@ -66,9 +66,8 @@ class DmxModel : public ModelWithScreenLocation<BoxedScreenLocation>
     protected:
         virtual void InitModel() override;
 
-        virtual int GetChannelValue( int channel, bool bits16);
+        virtual int GetChannelValue( int channel, bool bits16, bool* driven = nullptr);
         int GetChannelValue(int channel_coarse, int channel_fine);
-        bool IsChannelDriven(int channel, bool bits16) const;
         void SetNodeNames(const std::string& default_names, bool force = false);
 
         int _dmxChannelCount = 1;

--- a/src-core/models/DMX/DmxModel.h
+++ b/src-core/models/DMX/DmxModel.h
@@ -68,6 +68,7 @@ class DmxModel : public ModelWithScreenLocation<BoxedScreenLocation>
 
         virtual int GetChannelValue( int channel, bool bits16);
         int GetChannelValue(int channel_coarse, int channel_fine);
+        bool IsChannelDriven(int channel, bool bits16) const;
         void SetNodeNames(const std::string& default_names, bool force = false);
 
         int _dmxChannelCount = 1;

--- a/src-core/models/DMX/DmxServo.cpp
+++ b/src-core/models/DMX/DmxServo.cpp
@@ -294,7 +294,9 @@ void DmxServo::DrawModel(IModelPreview* preview, xlGraphicsContext* ctx, xlGraph
         if (servos[i]->GetChannel() > 0 && active) {
             int chan = servos[i]->GetChannel() - 1;
             bool bits16 = servos[i]->Is16Bit();
-            servo_pos[i] = servos[i]->GetPosition(GetChannelValue(chan, bits16), IsChannelDriven(chan, bits16));
+            bool driven = false;
+            int value = GetChannelValue(chan, bits16, &driven);
+            servo_pos[i] = servos[i]->GetPosition(value, driven);
         }
         servos[i]->FillMotionMatrix(servo_pos[i], motionMatrix);
         motionMatrix = glm::translate(motionMatrix, glm::vec3(0, 0, 0.2 * float(i) + 0.1));

--- a/src-core/models/DMX/DmxServo.cpp
+++ b/src-core/models/DMX/DmxServo.cpp
@@ -292,7 +292,9 @@ void DmxServo::DrawModel(IModelPreview* preview, xlGraphicsContext* ctx, xlGraph
         motionMatrix = glm::translate(motionMatrix, glm::vec3(0, 0, 0.2 * float(i)));
         static_images[i]->Draw(this, preview, program, motionMatrix, transparency, brightness, !motion_images[i]->GetExists(), 0, 0, false, false);
         if (servos[i]->GetChannel() > 0 && active) {
-            servo_pos[i] = servos[i]->GetPosition(GetChannelValue(servos[i]->GetChannel() - 1, servos[i]->Is16Bit()));
+            int chan = servos[i]->GetChannel() - 1;
+            bool bits16 = servos[i]->Is16Bit();
+            servo_pos[i] = servos[i]->GetPosition(GetChannelValue(chan, bits16), IsChannelDriven(chan, bits16));
         }
         servos[i]->FillMotionMatrix(servo_pos[i], motionMatrix);
         motionMatrix = glm::translate(motionMatrix, glm::vec3(0, 0, 0.2 * float(i) + 0.1));

--- a/src-core/models/DMX/DmxServo3D.cpp
+++ b/src-core/models/DMX/DmxServo3D.cpp
@@ -393,6 +393,17 @@ void DmxServo3d::DrawModel(IModelPreview* preview, xlGraphicsContext* ctx, xlGra
         servos[i]->FillMotionMatrix(servo_pos[i], servo_matrix[i]);
     }
 
+    // apply the servo(s) that actually drive a given mesh index, honoring any
+    // custom Servo Linkage remapping -- a mesh's own index only drives it when
+    // no servo has been explicitly redirected to (or away from) it
+    auto applyMeshServos = [&](glm::mat4& matrix, int meshIdx) {
+        for (int j = 0; j < (int)servos.size(); ++j) {
+            if (servo_links[j] == meshIdx || (servo_links[j] == -1 && j == meshIdx)) {
+                matrix = matrix * servo_matrix[j];
+            }
+        }
+    };
+
     // Determine motion mesh linkages
     for (int i = 0; i < num_motion; ++i) {
         int link = mesh_links[i];
@@ -410,25 +421,14 @@ void DmxServo3d::DrawModel(IModelPreview* preview, xlGraphicsContext* ctx, xlGra
             while (!link_list.empty()) {
                 link = link_list.back();
                 link_list.pop_back();
-                motion_matrix[i] = motion_matrix[i] * servo_matrix[link];
+                applyMeshServos(motion_matrix[i], link);
             }
         }
     }
 
     // add motion based on servo mapping
     for (int i = 0; i < (int)servos.size(); ++i) {
-        // see if servo links to his own mesh
-        if (servo_links[i] == -1) {
-            motion_matrix[i] = motion_matrix[i] * servo_matrix[i];
-        }
-        // check if any other servos map to this mesh
-        for (int j = 0; j < (int)servos.size(); ++j) {
-            if (j != i) {
-                if (servo_links[j] == i) {
-                    motion_matrix[i] = motion_matrix[i] * servo_matrix[j];
-                }
-            }
-        }
+        applyMeshServos(motion_matrix[i], i);
     }
 
     // Draw Motion Meshs

--- a/src-core/models/DMX/DmxServo3D.cpp
+++ b/src-core/models/DMX/DmxServo3D.cpp
@@ -382,7 +382,9 @@ void DmxServo3d::DrawModel(IModelPreview* preview, xlGraphicsContext* ctx, xlGra
     // Get servo positions and fill motion matrices
     for (int i = 0; i < (int)servos.size(); ++i) {
         if (servos[i]->GetChannel() > 0 && active) {
-            servo_pos[i] = servos[i]->GetPosition(GetChannelValue(servos[i]->GetChannel() - 1, servos[i]->Is16Bit()));
+            int chan = servos[i]->GetChannel() - 1;
+            bool bits16 = servos[i]->Is16Bit();
+            servo_pos[i] = servos[i]->GetPosition(GetChannelValue(chan, bits16), IsChannelDriven(chan, bits16));
             if (servos[i]->IsTranslate()) {
                 glm::vec3 scale = GetBaseObjectScreenLocation().GetScaleMatrix();
                 servo_pos[i] /= scale.x;

--- a/src-core/models/DMX/DmxServo3D.cpp
+++ b/src-core/models/DMX/DmxServo3D.cpp
@@ -76,7 +76,7 @@ void DmxServo3d::SetNumServos(int val)
     for (int i = 0; i < num_servos; ++i) {
         if (servos[i] == nullptr) {
             auto new_name = "Servo" + std::to_string(i + 1);
-            servos[i] = std::make_unique<Servo>(new_name, true);
+            servos[i] = std::make_unique<Servo>(new_name, false);
             servos[i]->SetChannel(_16bit ? i * 2 + 1 : i + 1);
         }
     }
@@ -155,7 +155,7 @@ void DmxServo3d::InitModel()
     for (int i = 0; i < num_servos; ++i) {
         if (servos[i] == nullptr) {
             std::string new_name = "Servo" + std::to_string(i + 1);
-            servos[i] = std::make_unique<Servo>(new_name, true);
+            servos[i] = std::make_unique<Servo>(new_name, false);
             servos[i]->SetChannel(_16bit ? i * 2 + 1 : i + 1);
         }
     }

--- a/src-core/models/DMX/DmxServo3D.cpp
+++ b/src-core/models/DMX/DmxServo3D.cpp
@@ -384,7 +384,9 @@ void DmxServo3d::DrawModel(IModelPreview* preview, xlGraphicsContext* ctx, xlGra
         if (servos[i]->GetChannel() > 0 && active) {
             int chan = servos[i]->GetChannel() - 1;
             bool bits16 = servos[i]->Is16Bit();
-            servo_pos[i] = servos[i]->GetPosition(GetChannelValue(chan, bits16), IsChannelDriven(chan, bits16));
+            bool driven = false;
+            int value = GetChannelValue(chan, bits16, &driven);
+            servo_pos[i] = servos[i]->GetPosition(value, driven);
             if (servos[i]->IsTranslate()) {
                 glm::vec3 scale = GetBaseObjectScreenLocation().GetScaleMatrix();
                 servo_pos[i] /= scale.x;
@@ -397,10 +399,17 @@ void DmxServo3d::DrawModel(IModelPreview* preview, xlGraphicsContext* ctx, xlGra
 
     // apply the servo(s) that actually drive a given mesh index, honoring any
     // custom Servo Linkage remapping -- a mesh's own index only drives it when
-    // no servo has been explicitly redirected to (or away from) it
+    // no servo has been explicitly redirected to (or away from) it. The
+    // mesh's own servo is always applied first, then any others redirected
+    // onto it, matching the original (pre-refactor) composition order --
+    // matrix multiplication is not commutative, so this order matters for
+    // rotate-style servos.
     auto applyMeshServos = [&](glm::mat4& matrix, int meshIdx) {
+        if (servo_links[meshIdx] == -1) {
+            matrix = matrix * servo_matrix[meshIdx];
+        }
         for (int j = 0; j < (int)servos.size(); ++j) {
-            if (servo_links[j] == meshIdx || (servo_links[j] == -1 && j == meshIdx)) {
+            if (j != meshIdx && servo_links[j] == meshIdx) {
                 matrix = matrix * servo_matrix[j];
             }
         }

--- a/src-core/models/DMX/DmxSkull.cpp
+++ b/src-core/models/DMX/DmxSkull.cpp
@@ -254,7 +254,11 @@ float DmxSkull::GetServoPos(Servo* _servo, bool active)
 {
     float servo_pos = 0.0f;
     if (active && _servo->GetChannel() > 0) {
-        servo_pos = _servo->GetPosition(GetChannelValue(_servo->GetChannel() - 1, _servo->Is16Bit()));
+        int chan = _servo->GetChannel() - 1;
+        bool bits16 = _servo->Is16Bit();
+        bool driven = false;
+        int value = GetChannelValue(chan, bits16, &driven);
+        servo_pos = _servo->GetPosition(value, driven);
         if (_servo->IsTranslate()) {
             glm::vec3 scale = GetBaseObjectScreenLocation().GetScaleMatrix();
             servo_pos /= scale.x;

--- a/src-core/models/DMX/Servo.cpp
+++ b/src-core/models/DMX/Servo.cpp
@@ -64,9 +64,19 @@ bool Servo::IsRotate() const {
             servo_style_val == SERVO_STYLE_ROTATEZ);
 }
 
-float Servo::GetPosition(int channel_value) {
-    if (channel_value == 0) {
-        channel_value = lastValue;
+float Servo::GetPosition(int channel_value, bool driven) {
+    if (!driven) {
+        if (controller_zero == "Min") {
+            channel_value = min_limit;
+        } else if (controller_zero == "Max") {
+            channel_value = max_limit;
+        } else if (controller_zero == "Center") {
+            channel_value = (min_limit + max_limit) / 2;
+        } else {
+            // "Hold" and "Stop PWM" have no preview equivalent of their own --
+            // both just keep showing wherever the servo last was
+            channel_value = lastValue;
+        }
     }
     if (channel_value < min_limit) {
         channel_value = min_limit;

--- a/src-core/models/DMX/Servo.cpp
+++ b/src-core/models/DMX/Servo.cpp
@@ -66,7 +66,17 @@ bool Servo::IsRotate() const {
 
 float Servo::GetPosition(int channel_value) {
     if (channel_value == 0) {
-        channel_value = lastValue;
+        if (controller_zero == "Min") {
+            channel_value = min_limit;
+        } else if (controller_zero == "Max") {
+            channel_value = max_limit;
+        } else if (controller_zero == "Center") {
+            channel_value = (min_limit + max_limit) / 2;
+        } else {
+            // "Hold" and "Stop PWM" have no preview equivalent of their own --
+            // both just keep showing wherever the servo last was
+            channel_value = lastValue;
+        }
     }
     if (channel_value < min_limit) {
         channel_value = min_limit;

--- a/src-core/models/DMX/Servo.cpp
+++ b/src-core/models/DMX/Servo.cpp
@@ -66,17 +66,7 @@ bool Servo::IsRotate() const {
 
 float Servo::GetPosition(int channel_value) {
     if (channel_value == 0) {
-        if (controller_zero == "Min") {
-            channel_value = min_limit;
-        } else if (controller_zero == "Max") {
-            channel_value = max_limit;
-        } else if (controller_zero == "Center") {
-            channel_value = (min_limit + max_limit) / 2;
-        } else {
-            // "Hold" and "Stop PWM" have no preview equivalent of their own --
-            // both just keep showing wherever the servo last was
-            channel_value = lastValue;
-        }
+        channel_value = lastValue;
     }
     if (channel_value < min_limit) {
         channel_value = min_limit;

--- a/src-core/models/DMX/Servo.h
+++ b/src-core/models/DMX/Servo.h
@@ -38,7 +38,7 @@ public:
     bool IsTranslate() const;
     bool IsRotate() const;
     void FillMotionMatrix(float servo_pos, glm::mat4& motion_matrix);
-    float GetPosition(int channel_value);
+    float GetPosition(int channel_value, bool driven = true);
     bool Is16Bit() const { return _16bit; }
     bool Is2D() const { return is_2d; }
     


### PR DESCRIPTION
## Summary
- Fix Servo 3D pivot offsets: dynamically-added servos lost Z axis and used wrong scale
- Fix Servo 3D mesh linkage to resolve remapped Servo Linkage, not mesh index
- Fix mesh-linkage composition order regression and wire in the merged GetChannelValue
- Make servo Zero Behavior preview accurate using pixel alpha, not value==0 (with an interim layout/sequencer-preview approach tried and reverted in favor of this)
- Extend the fix to DmxSkull's servo preview and dedupe channel reads

Rebased cleanly onto current master (2026.13) with no conflicts; confirmed a full Release/x64 build succeeds with these changes applied.

## Test plan
- [ ] Verify Servo 3D models with dynamically-added servos preview correct pivot/Z-axis behavior
- [ ] Verify Servo 3D mesh linkage follows remapped Servo Linkage rather than raw mesh index
- [ ] Verify Zero Behavior preview matches DMX channel value (via pixel alpha) for both DmxServo3D and DmxSkull models
- [ ] Regression-check existing Servo/DMX effects still render correctly in layout and sequencer previews