### PR TITLE
Effect symbols: fix render-thread race and multi-second edit freezes

### DIFF
--- a/src-core/render/Effect.cpp
+++ b/src-core/render/Effect.cpp
@@ -29,6 +29,8 @@
 #include <filesystem>
 #include <chrono>
 #include <unordered_map>
+#include <map>
+#include <algorithm>
 #include <regex>
 
 #include <log.h>
@@ -193,7 +195,15 @@ Effect::Effect(const Effect& ef)
     mPaletteMap = ef.mPaletteMap;
     mColors = ef.mColors;
     mCC = ef.mCC;
-    _linkedSymbolId = ef._linkedSymbolId;
+
+    // Deliberately NOT copying _linkedSymbolId. This copy is a short-lived
+    // render temporary (RenderEngine's `new Effect(*ef)`) that is never passed
+    // to RegisterLinkedEffect, so it owns no entry in the symbol manager. If it
+    // carried the id, ~Effect would call UnregisterLinkedEffect from a render
+    // worker thread — mutating the shared multimap for an entry it never owned,
+    // and matching a live effect outright whenever the allocator reused the
+    // address. It would also let IncrementChangeCount fan symbol changes out
+    // off the main thread. Render reads mSettings/mPaletteMap, never the id.
 }
 
 Effect::Effect(EffectManager* effectManager, EffectLayer* parent,int id, const std::string & name, const std::string &settings, const std::string &palette, int startTimeMS, int endTimeMS, int Selected, bool Protected, bool importing) :
@@ -370,10 +380,18 @@ std::string Effect::GetDescription() const
         return GetSetting("X_Effect_Description");
 }
 
+// A symbol captures an effect's *settings*, not where it sits on the timeline,
+// so moving or resizing an effect must not fan out to its linked siblings.
+// Without the suppressor a single drag ran CopyFromEffect plus a full
+// settings+palette re-parse on every sibling and posted one render event each,
+// twice over (start and end) — seconds of frozen UI per drag on a symbol with
+// a few hundred links. The layer's own dirty-marking still happens, so this
+// effect re-renders normally.
 void Effect::SetStartTimeMS(int startTimeMS)
 {
     assert(!IsLocked());
 
+    ScopedSymbolPropagationSuppressor noFanOut;
     if (startTimeMS > mStartTime) {
         IncrementChangeCount();
         mStartTime = startTimeMS;
@@ -387,6 +405,7 @@ void Effect::SetEndTimeMS(int endTimeMS)
 {
     assert(!IsLocked());
 
+    ScopedSymbolPropagationSuppressor noFanOut;
     if (endTimeMS < mEndTime) {
         IncrementChangeCount();
         mEndTime = endTimeMS;
@@ -537,22 +556,41 @@ void Effect::IncrementChangeCount()
 
                     s_propagatingSymbolChanges = prevPropagating;
 
+                    // Coalesce the render requests per model rather than per
+                    // effect. A symbol reused a few hundred times still spans
+                    // only a handful of models, so the naive per-effect loop
+                    // queued one render job per linked effect (986 on a real
+                    // sequence across 5 models), and each job pays a full
+                    // RenderJob + PixelBuffer::InitBuffer setup. That setup
+                    // dominates, so one widened job per model is far cheaper
+                    // than many narrow ones — this is also what
+                    // RenderDirtyModels does for every ordinary edit.
                     RenderContext* ctx = seqElements->GetRenderContext();
                     if (ctx != nullptr) {
+                        std::map<std::string, std::pair<int, int>> perModel;
                         for (Effect* effect : linkedEffects) {
                             if (effect != this && effect != nullptr) {
                                 EffectLayer* el = effect->GetParentEffectLayer();
                                 if (el != nullptr && el->GetParentElement() != nullptr) {
-                                    // Async: must NOT render synchronously here — we hold
-                                    // this effect's settingsLock, and the render workers
-                                    // would deadlock waiting for it (the indefinite hang
-                                    // when changing a linked effect's color to a gradient).
-                                    ctx->RequestRenderForModel(
-                                        el->GetParentElement()->GetModelName(),
-                                        effect->GetStartTimeMS(),
-                                        effect->GetEndTimeMS());
+                                    const std::string& mn = el->GetParentElement()->GetModelName();
+                                    int s = effect->GetStartTimeMS();
+                                    int e = effect->GetEndTimeMS();
+                                    auto it = perModel.find(mn);
+                                    if (it == perModel.end()) {
+                                        perModel.emplace(mn, std::make_pair(s, e));
+                                    } else {
+                                        it->second.first = std::min(it->second.first, s);
+                                        it->second.second = std::max(it->second.second, e);
+                                    }
                                 }
                             }
+                        }
+                        for (const auto& [modelName, range] : perModel) {
+                            // Async: must NOT render synchronously here — we hold
+                            // this effect's settingsLock, and the render workers
+                            // would deadlock waiting for it (the indefinite hang
+                            // when changing a linked effect's color to a gradient).
+                            ctx->RequestRenderForModel(modelName, range.first, range.second);
                         }
                     }
                 }

--- a/src-core/render/EffectSymbolManager.cpp
+++ b/src-core/render/EffectSymbolManager.cpp
@@ -29,6 +29,7 @@ EffectSymbolManager::~EffectSymbolManager()
 
 void EffectSymbolManager::Clear()
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     _linkedEffects.clear();
     _symbols.clear();
     _nextSymbolId = 1;
@@ -36,6 +37,7 @@ void EffectSymbolManager::Clear()
 
 std::string EffectSymbolManager::GenerateUniqueId()
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     std::string id;
     do {
         id = "sym_" + std::to_string(_nextSymbolId++);
@@ -45,6 +47,7 @@ std::string EffectSymbolManager::GenerateUniqueId()
 
 EffectSymbol* EffectSymbolManager::CreateSymbol(const std::string& name, const Effect* sourceEffect)
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     if (sourceEffect == nullptr) return nullptr;
 
     std::string uniqueName = name;
@@ -68,6 +71,7 @@ EffectSymbol* EffectSymbolManager::CreateSymbol(const std::string& name, const E
 
 EffectSymbol* EffectSymbolManager::CreateEmptySymbol(const std::string& name, const std::string& effectType, int effectIndex)
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     std::string uniqueName = name;
     if (SymbolNameExists(name)) {
         uniqueName = GetUniqueSymbolName(name);
@@ -90,6 +94,7 @@ EffectSymbol* EffectSymbolManager::CreateEmptySymbol(const std::string& name, co
 
 EffectSymbol* EffectSymbolManager::GetSymbol(const std::string& id) const
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     auto it = _symbols.find(id);
     if (it != _symbols.end()) {
         return it->second.get();
@@ -99,6 +104,7 @@ EffectSymbol* EffectSymbolManager::GetSymbol(const std::string& id) const
 
 EffectSymbol* EffectSymbolManager::GetSymbolByName(const std::string& name) const
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     for (const auto& pair : _symbols) {
         if (pair.second->GetName() == name) {
             return pair.second.get();
@@ -109,6 +115,7 @@ EffectSymbol* EffectSymbolManager::GetSymbolByName(const std::string& name) cons
 
 std::vector<EffectSymbol*> EffectSymbolManager::GetAllSymbols() const
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     std::vector<EffectSymbol*> result;
     result.reserve(_symbols.size());
     for (const auto& pair : _symbols) {
@@ -119,6 +126,7 @@ std::vector<EffectSymbol*> EffectSymbolManager::GetAllSymbols() const
 
 bool EffectSymbolManager::DeleteSymbol(const std::string& id)
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     auto it = _symbols.find(id);
     if (it == _symbols.end()) {
         return false;
@@ -145,6 +153,7 @@ bool EffectSymbolManager::DeleteSymbol(const std::string& id)
 
 bool EffectSymbolManager::RenameSymbol(const std::string& id, const std::string& newName)
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     auto it = _symbols.find(id);
     if (it == _symbols.end()) {
         return false;
@@ -167,16 +176,19 @@ bool EffectSymbolManager::RenameSymbol(const std::string& id, const std::string&
 
 bool EffectSymbolManager::SymbolExists(const std::string& id) const
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     return _symbols.find(id) != _symbols.end();
 }
 
 bool EffectSymbolManager::SymbolNameExists(const std::string& name) const
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     return GetSymbolByName(name) != nullptr;
 }
 
 std::string EffectSymbolManager::GetUniqueSymbolName(const std::string& baseName) const
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     if (!SymbolNameExists(baseName)) {
         return baseName;
     }
@@ -192,6 +204,7 @@ std::string EffectSymbolManager::GetUniqueSymbolName(const std::string& baseName
 
 void EffectSymbolManager::RegisterLinkedEffect(Effect* effect, const std::string& symbolId)
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     if (effect == nullptr || !SymbolExists(symbolId)) return;
 
     UnregisterLinkedEffect(effect);
@@ -200,6 +213,7 @@ void EffectSymbolManager::RegisterLinkedEffect(Effect* effect, const std::string
 
 void EffectSymbolManager::UnregisterLinkedEffect(Effect* effect)
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     if (effect == nullptr) return;
 
     for (auto it = _linkedEffects.begin(); it != _linkedEffects.end(); ) {
@@ -213,6 +227,7 @@ void EffectSymbolManager::UnregisterLinkedEffect(Effect* effect)
 
 std::vector<Effect*> EffectSymbolManager::GetLinkedEffects(const std::string& symbolId) const
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     std::vector<Effect*> result;
     auto range = _linkedEffects.equal_range(symbolId);
     for (auto it = range.first; it != range.second; ++it) {
@@ -223,11 +238,13 @@ std::vector<Effect*> EffectSymbolManager::GetLinkedEffects(const std::string& sy
 
 size_t EffectSymbolManager::GetLinkedEffectCount(const std::string& symbolId) const
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     return _linkedEffects.count(symbolId);
 }
 
 void EffectSymbolManager::UpdateSymbolSettings(const std::string& id, const std::string& settings)
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     EffectSymbol* symbol = GetSymbol(id);
     if (symbol == nullptr) return;
 
@@ -237,6 +254,7 @@ void EffectSymbolManager::UpdateSymbolSettings(const std::string& id, const std:
 
 void EffectSymbolManager::UpdateSymbolPalette(const std::string& id, const std::string& palette)
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     EffectSymbol* symbol = GetSymbol(id);
     if (symbol == nullptr) return;
 
@@ -246,6 +264,7 @@ void EffectSymbolManager::UpdateSymbolPalette(const std::string& id, const std::
 
 void EffectSymbolManager::NotifySymbolChanged(const std::string& symbolId)
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     EffectSymbol* symbol = GetSymbol(symbolId);
     if (symbol == nullptr) return;
 
@@ -264,6 +283,7 @@ void EffectSymbolManager::NotifySymbolChanged(const std::string& symbolId)
 
 void EffectSymbolManager::LoadFromXml(const pugi::xml_node& symbolsNode)
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     if (!symbolsNode || std::strcmp(symbolsNode.name(), "EffectSymbols") != 0) {
         return;
     }
@@ -295,6 +315,7 @@ void EffectSymbolManager::LoadFromXml(const pugi::xml_node& symbolsNode)
 
 void EffectSymbolManager::SaveToXml(pugi::xml_node& parent) const
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     auto node = parent.append_child("EffectSymbols");
     for (const auto& pair : _symbols) {
         pair.second->SaveToXml(node);
@@ -303,6 +324,7 @@ void EffectSymbolManager::SaveToXml(pugi::xml_node& parent) const
 
 void EffectSymbolManager::AddListener(IEffectSymbolListener* listener)
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     if (listener != nullptr) {
         _listeners.push_back(listener);
     }
@@ -310,6 +332,7 @@ void EffectSymbolManager::AddListener(IEffectSymbolListener* listener)
 
 void EffectSymbolManager::RemoveListener(IEffectSymbolListener* listener)
 {
+    std::lock_guard<std::recursive_mutex> lock(_lock);
     _listeners.erase(
         std::remove(_listeners.begin(), _listeners.end(), listener),
         _listeners.end()

--- a/src-core/render/EffectSymbolManager.h
+++ b/src-core/render/EffectSymbolManager.h
@@ -14,6 +14,7 @@
 #include <map>
 #include <vector>
 #include <memory>
+#include <mutex>
 
 class EffectSymbol;
 class Effect;
@@ -42,7 +43,7 @@ public:
     EffectSymbol* GetSymbol(const std::string& id) const;
     EffectSymbol* GetSymbolByName(const std::string& name) const;
     std::vector<EffectSymbol*> GetAllSymbols() const;
-    size_t GetSymbolCount() const { return _symbols.size(); }
+    size_t GetSymbolCount() const { std::lock_guard<std::recursive_mutex> lock(_lock); return _symbols.size(); }
     bool DeleteSymbol(const std::string& id);
     bool RenameSymbol(const std::string& id, const std::string& newName);
     bool SymbolExists(const std::string& id) const;
@@ -69,6 +70,15 @@ public:
 
 private:
     std::string GenerateUniqueId();
+
+    // Guards every container below. Effects are destroyed on render worker
+    // threads (EffectLayer::CleanupAfterRender runs inside RenderJob), and
+    // ~Effect calls UnregisterLinkedEffect, so _linkedEffects is mutated off
+    // the main thread while the UI mutates it too — copy/paste of linked
+    // effects corrupted the multimap and aborted in __tree_remove.
+    // Recursive because RegisterLinkedEffect calls SymbolExists and
+    // UnregisterLinkedEffect, and DeleteSymbol calls NotifySymbolChanged.
+    mutable std::recursive_mutex _lock;
 
     std::map<std::string, std::unique_ptr<EffectSymbol>> _symbols;
     std::multimap<std::string, Effect*> _linkedEffects;


### PR DESCRIPTION
Follow-up to #6859, covering three further problems with effects linked to a reusable `EffectSymbol`. All three are on master today.

## 1. Data race corrupting `EffectSymbolManager` (crash)

`EffectSymbolManager` has **no locking at all**, but `_linkedEffects` is mutated from two threads:

- **Render workers** — `RenderJob::FinishRender` → `Element::CleanupAfterRender` → `~Effect` → `UnregisterLinkedEffect`
- **Main thread** — paste → `LinkToSymbol` → `RegisterLinkedEffect`

Two threads restructuring one `std::multimap` is undefined behaviour. The red-black tree's invariants break and it aborts inside `__tree_remove`:

```
#3  std::__tree_remove<std::__tree_node_base<void*>*>
#4  std::__tree<...Effect*...>::__remove_node_pointer
#6  std::multimap<std::string, Effect*>::erase
#7  EffectSymbolManager::UnregisterLinkedEffect   EffectSymbolManager.cpp:207
#8  Effect::~Effect                               Effect.cpp:262
#11 EffectLayer::CleanupAfterRender               EffectLayer.cpp:71
#14 RenderJob::FinishRender                       RenderEngine.cpp:3145
#17 JobPoolWorker::ProcessJob                     JobPool.cpp:394
```

Reproduced by copy/pasting linked effects while a render was draining.

Every method now takes a `recursive_mutex`. Recursive is required rather than incidental — `RegisterLinkedEffect` calls both `SymbolExists` and `UnregisterLinkedEffect`, and `DeleteSymbol` calls `NotifySymbolChanged`; a plain mutex would self-deadlock immediately.

## 2. Render temporaries claiming symbol ownership

`RenderEngine.cpp` creates throwaway effects via `new Effect(*ef)`. The copy constructor copied `_linkedSymbolId` even though the copy is never passed to `RegisterLinkedEffect` — so `~Effect` mutated the shared multimap from a worker thread for an entry it never owned, and would unregister a **live** effect whenever the allocator reused that address. It also let `IncrementChangeCount` fan symbol changes out off the main thread.

Render reads `mSettings`/`mPaletteMap` and never the id, and every other reader (`SequenceFile`, `TimeLine`, `EffectsGrid`) is main-thread, so the copy no longer carries it.

## 3. Multi-second UI freezes when editing a linked effect

**Moving or resizing.** `SetStartTimeMS`/`SetEndTimeMS` call `IncrementChangeCount`, which fanned out to every linked sibling. A symbol captures an effect's *settings*, not its timeline position, so this work was not merely slow but wrong. A single drag ran it twice (start and end), doing a full settings + palette re-parse per sibling and queueing a render job each. Both setters now hold `ScopedSymbolPropagationSuppressor`. The layer's own dirty-marking is unaffected, so the moved effect still re-renders.

**Settings changes.** These legitimately need to propagate, but the render fan-out queued one job per *effect* rather than per *model*. Measured on a real sequence:

| symbol | linked effects | models |
|---|---:|---:|
| `sym_2` | 707 | 5 |
| `sym_4` | 99 | 2 |
| `sym_1` | 97 | 1 |
| `sym_3` | 91 | 1 |
| `sym_5` | 13 | 1 |

986 render jobs across 11 model-slots, each paying a full `RenderJob` + `PixelBuffer::InitBuffer` setup — and that setup dominates the profile. Coalescing per model into one widened range takes it to **986 → 11**, which is what `RenderDirtyModels` already does for ordinary edits.

I measured the obvious alternative first: merging adjacent time ranges gives **986 → 986**, no reduction at all, because the effects don't overlap in time. Per-model coalescing was the option that actually pays.

## Verification

Builds clean on macOS for both `x86_64` and `arm64`. Headless render of the reproducing sequence completes and is byte-identical run to run:

```
IDENTICAL: 10560 frames x 44448 channels match exactly
```

The two freeze fixes were confirmed by hand in the GUI — dragging and render-style changes on a 700-link symbol are both responsive now.

One note for reviewers: the race fix is verified by construction rather than by a reproducing test — a race needing a specific interleaving won't reproduce on demand. What is certain is that the mechanism in the trace above is now impossible: all mutation of `_linkedEffects` is serialised under one lock, and render temporaries no longer touch the map at all.
