### PR TITLE
iPad: undoing a Model Set edit restores every member

### DIFF
--- a/plans/platform-parity/06-layout-models.md
+++ b/plans/platform-parity/06-layout-models.md
@@ -343,6 +343,7 @@ read-only category header (`ModelPropertyAdapter.cpp:307`); the iPad likewise sh
 | 243 | Escape finalizes a poly-line / unselects in 3D; Return finalizes | `LayoutPanel.cpp:9888-9905` | ✅ | `LayoutEditorView.swift:4161-4177` |
 | **Undo / save** |
 | 244 | Undo point per layout operation | `CreateUndoPoint` `LayoutPanel.cpp:10779`, `DoUndo` `:10597` | ✅ | `pushLayoutUndoSnapshotForModel:` / `…ForViewObject:` / `…TerrainHeightmap` (`XLSequenceDocument.h:2002`, `:2007`, `:2013`), undo `:2018`, can-undo `:2021` |
+| 244a | Undoing a Model Set edit restores every member | Snapshot promoted to `"All"` when the model is in a Set, `CreateUndoPoint` `LayoutPanel.cpp:10579` | ✅ | `PushLayoutUndoSnapshotForModel` snapshots all Set members under one `LayoutUndoEntry::groupId`; `UndoLastLayoutChange` pops the whole run (`iPadRenderContext.cpp:1416`, `:1497`). Previously restored only the grabbed model and left the peers displaced, since a Set drag translates every peer (`XLMetalBridge.mm:2354`) |
 | 245 | Save layout | `ButtonSavePreview` `LayoutPanel.cpp:1092`, handler `:4435`; disabled read-only `xLightsMain.cpp:9307` | ✅ | Canvas Save with unsaved-dot `LayoutEditorView.swift:3100`, bridge `XLSequenceDocument.h:1421`, dirty flag `:1987` |
 | 246 | Confirm-before-save with explicit discard-and-rollback | Desktop saves directly | 🔵 | `LayoutEditorView.swift:1052-1065`, `discardChanges` replays the undo stack `:4623` |
 | **Added by the 2026-08-01 cross-check** (appended, not renumbered — see the numbering rule) |

--- a/src-iPad/Bridge/iPadRenderContext.cpp
+++ b/src-iPad/Bridge/iPadRenderContext.cpp
@@ -28,6 +28,7 @@
 #include "effects/ShaderEffect.h"
 #include "models/Model.h"
 #include "models/ModelGroup.h"
+#include "models/ModelSet.h"
 #include "models/MeshObject.h"
 #include "models/ImageObject.h"
 #include "models/GridlinesObject.h"
@@ -1379,13 +1380,25 @@ bool iPadRenderContext::SaveLayoutChangesTo(const std::string& targetPath, bool 
     return true;
 }
 
-void iPadRenderContext::PushLayoutUndoSnapshotForModel(const std::string& modelName) {
-    if (modelName.empty()) return;
+void iPadRenderContext::TrimLayoutUndoStack() {
+    while (_layoutUndoStack.size() > kLayoutUndoMaxDepth) {
+        const uint32_t group = _layoutUndoStack.front().groupId;
+        // A Set with more members than the cap is one gesture filling the whole
+        // stack; trimming it would silently discard the snapshot just pushed.
+        if (group != 0 && group == _layoutUndoStack.back().groupId) break;
+        _layoutUndoStack.pop_front();
+        if (group == 0) continue;
+        while (!_layoutUndoStack.empty() && _layoutUndoStack.front().groupId == group) {
+            _layoutUndoStack.pop_front();
+        }
+    }
+}
+
+bool iPadRenderContext::CaptureModelUndoEntry(const std::string& modelName, LayoutUndoEntry& e) const {
     Model* m = AllModels.GetModel(modelName);
-    if (!m) return;
+    if (!m) return false;
     auto& loc = m->GetModelScreenLocation();
     glm::vec3 rot = loc.GetRotation();
-    LayoutUndoEntry e;
     e.target = UndoTarget::Model;
     e.modelName = modelName;
     e.hcenter = loc.GetHcenterPos();
@@ -1400,10 +1413,38 @@ void iPadRenderContext::PushLayoutUndoSnapshotForModel(const std::string& modelN
     e.locked  = loc.IsLocked();
     e.layoutGroup    = m->GetLayoutGroup();
     e.controllerName = m->GetControllerName();
+    return true;
+}
 
-    _layoutUndoStack.push_back(std::move(e));
-    while (_layoutUndoStack.size() > kLayoutUndoMaxDepth) {
-        _layoutUndoStack.pop_front();
+void iPadRenderContext::PushLayoutUndoSnapshotForModel(const std::string& modelName) {
+    if (modelName.empty()) return;
+
+    // Editing a Model Set member drags every peer along, so all members have to
+    // be snapshotted under one group id - otherwise undo restores the grabbed
+    // model and leaves the rest of the Set displaced.
+    std::vector<std::string> names;
+    if (const ModelSet* s = AllModels.GetSetManager().GetSetContaining(modelName)) {
+        names = s->GetMembers();
+    } else {
+        names.push_back(modelName);
+    }
+
+    uint32_t group = 0;
+    if (names.size() > 1) {
+        group = _nextLayoutUndoGroupId++;
+        if (_nextLayoutUndoGroupId == 0) _nextLayoutUndoGroupId = 1;
+    }
+
+    bool pushedAny = false;
+    for (const auto& n : names) {
+        LayoutUndoEntry e;
+        if (!CaptureModelUndoEntry(n, e)) continue;
+        e.groupId = group;
+        _layoutUndoStack.push_back(std::move(e));
+        pushedAny = true;
+    }
+    if (pushedAny) {
+        TrimLayoutUndoStack();
     }
 }
 
@@ -1439,9 +1480,7 @@ void iPadRenderContext::PushLayoutUndoSnapshotForViewObject(const std::string& o
     e.locked  = loc.IsLocked();
     e.layoutGroup = vo->GetLayoutGroup();
     _layoutUndoStack.push_back(std::move(e));
-    while (_layoutUndoStack.size() > kLayoutUndoMaxDepth) {
-        _layoutUndoStack.pop_front();
-    }
+    TrimLayoutUndoStack();
 }
 
 void iPadRenderContext::PushTerrainHeightmapUndoSnapshot(const std::string& terrainName) {
@@ -1455,16 +1494,26 @@ void iPadRenderContext::PushTerrainHeightmapUndoSnapshot(const std::string& terr
     e.modelName = terrainName;
     e.pointData = sloc.GetDataAsString();
     _layoutUndoStack.push_back(std::move(e));
-    while (_layoutUndoStack.size() > kLayoutUndoMaxDepth) {
-        _layoutUndoStack.pop_front();
-    }
+    TrimLayoutUndoStack();
 }
 
 bool iPadRenderContext::UndoLastLayoutChange() {
     if (_layoutUndoStack.empty()) return false;
-    LayoutUndoEntry e = _layoutUndoStack.back();
-    _layoutUndoStack.pop_back();
 
+    // Entries sharing a non-zero group id were pushed by one gesture (a Model
+    // Set move), so one undo has to consume the whole run.
+    const uint32_t group = _layoutUndoStack.back().groupId;
+    bool applied = false;
+    do {
+        LayoutUndoEntry e = _layoutUndoStack.back();
+        _layoutUndoStack.pop_back();
+        applied = ApplyLayoutUndoEntry(e) || applied;
+    } while (group != 0 && !_layoutUndoStack.empty() &&
+             _layoutUndoStack.back().groupId == group);
+    return applied;
+}
+
+bool iPadRenderContext::ApplyLayoutUndoEntry(const LayoutUndoEntry& e) {
     switch (e.target) {
     case UndoTarget::Model: {
         Model* m = AllModels.GetModel(e.modelName);

--- a/src-iPad/Bridge/iPadRenderContext.h
+++ b/src-iPad/Bridge/iPadRenderContext.h
@@ -733,6 +733,9 @@ public:
         std::string controllerName;     // Model only.
         // Heightmap snapshot — comma-delimited point data string.
         std::string pointData;
+        // Non-zero ties entries pushed by one gesture (a Model Set move drags
+        // every member), so one undo restores all of them. 0 = standalone.
+        uint32_t groupId = 0;
     };
     void PushLayoutUndoSnapshotForModel(const std::string& modelName);
     // J-17 — capture a view-object's common transform + locked
@@ -864,6 +867,13 @@ private:
     // J-2 — undo stack for layout edits. Bounded to 100 entries.
     std::deque<LayoutUndoEntry> _layoutUndoStack;
     static constexpr size_t kLayoutUndoMaxDepth = 100;
+    // Never 0 - that value marks a standalone entry.
+    uint32_t _nextLayoutUndoGroupId = 1;
+    bool CaptureModelUndoEntry(const std::string& modelName, LayoutUndoEntry& e) const;
+    bool ApplyLayoutUndoEntry(const LayoutUndoEntry& e);
+    // Drops oldest entries past kLayoutUndoMaxDepth a whole group at a time so
+    // a trim can't leave half a Set restorable.
+    void TrimLayoutUndoStack();
 
     // Cache of the show folder's <colors> palette so per-frame bracket
     // queries don't re-scan XML. Populated on every LoadShowFolder.


### PR DESCRIPTION
## The bug (iPad only)

Dragging a Model Set member on iPad translates every peer — `moveModel:` resolves the Set (`XLMetalBridge.mm:2301`) and calls `TranslateModelSetPeers` (`:2354`). But the drag pushed an undo snapshot only for the *grabbed* model (`PreviewPaneView.swift:930`, `:955`, `:1121`), and `UndoLastLayoutChange` popped a single entry.

So: drag a Set, every member moves. Undo, and only the grabbed model comes back — the rest stay where the drag left them, and the Set is broken apart visually.

Desktop already handles this by promoting a Set member's move to a full `"All"` undo snapshot (`LayoutPanel.cpp:10579`). The iPad's undo is a value snapshot of a single object, so it had no equivalent.

## The fix

`LayoutUndoEntry` gains a `groupId`. `PushLayoutUndoSnapshotForModel` resolves the Set containing the model and snapshots every member under one shared id; `UndoLastLayoutChange` pops the whole run when the top entry carries a non-zero id. One undo restores the entire Set.

Doing the expansion inside the push function means all three drag sites plus every property-edit call site inherit it — no Swift changes and nothing to keep in sync as new call sites appear.

Supporting cleanups:

- Capture and apply are split into `CaptureModelUndoEntry` / `ApplyLayoutUndoEntry` so the multi-entry push and the multi-entry pop reuse them instead of duplicating the field lists.
- The three copies of the depth-trim loop collapse into `TrimLayoutUndoStack`, which drops **whole groups** — otherwise reaching the 100-entry cap could leave half a Set restorable. It also refuses to drop a group spanning the entire stack, so a Set with more members than the cap can't silently discard the snapshot just taken.

`canUndoLayoutChange` (a bool) is the only undo-state accessor the UI reads, so the extra entries aren't visible anywhere.

## Testing

- `xLights-iPadLib` Debug, `-destination 'generic/platform=iOS'`: pass
- iPad-only change, so no desktop build applies and no `.cbp` / `.vcxproj` / CMake entries are needed (no new source files).

Not exercised on device — the change is compile-verified only.

## Parity

Scorecard row 244a added to `plans/platform-parity/06-layout-models.md`. No `README.txt` entry, per the iPad-changes convention in AGENTS.md §10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
