### PR TITLE
Fix Effect-drag waveform markers as statusbar text

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,8 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.15  August ??, 2026
+    -bug (MrPierreB)             Effect drag: waveform time markers now show the full selection span rather than just the grabbed effect
+    -bug (MrPierreB)             Effect drag: restore start/end/duration status bar text during move drag
     -enh (dkulp)                 Each show folder now carries a random id in xlights_rgbeffects.xml so a show
                                  that submits many crash reports is counted once rather than once per report.
                                  It identifies the show only - no machine, user or location - and is written

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -8434,7 +8434,21 @@ void EffectsGrid::UpdateEffectMoveDragState(int x, int y, bool snapToTiming, boo
     mEffectMoveHasCollision = anyCollision;
     SetCursor(anyCollision ? s_noEntry : s_sizing);
 
-    ((MainSequencer*)mParent)->PanelWaveForm->SetEffectDragOverride(anchorOrigStart + mEffectMoveTargetDeltaMS, anchorOrigEnd + mEffectMoveTargetDeltaMS);
+    // Update waveform markers and status bar with the projected range across all dragged effects
+    {
+        int minStart = INT_MAX, maxEnd = 0;
+        for (auto& snap : mEffectMoveSnapshots) {
+            minStart = std::min(minStart, snap.origStartTimeMS + mEffectMoveTargetDeltaMS);
+            maxEnd   = std::max(maxEnd,   snap.origEndTimeMS   + mEffectMoveTargetDeltaMS);
+        }
+        if (minStart != INT_MAX) {
+            ((MainSequencer*)mParent)->PanelWaveForm->SetEffectDragOverride(minStart, maxEnd);
+            xlights->SetStatusText(
+                wxString::Format("start: %s  end: %s  duration: %s",
+                                 FORMATTIME(minStart), FORMATTIME(maxEnd),
+                                 FORMATTIME(maxEnd - minStart)), true);
+        }
+    }
 
     wxSize sz = GetSize();
     int zone = FromDIP(40);


### PR DESCRIPTION
Since commit [4c968c0ea ](https://github.com/xLightsSequencer/xLights/commit/4c968c0ea) (ghost drag PR #6479 ), the waveform time markers and status bar text stopped updating during effect move drags.

AGFazio's follow-up PR #6752 restored the waveform markers but only for the anchor effect (the one clicked to start the drag), but the status bar text was not restored.
 
This PR fixes both remaining gaps: the waveform override now spans the earliest start to the latest end across all selected effects, and the status bar "start / end / duration" text is restored during drag.