### PR TITLE
Restore FadeIn/Out bind to existing timings

### DIFF
--- a/src-ui-wx/sequencer/BlendingPanel.cpp
+++ b/src-ui-wx/sequencer/BlendingPanel.cpp
@@ -319,11 +319,13 @@ wxWindow* BlendingPanel::BuildTransitionHeader(wxWindow* parentWin, wxSizer* siz
         FireChangeEvent();
         e.Skip();
     });
-
+    
     if (isIn) {
+        fadeCombo->Bind(wxEVT_COMBOBOX_DROPDOWN, &BlendingPanel::OnFadeinDropdown, this);
         _inTypeChoice = typeChoice;
         _fadeinCombo = fadeCombo;
     } else {
+        fadeCombo->Bind(wxEVT_COMBOBOX_DROPDOWN, &BlendingPanel::OnFadeoutDropdown, this);
         _outTypeChoice = typeChoice;
         _fadeoutCombo = fadeCombo;
     }
@@ -409,19 +411,11 @@ void BlendingPanel::OnFadeoutText(wxCommandEvent& /*event*/) {
 }
 
 void BlendingPanel::OnFadeinDropdown(wxCommandEvent& /*event*/) {
-    if (auto* p = GetPropertyInfo("Fadein")) {
-        if (auto* cb = dynamic_cast<BulkEditComboBox*>(p->comboBox)) {
-            cb->PopulateComboBox();
-        }
-    }
+    if (_fadeinCombo) _fadeinCombo->PopulateComboBox();
 }
 
 void BlendingPanel::OnFadeoutDropdown(wxCommandEvent& /*event*/) {
-    if (auto* p = GetPropertyInfo("Fadeout")) {
-        if (auto* cb = dynamic_cast<BulkEditComboBox*>(p->comboBox)) {
-            cb->PopulateComboBox();
-        }
-    }
+    if (_fadeoutCombo) _fadeoutCombo->PopulateComboBox();
 }
 
 void BlendingPanel::OnTransitionTypeSelect(wxCommandEvent& /*event*/) {


### PR DESCRIPTION
Was removed by one of the refactors. Dropdown list now shows default options plus values. Used in the current sequence. BulkEdit also shows the new values.