### PR TITLE
Fix single-click on multi-selected effect not narrowing selection

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.15  August ??, 2026
+    -bug (MrPierreB)             Clicking an effect in a multi-selection now narrows the selection to just that effect instead of keeping all effects selected.
     -enh (dkulp)                 Each show folder now carries a random id in xlights_rgbeffects.xml so a show
                                  that submits many crash reports is counted once rather than once per report.
                                  It identifies the show only - no machine, user or location - and is written

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -4003,7 +4003,9 @@ void EffectsGrid::mouseReleased(wxMouseEvent& event) {
                     RaiseSelectedEffectChanged(mSelectedEffect, false);
                 }
             } else if (!mEffectMoveDragThresholdExceeded && mEffectMoveDragGroup && mEffectMoveAnchorEffect != nullptr) {
-                // Keep the group selected; just update the settings panel to the clicked effect
+                // Click-without-drag on a group member: narrow selection to just the clicked effect
+                mSequenceElements->UnSelectAllEffects();
+                mEffectMoveAnchorEffect->SetSelected(EFFECT_SELECTED);
                 mSelectedEffect = mEffectMoveAnchorEffect;
                 RaiseSelectedEffectChanged(mSelectedEffect, false);
             }


### PR DESCRIPTION
Clicking an effect that's part of a multi-selection should narrow the selection to just that effect. Since the ghost drag-to-move feature was added (#6479), clicking preserved the full group selection even when no drag occurred - treating click and drag-start identically. 
The fix defers deselection to mouseUp (the standard pattern): if the drag threshold is never exceeded, narrow to the clicked effect. If a drag occurs, the group still moves together.