### PR TITLE
Layout: fix use-after-free crash on tree selection after a model delete/refresh

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -8901,6 +8901,14 @@ int LayoutPanel::GetSelectedModelIndex() const
 Model* LayoutPanel::GetModelFromTreeItem(wxTreeListItem treeItem) {
     ModelTreeData *data = (ModelTreeData*)ActiveModelTree()->GetItemData(treeItem);
     Model* model = ((data != nullptr) ? data->GetModel() : nullptr);
+    // A queued tree selection-changed event can be delivered after the model it
+    // referenced was deleted or the tree was refreshed, leaving the item holding
+    // a freed Model*. Validate before returning so callers that dereference the
+    // result (e.g. HandleSelectionChanged's force-select and panel-display paths)
+    // can't crash on a stale pointer.
+    if (model != nullptr && !xlights->AllModels.IsModelValid(model)) {
+        return nullptr;
+    }
     return model;
 }
 


### PR DESCRIPTION
## What
Fixes a use-after-free crash (`EXC_BAD_ACCESS`) in `LayoutPanel::HandleSelectionChanged()` when a Layout **Models tree** selection changes right after a model was deleted or the tree was refreshed. Reported from the shipped 2026.14 build; the fault address is a garbage pointer, i.e. a dereference of freed memory.

## Root cause
A tree selection-changed event (`wxTreeListCtrl` → `outlineViewSelectionDidChange:`) is queued **before** a model delete / full tree refresh and delivered **after** it, so the selected tree item still holds a `Model*` that has already been freed.

`HandleSelectionChanged()` guards the *first* loop with `AllModels.IsModelValid(model)` and skips stale items — but the later paths in the same function (the "force select" fallback and the group/submodel/model panel-display branches) call `GetModelFromTreeItem()` and immediately dereference the result (`model->GetDisplayAs()`, `model->IsFromBase()`, `SetupPropGrid(model)`) **without** re-checking validity. A stale pointer reaching one of those lines crashes.

```
Thread 0 Crashed:
5  LayoutPanel::HandleSelectionChanged() + 1388
17 wxTreeListCtrl::SendItemEvent(...)
22 -[wxCocoaOutlineView outlineViewSelectionDidChange:]
28 -[NSTableView _sendSelectionChangedNotificationForRows:columns:]
30 -[NSTableView mouseDown:]
```

## Fix
Move the validity check into `GetModelFromTreeItem()` itself, so it returns `nullptr` for a freed model. Every caller already null-checks the return value, so this single change closes all the unguarded dereference paths at once — not just the ones in `HandleSelectionChanged()`.

```cpp
Model* LayoutPanel::GetModelFromTreeItem(wxTreeListItem treeItem) {
    ModelTreeData *data = (ModelTreeData*)ActiveModelTree()->GetItemData(treeItem);
    Model* model = ((data != nullptr) ? data->GetModel() : nullptr);
    if (model != nullptr && !xlights->AllModels.IsModelValid(model)) {
        return nullptr;
    }
    return model;
}
```

The existing explicit `IsModelValid` check inside `HandleSelectionChanged()`'s first loop is now redundant (stale items already come back as `nullptr`) but is left in place as harmless defense-in-depth; it can be removed in a follow-up if desired.

## Testing
Built (macOS Debug). The change mirrors the validity check the same function already relied on, so it introduces no new API surface.

## iPad parity
Desktop-only (`src-ui-wx/layout/`); the iPad layout selection path is separate. No iPad counterpart to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
