### PR TITLE
Layout: open Wiring View and Node Layout as modeless windows

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -8051,9 +8051,16 @@ void LayoutPanel::ShowWiring()
 {
     Model* md = dynamic_cast<Model*>(selectedBaseObject);
     if (md == nullptr || md->GetDisplayAs() == DisplayAsType::ModelGroup || md->GetDisplayAs() == DisplayAsType::SubModel) return;
-    WiringDialog dlg(this, md->GetName());
-    dlg.SetData(md);
-    dlg.ShowModal();
+    // Show modeless so the user can keep working in xLights with the wiring
+    // window open behind it. WiringDialog::SetData snapshots everything it needs
+    // (points, rows/cols, name) and keeps no Model* pointer, so it is safe to
+    // outlive the model. Parent to the top-level frame so it stacks like a
+    // normal window (can go behind the main window) rather than floating on the
+    // layout panel. Heap-allocated; it destroys itself on close.
+    WiringDialog* dlg = new WiringDialog(wxGetTopLevelParent(this), md->GetName());
+    dlg->SetData(md);
+    dlg->Bind(wxEVT_CLOSE_WINDOW, [dlg](wxCloseEvent&) { dlg->Destroy(); });
+    dlg->Show();
 }
 
 void LayoutPanel::ExportModelAsCAD()

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -8042,9 +8042,18 @@ void LayoutPanel::ShowNodeLayout()
     Model* md = dynamic_cast<Model*>(selectedBaseObject);
     if (md == nullptr || md->GetDisplayAs() == DisplayAsType::ModelGroup || md->GetDisplayAs() == DisplayAsType::SubModel) return;
     wxString html = md->ChannelLayoutHtml(xlights->GetOutputManager(), IsDarkMode());
-    ChannelLayoutDialog dialog(this);
-    dialog.SetHtmlSource(html);
-    dialog.ShowModal();
+    // Show modeless (like Wiring View) so the user can keep working in xLights
+    // with the node-layout window open behind it. The dialog only holds the HTML
+    // string we hand it here (no Model* pointer), so it is safe to outlive the
+    // model. Parent to the top-level frame so it stacks like a normal window.
+    // Heap-allocated; it destroys itself on close.
+    ChannelLayoutDialog* dlg = new ChannelLayoutDialog(wxGetTopLevelParent(this));
+    dlg->SetHtmlSource(html);
+    dlg->Bind(wxEVT_CLOSE_WINDOW, [dlg](wxCloseEvent&) { dlg->Destroy(); });
+    // The OK button on a modeless dialog would only hide it (wxDialog's default),
+    // never firing the close event, so route it through Close() to destroy.
+    dlg->Bind(wxEVT_BUTTON, [dlg](wxCommandEvent&) { dlg->Close(); }, wxID_OK);
+    dlg->Show();
 }
 
 void LayoutPanel::ShowWiring()


### PR DESCRIPTION
## What
Right-click a model in the Layout panel → **Wiring View** or **Node Layout**. Both previously opened **modally**, blocking the rest of xLights until you closed them. This PR makes both **modeless**, so you can keep working in xLights (select models, pan the preview, wire things up) with the reference window open behind you — and open several at once (e.g. Wiring View on two different props side by side).

## How
`ShowWiring()` and `ShowNodeLayout()` (`src-ui-wx/layout/LayoutPanel.cpp`) now heap-allocate the dialog, parent it to the top-level frame (so it stacks like a normal window and can go behind the main window rather than floating over the layout panel), and `Show()` it modeless instead of `ShowModal()`. Each dialog destroys itself on close.

**Lifetime safety:** neither dialog retains a `Model*`.
- `WiringDialog::SetData()` snapshots everything it needs (points, rows/cols, name) up front.
- `ChannelLayoutDialog` only holds the HTML string handed to `SetHtmlSource()`.

So both are safe to outlive the selected model.

**Close handling:** `WiringDialog` has no buttons — the title-bar close fires `wxEVT_CLOSE_WINDOW` → `Destroy()`. `ChannelLayoutDialog` has an OK button; on a modeless dialog wxDialog's default OK only *hides* the window (never firing the close event), so its OK is routed through `Close()` to actually destroy it.

The other, modal `WiringDialog` use inside the Custom Model editor is unchanged.

## Testing
Built (macOS Debug) and exercised manually: both windows open modeless, xLights stays fully usable behind them, multiple windows coexist, and both close cleanly via the title-bar ✕ and (for Node Layout) the OK button.

## iPad parity
Desktop-only Layout-panel model-inspection dialogs; the iPad app has no Wiring View / Node Layout surface. This is a modality change to existing desktop-only dialogs — no iPad counterpart to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
