### PR TITLE
Fix Show Controller messing up the control properties items (#6909)

### DIFF
--- a/src-ui-wx/controllerproperties/ControllerEthernetPropertyAdapter.cpp
+++ b/src-ui-wx/controllerproperties/ControllerEthernetPropertyAdapter.cpp
@@ -407,7 +407,21 @@ void ControllerEthernetPropertyAdapter::AddProperties(wxPropertyGrid* propertyGr
 
 bool ControllerEthernetPropertyAdapter::HandlePropertyEvent(wxPropertyGridEvent& event, OutputModelManager* outputModelManager) {
 
-    if (ControllerPropertyAdapter::HandlePropertyEvent(event, outputModelManager)) return true;
+    auto const oldProtocol = _ethernet.GetProtocol();
+    if (ControllerPropertyAdapter::HandlePropertyEvent(event, outputModelManager)) {
+        // Vendor/Model/Variant changes can silently switch the controller to its
+        // caps' preferred protocol (Controller::VMVChanged), recreating the
+        // output objects out from under the property grid. Rebuild the
+        // protocol-specific rows so stale ones from the old protocol don't
+        // linger alongside the new ones.
+        if (_ethernet.GetProtocol() != oldProtocol) {
+            wxPropertyGrid* grid = dynamic_cast<wxPropertyGrid*>(event.GetEventObject());
+            if (grid) {
+                RebuildOutputProperties(grid, outputModelManager);
+            }
+        }
+        return true;
+    }
 
     wxString const name = event.GetPropertyName();
 
@@ -675,21 +689,26 @@ void ControllerEthernetPropertyAdapter::ValidateProperties(OutputManager* om, wx
 }
 
 void ControllerEthernetPropertyAdapter::SetProtocolAndRebuildProperties(const std::string& protocol, wxPropertyGrid* grid, OutputModelManager* outputModelManager) {
-    auto const& outputs = _ethernet.GetOutputs();
-    if (outputs.size() > 0) {
-        auto adapter = OutputPropertyAdapter::Create(*outputs.front());
-        adapter->RemoveProperties(grid);
-    }
     _ethernet.SetProtocol(protocol);
+    RebuildOutputProperties(grid, outputModelManager);
+}
 
+void ControllerEthernetPropertyAdapter::RebuildOutputProperties(wxPropertyGrid* grid, OutputModelManager* outputModelManager) {
+    OutputPropertyAdapter::RemoveAllProperties(grid);
     if (_ethernet.GetOutputCount() > 0) {
         std::list<wxPGProperty*> expandProperties;
         auto before = grid->GetProperty("Managed");
         auto adapter = OutputPropertyAdapter::Create(*_ethernet.GetFirstOutput());
         adapter->AddProperties(grid, before, &_ethernet, _ethernet.AllSameSize(), expandProperties);
     }
-    outputModelManager->AddASAPWork(OutputModelManager::WORK_NETWORK_CONFIG_CHANGE, "ControllerEthernet::HandlePropertyEvent::Protocol");
-    outputModelManager->AddLayoutTabWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "ControllerEthernet::HandlePropertyEvent::Protocol", nullptr);
+    wxPGProperty* p = grid->GetProperty("Protocol");
+    if (p) {
+        auto protocols = GetEthernetProtocols(_ethernet);
+        p->SetChoices(protocols);
+        p->SetChoiceSelection(EncodeChoices(protocols, _ethernet.GetProtocol()));
+    }
+    outputModelManager->AddASAPWork(OutputModelManager::WORK_NETWORK_CONFIG_CHANGE, "ControllerEthernet::RebuildOutputProperties");
+    outputModelManager->AddLayoutTabWork(OutputModelManager::WORK_CALCULATE_START_CHANNELS, "ControllerEthernet::RebuildOutputProperties", nullptr);
 }
 
 void ControllerEthernetPropertyAdapter::HandleExpanded(wxPropertyGridEvent& event, bool expanded) {

--- a/src-ui-wx/controllerproperties/ControllerEthernetPropertyAdapter.h
+++ b/src-ui-wx/controllerproperties/ControllerEthernetPropertyAdapter.h
@@ -30,6 +30,12 @@ public:
 
 private:
     void SetProtocolAndRebuildProperties(const std::string& protocol, wxPropertyGrid* grid, OutputModelManager* outputModelManager);
+    // Removes/re-adds the protocol-specific output rows and refreshes the
+    // Protocol choices/selection to match the controller's current protocol.
+    // Shared by SetProtocolAndRebuildProperties (manual Protocol dropdown
+    // change) and HandlePropertyEvent (Vendor/Model/Variant changes that
+    // silently switch protocol via Controller::VMVChanged).
+    void RebuildOutputProperties(wxPropertyGrid* grid, OutputModelManager* outputModelManager);
 
     ControllerEthernet& _ethernet;
 };

--- a/src-ui-wx/controllerproperties/OutputPropertyAdapters.cpp
+++ b/src-ui-wx/controllerproperties/OutputPropertyAdapters.cpp
@@ -68,6 +68,18 @@ std::unique_ptr<OutputPropertyAdapter> OutputPropertyAdapter::Create(Output& out
     return std::make_unique<OutputPropertyAdapter>(output);
 }
 
+void OutputPropertyAdapter::RemoveAllProperties(wxPropertyGrid* propertyGrid) {
+    static const char* const names[] = {
+        "Universe", "Universes", "UniversePerString", "UniversesDisplay", "IndivSizes", "Sizes",
+        "ForceSourcePort", "ChannelsPerPacket", "KeepChannelNumbers", "Version",
+        "DontSendConfig", "SendDataMulticast", "SupportsSmartRemotes", "SupportsVirtualStrings",
+        "HTTPPort", "DeviceChannels", "Channels"
+    };
+    for (const auto* name : names) {
+        propertyGrid->DeleteProperty(name);
+    }
+}
+
 // =========================================================================
 // LOR custom property editors (moved from LOROptimisedOutput.cpp)
 // =========================================================================

--- a/src-ui-wx/controllerproperties/OutputPropertyAdapters.h
+++ b/src-ui-wx/controllerproperties/OutputPropertyAdapters.h
@@ -34,6 +34,14 @@ public:
 
     static std::unique_ptr<OutputPropertyAdapter> Create(Output& output);
 
+    // Deletes every property name any OutputPropertyAdapter subclass might have
+    // added, regardless of which protocol is currently active. Used instead of
+    // RemoveProperties() on a single adapter instance whenever the protocol may
+    // have changed without the caller having a handle on the adapter that added
+    // the properties still on the grid (e.g. Controller::VMVChanged() switching
+    // to a caps' preferred protocol out from under the UI).
+    static void RemoveAllProperties(wxPropertyGrid* propertyGrid);
+
 protected:
     Output& _output;
 };

--- a/src-ui-wx/layout/ControllerListPanel.cpp
+++ b/src-ui-wx/layout/ControllerListPanel.cpp
@@ -1537,7 +1537,9 @@ void ControllerListPanel::OnControllerPropertyGridChange(wxPropertyGridEvent& ev
             }
             // Size / location fields share the model property-grid key names, so
             // they can only be reached once the controller keys have missed.
-            if (_propGrid->GetPropertyByName("ModelX") != nullptr &&
+            // "Model" itself (the controller's Model/Category field) also starts
+            // with "Model" and must stay routed to the adapter below.
+            if (_propGrid->GetPropertyByName("ModelX") != nullptr && name != "Model" &&
                 (name == "Locked" || name.StartsWith("Model") ||
                  name.StartsWith("Scale") || name.StartsWith("Rotate"))) {
                 ScreenLocationPropertyHelper::OnPropertyGridChange(


### PR DESCRIPTION
When selecting show controller on the top controller panel for a new panel it would not populate the bottom panel correctly and caused missing and duplicated items.