### PR TITLE
fixing dialog from prompting when no changes

### DIFF
--- a/src-ui-wx/model/ModelDefinitionsDialog.cpp
+++ b/src-ui-wx/model/ModelDefinitionsDialog.cpp
@@ -242,7 +242,8 @@ void ModelDefinitionsDialog::OnOK(wxCommandEvent&)
 
 void ModelDefinitionsDialog::ConfirmClose()
 {
-    if (wxMessageBox("Are you sure you want to close?",
+    if (_isDirty &&
+        wxMessageBox("Are you sure you want to close?",
                      "Are you sure?", wxYES_NO | wxCENTER, this) == wxNO) {
         return;
     }


### PR DESCRIPTION
When the model definition dialog box has no changes, do not prompt a confirmation dialog on cancel.