### PR TITLE
Model Definitions: name the model in the dialog title

### DIFF
--- a/src-ui-wx/model/ModelDefinitionsDialog.cpp
+++ b/src-ui-wx/model/ModelDefinitionsDialog.cpp
@@ -16,6 +16,7 @@
 #include "models/Model.h"
 #include "outputs/OutputManager.h"
 #include <wx/button.h>
+#include <wx/intl.h> // _() - don't rely on a transitive include
 #include <wx/sizer.h>
 #include <wx/splitter.h>
 #include <wx/msgdlg.h>
@@ -31,7 +32,13 @@ END_EVENT_TABLE()
 
 ModelDefinitionsDialog::ModelDefinitionsDialog(wxWindow* parent, OutputManager* outputManager,
                                                Model* model, int initialTab)
-    : wxDialog(parent, wxID_ANY, "Model Definitions", wxDefaultPosition, wxDefaultSize,
+    // Name the model in the title - with three tabs and a preview it was
+    // otherwise impossible to tell which model was being edited.
+    : wxDialog(parent, wxID_ANY,
+               model != nullptr
+                   ? wxString::Format(_("Model Definitions - %s"), wxString::FromUTF8(model->GetName()))
+                   : wxString(_("Model Definitions")),
+               wxDefaultPosition, wxDefaultSize,
                wxCAPTION | wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMAXIMIZE_BOX),
       _outputManager(outputManager),
       _model(model)


### PR DESCRIPTION
## What

The **Faces / States / SubModels** dialog was titled just *"Model Definitions"*, so with three tabs and a node preview filling the window there was nothing on screen telling you **which model you were editing**.

The model's name now appears in the **title bar**:

```
Model Definitions - Bauble-Round-Small
```

All six entry points share this one dialog — the Layout right-click **SubModels / Faces / States** items, and the same three from the **model property grid** — so they all pick it up from the single constructor change. Falls back to the plain title if no model is passed.

## Cross-platform

- Pure wxWidgets API (`wxString::Format` / `wxString::FromUTF8` / `_()`), no platform-specific code, so macOS / Windows / Linux behave identically.
- **No new source files**, so no `.cbp` / `.vcxproj` / `.vcxproj.filters` / `CMakeLists.txt` changes are required.
- Verified with the **`NO_PCH`** build as well as the normal one, specifically to prove the include story holds where the macOS PCH isn't masking anything.

## Notes on the details (pre-empting the usual review points)

- **UTF-8 boundary:** `GetName()` returns `const std::string&`, so it's converted explicitly with `wxString::FromUTF8(...)` rather than relying on implicit conversion (which corrupts non-ASCII model names on Windows). Passing a `wxString` also side-steps the `std::string`-into-`%s` question entirely.
- **Localization:** both title forms are wrapped in `_()`, and the format specifier is kept in the translatable string so translators can reorder it.
- **Explicit include:** added `#include <wx/intl.h>` for `_()` — it was previously only resolving through a transitive include, which is exactly the kind of thing that builds on macOS and fails elsewhere.
- **Null-safe:** guards `model != nullptr` even though all current call sites pass a real model.
- Plain ASCII hyphen in the title (no en/em-dash), no tabs, no other churn — the diff is one include plus the title expression.

## iPad parity

Desktop-only (`src-ui-wx/model/`). The iPad has no equivalent Model Definitions dialog, so there's nothing to mirror.
