### PR TITLE
#6797 - Set tree model to default vertical strands

### DIFF
--- a/src-core/models/ModelManager.cpp
+++ b/src-core/models/ModelManager.cpp
@@ -1425,6 +1425,7 @@ Model* ModelManager::CreateDefaultModel(const std::string& type, const std::stri
         m->SetNumMatrixStrings(16);
         m->SetNodesPerString(50);
         m->SetStrandsPerString(1);
+        m->SetVertical(true);
         model = m;
     } else if (type == "Matrix") {
         auto* m = new MatrixModel(*this);


### PR DESCRIPTION
Set native tree model to default to vertical strand direction. 