### PR TITLE
Add/Remove to Existing Groups: filterable group list, ticked groups stay visible

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -73,6 +73,7 @@
 #include "model/WiringDialog.h"
 #include "model/ModelDimmingCurveDialog.h"
 #include "UtilFunctions.h"
+#include "shared/dialogs/CheckboxSelectDialog.h"
 #include "shared/utils/ExternalHooksUI.h"
 #include "color/ColorManager.h"
 #include "utils/VectorMath.h"
@@ -3672,7 +3673,10 @@ void LayoutPanel::AddSelectedToExistingGroups() {
         return;
     }
 
-    wxMultiChoiceDialog dlg(this, "Select existing groups to add selections to", "Existing Group", choices);
+    // Filterable picker - group lists get long. Groups you have already ticked
+    // stay visible when you change the filter, so you can search, tick, search
+    // again and tick more without losing your earlier choices.
+    CheckboxSelectDialog dlg(this, _("Select existing groups to add selections to"), choices);
     OptimiseDialogPosition(&dlg);
 
     std::string selectgroupName;
@@ -3680,8 +3684,8 @@ void LayoutPanel::AddSelectedToExistingGroups() {
 
     if (dlg.ShowModal() == wxID_OK) {
         xlights->AbortRender();
-        for (auto const& idx : dlg.GetSelections()) {
-            std::string groupName = choices.at(idx).ToStdString();
+        for (auto const& groupNameStr : dlg.GetSelectedItems()) {
+            std::string groupName = groupNameStr.ToStdString();
 
             Model* addToGroupModel = xlights->GetModel(groupName);
 
@@ -3736,14 +3740,15 @@ void LayoutPanel::RemoveSelectedFromExistingGroups() {
             for (const auto& it : inModelGroups) {
                 choices.Add(it);
             }
-            wxMultiChoiceDialog dlg(this, "Select groups to remove model from", "Model in Groups", choices);
+            // Same filterable picker as the add-to-groups path above.
+            CheckboxSelectDialog dlg(this, _("Select groups to remove model from"), choices);
             OptimiseDialogPosition(&dlg);
 
             bool reload = false;
             if (dlg.ShowModal() == wxID_OK) {
                 xlights->AbortRender();
-                for (auto const& idx : dlg.GetSelections()) {
-                    std::string groupName = choices.at(idx).ToStdString();
+                for (auto const& groupNameStr : dlg.GetSelectedItems()) {
+                    std::string groupName = groupNameStr.ToStdString();
                     Model* grp = xlights->GetModel(groupName);
                     if (grp != nullptr && grp->GetDisplayAs() == DisplayAsType::ModelGroup) {
                         ModelGroup* modelGroup = dynamic_cast<ModelGroup*>(grp);

--- a/src-ui-wx/shared/dialogs/CheckboxSelectDialog.cpp
+++ b/src-ui-wx/shared/dialogs/CheckboxSelectDialog.cpp
@@ -204,10 +204,14 @@ void CheckboxSelectDialog::PopulateList()
     CheckListBox_Items->Clear();
     for (const auto& item : _allItems)
     {
-        if (MatchesFilter(item))
+        // Items you have already ticked stay listed even when the filter would
+        // exclude them, so you can filter, tick some, change the filter, tick
+        // more, and still see everything chosen before pressing OK.
+        const bool isChecked = _checked.find(item) != _checked.end();
+        if (isChecked || MatchesFilter(item))
         {
             CheckListBox_Items->Append(item);
-            if (_checked.find(item) != _checked.end())
+            if (isChecked)
             {
                 CheckListBox_Items->Check(CheckListBox_Items->GetCount() - 1);
             }


### PR DESCRIPTION
## What

Right-click a model → **Add to Existing Groups** (and its sibling **Remove from Existing Groups**) presented a plain, unfilterable list. Once a show has a lot of groups that's a long scroll with no way to search.

Both now use the existing filterable **`CheckboxSelectDialog`** rather than introducing another picker.

## The important behaviour: ticked groups stay visible

`CheckboxSelectDialog` already treated `_checked` as the source of truth across filter changes, so a ticked item was never actually *lost* — but it **disappeared from view** as soon as the filter stopped matching it, which makes selecting across several searches feel like your ticks were thrown away.

`PopulateList()` now also lists an item when it is already ticked:

```cpp
const bool isChecked = _checked.find(item) != _checked.end();
if (isChecked || MatchesFilter(item))   // was: if (MatchesFilter(item))
```

So the flow works: **filter → tick a few → change the filter → tick a few more → everything you chose is still listed and ticked when you press OK.** Unticking a pinned item drops it from the selection, and it leaves the list on the next filter change.

## Heads-up: this touches the shared dialog

The sticky-ticked change is in `CheckboxSelectDialog`, so the other pickers using it inherit it too. That's intentional — never losing sight of what you've ticked is strictly better in a multi-select picker, and it's additive (it only ever shows *more* rows, never hides something you'd expect to see). Happy to gate it behind a constructor flag if you'd rather it stayed local to the group pickers.

## Behaviour preserved

- Selections are read **by name** via `GetSelectedItems()` instead of by index into the `choices` array, so the existing dedupe / `groupChanged` / `AddASAPWork` logic is untouched.
- The "you have selected all available groups" early-out, the group-vs-model filtering of the choice list, and the submodel full-name handling are all unchanged.
- Dialog titles are now wrapped in `_()` to match the convention in the rest of the file.

## Not touched

`LayoutPanel.cpp` still has one `wxMultiChoiceDialog` — the *Export Face/States/SubModels to Other Models* picker. That one is already being converted in #6751, so it's deliberately left alone here to avoid a conflict. The `<wx/choicdlg.h>` include therefore stays valid.

## Cross-platform

Pure wxWidgets, no platform-specific code, no new source files (so no `.cbp` / `.vcxproj` / `.filters` / CMake changes needed). Built clean on macOS.
