### PR TITLE
Fixes #6697 — dragging a locked effect across rows/layers duplicated it

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -89,6 +89,8 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                  hardware supports it.
     -bug (cybercop23)            Fix Face and State effect definition choices when switching between different
                                  model groups.
+    -bug (derwin12)              Fixed locked effects duplicating when dragged across rows/layers (#6697)
+
 2026.15  August 4, 2026
     -change (dkulp)              Faces: the automatic eye blink is now computed independently per frame, so
                                  the render engine can render Faces frames in parallel. Blink timing may

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -2320,7 +2320,7 @@ void EffectsGrid::mouseDown(wxMouseEvent& event) {
                 if (el == nullptr) continue;
                 for (int i = 0; i < el->GetEffectCount(); i++) {
                     Effect* e = el->GetEffect(i);
-                    if (e->GetSelected() != EFFECT_NOT_SELECTED) {
+                    if (e->GetSelected() != EFFECT_NOT_SELECTED && !e->IsLocked()) {
                         mEffectMoveSnapshots.push_back({e, el, e->GetStartTimeMS(), e->GetEndTimeMS(), vrow});
                     }
                 }
@@ -8583,6 +8583,7 @@ void EffectsGrid::ApplyEffectMoveDrag() {
     Effect* newAnchorEff = nullptr;
     std::vector<Effect*> newEffects;
     for (auto& snap : mEffectMoveSnapshots) {
+        if (snap.effect->IsLocked()) continue;
         int targetVisibleRow = snap.origVisibleRow + rowDelta;
         if (targetVisibleRow < 0 || targetVisibleRow >= (int)mSequenceElements->GetVisibleRowInformationSize()) continue;
         Row_Information_Struct* targetRI = mSequenceElements->GetVisibleRowInformation(targetVisibleRow);


### PR DESCRIPTION
also dont drag/ghost the locked effects as you move.