### PR TITLE
Linux: move log file out of /tmp

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,9 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.15  August ??, 2026
+    -bug (scott)                 Linux: the log file (xLights_spdlog.log) now lives in $XDG_STATE_HOME (default
+                                 ~/.local/state/xLights) instead of /tmp, where it was wiped on every reboot
+                                 and could vanish mid-session to a systemd-tmpfiles sweep
     -enh (dkulp)                 Windows video decode: hardware decoding and the DirectX11 reader are now the
                                  default, and that reader converts and scales on the GPU with the colour space
                                  stated explicitly instead of leaving it to the system. Video-heavy sequences

--- a/src-ui-wx/settings/XLightsConfigAdapter.cpp
+++ b/src-ui-wx/settings/XLightsConfigAdapter.cpp
@@ -65,7 +65,18 @@ std::filesystem::path GetLogFileFolder() {
     const char* home = std::getenv("HOME");
     dir = std::filesystem::path(home && *home ? home : ".") / "Library" / "Logs";
 #else
-    dir = std::filesystem::path( "/tmp/");
+    // Was hardcoded to /tmp — wiped on reboot (and subject to mid-session
+    // systemd-tmpfiles sweeps), so "please attach your log" often produced
+    // nothing to attach. XDG_STATE_HOME (default ~/.local/state) is the XDG
+    // Base Directory spec's location for exactly this: logs/history that
+    // should persist across restarts but aren't user "data" or "config".
+    const char* xdgState = std::getenv("XDG_STATE_HOME");
+    if (xdgState && *xdgState) {
+        dir = std::filesystem::path(xdgState) / "xLights";
+    } else {
+        const char* home = std::getenv("HOME");
+        dir = std::filesystem::path(home && *home ? home : ".") / ".local" / "state" / "xLights";
+    }
 #endif
 
     std::error_code ec;


### PR DESCRIPTION
## Summary
- `GetLogFileFolder()` (`src-ui-wx/settings/XLightsConfigAdapter.cpp`) hardcoded the Linux log directory to `/tmp`, unlike Windows (`%APPDATA%\xLights\Logs`) and macOS (`~/Library/Logs`), both of which persist across restarts.
- `/tmp` is wiped on every reboot and can be swept mid-session by `systemd-tmpfiles`, so "please attach your log" often produced nothing for a Linux user to attach — row 71 of `plans/platform-parity/15-desktop-platform-matrix.md`.
- Switch to `$XDG_STATE_HOME` (default `~/.local/state/xLights`) — the XDG Base Directory spec's designated location for exactly this: logs/history that should survive restarts but aren't "config" (settings.json, one function up, already uses `$XDG_CONFIG_HOME`) or "data".

## Scope
Every call site (`xLightsMain.cpp`, `xLightsApp.cpp`, `ShowFolderSearchDialog.cpp`, `common/xlBaseApp.cpp`) already goes through `GetLogFileFolder()`/`GetLogFilePath()`, so this one function is the only place that needed to change. `src-ui-wx`-only file — no iPad build implication.

## Verification
- Extracted the exact function body into a standalone program and compiled/ran it: confirmed it builds cleanly, defaults to `~/.local/state/xLights` when `XDG_STATE_HOME` is unset, and correctly honors `XDG_STATE_HOME` when set.
- Grepped for other `/tmp` log references — none; this was the only hardcoded path.

## Test plan
- [ ] Build and run on Linux, confirm the log file appears at `~/.local/state/xLights/xLights_spdlog.log` (or `$XDG_STATE_HOME/xLights/...` if set) and not in `/tmp`
- [ ] Confirm Help > "Open Log Folder" / diagnostics bundle / crash-report paths (all of which read `GetLogFileFolder()`) still find the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)