### PR TITLE
Fix Windows crash from ISF shader sliders with min==max range

### DIFF
--- a/src-core/effects/ShaderEffect.cpp
+++ b/src-core/effects/ShaderEffect.cpp
@@ -1539,25 +1539,38 @@ nlohmann::json ShaderConfig::GetDynamicPropertiesJson() const
         entry["label"] = p.GetLabel();
 
         switch (p._type) {
-        case ShaderParmType::SHADER_PARM_FLOAT:
+        case ShaderParmType::SHADER_PARM_FLOAT: {
             entry["type"] = "float";
             entry["controlType"] = "slider";
             entry["settingPrefix"] = "SLIDER";
             entry["divisor"] = 100;
-            entry["min"] = static_cast<int>(p._min * 100.0);
-            entry["max"] = static_cast<int>(p._max * 100.0);
+            int minInt = static_cast<int>(p._min * 100.0);
+            int maxInt = static_cast<int>(p._max * 100.0);
+            // A narrow ISF-declared range can truncate to the same int (or
+            // the shader can just declare min >= max); wxSlider::Create()
+            // asserts "minValue < maxValue" on that and leaves the control's
+            // native peer uncreated, which then corrupts state for whatever
+            // uses the panel next. Guarantee a usable range here instead.
+            if (maxInt <= minInt) maxInt = minInt + 1;
+            entry["min"] = minInt;
+            entry["max"] = maxInt;
             entry["default"] = p._default;
             entry["valueCurve"] = true;
             break;
+        }
 
-        case ShaderParmType::SHADER_PARM_LONG:
+        case ShaderParmType::SHADER_PARM_LONG: {
             entry["type"] = "int";
             entry["controlType"] = "slider";
-            entry["min"] = static_cast<int>(p._min);
-            entry["max"] = static_cast<int>(p._max);
+            int minInt = static_cast<int>(p._min);
+            int maxInt = static_cast<int>(p._max);
+            if (maxInt <= minInt) maxInt = minInt + 1;
+            entry["min"] = minInt;
+            entry["max"] = maxInt;
             entry["default"] = static_cast<int>(p._default);
             entry["valueCurve"] = true;
             break;
+        }
 
         case ShaderParmType::SHADER_PARM_LONGCHOICE: {
             entry["type"] = "enum";

--- a/src-ui-wx/effectpanels/JsonEffectPanel.cpp
+++ b/src-ui-wx/effectpanels/JsonEffectPanel.cpp
@@ -647,9 +647,11 @@ void JsonEffectPanel::BuildXYCenter(wxWindow* parentWin, wxSizer* parentSizer,
     const auto& yProp = yIt->second;
     int xMin = xProp.value("min", 0);
     int xMax = xProp.value("max", 100);
+    if (xMax <= xMin) xMax = xMin + 1;
     int xDef = xProp.value("default", 0);
     int yMin = yProp.value("min", 0);
     int yMax = yProp.value("max", 100);
+    if (yMax <= yMin) yMax = yMin + 1;
     int yDef = yProp.value("default", 0);
     bool xHasVC = xProp.value("valueCurve", false);
     bool yHasVC = yProp.value("valueCurve", false);
@@ -929,6 +931,10 @@ void JsonEffectPanel::BuildPropertyRow(wxWindow* parentWin, wxSizer* sizer, cons
     if (controlType == "slider") {
         int minVal = prop.value("min", 0);
         int maxVal = prop.value("max", 100);
+        // wxSlider::Create() asserts "minValue < maxValue"; a bad/narrow
+        // JSON range would trip that and leave the slider's native peer
+        // uncreated, corrupting state for whatever runs next in the panel.
+        if (maxVal <= minVal) maxVal = minVal + 1;
         int defaultInt;
         if (divisor > 1) {
             double defaultFloat = prop.value("default", 0.0);
@@ -1461,7 +1467,8 @@ void JsonEffectPanel::BuildPropertyRow(wxWindow* parentWin, wxSizer* sizer, cons
             readAxis(axis, axMin, axMax, axDef);
             const std::string axId = id + axis;
             const int scaledMin = static_cast<int>(axMin * (divisor > 1 ? divisor : 1));
-            const int scaledMax = static_cast<int>(axMax * (divisor > 1 ? divisor : 1));
+            int scaledMax = static_cast<int>(axMax * (divisor > 1 ? divisor : 1));
+            if (scaledMax <= scaledMin) scaledMax = scaledMin + 1;
             const int scaledDef = static_cast<int>(axDef * (divisor > 1 ? divisor : 1));
 
             PropertyInfo axInfo;


### PR DESCRIPTION
the values for atleast one shader resulted in the max being less than the min.