### PR TITLE
Fix float number entry (#6814)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,7 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.15  August ??, 2026
+    -bug (derwin12)              Fix typing negative numbers into effect slider/textbox pairs
     -bug (dkulp)                 Fix a crash on app close resetting the effect panels to defaults, and track
                                  effect-panel window lifetime so a destroyed panel can never be reused
     -bug (derwin12)              Fix MovingHead Advanced: reset Path and Pattern on new effect

--- a/src-ui-wx/shared/controls/BulkEditControls.cpp
+++ b/src-ui-wx/shared/controls/BulkEditControls.cpp
@@ -1202,16 +1202,31 @@ void BulkEditTextCtrl::TextUpdate(bool force)
                 long lval = 0;
                 bool ok = GetValue().ToCLong(&lval);
                 auto t = static_cast<int>(lval);
-                if (!ok || s->GetValue() != t)
+                if (!ok)
                 {
-                    if (!ok || force || (s->GetMin() <= 0 && s->GetMax() >= 0) || t >= s->GetMin())
+                    // Mid-typing states (e.g. "-", "" while backspacing) don't parse yet.
+                    // Only snap back to the slider's value once the user is done editing;
+                    // otherwise this fires on every keystroke and clobbers what they're typing.
+                    if (force)
+                    {
+                        wxString corrected = wxString::Format("%d", s->GetValue());
+                        SetValue(corrected);
+                    }
+                }
+                else
+                {
+                    if (s->GetValue() != t && (force || (s->GetMin() <= 0 && s->GetMax() >= 0) || t >= s->GetMin()))
                     {
                         s->SetValue(t);
-                        if (!ok || (s->GetValue() != t && force))
-                        {
-                            wxString corrected = wxString::Format("%d", s->GetValue());
-                            if (!ok) SetValue(corrected); else ChangeValue(corrected);
-                        }
+                    }
+                    // Re-canonicalize the displayed text from the (possibly clamped)
+                    // slider value once editing is done, even if the slider didn't need
+                    // to move — otherwise a fully-typed, in-range value like "-5" is left
+                    // un-reformatted until something else repaints the field.
+                    if (force)
+                    {
+                        wxString corrected = wxString::Format("%d", s->GetValue());
+                        if (GetValue() != corrected) ChangeValue(corrected);
                     }
                 }
             }
@@ -1221,16 +1236,24 @@ void BulkEditTextCtrl::TextUpdate(bool force)
                 double dval = 0.0;
                 bool ok = GetValue().ToCDouble(&dval);
                 auto t = static_cast<int>(dval * 10);
-                if (!ok || s->GetValue() != t)
+                if (!ok)
                 {
-                    if (!ok || force || (s->GetMin() <= 0 && s->GetMax() >= 0) || t >= s->GetMin())
+                    if (force)
+                    {
+                        wxString corrected = wxString::Format("%.1f", (float)s->GetValue() / 10.0);
+                        SetValue(corrected);
+                    }
+                }
+                else
+                {
+                    if (s->GetValue() != t && (force || (s->GetMin() <= 0 && s->GetMax() >= 0) || t >= s->GetMin()))
                     {
                         s->SetValue(t);
-                        if (!ok || (s->GetValue() != t && force))
-                        {
-                            wxString corrected = wxString::Format("%.1f", (float)s->GetValue() / 10.0);
-                            if (!ok) SetValue(corrected); else ChangeValue(corrected);
-                        }
+                    }
+                    if (force)
+                    {
+                        wxString corrected = wxString::Format("%.1f", (float)s->GetValue() / 10.0);
+                        if (GetValue() != corrected) ChangeValue(corrected);
                     }
                 }
             }
@@ -1240,16 +1263,24 @@ void BulkEditTextCtrl::TextUpdate(bool force)
                 double dval = 0.0;
                 bool ok = GetValue().ToCDouble(&dval);
                 auto t = static_cast<int>(dval * 100.0);
-                if (!ok || s->GetValue() != t)
+                if (!ok)
                 {
-                    if (!ok || force || (s->GetMin() <= 0 && s->GetMax() >= 0) || t >= s->GetMin())
+                    if (force)
+                    {
+                        wxString corrected = wxString::Format("%.2f", (float)s->GetValue() / 100.0);
+                        SetValue(corrected);
+                    }
+                }
+                else
+                {
+                    if (s->GetValue() != t && (force || (s->GetMin() <= 0 && s->GetMax() >= 0) || t >= s->GetMin()))
                     {
                         s->SetValue(t);
-                        if (!ok || (s->GetValue() != t && force))
-                        {
-                            wxString corrected = wxString::Format("%.2f", (float)s->GetValue() / 100.0);
-                            if (!ok) SetValue(corrected); else ChangeValue(corrected);
-                        }
+                    }
+                    if (force)
+                    {
+                        wxString corrected = wxString::Format("%.2f", (float)s->GetValue() / 100.0);
+                        if (GetValue() != corrected) ChangeValue(corrected);
                     }
                 }
             }
@@ -1259,16 +1290,24 @@ void BulkEditTextCtrl::TextUpdate(bool force)
                 double dval = 0.0;
                 bool ok = GetValue().ToCDouble(&dval);
                 auto t = static_cast<int>(dval * 360.0);
-                if (!ok || s->GetValue() != t)
+                if (!ok)
                 {
-                    if (!ok || force || (s->GetMin() <= 0 && s->GetMax() >= 0) || t >= s->GetMin())
+                    if (force)
+                    {
+                        wxString corrected = wxString::Format("%.2f", (float)s->GetValue() / 360.0);
+                        SetValue(corrected);
+                    }
+                }
+                else
+                {
+                    if (s->GetValue() != t && (force || (s->GetMin() <= 0 && s->GetMax() >= 0) || t >= s->GetMin()))
                     {
                         s->SetValue(t);
-                        if (!ok || (s->GetValue() != t && force))
-                        {
-                            wxString corrected = wxString::Format("%.2f", (float)s->GetValue() / 360.0);
-                            if (!ok) SetValue(corrected); else ChangeValue(corrected);
-                        }
+                    }
+                    if (force)
+                    {
+                        wxString corrected = wxString::Format("%.2f", (float)s->GetValue() / 360.0);
+                        if (GetValue() != corrected) ChangeValue(corrected);
                     }
                 }
             }


### PR DESCRIPTION
Fix typing negative numbers into effect slider/textbox pairs (e.g. Spirals
Movement): entering a value that wasn't yet a complete number (like "-") reset
the field to 0.0 on every keystroke instead of letting you keep typing
Movement): entering a value that wasn't yet a complete number (like "-") reset
the field to 0.0 on every keystroke instead of letting you keep typing