### PR TITLE
Fix show marked dirty (unsaved changes) immediately after every load from Menu

### DIFF
--- a/src-core/XmlSerializer/XmlDeserializingModelFactory.cpp
+++ b/src-core/XmlSerializer/XmlDeserializingModelFactory.cpp
@@ -266,7 +266,7 @@ void XmlDeserializingModelFactory::DeserializeCommonModelAttributes(Model* model
     model->SetTransparency(node.attribute(XmlNodeKeys::TransparencyAttribute).as_int(0));
     model->SetBlackTransparency(node.attribute(XmlNodeKeys::BTransparencyAttribute).as_int(0));
     model->SetDescription(node.attribute(XmlNodeKeys::DescriptionAttribute).as_string());
-    model->SetTagColourAsString(node.attribute(XmlNodeKeys::TagColourAttribute).as_string("#000000"));
+    model->SetModelTagColour(xlColor(node.attribute(XmlNodeKeys::TagColourAttribute).as_string("#000000")));
     model->SetNodeNames(node.attribute(XmlNodeKeys::NodeNamesAttribute).as_string());
     model->SetStrandNames(node.attribute(XmlNodeKeys::StrandNamesAttribute).as_string());
     model->SetCustomColor(node.attribute(XmlNodeKeys::CustomColorAttribute).as_string("#000000"));
@@ -1005,7 +1005,7 @@ Model* XmlDeserializingModelFactory::DeserializeModelGroup(pugi::xml_node node, 
     }
 
     // Tag colour
-    model->SetTagColourAsString(node.attribute(XmlNodeKeys::TagColourAttribute).as_string("#000000"));
+    model->SetModelTagColour(xlColor(node.attribute(XmlNodeKeys::TagColourAttribute).as_string("#000000")));
 
     // Parse and add models to the group
     std::string modelsStr = node.attribute("models").as_string("");

--- a/src-core/models/BaseObject.cpp
+++ b/src-core/models/BaseObject.cpp
@@ -300,10 +300,12 @@ bool BaseObject::IsContained(IModelPreview* preview, int x1, int y1, int x2, int
 }
 
 void BaseObject::SetActive(bool active) {
-	_active = active; 
+	if (_active != active) {
+		_active = active;
 
-    AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "BaseObject::SetActive");
-    AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "BaseObject::SetActive");
-    AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BaseObject::SetActive"); // because the names are displayed differently
+		AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "BaseObject::SetActive");
+		AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "BaseObject::SetActive");
+		AddASAPWork(OutputModelManager::WORK_RELOAD_ALLMODELS, "BaseObject::SetActive"); // because the names are displayed differently
+	}
 }
 

--- a/src-core/models/Model.cpp
+++ b/src-core/models/Model.cpp
@@ -4216,10 +4216,12 @@ xlColor Model::GetTagColour() {
 }
 
 void Model::SetTagColourAsString(std::string const& colour) {
-    _modelTagColourString = colour;
-    _modelTagColourValid = false;
-    IncrementChangeCount();
-    AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "Model::SetTagColourAsString");
+    if (_modelTagColourString != colour) {
+        _modelTagColourString = colour;
+        _modelTagColourValid = false;
+        IncrementChangeCount();
+        AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "Model::SetTagColourAsString");
+    }
 }
 void Model::SetTagColour(const xlColor& colour)
 {
@@ -4382,7 +4384,8 @@ void Model::AddSuperStringColour(xlColor c)
 
 void Model::SetShadowModelFor(const std::string& shadowModelFor)
 {
-    if ( shadowModelFor != name ) { // models should not be a shadow model for themselves
+    // models should not be a shadow model for themselves
+    if (shadowModelFor != name && shadowModelFor != _shadowModelFor) {
         _shadowModelFor = shadowModelFor;
         IncrementChangeCount();
         AddASAPWork(OutputModelManager::WORK_RGBEFFECTS_CHANGE, "Model::SetShadowModelFor");

--- a/src-core/outputs/NullOutput.cpp
+++ b/src-core/outputs/NullOutput.cpp
@@ -19,6 +19,7 @@
 NullOutput::NullOutput(pugi::xml_node node) : Output(node) {
 
     SetId(node.attribute("Id").as_int(64001));
+    _dirty = false;
 }
 
 NullOutput::NullOutput(const NullOutput& from) : Output(from)
@@ -28,6 +29,7 @@ NullOutput::NullOutput(const NullOutput& from) : Output(from)
 pugi::xml_node NullOutput::Save(pugi::xml_node parent) {
 
     pugi::xml_node node = parent.append_child("network");
+    node.append_attribute("Id") = GetId();
     Output::SaveAttr(node);
 
     return node;

--- a/src-core/outputs/Output.cpp
+++ b/src-core/outputs/Output.cpp
@@ -45,6 +45,8 @@ void Output::SaveAttr(pugi::xml_node node) {
 
     node.append_attribute("MaxChannels") = _channels;
 
+    node.append_attribute("Enabled") = _enabled ? "Yes" : "No";
+
     node.remove_attribute("FPPProxy");
     if (IsUsingFPPProxy()) {
         node.append_attribute("FPPProxy") = _fppProxy;

--- a/src-core/outputs/Output.h
+++ b/src-core/outputs/Output.h
@@ -117,13 +117,20 @@ public:
 
     #pragma region Getters and Setters
     std::string GetCommPort() const { return _commPort; }
-    void SetCommPort(const std::string& commPort) { _commPort = commPort; _dirty = true; }
+    void SetCommPort(const std::string& commPort) {
+        if (_commPort != commPort) {
+            _commPort = commPort;
+            _dirty = true;
+        }
+    }
 
     int GetBaudRate() const;
-    virtual void SetBaudRate(int baudRate) 
+    virtual void SetBaudRate(int baudRate)
     {
-        _baudRate = baudRate;
-        _dirty = true;
+        if (_baudRate != baudRate) {
+            _baudRate = baudRate;
+            _dirty = true;
+        }
     }
 
     std::string GetIP() const { return _ip; }
@@ -144,7 +151,12 @@ public:
     std::string GetForceLocalIPToUse() const;
 
     int GetUniverse() const { return _universe; }
-    void SetUniverse(int universe) { _universe = universe; _dirty = true; }
+    void SetUniverse(int universe) {
+        if (_universe != universe) {
+            _universe = universe;
+            _dirty = true;
+        }
+    }
     virtual std::string GetUniverseString() const { return std::to_string(GetUniverse()); }
 
     int32_t GetChannels() const { return _channels; }
@@ -167,7 +179,12 @@ public:
     void ClearDirty() { _dirty = false; }
 
     bool IsEnabled() const { return _enabled; }
-    void Enable(bool enable) { _enabled = enable; _dirty = true; }
+    void Enable(bool enable) {
+        if (_enabled != enable) {
+            _enabled = enable;
+            _dirty = true;
+        }
+    }
 
     void Suspend(bool suspend) { _suspend = suspend; }
 
@@ -191,7 +208,12 @@ public:
 
     virtual std::string GetType() const = 0;
 
-    void SetSuppressDuplicateFrames(const bool suppressDuplicateFrames) { _suppressDuplicateFrames = suppressDuplicateFrames; _dirty = true; }
+    void SetSuppressDuplicateFrames(const bool suppressDuplicateFrames) {
+        if (_suppressDuplicateFrames != suppressDuplicateFrames) {
+            _suppressDuplicateFrames = suppressDuplicateFrames;
+            _dirty = true;
+        }
+    }
     bool IsSuppressDuplicateFrames() const { return _suppressDuplicateFrames; }
 
     virtual void SetTransientData(int32_t& startChannel, int nullnumber);

--- a/src-core/outputs/OutputManager.cpp
+++ b/src-core/outputs/OutputManager.cpp
@@ -171,6 +171,24 @@ bool OutputManager::Load(const std::string& showdir, bool syncEnabled) {
 
     DeleteTestPreset();
 
+    // OutputManager is a single long-lived instance reused across show-folder
+    // switches within a session (unlike Controller/Output, which get freshly
+    // constructed per load). Without this reset, a stale _dirty=true left over
+    // from a prior show (e.g. from SetSyncEnabled, SetGlobalFPPProxy, the
+    // BaseShowDir fallback-resolve below, etc.) would incorrectly carry over
+    // and mark every subsequently loaded show dirty, even one loaded fresh
+    // from the command line at startup (where this constructor-default reset
+    // is still untouched).
+    _dirty = false;
+
+    // Same reasoning as _dirty above: DidConvert() drives SetDir()'s decision
+    // to mark UnsavedNetworkChanges true (see xLightsFrame::SetDir). Without
+    // resetting it here, converting one legacy-format show earlier in the
+    // session would leave every later show in that session permanently
+    // flagged as "converted" too, even ones that never went through the
+    // legacy conversion path.
+    _didConvert = false;
+
     _showDir = showdir;
     _filename = (std::filesystem::path(showdir) / GetNetworksFileName()).string();
     ObtainAccessToURL(_filename);

--- a/src-core/outputs/OutputManager.h
+++ b/src-core/outputs/OutputManager.h
@@ -208,7 +208,7 @@ public:
     bool AtLeastOneOutputUsingProtocol(const std::string& protocol) const;
     std::list<std::string> GetForceIPs(const std::string& protocol) const;
 
-    void SetSuppressFrames(int suppressFrames) { _suppressFrames = suppressFrames; _dirty = true; }
+    void SetSuppressFrames(int suppressFrames) { if (_suppressFrames != suppressFrames) { _suppressFrames = suppressFrames; _dirty = true; } }
     int GetSuppressFrames() const { return _suppressFrames; }
     
     std::string GetChannelName(int32_t channel);
@@ -236,13 +236,20 @@ public:
     bool IsSyncEnabled() const { return _syncEnabled; }
     static bool IsSyncEnabled_() { return __isSync; }
     void SetSyncEnabled(bool syncEnabled) {
-        _syncEnabled = syncEnabled;
-        OutputManager::__isSync = syncEnabled;
-        _dirty = true;
-        if (!_syncEnabled) SetSyncUniverse(0);
+        if (_syncEnabled != syncEnabled) {
+            _syncEnabled = syncEnabled;
+            OutputManager::__isSync = syncEnabled;
+            _dirty = true;
+            if (!_syncEnabled) SetSyncUniverse(0);
+        }
     }
     int GetSyncUniverse() const { return _syncUniverse; }
-    void SetSyncUniverse(int syncUniverse) { _syncUniverse = syncUniverse; _dirty = true;}
+    void SetSyncUniverse(int syncUniverse) {
+        if (_syncUniverse != syncUniverse) {
+            _syncUniverse = syncUniverse;
+            _dirty = true;
+        }
+    }
     #pragma endregion 
 
     #pragma region Data Setting

--- a/src-core/outputs/SerialOutput.cpp
+++ b/src-core/outputs/SerialOutput.cpp
@@ -34,6 +34,8 @@
 #pragma region Private Functions
 void SerialOutput::SaveAttr(pugi::xml_node node) {
 
+    node.append_attribute("Id") = GetId();
+
     if (_commPort != "") {
         node.append_attribute("ComPort") = _commPort;
     }
@@ -61,6 +63,7 @@ SerialOutput::SerialOutput(pugi::xml_node node) : Output(node) {
         _baudRate = node.attribute("BaudRate").as_int(0);
     }
     SetId(node.attribute("Id").as_int(0));
+    _dirty = false;
 }
 
 SerialOutput::SerialOutput(const SerialOutput& from) :

--- a/src-core/outputs/xxxEthernetOutput.h
+++ b/src-core/outputs/xxxEthernetOutput.h
@@ -62,7 +62,7 @@ public:
     virtual bool IsValidChannelCount(int32_t channelCount) const override { return channelCount > 0 && static_cast<uint32_t>(channelCount) <= xxxETHERNET_MAX_CHANNELS; }
 
     int GetId() const { return _universe; }
-    void SetId(int id) { _universe = id; _dirty = true; }
+    void SetId(int id) { if (_universe != id) { _universe = id; _dirty = true; } }
 
     virtual std::string GetLongDescription() const override;
 

--- a/src-ui-wx/app-shell/TabSetup.cpp
+++ b/src-ui-wx/app-shell/TabSetup.cpp
@@ -243,8 +243,10 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
     // already gets an equivalent reset further down once network load
     // completes; RGB effects / presets get reloaded fresh from the new show's
     // own files, so start them clean here too.
-    UnsavedRgbEffectsChanges = false;
-    UnsavedPresetChanges = false;
+    if (wxFileName::DirExists(nd)) {
+        UnsavedRgbEffectsChanges = false;
+        UnsavedPresetChanges = false;
+    }
 
     viewpoint_mgr.Clear();
 

--- a/src-ui-wx/app-shell/TabSetup.cpp
+++ b/src-ui-wx/app-shell/TabSetup.cpp
@@ -232,6 +232,20 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
 
     // Check to see if any show directory files need to be saved
     CheckUnsavedChanges();
+
+    // Whatever the user chose above was about the OLD show directory's files.
+    // xLightsFrame is a single long-lived instance reused across every show
+    // switch in a session (constructed once, its flags default-initialized
+    // false only that one time), so without resetting these here, declining
+    // to save above (or any other unrelated earlier edit in this session)
+    // would leave the Save button permanently red for every show loaded
+    // afterward, even ones that were never touched. UnsavedNetworkChanges
+    // already gets an equivalent reset further down once network load
+    // completes; RGB effects / presets get reloaded fresh from the new show's
+    // own files, so start them clean here too.
+    UnsavedRgbEffectsChanges = false;
+    UnsavedPresetChanges = false;
+
     viewpoint_mgr.Clear();
 
     // Force re-initialization of Effect Presets panel when show directory changes.
@@ -484,7 +498,20 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
         }
     }
 
+    // Model/object deserialization calls the same public setters used for
+    // interactive edits (SetActive, ControllerConnection::SetCtrlPort, etc.),
+    // each of which queues ASAP work whenever the loaded value legitimately
+    // differs from that field's in-memory default on a freshly constructed
+    // object -- which is the common case for any real, configured model.
+    // Suppressing ASAP work for the duration of the load (mirroring the same
+    // DisableASAPWork bracket LayoutPanel.cpp already uses around other bulk
+    // operations) avoids marking the show dirty for content that hasn't
+    // actually changed since it was last saved. The channel/controller-config
+    // work that genuinely needs to run after a load is already explicitly
+    // re-queued via AddImmediateWork just below, so nothing legitimate is lost.
+    _outputModelManager.DisableASAPWork(true);
     LoadEffectsFile();
+    _outputModelManager.DisableASAPWork(false);
 
     spdlog::debug("Get start channels right.");
     // make sure these won't refire


### PR DESCRIPTION
Guard a few settings that check if the value is actually changed before marking the item as changed and dirty.