### PR TITLE
Linux: enable VA-API hardware video decode

### DIFF
--- a/README.linux
+++ b/README.linux
@@ -96,6 +96,20 @@ Instructions for other Linux distributions will vary.
        (mesa-vulkan-drivers covers Intel/AMD; NVIDIA users get Vulkan from the
        proprietary driver. Enable it under Preferences > Other > GPU rendering.)
 
+     Hardware video decode (VA-API):
+       No build-time dependency — decode goes through FFmpeg's generic
+       hwaccel API (libavcodec/libavutil, already required above), which
+       resolves VAAPI via the distro's own libva at runtime; nothing
+       VAAPI-specific is linked by xLights itself.
+
+       RUNTIME: needs a VA-API driver for the GPU (Intel: intel-media-va-driver
+       or intel-media-va-driver-non-free for newer iGPUs; AMD/Mesa:
+       mesa-va-drivers):
+         sudo apt-get install vainfo intel-media-va-driver mesa-va-drivers
+       `vainfo` confirms the driver initializes ("VAProfile..." lines printed)
+       before relying on it. Enable under Preferences > Other > Hardware Video
+       Decoding — it auto-tries vaapi then vdpau, no manual selection needed.
+
      Example commands to install packages on Fedora 42
 
      Fedora 38+ defaults to "ffmpeg-free" library to switch to full ffmpeg run, add rpmfusion repo first:

--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,9 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.15  August ??, 2026
+    -bug (scott)                 Linux: hardware video decoding (VA-API, Preferences > Other) actually works now.
+                                 The Linux build force-disabled it in code regardless of the setting, so the
+                                 checkbox was hidden and had no effect even if re-enabled via config file
     -enh (dkulp)                 Windows video decode: hardware decoding and the DirectX11 reader are now the
                                  default, and that reader converts and scales on the GPU with the colour space
                                  stated explicitly instead of leaving it to the system. Video-heavy sequences

--- a/src-core/media/FFmpegVideoReader.cpp
+++ b/src-core/media/FFmpegVideoReader.cpp
@@ -81,11 +81,7 @@ WINHARDWARERENDERTYPE FFmpegVideoReader::HW_ACCELERATION_TYPE = WINHARDWARERENDE
 
 void FFmpegVideoReader::SetHardwareAcceleratedVideo(bool accel)
 {
-#ifdef __LINUX__
-    HW_ACCELERATION_ENABLED = false;
-#else
     HW_ACCELERATION_ENABLED = accel;
-#endif
 }
 
 void FFmpegVideoReader::SetHardwareRenderType(int type)

--- a/src-ui-wx/preferences/OtherSettingsPanel.cpp
+++ b/src-ui-wx/preferences/OtherSettingsPanel.cpp
@@ -276,7 +276,11 @@ OtherSettingsPanel::OtherSettingsPanel(wxWindow* parent, xLightsFrame* f, wxWind
 #endif
 
 #ifdef __LINUX__
-    HardwareVideoDecodingCheckBox->Hide();
+    // The renderer choice list is Windows-vendor-specific (CUDA/QSV/AMF/
+    // DirectX11); Linux's decode path always auto-tries vaapi then vdpau
+    // (FFmpegVideoReader.cpp reopenContext()), so there is nothing for this
+    // dropdown to select between here. The checkbox itself is real: it gates
+    // that vaapi/vdpau auto-selection.
     ShaderCheckbox->Hide();
     HardwareVideoRenderChoice->Hide();
 #endif


### PR DESCRIPTION
## Summary
- `FFmpegVideoReader::SetHardwareAcceleratedVideo()` (`src-core/media/FFmpegVideoReader.cpp`) force-disabled hardware decode on Linux regardless of the passed-in value: `#ifdef __LINUX__ HW_ACCELERATION_ENABLED = false; #else ...`. The vaapi/vdpau candidate list in `reopenContext()` was already fully implemented and reachable via FFmpeg's generic hwaccel API (`av_hwdevice_find_type_by_name`, `avcodec_get_hw_config`) — it just never ran, on any Linux build.
- `OtherSettingsPanel.cpp` additionally hid the "Hardware Video Decoding" checkbox entirely on Linux, so the setting was both invisible in the UI and, even if re-enabled via a hand-edited config file, silently ignored by the code above.
- This is rows 36/37 of `plans/platform-parity/15-desktop-platform-matrix.md` (the cross-OS desktop audit) — noted there as "unreachable because the pref is hidden and defaults off."

## Changes
- Remove the `__LINUX__` force-disable — `SetHardwareAcceleratedVideo()` now behaves the same on all platforms.
- Unhide the `HardwareVideoDecodingCheckBox` on Linux. Left `HardwareVideoRenderChoice` (the CUDA/QSV/AMF/DirectX11 dropdown) and `ShaderCheckbox` hidden — the renderer dropdown's options are Windows-vendor-specific and Linux's decode path always auto-tries vaapi then vdpau with no manual backend selection, so there's nothing for it to select between.
- `README.linux`: document the VA-API runtime driver requirement (`mesa-va-drivers` / `intel-media-va-driver`) and `vainfo` as the way to confirm a driver actually initializes. No new **build** dependency — decode goes through FFmpeg's own `libavcodec`/`libavutil` hwaccel dispatch (already-required packages), which resolves VAAPI via the distro's `libva` at runtime.
- `README.txt` release note.

## Verification
- Compiled `FFmpegVideoReader.cpp` with `-fsyntax-only` against the real FFmpeg 8.0.1 dev headers/libs on this box: zero errors.
- Confirmed with `vainfo` on this machine that the Intel iHD VA-API driver initializes and advertises `VAEntrypointVLD` (decode) for H.264/HEVC/VP8/VP9/MPEG2 — i.e., the code path this PR unblocks has real hardware to exercise, not just a hypothetical.
- Did not do a full xLights build in this environment (would need the complete dependency chain: wxWidgets, SDL2, etc.) — a full `make`/`cmake` build plus playing a video through the House Preview with the checkbox enabled is the remaining verification step.

## Test plan
- [ ] `make clean && make` (or the CMake build), confirm it builds
- [ ] Preferences > Other > "Hardware Video Decoding" is now visible and togglable on Linux
- [ ] With it enabled and a VA-API driver installed, play a video-effect-heavy sequence and confirm no regression vs. software decode (same frame content; `--fseqcmp`-style headless-to-headless determinism check if convenient)
- [ ] With it enabled but no VA-API driver installed, confirm graceful fallback to software decode (the existing `CreateHWDeviceContext` absence-caching logic already handles this — not new behavior from this PR, but worth confirming end-to-end now that the path is reachable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)