### PR TITLE
Filterable model pickers for the Export-to-Other-Models dialogs

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -50,6 +50,7 @@
 #include "layout/LayoutPanel.h"
 #include "layout/ModelPreview.h"
 #include "xLightsMain.h"
+#include "shared/dialogs/CheckboxSelectDialog.h"
 #include "xLightsApp.h"
 #include "settings/XLightsConfigAdapter.h"
 #include "model/ChannelLayoutDialog.h"
@@ -8108,15 +8109,15 @@ void LayoutPanel::ExportFacesStatesSubModels() {
         choices.Add(model->Name());
     }
 
-    wxMultiChoiceDialog dlg(this, "Export Face/States/SubModels to Other Models", "Choose Model(s)", choices);
+    CheckboxSelectDialog dlg(this, "Export Face/States/SubModels to Other Models", choices);
     OptimiseDialogPosition(&dlg);
 
     if (dlg.ShowModal() == wxID_OK) {
         std::map<std::string, std::map<std::string, std::string>> sourceFaces = selectedModel->GetFaceInfo();
         std::map<std::string, std::map<std::string, std::string>> sourceStates = selectedModel->GetStateInfo();
 
-        for (auto const& idx : dlg.GetSelections()) {
-            Model* targetModel = xlights->GetModel(choices.at(idx));
+        for (auto const& name : dlg.GetSelectedItems()) {
+            Model* targetModel = xlights->GetModel(name);
 
             auto targetFaces = targetModel->GetFaceInfo();
             for (const auto& [name, data] : sourceFaces) {

--- a/src-ui-wx/model/ModelFacesPanel.cpp
+++ b/src-ui-wx/model/ModelFacesPanel.cpp
@@ -35,6 +35,7 @@
 #include "WQ.xpm"
 
 #include "ModelFacesPanel.h"
+#include "shared/dialogs/CheckboxSelectDialog.h"
 #include "FaceMatrixHelpers.h"
 #include "render/SequenceFile.h"
 #include "shared/utils/NodesGridCellEditor.h"
@@ -2380,13 +2381,13 @@ void ModelFacesPanel::ExportFacesToOtherModels()
     xLightsFrame* xlights = xLightsApp::GetFrame();
     wxArrayString choices = getModelList(&xlights->AllModels);
 
-    wxMultiChoiceDialog dlg(this, "Export Face Definitions to Other Models", "Choose Model(s)", choices);
+    CheckboxSelectDialog dlg(this, "Export Face Definitions to Other Models", choices);
     OptimiseDialogPosition(&dlg);
 
     if (dlg.ShowModal() == wxID_OK) {
         std::map<std::string, std::map<std::string, std::string>> sourceFaces = GetFaceInfo();
-        for (auto const& idx : dlg.GetSelections()) {
-            Model* targetModel = xlights->GetModel(choices.at(idx));
+        for (auto const& name : dlg.GetSelectedItems()) {
+            Model* targetModel = xlights->GetModel(name);
             targetModel->SetFaceInfo(sourceFaces);
             targetModel->IncrementChangeCount();
         }

--- a/src-ui-wx/model/ModelStatesPanel.cpp
+++ b/src-ui-wx/model/ModelStatesPanel.cpp
@@ -9,6 +9,7 @@
  **************************************************************/
 
 #include "ModelStatesPanel.h"
+#include "shared/dialogs/CheckboxSelectDialog.h"
 #include "settings/XLightsConfigAdapter.h"
 #include <wx/settings.h>
 #include <wx/progdlg.h>
@@ -2645,13 +2646,13 @@ void ModelStatesPanel::ExportStatesToOtherModels()
     xLightsFrame* xlights = xLightsApp::GetFrame();
     wxArrayString choices = getModelList(&xlights->AllModels);
 
-    wxMultiChoiceDialog dlg(this, "Export States to Other Models", "Choose Model(s)", choices);
+    CheckboxSelectDialog dlg(this, "Export States to Other Models", choices);
     OptimiseDialogPosition(&dlg);
 
     if (dlg.ShowModal() == wxID_OK) {
         std::map<std::string, std::map<std::string, std::string>> sourceStates = GetStateInfo();
-        for (auto const& idx : dlg.GetSelections()) {
-            Model* targetModel = xlights->GetModel(choices.at(idx));
+        for (auto const& name : dlg.GetSelectedItems()) {
+            Model* targetModel = xlights->GetModel(name);
             targetModel->SetStateInfo(sourceStates);
             targetModel->IncrementChangeCount();
         }

--- a/src-ui-wx/model/SubModelsPanel.cpp
+++ b/src-ui-wx/model/SubModelsPanel.cpp
@@ -4601,12 +4601,12 @@ void SubModelsPanel::ExportSubmodelToOtherModels()
     xLightsFrame* xlights = xLightsApp::GetFrame();
     wxArrayString choices = getModelList(&xlights->AllModels);
 
-    wxMultiChoiceDialog dlg(this, "Export SubModels to Other Models", "Choose Model(s)", choices);
+    CheckboxSelectDialog dlg(this, "Export SubModels to Other Models", choices);
     OptimiseDialogPosition(&dlg);
 
     if (dlg.ShowModal() == wxID_OK) {
-        for (auto const& idx : dlg.GetSelections()) {
-            Model* m = xlights->GetModel(choices.at(idx));
+        for (auto const& name : dlg.GetSelectedItems()) {
+            Model* m = xlights->GetModel(name);
             SaveSubModelInfoIntoThisModel(m);
             for (auto& it : m->GetSubModels()) {
                 it->IncrementChangeCount();


### PR DESCRIPTION
## Summary
Routes the four "Export → Other Models" model pickers through the existing filterable `CheckboxSelectDialog` instead of the unfiltered `wxMultiChoiceDialog`, so their model lists can be searched/filtered:

- **Export Faces/States/SubModels** — layout model right-click (`LayoutPanel.cpp`)
- **Export Face Definitions** — Faces panel (`ModelFacesPanel.cpp`)
- **Export States** — States panel (`ModelStatesPanel.cpp`)
- **Export SubModels** — SubModels panel (`SubModelsPanel.cpp`)

`CheckboxSelectDialog` already provides the search/filter box (e.g. the EffectsGrid "Choose Model(s)" copy-layers dialog uses it). These four export pickers were the remaining ones still on the unfiltered `wxMultiChoiceDialog` — on a show with many props the list was hard to navigate. This is a small, behavior-preserving swap: same selections in, same models exported.

## Notes
- No change to `CheckboxSelectDialog` itself — it is used as-is.
- `GetSelectedItems()` returns the checked model names (guaranteed to be in the passed list), replacing the old index-based `GetSelections()` / `choices.at(idx)`; the dirty / change-count behavior at each site is unchanged.

## Test Plan
- [x] macOS Debug build succeeds.
- [ ] Right-click a model → **Export Faces/States/SubModels** → the picker shows a **Filter** box; typing narrows the list; checked models persist across filtering; **OK** exports to exactly the checked models. Same for the Faces / States / SubModels panel "Export … to Other Models" menu items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
