### PR TITLE
Auto-close toolbar gaps and reset toolbars without a restart

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,6 +13,8 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
 2026.16  August ??, 2026
     -change (cybercop23)         Add warning prompt when opening a sequence outside the show directory. Save requires
                                  saving inside the show directory - Save As was already ensuring that path.
+    -enh (cybercop23)            Toolbars automatically close gaps between docked items when moved and update
+                                 visibility live when switching tabs.
     -bug (kylegrymonprez)        Layout: on the Controllers tab, "Show on Layout" for a controller
                                  could fall into edgecases where it wouldn't show in the property grid.
     -enh (derwin12)              Ripple can now trigger a new cycle from a timing track, matching Shockwave

--- a/src-ui-wx/app-shell/TabSetup.cpp
+++ b/src-ui-wx/app-shell/TabSetup.cpp
@@ -547,6 +547,7 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
     EnableSequenceControls(true);
 
     Notebook1->ChangeSelection(LAYOUTTAB);
+    UpdateEffectsToolbarVisibility();
     SetStatusText("");
     FileNameText->SetLabel(nd);
 

--- a/src-ui-wx/wxsmith/xLightsframe.wxs
+++ b/src-ui-wx/wxsmith/xLightsframe.wxs
@@ -982,6 +982,11 @@
 						<checkable>1</checkable>
 					</object>
 					<object class="separator" />
+					<object class="wxMenuItem" name="ID_MNU_AUTOARRANGETOOLBARS" variable="MenuItem_AutoArrangeToolbars" member="yes">
+						<label>Auto Arrange</label>
+						<handler function="OnMenuItem_AutoArrangeToolbarsSelected" entry="EVT_MENU" />
+						<checkable>1</checkable>
+					</object>
 					<object class="wxMenuItem" name="ID_MENUITEM5" variable="MenuItem13" member="no">
 						<label>Reset Toolbars</label>
 						<handler function="ResetToolbarLocations" entry="EVT_MENU" />

--- a/src-ui-wx/xLightsApp.cpp
+++ b/src-ui-wx/xLightsApp.cpp
@@ -1750,6 +1750,15 @@ void xLightsApp::WipeSettings()
     WipeXLightsConfig();
 }
 
+int xLightsApp::FilterEvent(wxEvent& event)
+{
+    if (event.GetEventType() == wxEVT_LEFT_UP && __frame != nullptr) {
+        xLightsFrame* frame = __frame;
+        frame->CallAfter([frame] { frame->CompressToolbarGaps(); });
+    }
+    return wxEventFilter::Event_Skip;
+}
+
 bool xLightsApp::ProcessIdle() {
     uint64_t now = wxGetLocalTimeMillis().GetValue();
     bool b = CurlManager::INSTANCE.processCurls();

--- a/src-ui-wx/xLightsApp.h
+++ b/src-ui-wx/xLightsApp.h
@@ -35,6 +35,7 @@ public:
     xLightsApp();
 
     virtual bool OnInit() override;
+    virtual int FilterEvent(wxEvent& event) override;
     static xLightsFrame* GetFrame() { return __frame; }
     static wxString showDir;
     static wxString mediaDir;

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -41,6 +41,7 @@
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>
 
+#include <algorithm>
 #include <cctype>
 #include <cstring>
 #include <thread>
@@ -564,6 +565,7 @@ void xLightsFrame::RebuildEffectsToolbar()
     // no sequence open or while rendering, and the drag they start dereferences
     // the not-yet-set SequenceElements.
     EnableEffectsToolbar();
+    UpdateEffectsToolbarVisibility();
 }
 
 void xLightsFrame::SetEffectsToolbarLayout(std::vector<std::pair<std::string, bool>> layout)
@@ -924,6 +926,7 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     AUIStatusBar->SetSizer(StatusBarSizer);
     MainAuiManager->AddPane(AUIStatusBar, wxAuiPaneInfo().Name(_T("Status Bar")).DefaultPane().Caption(_("Status bar")).CaptionVisible(false).CloseButton(false).Bottom().DockFixed().Dockable(false).Floatable(false).FloatingPosition(wxPoint(0,0)).FloatingSize(wxSize(0,0)).Movable(false).PaneBorder(false));
     MainAuiManager->Update();
+    _defaultToolbarPerspective = MainAuiManager->SavePerspective();
     MenuBar = new wxMenuBar();
     MenuFile = new wxMenu();
     MenuItem3 = new wxMenuItem(MenuFile, ID_NEW_SEQUENCE, _("New Sequence\tCtrl-n"), wxEmptyString, wxITEM_NORMAL);
@@ -1730,6 +1733,8 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
         MainAuiManager->GetPane("Status Bar").MinSize(wxSize(-1, size));
         MainAuiManager->Update();
     }
+    config->Read("ShowEffectsToolbar", &_effectsToolbarChecked, true);
+    UpdateEffectsToolbarVisibility();
     UpdateToolbarsMenu();
     spdlog::debug("Perspectives loaded.");
 
@@ -2237,7 +2242,15 @@ xLightsFrame::~xLightsFrame()
     if (mResetToolbars) {
         config->DeleteEntry("ToolbarLocations");
     } else {
+        if (MainAuiManager != nullptr) {
+            wxAuiPaneInfo& pane = MainAuiManager->GetPane("EffectsToolBar");
+            if (pane.IsOk()) {
+                pane.Show(_effectsToolbarChecked);
+            }
+        }
         config->Write("ToolbarLocations", TOOLBAR_SAVE_VERSION + MainAuiManager->SavePerspective());
+        config->Write("ShowEffectsToolbar", _effectsToolbarChecked);
+        UpdateEffectsToolbarVisibility();
     }
     config->Write("xLightsIconSize", mIconSize);
     SaveToolbarLayout(config, "EffectsToolbarLayout", _effectsToolbarLayout);
@@ -2968,7 +2981,74 @@ void xLightsFrame::OnNotebook1PageChanged1(wxAuiNotebookEvent& event)
         MenuItem_File_Save->SetItemLabel("Save");
         SetStatusText(_(""));
     }
+    UpdateEffectsToolbarVisibility();
     SetAudioControls();
+}
+
+void xLightsFrame::UpdateEffectsToolbarVisibility()
+{
+    if (MainAuiManager == nullptr || Notebook1 == nullptr) return;
+
+    wxAuiPaneInfo& pane = MainAuiManager->GetPane("EffectsToolBar");
+    if (!pane.IsOk()) return;
+
+    bool isSequencer = (Notebook1->GetSelection() == NEWSEQUENCER);
+    bool shouldShow = _effectsToolbarChecked && isSequencer;
+
+    if (pane.IsShown() != shouldShow) {
+        pane.Show(shouldShow);
+        CompressToolbarGaps();
+        MainAuiManager->Update();
+    }
+}
+
+void xLightsFrame::CompressToolbarGaps()
+{
+    static bool inCompress = false;
+    if (inCompress || MainAuiManager == nullptr) return;
+
+    struct CompressGuard {
+        bool& flag;
+        CompressGuard(bool& f) : flag(f) { flag = true; }
+        ~CompressGuard() { flag = false; }
+    } guard(inCompress);
+
+    wxAuiPaneInfoArray& panes = MainAuiManager->GetAllPanes();
+
+    for (auto& pane : panes) {
+        if (pane.HasFlag(wxAuiPaneInfo::actionPane)) {
+            return;
+        }
+    }
+
+    std::map<std::tuple<int, int, int>, std::vector<wxAuiPaneInfo*>> rows;
+    for (auto& pane : panes) {
+        if (!pane.IsToolbar() || !pane.IsDocked() || !pane.IsShown()) continue;
+        rows[{pane.dock_direction, pane.dock_layer, pane.dock_row}].push_back(&pane);
+    }
+
+    bool changed = false;
+    for (auto& entry : rows) {
+        std::vector<wxAuiPaneInfo*>& rowPanes = entry.second;
+        std::sort(rowPanes.begin(), rowPanes.end(), [](wxAuiPaneInfo* a, wxAuiPaneInfo* b) {
+            return a->dock_pos < b->dock_pos;
+        });
+        int pos = 0;
+        for (auto* pane : rowPanes) {
+            if (pane->dock_pos != pos) {
+                pane->dock_pos = pos;
+                changed = true;
+            }
+            ++pos;
+        }
+    }
+
+    if (changed) {
+        wxString fixedPerspective = MainAuiManager->SavePerspective();
+        MainAuiManager->LoadPerspective(fixedPerspective);
+        MainAuiManager->Update();
+        spdlog::info("CompressToolbarGaps: closed a toolbar gap.");
+    }
 }
 
 void xLightsFrame::CycleOutputsIfOn()
@@ -3890,8 +3970,19 @@ void xLightsFrame::SetGridSpacing(int size)
 
 void xLightsFrame::ResetToolbarLocations(wxCommandEvent& event)
 {
-    DisplayInfo("Toolbar locations will reset to defaults upon restart.", this);
-    mResetToolbars = true;
+    _effectsToolbarChecked = true;
+    auto* config = GetXLightsConfig();
+    if (config != nullptr) {
+        config->DeleteEntry("ToolbarLocations");
+        config->DeleteEntry("ShowEffectsToolbar");
+    }
+    if (MainAuiManager != nullptr && !_defaultToolbarPerspective.IsEmpty()) {
+        MainAuiManager->LoadPerspective(_defaultToolbarPerspective);
+        UpdateEffectsToolbarVisibility();
+        UpdateToolbarsMenu();
+        MainAuiManager->Update();
+    }
+    mResetToolbars = false;
 }
 
 void xLightsFrame::SetToolIconSize(int size)
@@ -6676,6 +6767,17 @@ void xLightsFrame::BuildToolbarsMenu()
 
 void xLightsFrame::ToggleToolbarPane(const wxString& paneName)
 {
+    if (paneName == "EffectsToolBar") {
+        _effectsToolbarChecked = !_effectsToolbarChecked;
+        auto* config = GetXLightsConfig();
+        if (config != nullptr) {
+            config->Write("ShowEffectsToolbar", _effectsToolbarChecked);
+        }
+        UpdateEffectsToolbarVisibility();
+        UpdateToolbarsMenu();
+        return;
+    }
+
     wxAuiPaneInfo& pane = MainAuiManager->GetPane(paneName);
     if (!pane.IsOk()) return;
     if (pane.IsShown()) {
@@ -6690,7 +6792,11 @@ void xLightsFrame::ToggleToolbarPane(const wxString& paneName)
 void xLightsFrame::UpdateToolbarsMenu()
 {
     for (auto& [paneName, item] : _toolbarMenuItems) {
-        item->Check(MainAuiManager->GetPane(paneName).IsShown());
+        if (paneName == "EffectsToolBar") {
+            item->Check(_effectsToolbarChecked);
+        } else {
+            item->Check(MainAuiManager->GetPane(paneName).IsShown());
+        }
     }
 }
 

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -306,6 +306,7 @@ const wxWindowID xLightsFrame::ID_MENU_USER_DICT = wxNewId();
 const wxWindowID xLightsFrame::ID_MENU_FIND_SHOW_FOLDER = wxNewId();
 const wxWindowID xLightsFrame::ID_MENUITEM5 = wxNewId();
 const wxWindowID xLightsFrame::ID_MNU_SHOWRAMPS = wxNewId();
+const wxWindowID xLightsFrame::ID_MNU_AUTOARRANGETOOLBARS = wxNewId();
 const wxWindowID xLightsFrame::ID_MENUITEM_TOOLBARS = wxNewId();
 const wxWindowID xLightsFrame::ID_MENUITEM_SAVE_PERSPECTIVE = wxNewId();
 const wxWindowID xLightsFrame::ID_MENUITEM_SAVE_AS_PERSPECTIVE = wxNewId();
@@ -1084,6 +1085,8 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     MenuItem_ShowACRamps = new wxMenuItem(MenuItemToolbars, ID_MNU_SHOWRAMPS, _("Show AC Ramps"), _("Show on effects and twinkle effects as ramps."), wxITEM_CHECK);
     MenuItemToolbars->Append(MenuItem_ShowACRamps);
     MenuItemToolbars->AppendSeparator();
+    MenuItem_AutoArrangeToolbars = new wxMenuItem(MenuItemToolbars, ID_MNU_AUTOARRANGETOOLBARS, _("Auto Arrange"), wxEmptyString, wxITEM_CHECK);
+    MenuItemToolbars->Append(MenuItem_AutoArrangeToolbars);
     MenuItem13 = new wxMenuItem(MenuItemToolbars, ID_MENUITEM5, _("Reset Toolbars"), wxEmptyString, wxITEM_NORMAL);
     MenuItemToolbars->Append(MenuItem13);
     MenuView->Append(ID_MENUITEM_TOOLBARS, _("Toolbars"), MenuItemToolbars, wxEmptyString);
@@ -1323,6 +1326,7 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     Connect(wxID_ZOOM_OUT, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnAuiToolBarItem_ZoomOutClick);
     Connect(ID_MENUITEM5, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::ResetToolbarLocations);
     Connect(ID_MNU_SHOWRAMPS, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItem_ShowACRampsSelected);
+    Connect(ID_MNU_AUTOARRANGETOOLBARS, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItem_AutoArrangeToolbarsSelected);
     Connect(ID_MENUITEM_SAVE_PERSPECTIVE, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItemViewSavePerspectiveSelected);
     Connect(ID_MENUITEM_SAVE_AS_PERSPECTIVE, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItemViewSaveAsPerspectiveSelected);
     Connect(ID_MENUITEM_LOAD_PERSPECTIVE, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuItemLoadEditPerspectiveSelected);
@@ -1792,6 +1796,10 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     config->Read("xLightsShowACRamps", &_showACRamps, false);
     MenuItem_ShowACRamps->Check(_showACRamps);
     spdlog::debug("Show AC Ramps: {}.", toStr(_showACRamps));
+
+    config->Read("xLightsAutoArrangeToolbars", &_autoArrangeToolbars, false);
+    MenuItem_AutoArrangeToolbars->Check(_autoArrangeToolbars);
+    spdlog::debug("Auto Arrange Toolbars: {}.", toStr(_autoArrangeToolbars));
 
     config->Read("xLightsEnableRenderCache", &_enableRenderCache, _("Locked Only"));
     spdlog::debug("Enable Render Cache: {}.", (const char*)_enableRenderCache.c_str());
@@ -2272,6 +2280,7 @@ xLightsFrame::~xLightsFrame()
     config->Write("xLightsShowZoneIndicator", _showZoneIndicator);
     config->Write("xLightsExcludeAudioPkgSeq", _excludeAudioFromPackagedSequences);
     config->Write("xLightsShowACRamps", _showACRamps);
+    config->Write("xLightsAutoArrangeToolbars", _autoArrangeToolbars);
     config->Write("xLightsEnableRenderCache", _enableRenderCache);
     config->Write("xLightsRenderCacheMaxSizeMB", _renderCacheMaximumSizeMB);
     config->Write("xLightsPlayControlsOnPreview", _playControlsOnPreview);
@@ -3004,6 +3013,8 @@ void xLightsFrame::UpdateEffectsToolbarVisibility()
 
 void xLightsFrame::CompressToolbarGaps()
 {
+    if (!_autoArrangeToolbars) return;
+
     static bool inCompress = false;
     if (inCompress || MainAuiManager == nullptr) return;
 
@@ -6804,6 +6815,11 @@ void xLightsFrame::OnMenuItem_ShowACRampsSelected(wxCommandEvent& event)
 {
     _showACRamps = MenuItem_ShowACRamps->IsChecked();
     mainSequencer->PanelEffectGrid->Refresh();
+}
+
+void xLightsFrame::OnMenuItem_AutoArrangeToolbarsSelected(wxCommandEvent& event)
+{
+    _autoArrangeToolbars = MenuItem_AutoArrangeToolbars->IsChecked();
 }
 
 void xLightsFrame::SetTimingPlayOnDClick(bool b)

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -666,10 +666,13 @@ public:
     void OnCharHook(wxKeyEvent& event);
     void OnHelp(wxHelpEvent& event);
 
+    void CompressToolbarGaps();
+
 private :
 
     void DoMenuAction(wxMenuEvent &evt);
 	void ShowHideAllSequencerWindows(bool show);
+    void UpdateEffectsToolbarVisibility();
     void SyncFloatingPanePositions();
 	void ResetAllSequencerWindows();
 	void SetEffectAssistWindowState(bool show);
@@ -1679,6 +1682,8 @@ private:
     // Last value passed to EnableSequenceControls, so a toolbar rebuilt outside
     // that call can still apply the right enable state to its new buttons.
     bool _sequenceControlsEnabled = false;
+    bool _effectsToolbarChecked = true;
+    wxString _defaultToolbarPerspective;
     int mGridSpacing;
     bool mGridIconBackgrounds;
     bool mShowAlternateTimingFormat = false;

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -607,6 +607,7 @@ public:
     void OnChoiceParm2Select(wxCommandEvent& event);
     void OnAC_SelectClick(wxCommandEvent& event);
     void OnMenuItem_ShowACRampsSelected(wxCommandEvent& event);
+    void OnMenuItem_AutoArrangeToolbarsSelected(wxCommandEvent& event);
     void OnMenuItem_PerspectiveAutosaveSelected(wxCommandEvent& event);
     void OnMenuItem_GenerateLyricsSelected(wxCommandEvent& event);
     void OnMenuItem_CrashXLightsSelected(wxCommandEvent& event);
@@ -808,6 +809,7 @@ public:
     static const wxWindowID ID_MENU_FIND_SHOW_FOLDER;
     static const wxWindowID ID_MENUITEM5;
     static const wxWindowID ID_MNU_SHOWRAMPS;
+    static const wxWindowID ID_MNU_AUTOARRANGETOOLBARS;
     static const wxWindowID ID_MENUITEM_TOOLBARS;
     static const wxWindowID ID_MENUITEM_SAVE_PERSPECTIVE;
     static const wxWindowID ID_MENUITEM_SAVE_AS_PERSPECTIVE;
@@ -992,6 +994,7 @@ public:
     wxMenuItem* MenuItem_SD_HP;
     wxMenuItem* MenuItem_SD_MP;
     wxMenuItem* MenuItem_ShowACRamps;
+    wxMenuItem* MenuItem_AutoArrangeToolbars;
     wxMenuItem* MenuItem_ShowKeyBindings;
     wxMenuItem* MenuItem_SilentVol;
     wxMenuItem* MenuItem_TOD;
@@ -1075,6 +1078,7 @@ public:
     bool _hwVideoAccleration = true;
     int _hwVideoRenderer = 0;
     bool _showACRamps = false;
+    bool _autoArrangeToolbars = false;
     std::vector<std::pair<wxString, wxMenuItem*>> _toolbarMenuItems;
     wxString _enableRenderCache;
     size_t _renderCacheMaximumSizeMB = 0;


### PR DESCRIPTION
When moving toolbars around or rearranging them, some of them could go off the screen and needed to restart xLights to get it back. No need to restart and now the gap between toolbars auto-closes once the toolbar is placed.