### PR TITLE
Fix copy n paste of MH Effect (#6806)

### DIFF
--- a/src-ui-wx/effectpanels/MovingHeadPanel.cpp
+++ b/src-ui-wx/effectpanels/MovingHeadPanel.cpp
@@ -856,19 +856,35 @@ void MovingHeadPanel::OnResize(wxSizeEvent& event)
             }
         }
     }
-    if (!m_minSizeSet) {
-        wxWindow* p = GetParent();
-        while (p && !p->GetName().IsSameAs("Effect"))
-            p = p->GetParent();
-        if (p) {
-            wxAuiManager* mgr = wxAuiManager::GetManager(p);
-            if (mgr) {
-                wxAuiPaneInfo& pane = mgr->GetPane(p);
-                if (pane.IsOk()) {
-                    pane.MinSize(wxSize(350, -1));
-                    mgr->Update();
-                    m_minSizeSet = true;
-                }
+    if (!m_minSizeSet && IsShownOnScreen()) {
+        // This must stay gated on IsShownOnScreen(): it used to run once during
+        // initial choicebook construction, long before the panel was ever really
+        // laid out, using GetBestSize() values that were meaningless that early.
+        // Because m_minSizeSet then latched true permanently, that garbage
+        // snapshot stuck for the rest of the run. FlexGridSizer_Main->CalcMin()
+        // forces a fresh recompute from the sizer's current children instead of
+        // relying on GetBestSize(), which is cached and can go stale.
+        //
+        // wxAuiManager::GetManager(this) doesn't reliably find the manager from
+        // this deep in the choicebook/scrolledwindow nesting. SketchPanel.cpp's
+        // getSketchAssistPanel() hits the same problem reaching the
+        // "EffectAssist" pane and works around it by walking parents for the
+        // actual xLightsFrame and using its m_mgr directly -- do the same here,
+        // then look the pane up by its *AUI pane name* ("Effect", set in
+        // CreateSequencer's m_mgr->AddPane(effectsPnl, ...Name("Effect")...)).
+        xLightsFrame* frame = nullptr;
+        for (wxWindow* w = GetParent(); w != nullptr; w = w->GetParent()) {
+            frame = dynamic_cast<xLightsFrame*>(w);
+            if (frame != nullptr) break;
+        }
+        wxAuiManager* mgr = frame ? frame->m_mgr : nullptr;
+        if (mgr) {
+            wxAuiPaneInfo& pane = mgr->GetPane(wxT("Effect"));
+            if (pane.IsOk()) {
+                wxSize best = FlexGridSizer_Main->CalcMin();
+                pane.MinSize(wxSize(std::max(best.GetWidth(), FromDIP(350)), best.GetHeight()));
+                mgr->Update();
+                m_minSizeSet = true;
             }
         }
     }

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -56,7 +56,9 @@
 #include "effects/PicturesEffect.h"
 #include "effects/ShaderEffect.h"
 #include "effects/VideoEffect.h"
+#include "models/DMX/DmxMovingHeadComm.h"
 #include "models/Model.h"
+#include "models/ModelGroup.h"
 #include "utils/string_utils.h"
 #include "xLightsVersion.h"
 
@@ -5883,8 +5885,84 @@ int EffectsGrid::GetMSFromColumn(int col) const {
     return 0;
 }
 
+namespace {
+    // A Moving Head effect copied off a single-fixture model only ever has one
+    // of its 8 per-head E_TEXTCTRL_MHn_Settings slots populated (whichever head
+    // number that source model owns). Pasted verbatim onto a model group made
+    // entirely of moving heads, every other fixture in the group would render
+    // with no position/color data at all. EffectDroppedOnGrid (tabSequencer.cpp)
+    // already forces the buffer style to "Per Model Default" for a freshly
+    // dragged-and-dropped effect in this situation; paste needs the same
+    // treatment plus cloning that one populated slot's settings into every
+    // fixture's own slot (swapping in each fixture's actual head number so
+    // MovingHeadEffect can still tell them apart).
+    void FixupMovingHeadEffectForGroup(Effect* ef, Element* element) {
+        if (ef == nullptr || element == nullptr || ef->GetEffectName() != "Moving Head")
+            return;
+
+        xLightsFrame* xlights = xLightsApp::GetFrame();
+        Model* m = xlights->AllModels[element->GetModelName()];
+        if (m == nullptr || m->GetDisplayAs() != DisplayAsType::ModelGroup)
+            return;
+
+        auto mg = dynamic_cast<ModelGroup*>(m);
+        if (mg == nullptr)
+            return;
+
+        std::vector<int> fixtureNums;
+        for (const auto& it : mg->GetFlatModels(true, false)) {
+            if (it->GetDisplayAs() != DisplayAsType::DmxMovingHeadAdv && it->GetDisplayAs() != DisplayAsType::DmxMovingHead) {
+                return; // mixed group -- leave the pasted effect alone
+            }
+            auto mh = dynamic_cast<const DmxMovingHeadComm*>(it);
+            if (mh != nullptr) {
+                fixtureNums.push_back(mh->GetFixtureVal());
+            }
+        }
+        if (fixtureNums.empty())
+            return;
+
+        SettingsMap& settings = ef->GetSettings();
+        settings["B_CHOICE_BufferStyle"] = "Per Model Default";
+
+        std::string sourceHeadSettings;
+        for (int i = 1; i <= 8; ++i) {
+            std::string val = settings.Get("E_TEXTCTRL_MH" + std::to_string(i) + "_Settings", "");
+            if (!val.empty()) {
+                sourceHeadSettings = val;
+                break;
+            }
+        }
+        if (sourceHeadSettings.empty())
+            return;
+
+        for (int i = 1; i <= 8; ++i) {
+            settings["E_TEXTCTRL_MH" + std::to_string(i) + "_Settings"] = "";
+        }
+
+        for (int fixture : fixtureNums) {
+            if (fixture < 1 || fixture > 8)
+                continue;
+            wxArrayString cmds = wxSplit(sourceHeadSettings, ';');
+            wxArrayString newCmds;
+            for (auto& cmd : cmds) {
+                if (cmd.IsEmpty())
+                    continue;
+                int pos = cmd.Find(':');
+                wxString cmdType = (pos == wxNOT_FOUND) ? cmd : cmd.Left(pos);
+                if (cmdType == "Heads") {
+                    newCmds.Add(wxString::Format("Heads: %d", fixture));
+                } else {
+                    newCmds.Add(cmd);
+                }
+            }
+            settings["E_TEXTCTRL_MH" + std::to_string(fixture) + "_Settings"] = wxJoin(newCmds, ';').ToStdString();
+        }
+    }
+}
+
 Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersion, bool row_paste, bool layerMode) {
-    
+
 
     Effect* res = nullptr;
 
@@ -6376,6 +6454,7 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
                                     xlights->GetEffectManager().GetEffect(efdata[0].ToStdString())->adjustSettings(pasteDataVersion.ToStdString(), ef, false);
                                 }
                                 ef->HandlePastedSymbolLink();
+                                FixupMovingHeadEffectForGroup(ef, el->GetParentElement());
                                 mSequenceElements->get_undo_mgr().CaptureAddedEffect(el->GetParentElement()->GetModelName(), el->GetIndex(), ef->GetID());
                             }
                         }
@@ -6457,6 +6536,7 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
                                 xlights->GetEffectManager().GetEffect(efdata[0].ToStdString())->adjustSettings(pasteDataVersion.ToStdString(), ef, false);
                             }
                             ef->HandlePastedSymbolLink();
+                            FixupMovingHeadEffectForGroup(ef, el->GetParentElement());
                             mSequenceElements->get_undo_mgr().CreateUndoStep();
                             mSequenceElements->get_undo_mgr().CaptureAddedEffect(el->GetParentElement()->GetModelName(), el->GetIndex(), ef->GetID());
                             if (!is_timing_effect) {
@@ -6546,6 +6626,7 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
                                     xlights->GetEffectManager().GetEffect(efdata[0].ToStdString())->adjustSettings(pasteDataVersion.ToStdString(), ef, false);
                                 }
                                 ef->HandlePastedSymbolLink();
+                                FixupMovingHeadEffectForGroup(ef, el->GetParentElement());
                                 mSequenceElements->get_undo_mgr().CaptureAddedEffect(el->GetParentElement()->GetModelName(), el->GetIndex(), ef->GetID());
                                 RaiseSelectedEffectChanged(ef, true);
                                 mSelectedEffect = ef;


### PR DESCRIPTION
Copy single Head effect to Group now sets the entire group to that setting. Like it would if you copied butterfly from Tree to Trees.
