### PR TITLE
Fix hang opening sequences with heavily-reused effect symbols

### DIFF
--- a/src-core/render/Effect.cpp
+++ b/src-core/render/Effect.cpp
@@ -490,6 +490,17 @@ void Effect::SetLocked(bool lock)
 // to its symbol and back out to other linked effects.
 static thread_local bool s_propagatingSymbolChanges = false;
 
+Effect::ScopedSymbolPropagationSuppressor::ScopedSymbolPropagationSuppressor()
+    : _prev(s_propagatingSymbolChanges)
+{
+    s_propagatingSymbolChanges = true;
+}
+
+Effect::ScopedSymbolPropagationSuppressor::~ScopedSymbolPropagationSuppressor()
+{
+    s_propagatingSymbolChanges = _prev;
+}
+
 void Effect::IncrementChangeCount()
 {
     mParentLayer->IncrementChangeCount(GetStartTimeMS(), GetEndTimeMS());
@@ -509,6 +520,10 @@ void Effect::IncrementChangeCount()
                 EffectSymbolManager& symbolManager = seqElements->GetEffectSymbolManager();
                 EffectSymbol* symbol = symbolManager.GetSymbol(_linkedSymbolId);
                 if (symbol != nullptr) {
+                    // Restore the prior value rather than clearing: the guard now
+                    // has a second writer (ScopedSymbolPropagationSuppressor), so
+                    // clearing it here would silently drop an outer suppression.
+                    bool prevPropagating = s_propagatingSymbolChanges;
                     s_propagatingSymbolChanges = true;
 
                     symbol->CopyFromEffect(this);
@@ -520,7 +535,7 @@ void Effect::IncrementChangeCount()
                         }
                     }
 
-                    s_propagatingSymbolChanges = false;
+                    s_propagatingSymbolChanges = prevPropagating;
 
                     RenderContext* ctx = seqElements->GetRenderContext();
                     if (ctx != nullptr) {

--- a/src-core/render/Effect.h
+++ b/src-core/render/Effect.h
@@ -112,6 +112,25 @@ public:
     void ApplySymbolSettings(const EffectSymbol* symbol);
     void HandlePastedSymbolLink();
 
+    // Suppresses the outward half of symbol propagation (effect -> symbol ->
+    // every other linked effect) on this thread. Linking still applies the
+    // symbol's settings *to* the effect; only the fan-out is skipped.
+    //
+    // Sequence load must hold this: effects are linked one at a time, and each
+    // link would otherwise fan out to every sibling already registered, making
+    // the load O(K^2) in re-parses and, on desktop, posting K(K-1) render
+    // events per symbol. The file is already consistent with the symbol, so
+    // the fan-out is pure waste. See SequenceElements::LoadEffects.
+    class ScopedSymbolPropagationSuppressor {
+    public:
+        ScopedSymbolPropagationSuppressor();
+        ~ScopedSymbolPropagationSuppressor();
+        ScopedSymbolPropagationSuppressor(const ScopedSymbolPropagationSuppressor&) = delete;
+        ScopedSymbolPropagationSuppressor& operator=(const ScopedSymbolPropagationSuppressor&) = delete;
+    private:
+        bool _prev;
+    };
+
     bool IsModelRenderDisabled() const;
     bool IsEffectRenderDisabled() const;
     bool IsRenderDisabled() const;

--- a/src-core/render/SequenceElements.cpp
+++ b/src-core/render/SequenceElements.cpp
@@ -743,6 +743,11 @@ int SequenceElements::LoadEffects(EffectLayer* effectLayer,
                     if (newEffect != nullptr && !effect.attribute("linkedSymbol").empty()) {
                         std::string symbolId = effect.attribute("linkedSymbol").as_string("");
                         if (!symbolId.empty() && _effectSymbolManager.SymbolExists(symbolId)) {
+                            // Suppress the fan-out to already-linked siblings: the file
+                            // is already consistent with the symbol, and propagating on
+                            // every link makes the load quadratic (a 334-effect symbol
+                            // posts >111k render events on desktop, hanging the open).
+                            Effect::ScopedSymbolPropagationSuppressor noFanOut;
                             newEffect->LinkToSymbol(symbolId);
                         }
                     }

--- a/src-core/utils/UtilClasses.cpp
+++ b/src-core/utils/UtilClasses.cpp
@@ -21,6 +21,10 @@ const std::regex kEmbeddedKeyRe(
 // prepend the embedded portion back onto `remainder` (the still-unparsed tail
 // of the settings string). Returns true if a split occurred.
 bool RepairEmbeddedKey(std::string& value, std::string& remainder) {
+    // Every shape the regex matches ends in '=', and std::regex_search is orders
+    // of magnitude more expensive than this scan. Values are already split on
+    // ',' and '=' by the caller, so an embedded '=' is the rare case.
+    if (value.find('=') == std::string::npos) return false;
     std::smatch m;
     if (!std::regex_search(value, m, kEmbeddedKeyRe)) return false;
     size_t pos = m.position(0);


### PR DESCRIPTION
## Problem

Opening a sequence in which many effects are linked to a single `EffectSymbol` hangs xLights indefinitely — spinning cursor, no crash, no error.

`SequenceElements::LoadEffects` links effects to their symbol one at a time. Each `LinkToSymbol` calls `SetSettings` and `SetPalette`, and each of those calls `Effect::IncrementChangeCount`, which mirrors the change into the symbol and fans it back out to **every sibling already linked to that symbol**. Linking the Kth effect therefore re-applies settings to the K−1 before it, so the load is quadratic in the number of effects sharing a symbol.

On the sequence that surfaced this — 2320 effects, 493 linked across 5 symbols, 334 of them on one symbol — that works out to:

- **~222,000 full settings re-parses**, accounting for 11.5s of the open, and
- **~118,000 `RenderCommandEvent`s** posted to the wx event loop (`Σ K(K−1)` per symbol; the 334-effect symbol alone contributes 111,222).

The second is the actual hang. Every event handled by `xLightsFrame::RenderRange` constructs a full `RenderJob` and `PixelBuffer` for the model, so the main thread never gets back to the UI. A `sample` of the hung process showed **6918 of 6920** main-thread samples in:

```
ProcessPendingEvents -> xLightsFrame::RenderRange -> RenderEffectForModel
  -> RenderJob::RenderJob -> RenderJob::createMainBuffer
  -> PixelBufferClass::InitBuffer
```

It isn't deadlocked — it's grinding through a six-figure render queue. It would finish eventually, just not on any useful timescale.

## Fix

The fan-out is pure waste during load: the file on disk is already consistent with the symbol, and every linked effect receives the symbol's settings through its own `LinkToSymbol` call regardless.

- Add an RAII `Effect::ScopedSymbolPropagationSuppressor` that sets the existing `s_propagatingSymbolChanges` guard, and hold it around the load-time link in `LoadEffects`. Linking still applies symbol → effect; only the outward effect → symbol → siblings fan-out is skipped.
- Restore the prior guard value at the end of the propagation block in `IncrementChangeCount` rather than clearing it. The guard now has a second writer, so unconditionally clearing it could silently drop an outer suppression. No behaviour change today (the block only runs when the guard was already false).
- Skip the `std::regex_search` in `RepairEmbeddedKey` when the value contains no `=`. Every shape the pattern matches ends in `=`, so this cannot change behaviour. It's a hot path — the search ran on every setting value of every parse, not just during load.

## Results

Measured on the reproducing sequence, Debug build, macOS:

| | before | after |
|---|---:|---:|
| `ElementEffects` load | 11,499 ms | **162 ms** |
| Total sequence open | 12,172 ms | **918 ms** |
| CPU 40s after open | 141%, climbing | **0.3%, idle** |

## Correctness

Rendered output is unchanged. I rendered the sequence with the pre-fix code, rebuilt with the fix, and compared channel-for-channel:

```
IDENTICAL: 10560 frames x 44448 channels match exactly
```

## Testing notes

Draft pending wider testing on real shows.

The measurements and the fseq comparison above were taken on a branch based on this fork's integration branch, where the four touched files are within a few lines of master. On master itself I verified that all three modified `.cpp` files compile cleanly for both `x86_64` and `arm64`.
