### PR TITLE
Fix sequence marked dirty in seq settings (#6828)

### DIFF
--- a/src-ui-wx/sequencer/SeqSettingsDialog.cpp
+++ b/src-ui-wx/sequencer/SeqSettingsDialog.cpp
@@ -26,6 +26,7 @@
 #include <wx/textdlg.h>
 
 #include <list>
+#include <sstream>
 
 #include "SeqSettingsDialog.h"
 #include "sequencer/NewTimingDialog.h"
@@ -658,6 +659,8 @@ SeqSettingsDialog::SeqSettingsDialog(wxWindow* parent, SequenceFile* file_to_han
     UpdateDataLayer();
     needs_render = false;
 
+    _initialSettingsSignature = BuildSettingsSignature();
+
     int x, y, w, h;
     GetPosition(&x, &y);
     GetSize(&w, &h);
@@ -706,6 +709,35 @@ SeqSettingsDialog::~SeqSettingsDialog()
     }
 	//(*Destroy(SeqSettingsDialog)
 	//*)
+}
+
+std::string SeqSettingsDialog::BuildSettingsSignature() const
+{
+    std::ostringstream sig;
+    sig << xml_file->GetSequenceType() << "|"
+        << xml_file->GetMediaFile() << "|"
+        << xml_file->GetSequenceDurationMS() << "|"
+        << (int)xml_file->supportsModelBlending() << "|"
+        << xml_file->GetRenderMode() << "|";
+
+    for (int i = 0; i < (int)HEADER_INFO_TYPES::NUM_TYPES; ++i) {
+        sig << xml_file->GetHeaderInfo((HEADER_INFO_TYPES)i) << "|";
+    }
+
+    auto timings = xml_file->GetSequenceLoaded() ? xml_file->GetTimingList(xLightsParent->GetSequenceElements()) : xml_file->GetTimingList();
+    for (const auto& t : timings) {
+        sig << t << ",";
+    }
+    sig << "|";
+
+    DataLayerSet& data_layers = xml_file->GetDataLayers();
+    for (int i = 0; i < data_layers.GetNumLayers(); ++i) {
+        DataLayer* layer = data_layers.GetDataLayer(i);
+        sig << layer->GetName() << ":" << layer->GetSource() << ":" << layer->GetDataSource() << ":"
+            << layer->GetNumChannels() << ":" << layer->GetChannelOffset() << ",";
+    }
+
+    return sig.str();
 }
 
 void SeqSettingsDialog::RemoveWizard()

--- a/src-ui-wx/sequencer/SeqSettingsDialog.h
+++ b/src-ui-wx/sequencer/SeqSettingsDialog.h
@@ -49,6 +49,12 @@ class SeqSettingsDialog: public wxDialog
 
         const std::string GetView() const {return selected_view;}
 
+        // Snapshot of the settings that matter for "has anything actually changed"
+        // purposes, taken once population finishes. Compared against the current
+        // state on close so the caller can skip marking the sequence dirty when
+        // the user just opened the dialog and clicked Done without editing anything.
+        bool HasSettingsChanged() const { return BuildSettingsSignature() != _initialSettingsSignature; }
+
 		//(*Declarations(SeqSettingsDialog)
 		wxBitmapButton* BitmapButton_ModifyTiming;
 		wxBitmapButton* BitmapButton_Xml_Media_File;
@@ -385,4 +391,7 @@ class SeqSettingsDialog: public wxDialog
         void MediaLoad(const wxString& filename);
 		bool UpdateSequenceTiming();
 		void ValidateWindow();
+
+        std::string BuildSettingsSignature() const;
+        std::string _initialSettingsSignature;
 };

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -3563,7 +3563,9 @@ void xLightsFrame::ShowSequenceSettings()
 
     SetAudioControls();
 
-    _sequenceElements.IncrementChangeCount(nullptr);
+    if (dialog.HasSettingsChanged()) {
+        _sequenceElements.IncrementChangeCount(nullptr);
+    }
 }
 
 void xLightsFrame::OnMenu_Settings_SequenceSelected(wxCommandEvent& event)


### PR DESCRIPTION
Looks for changes in the various settings then marks dirty if changes found rather than always marking it dirty