### PR TITLE
Move the symbol pennant to the bottom of the end timing mark (#6778)

### DIFF
--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -7641,9 +7641,9 @@ void EffectsGrid::DrawEffects(xlGraphicsContext* ctx) {
                 if (e->IsLinkedToSymbol() && x > MINIMUM_EFFECT_WIDTH_FOR_SMALL_RECT) {
                     float indicatorSize = 6.0f;
                     xlColor symbolColor(0, 200, 255);
-                    backgrounds->AddVertex(x2 - indicatorSize, y1, symbolColor);
-                    backgrounds->AddVertex(x2, y1, symbolColor);
-                    backgrounds->AddVertex(x2, y1 + indicatorSize, symbolColor);
+                    backgrounds->AddVertex(x2 - indicatorSize, y2, symbolColor);
+                    backgrounds->AddVertex(x2, y2, symbolColor);
+                    backgrounds->AddVertex(x2, y2 - indicatorSize, symbolColor);
                 }
 
                 DrawFadeHints(e, x3, y1, x4, y2, backgrounds);


### PR DESCRIPTION
it was being hidden by the fade out line / diamond.