### PR TITLE
Model Sets: Align and Distribute move the whole Set (follow-up to #6541)

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -2716,22 +2716,23 @@ void LayoutPanel::TranslateModelSet(ModelSet* s, float delta, float (BaseObject:
 // member of a Set wins; later members are skipped so the Set only moves
 // once). Sets containing a locked model are skipped entirely. Loose models
 // move to the target individually as before.
-void LayoutPanel::AlignSetAware(Model* model, float target, float (BaseObject::*getter)(), void (BaseObject::*setter)(float), std::set<ModelSet*>& doneSets, std::set<ModelSet*>& blockedSets)
+bool LayoutPanel::AlignSetAware(Model* model, float target, float (BaseObject::*getter)(), void (BaseObject::*setter)(float), std::set<ModelSet*>& doneSets, std::set<ModelSet*>& blockedSets)
 {
     ModelSet* s = xlights->AllModels.GetSetManager().GetSetContaining(model->GetName());
     if (s == nullptr) {
         (model->*setter)(target);
-        return;
+        return true;
     }
     if (doneSets.count(s) != 0 || blockedSets.count(s) != 0) {
-        return;
+        return false;
     }
     if (ModelSetHasLockedMember(xlights->AllModels, s)) {
         blockedSets.insert(s);
-        return;
+        return false;
     }
     doneSets.insert(s);
     TranslateModelSet(s, target - (model->*getter)(), getter, setter);
+    return true;
 }
 
 void LayoutPanel::ReportBlockedSets(const std::set<ModelSet*>& blockedSets, const wxString& operation)
@@ -2744,8 +2745,10 @@ void LayoutPanel::ReportBlockedSets(const std::set<ModelSet*>& blockedSets, cons
         if (!names.empty()) names += ", ";
         names += wxString::Format("'%s'", wxString(s->GetName()));
     }
-    wxMessageBox(wxString::Format(_("Set %s was not moved because it contains a locked model."), names),
-                 operation, wxOK | wxICON_INFORMATION, this);
+    const wxString msg = blockedSets.size() == 1
+        ? wxString::Format(_("Set %s was not moved because it contains a locked model."), names)
+        : wxString::Format(_("Sets %s were not moved because they contain a locked model."), names);
+    wxMessageBox(msg, operation, wxOK | wxICON_INFORMATION, this);
 }
 
 void LayoutPanel::AddModelSetOptionsToMenu(wxMenu& menu)
@@ -8308,8 +8311,9 @@ void LayoutPanel::PreviewModelHDistribute()
         }
         else
         {
-            AlignSetAware(it, x, &BaseObject::GetHcenterPos, &BaseObject::SetHcenterPos, doneSets, blockedSets);
-            x += space;
+            if (AlignSetAware(it, x, &BaseObject::GetHcenterPos, &BaseObject::SetHcenterPos, doneSets, blockedSets)) {
+                x += space;
+            }
         }
     }
 
@@ -8367,8 +8371,9 @@ void LayoutPanel::PreviewModelVDistribute()
         }
         else
         {
-            AlignSetAware(it, y, &BaseObject::GetVcenterPos, &BaseObject::SetVcenterPos, doneSets, blockedSets);
-            y += space;
+            if (AlignSetAware(it, y, &BaseObject::GetVcenterPos, &BaseObject::SetVcenterPos, doneSets, blockedSets)) {
+                y += space;
+            }
         }
     }
 
@@ -8426,8 +8431,9 @@ void LayoutPanel::PreviewModelDDistribute()
         }
         else
         {
-            AlignSetAware(it, z, &BaseObject::GetDcenterPos, &BaseObject::SetDcenterPos, doneSets, blockedSets);
-            z += space;
+            if (AlignSetAware(it, z, &BaseObject::GetDcenterPos, &BaseObject::SetDcenterPos, doneSets, blockedSets)) {
+                z += space;
+            }
         }
     }
 

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -2698,6 +2698,56 @@ std::vector<Model*> LayoutPanel::GetSelectedModelsForSetActions() const
     return out;
 }
 
+void LayoutPanel::TranslateModelSet(ModelSet* s, float delta, float (BaseObject::*getter)(), void (BaseObject::*setter)(float))
+{
+    if (s == nullptr || delta == 0.0f) {
+        return;
+    }
+    for (const auto& name : s->GetMembers()) {
+        Model* mm = xlights->AllModels[name];
+        if (mm != nullptr) {
+            (mm->*setter)((mm->*getter)() + delta);
+        }
+    }
+}
+
+// Set-aware axis alignment used by the Align/Distribute handlers: a model
+// in a Set drags its whole Set rigidly by its own delta (the first aligned
+// member of a Set wins; later members are skipped so the Set only moves
+// once). Sets containing a locked model are skipped entirely. Loose models
+// move to the target individually as before.
+void LayoutPanel::AlignSetAware(Model* model, float target, float (BaseObject::*getter)(), void (BaseObject::*setter)(float), std::set<ModelSet*>& doneSets, std::set<ModelSet*>& blockedSets)
+{
+    ModelSet* s = xlights->AllModels.GetSetManager().GetSetContaining(model->GetName());
+    if (s == nullptr) {
+        (model->*setter)(target);
+        return;
+    }
+    if (doneSets.count(s) != 0 || blockedSets.count(s) != 0) {
+        return;
+    }
+    if (ModelSetHasLockedMember(xlights->AllModels, s)) {
+        blockedSets.insert(s);
+        return;
+    }
+    doneSets.insert(s);
+    TranslateModelSet(s, target - (model->*getter)(), getter, setter);
+}
+
+void LayoutPanel::ReportBlockedSets(const std::set<ModelSet*>& blockedSets, const wxString& operation)
+{
+    if (blockedSets.empty()) {
+        return;
+    }
+    wxString names;
+    for (ModelSet* s : blockedSets) {
+        if (!names.empty()) names += ", ";
+        names += wxString::Format("'%s'", wxString(s->GetName()));
+    }
+    wxMessageBox(wxString::Format(_("Set %s was not moved because it contains a locked model."), names),
+                 operation, wxOK | wxICON_INFORMATION, this);
+}
+
 void LayoutPanel::AddModelSetOptionsToMenu(wxMenu& menu)
 {
     auto selected = GetSelectedModelsForSetActions();
@@ -7644,14 +7694,43 @@ void LayoutPanel::PreviewModelAlignWithGround()
 
     std::vector<std::list<std::string>> selectedModelPaths = GetSelectedTreeModelPaths();
 
+    auto& setMgr = xlights->AllModels.GetSetManager();
+    std::set<ModelSet*> doneSets;
+    std::set<ModelSet*> blockedSets;
     for (size_t i = 0; i<modelPreview->GetModels().size(); i++)
     {
-        if (modelPreview->GetModels()[i]->GroupSelected() || modelPreview->GetModels()[i]->Selected())
+        Model* m = modelPreview->GetModels()[i];
+        if (m->GroupSelected() || m->Selected())
         {
-            modelPreview->GetModels()[i]->SetBottom(0.0F);
+            ModelSet* s = setMgr.GetSetContaining(m->GetName());
+            if (s == nullptr) {
+                m->SetBottom(0.0F);
+                continue;
+            }
+            if (doneSets.count(s) != 0 || blockedSets.count(s) != 0) {
+                continue;
+            }
+            if (ModelSetHasLockedMember(xlights->AllModels, s)) {
+                blockedSets.insert(s);
+                continue;
+            }
+            doneSets.insert(s);
+            // Ground the Set as a rigid unit: shift every member by the same
+            // amount so the lowest member touches the ground.
+            float minBottom = std::numeric_limits<float>::max();
+            for (const auto& name : s->GetMembers()) {
+                Model* mm = xlights->AllModels[name];
+                if (mm != nullptr) {
+                    minBottom = std::min(minBottom, mm->GetBottom());
+                }
+            }
+            if (minBottom != std::numeric_limits<float>::max()) {
+                TranslateModelSet(s, -minBottom, &BaseObject::GetBottom, &BaseObject::SetBottom);
+            }
         }
     }
 
+    ReportBlockedSets(blockedSets, "Align With Ground");
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_VISUAL_CHANGE, "LayoutPanel::PreviewModelAlignWithGround");
 
     ReselectTreeModels(selectedModelPaths);
@@ -7857,14 +7936,17 @@ void LayoutPanel::PreviewModelAlignTops()
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float top = modelPreview->GetModels()[selectedindex]->GetTop();
+    std::set<ModelSet*> doneSets;
+    std::set<ModelSet*> blockedSets;
     for (size_t i = 0; i < modelPreview->GetModels().size(); i++)
     {
         if(modelPreview->GetModels()[i]->GroupSelected())
         {
-            modelPreview->GetModels()[i]->SetTop(top);
+            AlignSetAware(modelPreview->GetModels()[i], top, &BaseObject::GetTop, &BaseObject::SetTop, doneSets, blockedSets);
         }
     }
 
+    ReportBlockedSets(blockedSets, "Align Tops");
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignTops");
 
     ReselectTreeModels(selectedModelPaths);
@@ -7879,14 +7961,17 @@ void LayoutPanel::PreviewModelAlignBottoms()
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float bottom = modelPreview->GetModels()[selectedindex]->GetBottom();
+    std::set<ModelSet*> doneSets;
+    std::set<ModelSet*> blockedSets;
     for (size_t i = 0; i<modelPreview->GetModels().size(); i++)
     {
         if(modelPreview->GetModels()[i]->GroupSelected())
         {
-            modelPreview->GetModels()[i]->SetBottom(bottom);
+            AlignSetAware(modelPreview->GetModels()[i], bottom, &BaseObject::GetBottom, &BaseObject::SetBottom, doneSets, blockedSets);
         }
     }
 
+    ReportBlockedSets(blockedSets, "Align Bottoms");
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignBottoms");
 
     ReselectTreeModels(selectedModelPaths);
@@ -7901,14 +7986,17 @@ void LayoutPanel::PreviewModelAlignLeft()
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float left = modelPreview->GetModels()[selectedindex]->GetLeft();
+    std::set<ModelSet*> doneSets;
+    std::set<ModelSet*> blockedSets;
     for (size_t i = 0; i<modelPreview->GetModels().size(); i++)
     {
         if(modelPreview->GetModels()[i]->GroupSelected())
         {
-            modelPreview->GetModels()[i]->SetLeft(left);
+            AlignSetAware(modelPreview->GetModels()[i], left, &BaseObject::GetLeft, &BaseObject::SetLeft, doneSets, blockedSets);
         }
     }
 
+    ReportBlockedSets(blockedSets, "Align Left");
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignLeft");
 
     ReselectTreeModels(selectedModelPaths);
@@ -7923,14 +8011,17 @@ void LayoutPanel::PreviewModelAlignFronts()
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float front = modelPreview->GetModels()[selectedindex]->GetFront();
+    std::set<ModelSet*> doneSets;
+    std::set<ModelSet*> blockedSets;
     for (size_t i = 0; i<modelPreview->GetModels().size(); i++)
     {
         if (modelPreview->GetModels()[i]->GroupSelected())
         {
-            modelPreview->GetModels()[i]->SetFront(front);
+            AlignSetAware(modelPreview->GetModels()[i], front, &BaseObject::GetFront, &BaseObject::SetFront, doneSets, blockedSets);
         }
     }
 
+    ReportBlockedSets(blockedSets, "Align Fronts");
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignFronts");
 
     ReselectTreeModels(selectedModelPaths);
@@ -7945,14 +8036,17 @@ void LayoutPanel::PreviewModelAlignBacks()
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float back = modelPreview->GetModels()[selectedindex]->GetBack();
+    std::set<ModelSet*> doneSets;
+    std::set<ModelSet*> blockedSets;
     for (size_t i = 0; i<modelPreview->GetModels().size(); i++)
     {
         if (modelPreview->GetModels()[i]->GroupSelected())
         {
-            modelPreview->GetModels()[i]->SetBack(back);
+            AlignSetAware(modelPreview->GetModels()[i], back, &BaseObject::GetBack, &BaseObject::SetBack, doneSets, blockedSets);
         }
     }
 
+    ReportBlockedSets(blockedSets, "Align Backs");
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignBacks");
 
     ReselectTreeModels(selectedModelPaths);
@@ -8054,14 +8148,17 @@ void LayoutPanel::PreviewModelAlignRight()
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float right = modelPreview->GetModels()[selectedindex]->GetRight();
+    std::set<ModelSet*> doneSets;
+    std::set<ModelSet*> blockedSets;
     for (size_t i = 0; i<modelPreview->GetModels().size(); i++)
     {
         if(modelPreview->GetModels()[i]->GroupSelected())
         {
-            modelPreview->GetModels()[i]->SetRight(right);
+            AlignSetAware(modelPreview->GetModels()[i], right, &BaseObject::GetRight, &BaseObject::SetRight, doneSets, blockedSets);
         }
     }
 
+    ReportBlockedSets(blockedSets, "Align Right");
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignRight");
 
     ReselectTreeModels(selectedModelPaths);
@@ -8076,14 +8173,17 @@ void LayoutPanel::PreviewModelAlignHCenter()
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float center = modelPreview->GetModels()[selectedindex]->GetHcenterPos();
+    std::set<ModelSet*> doneSets;
+    std::set<ModelSet*> blockedSets;
     for (size_t i = 0; i<modelPreview->GetModels().size(); i++)
     {
         if(modelPreview->GetModels()[i]->GroupSelected())
         {
-            modelPreview->GetModels()[i]->SetHcenterPos(center);
+            AlignSetAware(modelPreview->GetModels()[i], center, &BaseObject::GetHcenterPos, &BaseObject::SetHcenterPos, doneSets, blockedSets);
         }
     }
 
+    ReportBlockedSets(blockedSets, "Align Horizontal Centers");
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelAlignHCenter");
 
     ReselectTreeModels(selectedModelPaths);
@@ -8098,13 +8198,16 @@ void LayoutPanel::PreviewModelAlignVCenter()
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float center = modelPreview->GetModels()[selectedindex]->GetVcenterPos();
+    std::set<ModelSet*> doneSets;
+    std::set<ModelSet*> blockedSets;
     for (size_t i = 0; i < modelPreview->GetModels().size(); i++) {
         if (modelPreview->GetModels()[i]->GroupSelected())
         {
-            modelPreview->GetModels()[i]->SetVcenterPos(center);
+            AlignSetAware(modelPreview->GetModels()[i], center, &BaseObject::GetVcenterPos, &BaseObject::SetVcenterPos, doneSets, blockedSets);
         }
     }
 
+    ReportBlockedSets(blockedSets, "Align Vertical Centers");
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelVCenter");
 
     ReselectTreeModels(selectedModelPaths);
@@ -8119,13 +8222,16 @@ void LayoutPanel::PreviewModelAlignDCenter()
 
     CreateUndoPoint("All", modelPreview->GetModels()[selectedindex]->name);
     float center = modelPreview->GetModels()[selectedindex]->GetDcenterPos();
+    std::set<ModelSet*> doneSets;
+    std::set<ModelSet*> blockedSets;
     for (size_t i = 0; i < modelPreview->GetModels().size(); i++) {
         if (modelPreview->GetModels()[i]->GroupSelected())
         {
-            modelPreview->GetModels()[i]->SetDcenterPos(center);
+            AlignSetAware(modelPreview->GetModels()[i], center, &BaseObject::GetDcenterPos, &BaseObject::SetDcenterPos, doneSets, blockedSets);
         }
     }
 
+    ReportBlockedSets(blockedSets, "Align Depth Centers");
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelDCenter");
 
     ReselectTreeModels(selectedModelPaths);
@@ -8186,6 +8292,9 @@ void LayoutPanel::PreviewModelHDistribute()
 
     CreateUndoPoint("All", models.front()->name);
 
+    std::set<ModelSet*> doneSets;
+    std::set<ModelSet*> blockedSets;
+
     float x = -1;
     for (const auto& it : models)
     {
@@ -8199,11 +8308,12 @@ void LayoutPanel::PreviewModelHDistribute()
         }
         else
         {
-            it->SetHcenterPos(x);
+            AlignSetAware(it, x, &BaseObject::GetHcenterPos, &BaseObject::SetHcenterPos, doneSets, blockedSets);
             x += space;
         }
     }
 
+    ReportBlockedSets(blockedSets, "Horizontal Distribute");
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelHDistribute");
 
     ReselectTreeModels(selectedModelPaths);
@@ -8241,6 +8351,9 @@ void LayoutPanel::PreviewModelVDistribute()
 
     CreateUndoPoint("All", models.front()->name);
 
+    std::set<ModelSet*> doneSets;
+    std::set<ModelSet*> blockedSets;
+
     float y = -1;
     for (const auto& it : models)
     {
@@ -8254,11 +8367,12 @@ void LayoutPanel::PreviewModelVDistribute()
         }
         else
         {
-            it->SetVcenterPos(y);
+            AlignSetAware(it, y, &BaseObject::GetVcenterPos, &BaseObject::SetVcenterPos, doneSets, blockedSets);
             y += space;
         }
     }
 
+    ReportBlockedSets(blockedSets, "Vertical Distribute");
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelVDistribute");
 
     ReselectTreeModels(selectedModelPaths);
@@ -8296,6 +8410,9 @@ void LayoutPanel::PreviewModelDDistribute()
 
     CreateUndoPoint("All", models.front()->name);
 
+    std::set<ModelSet*> doneSets;
+    std::set<ModelSet*> blockedSets;
+
     float z = -1;
     for (const auto& it : models)
     {
@@ -8309,11 +8426,12 @@ void LayoutPanel::PreviewModelDDistribute()
         }
         else
         {
-            it->SetDcenterPos(z);
+            AlignSetAware(it, z, &BaseObject::GetDcenterPos, &BaseObject::SetDcenterPos, doneSets, blockedSets);
             z += space;
         }
     }
 
+    ReportBlockedSets(blockedSets, "Depth Distribute");
     xlights->GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "LayoutPanel::PreviewModelDDistribute");
 
     ReselectTreeModels(selectedModelPaths);

--- a/src-ui-wx/layout/LayoutPanel.h
+++ b/src-ui-wx/layout/LayoutPanel.h
@@ -457,7 +457,7 @@ class LayoutPanel: public wxPanel
         // Returns models present in the current selection (canvas + tree).
         std::vector<Model*> GetSelectedModelsForSetActions() const;
         void TranslateModelSet(ModelSet* s, float delta, float (BaseObject::*getter)(), void (BaseObject::*setter)(float));
-        void AlignSetAware(Model* model, float target, float (BaseObject::*getter)(), void (BaseObject::*setter)(float), std::set<ModelSet*>& doneSets, std::set<ModelSet*>& blockedSets);
+        bool AlignSetAware(Model* model, float target, float (BaseObject::*getter)(), void (BaseObject::*setter)(float), std::set<ModelSet*>& doneSets, std::set<ModelSet*>& blockedSets);
         void ReportBlockedSets(const std::set<ModelSet*>& blockedSets, const wxString& operation);
         void AddAlignOptionsToMenu(wxMenu* mnuAlign);
         void AddDistributeOptionsToMenu(wxMenu* mnuDistribute);

--- a/src-ui-wx/layout/LayoutPanel.h
+++ b/src-ui-wx/layout/LayoutPanel.h
@@ -48,11 +48,13 @@ class wxStaticText;
 #include <vector>
 #include <list>
 #include <map>
+#include <set>
 
 class xLightsFrame;
 class ModelPreview;
 class BaseObject;
 class Model;
+class ModelSet;
 class ModelGroup;
 class ModelPropertyAdapter;
 class ViewObjectPropertyAdapter;
@@ -454,6 +456,9 @@ class LayoutPanel: public wxPanel
         void DoManageSet();
         // Returns models present in the current selection (canvas + tree).
         std::vector<Model*> GetSelectedModelsForSetActions() const;
+        void TranslateModelSet(ModelSet* s, float delta, float (BaseObject::*getter)(), void (BaseObject::*setter)(float));
+        void AlignSetAware(Model* model, float target, float (BaseObject::*getter)(), void (BaseObject::*setter)(float), std::set<ModelSet*>& doneSets, std::set<ModelSet*>& blockedSets);
+        void ReportBlockedSets(const std::set<ModelSet*>& blockedSets, const wxString& operation);
         void AddAlignOptionsToMenu(wxMenu* mnuAlign);
         void AddDistributeOptionsToMenu(wxMenu* mnuDistribute);
         void AddResizeOptionsToMenu(wxMenu* mnuResize);


### PR DESCRIPTION
## Bug

Model Sets (#6541) made linked props move as one — but only for mouse drags. Every right-click **Align** option (With Ground, Tops, Bottoms, Left, Right, Fronts, Backs, H/V/D Center) and **Distribute** (H/V/D) still moved the clicked member individually, silently tearing the Set's arrangement apart.

## Fix

All Align and Distribute handlers are now Set-aware, via one shared helper (`AlignSetAware` / `TranslateModelSet` in `LayoutPanel.cpp`):

- Aligning a Set member **rigidly translates the whole Set** by that member's delta — relative offsets between members are preserved. The first aligned member of a Set wins; other selected members of the same Set ride along instead of fighting over the target, so a Set moves exactly once per operation.
- **Align With Ground** shifts the Set so its **lowest** member touches the ground — nothing gets flattened to the same height and nothing ends up underground.
- Sets containing a **locked model are skipped** with an information message naming the frozen Set(s) — the same rule Set rotation already applies.
- Loose (non-Set) models behave exactly as before.

## Scope / parity

Desktop-only (`src-ui-wx/layout/`): Model Sets and the layout Align/Distribute menu have no iPad counterpart today; the Sets feature is tracked in the layout parity theme.

## Testing

macOS Release (arm64), manual: linked a 3-model set, verified Align With Ground / Tops / Left / H-Center and H-Distribute move the set as a unit with offsets preserved; locked-member set skipped with message; loose models unchanged; undo restores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)