### PR TITLE
Add configurable Windows stem backend

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -15,6 +15,8 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                  built-in function (e.g. sinh/cosh/tanh) no longer fail to translate on
                                  the Vulkan (Windows/Linux) path and render solid yellow; such user
                                  functions are renamed so they no longer collide with the built-in
+    -enh (mpl13)                 Windows stem separation can select Auto, CPU, or GPU in Preferences;
+                                 CPU avoids graphics-driver crashes that cannot be caught by automatic fallback
     -enh (dkulp)                 FPP Connect: preserve per-controller UDP output pacing/bandwidth caps
                                  already configured on FPP10 instead of wiping them out when
                                  regenerating the universe outputs file; new optional <MaxPacing>

--- a/plans/ipad-parity/03-timing-audio.md
+++ b/plans/ipad-parity/03-timing-audio.md
@@ -59,7 +59,7 @@
 | Waveform filter — Non-Vocals | context-menu | ✅ | ✅ | parity | P2 | medium | feasible | `Waveform.cpp:266` ↔ `WaveformFilter.nonVocals` |
 | Waveform filter — Vocals (center extract) | context-menu | ✅ | ✅ | parity | P2 | medium | feasible | `Waveform.cpp:267` ↔ `WaveformFilter.vocals` |
 | Waveform filter — Perceptual (LUFS) | context-menu | ✅ | ✅ | parity | P2 | medium | feasible | `Waveform.cpp:268` ↔ `WaveformFilter.lufs` |
-| Waveform — HTDemucs stem separation (drums/bass/other/vocals) | context-menu | ✅ | ✅ | parity | P2 | hard | feasible | `Waveform.cpp:276-284` (macOS 12+) ↔ iPad `prepareStems` + install sheet `SequencerGridV2View.swift:898,1005`; both on-device CoreML, iOS 15+ |
+| Waveform — HTDemucs stem separation (drums/bass/other/vocals) | context-menu | ✅ | ✅ | parity | P2 | hard | feasible | `Waveform.cpp:276-284` (macOS 12+) ↔ iPad `prepareStems` + install sheet `SequencerGridV2View.swift:898,1005`; both on-device CoreML, iOS 15+. Windows additionally exposes an Auto/CPU/GPU backend preference for DirectML; it is not applicable to the CoreML-based iPad path. |
 | Waveform — double-height toggle | menu | ✅ | ✅ | parity | P3 | easy | feasible | `Waveform.cpp:307` ↔ `waveformDoubleHeight` `SequencerGridV2View.swift:233,1369` (B42) |
 | Waveform — show onsets overlay | context-menu | ✅ | ✅ | parity | P1 | medium | feasible | `Waveform.cpp:308` ↔ `SequencerGridV2View.swift:918`, `SequencerViewModel.swift:239` |
 | Waveform — show pitch contour | context-menu | ✅ | ✅ | parity | P2 | medium | feasible | `Waveform.cpp:309` ↔ `SequencerGridV2View.swift:929`, `SequencerViewModel.swift:250` |

--- a/src-core/media/StemSeparator.cpp
+++ b/src-core/media/StemSeparator.cpp
@@ -11,8 +11,12 @@
 #include "kiss_fft/tools/kiss_fftr.h"
 #include <spdlog/spdlog.h>
 #include <algorithm>
+#include <cctype>
 #include <cmath>
+#include <cstdlib>
 #include <cstring>
+#include <memory>
+#include <string>
 #include <vector>
 
 #ifdef __APPLE__
@@ -366,29 +370,65 @@ bool SeparateStems(AudioManager* audio,
     const int64_t waveformShape[] = {1, 2, (int64_t)chunkFrames};
     auto memInfo = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
 
+    std::string requestedBackend;
+    switch (opts.backend) {
+    case StemSeparatorBackend::Cpu: requestedBackend = "cpu"; break;
+    case StemSeparatorBackend::Gpu: requestedBackend = "gpu"; break;
+    case StemSeparatorBackend::Auto: requestedBackend = "auto"; break;
+    }
+    if (const char* value = std::getenv("XLIGHTS_STEM_BACKEND")) {
+        requestedBackend = value;
+        std::transform(requestedBackend.begin(), requestedBackend.end(), requestedBackend.begin(),
+                       [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    }
+
+    bool useDML = requestedBackend != "cpu";
+    bool allowCpuFallback = requestedBackend == "auto" || requestedBackend.empty();
+    if (requestedBackend != "auto" && requestedBackend != "cpu" &&
+        requestedBackend != "gpu" && requestedBackend != "directml" && !requestedBackend.empty()) {
+        spdlog::warn("SeparateStems: unknown XLIGHTS_STEM_BACKEND='{}'; using auto", requestedBackend);
+        requestedBackend = "auto";
+        useDML = true;
+        allowCpuFallback = true;
+    }
+    spdlog::info("SeparateStems: requested Windows backend '{}'", requestedBackend.empty() ? "auto" : requestedBackend);
+
     auto makeSession = [&](bool withDML) {
         Ort::SessionOptions sopts;
         sopts.SetGraphOptimizationLevel(GraphOptimizationLevel::ORT_ENABLE_ALL);
         sopts.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
         if (withDML) {
-            try {
-                Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_DML(sopts, 0));
-                spdlog::info("SeparateStems: DirectML GPU provider enabled (device 0)");
-            } catch (const Ort::Exception& e) {
-                spdlog::warn("SeparateStems: DirectML unavailable ({}), using CPU", e.what());
-            }
+            sopts.DisableMemPattern();
+            Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_DML(sopts, 0));
+            spdlog::info("SeparateStems: DirectML GPU provider enabled (device 0)");
         } else {
             spdlog::info("SeparateStems: running on CPU");
         }
         return Ort::Session(env, wpath.c_str(), sopts);
     };
 
-    Ort::Session session = makeSession(true);
+    std::unique_ptr<Ort::Session> session;
+    try {
+        session = std::make_unique<Ort::Session>(makeSession(useDML));
+    } catch (const Ort::Exception& e) {
+        if (!useDML || !allowCpuFallback) {
+            spdlog::error("SeparateStems: {} session creation failed: {}", useDML ? "DirectML" : "CPU", e.what());
+            return false;
+        }
+        spdlog::warn("SeparateStems: DirectML session creation failed ({}), using CPU", e.what());
+        useDML = false;
+        try {
+            session = std::make_unique<Ort::Session>(makeSession(false));
+        } catch (const Ort::Exception& cpuError) {
+            spdlog::error("SeparateStems: CPU session creation failed: {}", cpuError.what());
+            return false;
+        }
+    }
 
     Ort::AllocatorWithDefaultOptions allocator;
-    auto inputName0  = session.GetInputNameAllocated(0, allocator);
-    auto outputName0 = session.GetOutputNameAllocated(0, allocator);
-    auto outShape    = session.GetOutputTypeInfo(0).GetTensorTypeAndShapeInfo().GetShape();
+    auto inputName0  = session->GetInputNameAllocated(0, allocator);
+    auto outputName0 = session->GetOutputNameAllocated(0, allocator);
+    auto outShape    = session->GetOutputTypeInfo(0).GetTensorTypeAndShapeInfo().GetShape();
     // [1, S, 2, N] where S = number of stems (4 or 6). We map first 4: drums/bass/other/vocals.
     const bool isFourDim = (outShape.size() == 4);
     spdlog::info("SeparateStems: output '{}' {} stems, {} dims",
@@ -398,7 +438,8 @@ bool SeparateStems(AudioManager* audio,
     const char* outputNames[] = {outputName0.get()};
     const long totalChunks = (trackSize + stride - 1) / stride;
 
-    for (int attempt = 0; attempt < 2; attempt++) {
+    const int attemptCount = useDML && allowCpuFallback ? 2 : 1;
+    for (int attempt = 0; attempt < attemptCount; attempt++) {
         out.drumsL.assign(trackSize, 0.0f);  out.drumsR.assign(trackSize, 0.0f);
         out.bassL.assign(trackSize, 0.0f);   out.bassR.assign(trackSize, 0.0f);
         out.otherL.assign(trackSize, 0.0f);  out.otherR.assign(trackSize, 0.0f);
@@ -423,9 +464,9 @@ bool SeparateStems(AudioManager* audio,
                 Ort::Value inputTensor = Ort::Value::CreateTensor<float>(
                     memInfo, waveformBuf.data(), waveformBuf.size(), waveformShape, 3);
 
-                auto outputs = session.Run(Ort::RunOptions{nullptr},
-                                           inputNames, &inputTensor, 1,
-                                           outputNames, 1);
+                auto outputs = session->Run(Ort::RunOptions{nullptr},
+                                            inputNames, &inputTensor, 1,
+                                            outputNames, 1);
 
                 const float* outData = outputs[0].GetTensorMutableData<float>();
 
@@ -469,12 +510,18 @@ bool SeparateStems(AudioManager* audio,
             if (cancelled) {
                 return false;
             }
-            if (attempt == 0) {
+            if (useDML && allowCpuFallback && attempt == 0) {
                 spdlog::warn("SeparateStems: DirectML inference failed ({}), retrying on CPU", e.what());
-                session = makeSession(false);
+                try {
+                    session = std::make_unique<Ort::Session>(makeSession(false));
+                } catch (const Ort::Exception& cpuError) {
+                    spdlog::error("SeparateStems: CPU session creation failed: {}", cpuError.what());
+                    return false;
+                }
+                useDML = false;
                 needRetry = true;
             } else {
-                spdlog::error("SeparateStems: CPU inference failed: {}", e.what());
+                spdlog::error("SeparateStems: {} inference failed: {}", useDML ? "DirectML" : "CPU", e.what());
                 return false;
             }
         }

--- a/src-core/media/StemSeparator.h
+++ b/src-core/media/StemSeparator.h
@@ -1,14 +1,12 @@
 #pragma once
 
-// A8: HTDemucs-based 4-stem source separation. Splits the
-// AudioManager's stereo signal into drums / bass / other / vocals
-// streams via an on-device CoreML model (download-on-first-use, see
-// `AIModelStore`). Apple-only; the `.mm` implementation isn't
-// compiled on non-Apple targets and callers must guard with
-// `#ifdef __APPLE__`.
+// HTDemucs-based 4-stem source separation. Splits the AudioManager's
+// stereo signal into drums / bass / other / vocals. The build selects
+// CoreML on Apple platforms, OpenVINO where available, or ONNX Runtime
+// with DirectML/CPU on Windows.
 //
-// Model source: https://github.com/john-rocky/CoreML-Models/releases/tag/demucs-v1
-// Filename:     HTDemucs_SourceSeparation_F32.mlpackage
+// CoreML model source: https://github.com/john-rocky/CoreML-Models/releases/tag/demucs-v1
+// CoreML filename:     HTDemucs_SourceSeparation_F32.mlpackage
 // Input:        `mix` [1, 2, 343980]  stereo float @ 44.1 kHz (~7.8 s)
 // Output:       `time_output` [1, 8, 343980]  (drums L/R, bass L/R, other L/R, vocals L/R)
 

--- a/src-core/media/StemSeparator.h
+++ b/src-core/media/StemSeparator.h
@@ -19,6 +19,12 @@
 
 class AudioManager;
 
+enum class StemSeparatorBackend {
+    Auto = 0,
+    Cpu = 1,
+    Gpu = 2
+};
+
 struct StemOutput {
     std::vector<float> drumsL, drumsR;
     std::vector<float> bassL, bassR;
@@ -37,6 +43,7 @@ struct StemSeparatorOptions {
     // with a linear taper keeps chunk boundaries from clicking.
     // 0 = pure concatenation (fastest, audible click at seams).
     int overlapSamples = 4410; // 100 ms
+    StemSeparatorBackend backend = StemSeparatorBackend::Auto;
 };
 
 // Synchronous. Loads the model at `modelPath`, runs inference, and

--- a/src-ui-wx/preferences/OtherSettingsPanel.cpp
+++ b/src-ui-wx/preferences/OtherSettingsPanel.cpp
@@ -255,6 +255,7 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
 #if defined(__WXMSW__) && defined(HAVE_ORT)
     {
         wxFlexGridSizer* stemSizer = new wxFlexGridSizer(0, 2, 0, 0);
+        stemSizer->AddGrowableCol(1);
         stemSizer->Add(new wxStaticText(this, wxID_ANY, _("Stem separation backend:")), 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 5);
         StemBackendChoice = new wxChoice(this, ID_CHOICE_StemBackend);
         StemBackendChoice->Append(_("Auto"));

--- a/src-ui-wx/preferences/OtherSettingsPanel.cpp
+++ b/src-ui-wx/preferences/OtherSettingsPanel.cpp
@@ -57,6 +57,7 @@ const wxWindowID OtherSettingsPanel::ID_CHECKBOX11 = wxNewId();
 const wxWindowID OtherSettingsPanel::ID_CHECKBOX_CustomColorPicker = wxNewId();
 //*)
 const wxWindowID OtherSettingsPanel::ID_CHOICE_GfxBackend = wxNewId();
+const wxWindowID OtherSettingsPanel::ID_CHOICE_StemBackend = wxNewId();
 
 BEGIN_EVENT_TABLE(OtherSettingsPanel,wxPanel)
 	//(*EventTable(OtherSettingsPanel)
@@ -251,6 +252,26 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
     }
 #endif
 
+#if defined(__WXMSW__) && defined(HAVE_ORT)
+    {
+        wxFlexGridSizer* stemSizer = new wxFlexGridSizer(0, 2, 0, 0);
+        stemSizer->Add(new wxStaticText(this, wxID_ANY, _("Stem separation backend:")), 1, wxALL | wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, 5);
+        StemBackendChoice = new wxChoice(this, ID_CHOICE_StemBackend);
+        StemBackendChoice->Append(_("Auto"));
+        StemBackendChoice->Append(_("CPU"));
+        StemBackendChoice->Append(_("GPU"));
+        StemBackendChoice->SetSelection(0);
+        StemBackendChoice->SetToolTip(_("Auto tries the GPU first. Select CPU manually if the graphics driver crashes xLights; driver crashes cannot be caught automatically."));
+        stemSizer->Add(StemBackendChoice, 1, wxALL | wxEXPAND, 5);
+        stemSizer->AddSpacer(1);
+        wxStaticText* stemHelp = new wxStaticText(this, wxID_ANY, _("If Auto causes a graphics driver crash, select CPU manually; driver crashes cannot be caught automatically."));
+        stemHelp->Wrap(420);
+        stemSizer->Add(stemHelp, 1, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5);
+        GridBagSizer1->Add(stemSizer, wxGBPosition(15, 0), wxDefaultSpan, wxALL | wxEXPAND, 0);
+        Connect(ID_CHOICE_StemBackend, wxEVT_COMMAND_CHOICE_SELECTED, (wxObjectEventFunction)&OtherSettingsPanel::OnControlChanged);
+    }
+#endif
+
 #ifdef __LINUX__
     HardwareVideoDecodingCheckBox->Hide();
     ShaderCheckbox->Hide();
@@ -308,6 +329,13 @@ bool OtherSettingsPanel::TransferDataFromWindow() {
         config->Flush();
     }
 #endif
+#if defined(__WXMSW__) && defined(HAVE_ORT)
+    if (StemBackendChoice != nullptr) {
+        auto* config = GetXLightsConfig();
+        config->Write("xLightsStemBackend", StemBackendChoice->GetSelection());
+        config->Flush();
+    }
+#endif
     return true;
 }
 
@@ -341,6 +369,12 @@ bool OtherSettingsPanel::TransferDataToWindow() {
         if (!GraphicsBackendChoice->SetStringSelection(backend)) {
             GraphicsBackendChoice->SetSelection(0);
         }
+    }
+#endif
+#if defined(__WXMSW__) && defined(HAVE_ORT)
+    if (StemBackendChoice != nullptr) {
+        const long backend = GetXLightsConfig()->ReadLong("xLightsStemBackend", 0);
+        StemBackendChoice->SetSelection(backend >= 0 && backend < 3 ? static_cast<int>(backend) : 0);
     }
 #endif
 

--- a/src-ui-wx/preferences/OtherSettingsPanel.h
+++ b/src-ui-wx/preferences/OtherSettingsPanel.h
@@ -63,6 +63,7 @@ class OtherSettingsPanel: public wxPanel
 		// Hand-added (outside the wxSmith guards): preview graphics backend
 		// selector, only present on builds with the Vulkan backend compiled in.
 		wxChoice* GraphicsBackendChoice = nullptr;
+		wxChoice* StemBackendChoice = nullptr;
 
         virtual bool TransferDataFromWindow() override;
         virtual bool TransferDataToWindow() override;
@@ -98,6 +99,7 @@ class OtherSettingsPanel: public wxPanel
 		static const wxWindowID ID_CHECKBOX_CustomColorPicker;
 		//*)
 		static const wxWindowID ID_CHOICE_GfxBackend;
+		static const wxWindowID ID_CHOICE_StemBackend;
 
 	private:
         xLightsFrame *frame;

--- a/src-ui-wx/sequencer/Waveform.cpp
+++ b/src-ui-wx/sequencer/Waveform.cpp
@@ -44,6 +44,9 @@
 #include "media/StemSeparator.h"
 #include <wx/progdlg.h>
 #include "utils/CurlManager.h"
+#if defined(HAVE_ORT)
+#include "settings/XLightsConfigAdapter.h"
+#endif
 #include <atomic>
 #include <filesystem>
 #include <thread>
@@ -771,6 +774,13 @@ bool Waveform::PrepareStemData()
     }
 
     StemOutput stems;
+    StemSeparatorOptions stemOptions;
+#if defined(HAVE_ORT)
+    const long stemBackend = GetXLightsConfig()->ReadLong("xLightsStemBackend", 0);
+    if (stemBackend >= 0 && stemBackend <= 2) {
+        stemOptions.backend = static_cast<StemSeparatorBackend>(stemBackend);
+    }
+#endif
     {
         wxProgressDialog prog("Separating Stems",
             "Running HTDemucs — drums, bass, vocals, other…",
@@ -782,7 +792,7 @@ bool Waveform::PrepareStemData()
         std::atomic<int>  pct(0);
         std::thread worker([&] {
             ok = SeparateStems(_media, modelPath, stems,
-                               StemSeparatorOptions{},
+                               stemOptions,
                                [&pct](int p) { pct.store(p); },
                                &_stemSeparationCancel);
             done.store(true);


### PR DESCRIPTION
## Summary

- add a Windows preference for the stem-separation backend: Auto, CPU, or GPU
- keep Auto as the default, trying DirectML first and retrying the complete separation on a fresh CPU session after catchable session-creation or inference failures
- recreate and clear all output buffers before the CPU retry
- retain `XLIGHTS_STEM_BACKEND` as a diagnostic override
- explain in the preference that native graphics-driver crashes cannot be caught and require manually selecting CPU

## Why

Some DirectML failures are reported as ONNX Runtime exceptions and can safely fall back to CPU. Other failures occur inside the graphics driver and terminate xLights after the fallback has started. Users affected by those native driver crashes need a persistent CPU option, while systems with working DirectML should continue using the GPU.

## Backend behavior

| Setting | Behavior |
| --- | --- |
| Auto | Try DirectML; retry the complete operation with a new CPU session after a catchable failure |
| CPU | Do not initialize DirectML |
| GPU | Require DirectML; report failure without CPU fallback |

## Testing

- Windows Release x64 executable built and linked successfully with MSVC toolset v145
- live CPU test completed 41 chunks / 13,734,504 frames
- Auto test reproduced `DXGI_ERROR_DEVICE_HUNG`; the catchable ONNX error switched to CPU, followed by an uncatchable access violation in Intel driver `igxelpgicd64.dll`, confirming the need for the manual CPU preference
- `git diff --check` passes

The project requests the VS 2022 v143 toolset, which is not installed on the test machine, so verification used the installed v145 toolset. The repository-wide include-boundary script did not complete within three minutes on this Windows checkout.
