### PR TITLE
Render Progress stays on top xlights not all apps (#6795)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -18,6 +18,8 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -enh (derwin12)              Ripple can now trigger a new cycle from a timing track, matching Shockwave
                                  (Timing Track/Filter/Regex/Duration settings).
     -enh (derwin12)              Export House Preview Video now lets you choose the output resolution.
+    -bug (derwin12)              Fixes #6795 - the render progress dialog no longer stays on top of
+                                 other applications (was topmost system-wide, not just above xLights).
     -bug (dkulp)                 Fix crash setting a model's serial Speed in the Layout property grid. The Speed
                                  choices are built for the protocol in effect when the grid was created, so a
                                  speed picked before the grid caught up with a protocol change read past the end

--- a/src-ui-wx/diagnostics/RenderProgressDialog.cpp
+++ b/src-ui-wx/diagnostics/RenderProgressDialog.cpp
@@ -12,6 +12,8 @@
 #include "UtilFunctions.h"
 #include "shared/utils/wxUtilities.h"
 
+#include <wx/event.h>
+
 //(*InternalHeaders(RenderProgressDialog)
 #include <wx/button.h>
 #include <wx/intl.h>
@@ -34,7 +36,7 @@ RenderProgressDialog::RenderProgressDialog(wxWindow* parent)
 	//(*Initialize(RenderProgressDialog)
 	wxFlexGridSizer* FlexGridSizer1;
 
-	Create(parent, wxID_ANY, _("Rendering Progress"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxMAXIMIZE_BOX|wxSTAY_ON_TOP, _T("wxID_ANY"));
+	Create(parent, wxID_ANY, _("Rendering Progress"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxMAXIMIZE_BOX, _T("wxID_ANY"));
 	FlexGridSizer1 = new wxFlexGridSizer(2, 1, 0, 0);
 	FlexGridSizer1->AddGrowableCol(0);
 	FlexGridSizer1->AddGrowableRow(0);
@@ -68,11 +70,27 @@ RenderProgressDialog::RenderProgressDialog(wxWindow* parent)
         Layout();
     }
     EnsureWindowHeaderIsOnScreen(this);
+
+    _owner = parent;
+    if (_owner != nullptr) {
+        _owner->Bind(wxEVT_ACTIVATE, &RenderProgressDialog::OnOwnerActivate, this);
+    }
 }
 
 RenderProgressDialog::~RenderProgressDialog()
 {
 	//(*Destroy(RenderProgressDialog)
 	//*)
+    if (_owner != nullptr) {
+        _owner->Unbind(wxEVT_ACTIVATE, &RenderProgressDialog::OnOwnerActivate, this);
+    }
     SaveWindowPosition("RenderProgress", this);
+}
+
+void RenderProgressDialog::OnOwnerActivate(wxActivateEvent& event)
+{
+    event.Skip();
+    if (event.GetActive() && IsShown()) {
+        Raise();
+    }
 }

--- a/src-ui-wx/diagnostics/RenderProgressDialog.h
+++ b/src-ui-wx/diagnostics/RenderProgressDialog.h
@@ -42,4 +42,13 @@ class RenderProgressDialog: public wxDialog
 		//*)
 
 		DECLARE_EVENT_TABLE()
+
+	private:
+
+		// Re-raises this dialog above _owner when _owner is activated, so
+		// clicking the main frame can't bury this modeless dialog behind it
+		// (#6404) without resorting to wxSTAY_ON_TOP, which pins it above
+		// every application on the desktop, not just xLights (#6795).
+		wxWindow* _owner = nullptr;
+		void OnOwnerActivate(wxActivateEvent& event);
 };

--- a/src-ui-wx/wxsmith/RenderProgressDialog.wxs
+++ b/src-ui-wx/wxsmith/RenderProgressDialog.wxs
@@ -3,7 +3,7 @@
 	<object class="wxDialog" name="RenderProgressDialog">
 		<title>Rendering Progress</title>
 		<id_arg>0</id_arg>
-		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxMAXIMIZE_BOX|wxSTAY_ON_TOP</style>
+		<style>wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER|wxMAXIMIZE_BOX</style>
 		<object class="wxFlexGridSizer" variable="FlexGridSizer1" member="no">
 			<cols>1</cols>
 			<rows>2</rows>


### PR DESCRIPTION
Small tweak to the ONTOP change done previously.