### PR TITLE
Replace Model: keep the replaced model's size on mesh-based models

### DIFF
--- a/src-core/models/Model.cpp
+++ b/src-core/models/Model.cpp
@@ -20,6 +20,7 @@
 #include "Model.h"
 #include "ModelGroup.h"
 #include "ModelManager.h"
+#include "BoxedScreenLocation.h"
 #include "ModelScreenLocation.h"
 #include "RulerObject.h"
 #include "SubModel.h"
@@ -1067,6 +1068,42 @@ void Model::UpdateChannels()
     }
 
     IncrementChangeCount();
+}
+
+void Model::CopyGeometryFrom(const Model& other)
+{
+    ModelScreenLocation& dst = GetModelScreenLocation();
+    const ModelScreenLocation& src = other.GetModelScreenLocation();
+
+    // Boxed locations: copy the scale factors, not the M-dimensions. The
+    // M-dimension setters divide by RenderWi/RenderHt, and a model that has not
+    // been drawn yet may have no render size - mesh-backed models (DMX moving
+    // heads) take theirs from the OBJ bounding box on first draw, so it is still
+    // 0. SetMWidth would then yield a negative scale that
+    // BoxedScreenLocation::Init clamps to 1, dropping the model to its mesh's
+    // natural size. Scale is stored state and survives regardless of load order.
+    auto* dstBox = dynamic_cast<BoxedScreenLocation*>(&dst);
+    const auto* srcBox = dynamic_cast<const BoxedScreenLocation*>(&src);
+    if (dstBox != nullptr && srcBox != nullptr) {
+        dstBox->SetScaleX(srcBox->GetScaleX());
+        dstBox->SetScaleY(srcBox->GetScaleY());
+        dstBox->SetScaleZ(srcBox->GetScaleZ());
+    } else {
+        // No scale to copy on two-point / poly-point locations - they derive
+        // size from their point data. GetRestorableM* is the inverse of the
+        // setters, the pairing SaveDisplayDimensions and the serializer use.
+        // Size before centre: those locations compute the centre from the
+        // current size, so a centre set against a stale size lands the model
+        // off by half the size delta.
+        dst.SetMWidth(src.GetRestorableMWidth());
+        dst.SetMHeight(src.GetRestorableMHeight());
+        dst.SetMDepth(src.GetRestorableMDepth());
+    }
+
+    dst.SetHcenterPos(src.GetHcenterPos());
+    dst.SetVcenterPos(src.GetVcenterPos());
+    dst.SetDcenterPos(src.GetDcenterPos());
+    dst.SetRotation(src.GetRotation());
 }
 
 void Model::Setup()

--- a/src-core/models/Model.h
+++ b/src-core/models/Model.h
@@ -455,6 +455,10 @@ public:
 
     void UpdateChannels();
     void Setup() override;
+    // Take on another model's size, position and rotation. Used when a
+    // replacement model has to keep the geometry of the model it replaces.
+    // Callers still own Setup() / IncrementChangeCount().
+    void CopyGeometryFrom(const Model& other);
     virtual bool ModelRenamed(const std::string& oldName, const std::string& newName);
     [[nodiscard]] uint32_t GetNodeCount() const;
     [[nodiscard]] NodeBaseClass* GetNode(uint32_t node) const;

--- a/src-iPad/Metal/XLMetalBridge.mm
+++ b/src-iPad/Metal/XLMetalBridge.mm
@@ -1638,13 +1638,10 @@ float ReadAlignReference(Model* model, const std::string& edge) {
             }
         }
         if (keepSizePosition) {
-            clone->GetModelScreenLocation().SetRotation(target->GetModelScreenLocation().GetRotation());
-            clone->SetHcenterPos(target->GetHcenterPos());
-            clone->SetVcenterPos(target->GetVcenterPos());
-            clone->SetDcenterPos(target->GetDcenterPos());
-            clone->SetHeight(target->GetHeight());
-            clone->SetWidth(target->GetWidth());
-            clone->SetDepth(target->GetDepth());
+            // Shared with desktop ReplaceModel: goes through the screen location
+            // so a locked clone still copies, sizes before centring, and copies
+            // scale rather than M-dimensions - the clone has no render size yet.
+            clone->CopyGeometryFrom(*target);
         }
 
         // Atomic name swap: park the old target under a trash name,

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -59,6 +59,7 @@
 #include "layout/ViewObjectPanel.h"
 #include "layout/LayoutGroup.h"
 #include "layout/LayoutPrintPreviewDialog.h"
+#include "models/BoxedScreenLocation.h"
 #include "models/ModelImages.h"
 #include "models/SubModel.h"
 #include "models/PolyLineModel.h"
@@ -10084,20 +10085,10 @@ namespace {
 // working for a locked source. (Base linkage is not a concern here: the caller
 // clears FromBase on the clone, and base-linked targets are blocked up front.)
 //
-// Size MUST be set before the centre: two-point / poly-point screen locations
-// derive their centre from the current width/height/depth
-// (worldPos = centre - size/2), so a centre set against a stale size lands the
-// model off by half the size delta.
+// Size-before-centre ordering and the scale-vs-M-dimension choice live in
+// Model::CopyGeometryFrom, shared with the iPad's replaceModels.
 void CopyGeometryFromTarget(Model* clone, const Model* target) {
-    ModelScreenLocation& cloc = clone->GetModelScreenLocation();
-    const ModelScreenLocation& tloc = target->GetModelScreenLocation();
-    cloc.SetMWidth(tloc.GetMWidth());
-    cloc.SetMHeight(tloc.GetMHeight());
-    cloc.SetMDepth(tloc.GetMDepth());
-    cloc.SetHcenterPos(tloc.GetHcenterPos());
-    cloc.SetVcenterPos(tloc.GetVcenterPos());
-    cloc.SetDcenterPos(tloc.GetDcenterPos());
-    cloc.SetRotation(tloc.GetRotation());
+    clone->CopyGeometryFrom(*target);
     clone->Setup();
     clone->IncrementChangeCount();
 }


### PR DESCRIPTION
## The bug

Replace Model with **copy size/position** ticked dropped mesh-based models to their mesh's natural size. A 20 × 20 × 20 DMX moving head came out **5.42 × 5.99 × 5.42**.

## Why

The geometry copy went through the M-dimension setters, which divide by `RenderWi` / `RenderHt`. A freshly built clone has no render size yet — mesh-backed models take theirs from the OBJ bounding box on **first draw**, and `Setup()` does not establish it. Instrumenting the copy showed:

```
target:              RenderWi=22.07  RenderHt=24.28  RenderDp=11.37   M w=81.47 h=81.12 d=81.47
clone-before-Setup:  RenderWi=0      RenderHt=0      RenderDp=0       M w=-0 h=-0 d=-0
clone-after-Setup:   RenderWi=0      RenderHt=0      RenderDp=0       restorable w=-1 h=-1 d=-1
```

So `SetMWidth(77.78)` computed `77.78 / (0 - 1)` = **−77.78**, and `BoxedScreenLocation::Init()` clamped the negative scale back to `1.0`. The target's `scalex` of 3.692 was discarded — exactly the 3.69× shortfall measured. Width equalled depth in the result because `GetMDepth` is defined over `RenderWi`, not `RenderDp`.

The non-integer target render sizes are the giveaway that these come from a loaded mesh rather than a node grid.

## The fix

Copy the scale factors directly for boxed locations. Scale is stored state, so it survives regardless of when the mesh loads, and replacing like with like — the common case — reproduces the target's size exactly. Across two different meshes it carries the target's scale factor rather than its absolute size, which is the best available before the clone's geometry exists.

Two-point and poly-point locations have no scale to copy (they derive size from point data) and keep the M-dimension path, now using `GetRestorableM*` — the actual inverse of those setters, and the pairing `SaveDisplayDimensions` and the serializer already use. `Set(Get())` on the plain getters inflates by `RenderWi / (RenderWi - 1)`.

## iPad

Fixed in the same PR (State A). `replaceModels:keepSizePosition:` had the identical bug through `SetWidth`/`SetHeight`/`SetDepth`, and additionally set the centre **before** the size — the reverse of the order two-point and poly-point locations need. Rather than fix it twice, the logic moved into `Model::CopyGeometryFrom` and both platforms call it.

## Testing

- macOS Debug: pass
- macOS Debug with `NO_PCH`: pass
- `xLights-iPadLib` Debug, `generic/platform=iOS`: pass
- Manual: replacing a 20″ DMX moving head now keeps 20 × 20 × 20 (verified by the reporter). Diagnosed from instrumented logging, since the numbers are what identified the zero render size.

No new source files, so no `.cbp` / `.vcxproj` / CMake changes.

## Not included

`BoxedScreenLocation::SetMDepth` discards its argument entirely when `RenderWi == 1` (`scalez = 1`), unlike `SetMWidth`/`SetMHeight` which assign the value. That silently pins depth to 1 on every model whose `RenderWi` is 1 — all non-mesh DMX models — so setting their depth from the property grid, the bulk depth edit, or the iPad's align-depth does nothing. It is a real bug but a separate one, and changing shared depth semantics does not belong in this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
