### PR TITLE
Don't expand groups on paste #6900

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -11,6 +11,8 @@ Issue Tracker is found here: www.github.com/xLightsSequencer/xLights/issues
 XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.16  August ??, 2026
+    -bug (cybercop23)            Fix pasting effects onto a Model Group from expanding to show its member
+                                 models/strands (#6900)
     -bug (derwin12)              Fix Replace Model(s) With This Model now deletes the source model once it has
                                  been used to replace the selected target(s) (#6901)
     -enh (AlexB)                 macOS/Linux: the scroll wheel and trackpad slides adjust sliders and dropdowns,

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -5980,6 +5980,13 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
 
     Effect* res = nullptr;
 
+    auto isModelGroupElement = [this](Element* elem) -> bool {
+        if (elem == nullptr)
+            return false;
+        Model* m = xlights->AllModels[elem->GetModelName()];
+        return m != nullptr && m->GetDisplayAs() == DisplayAsType::ModelGroup;
+    };
+
     if (mSequenceElements == nullptr)
         return res;
 
@@ -6260,7 +6267,7 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
                             for (int si = 0; si < me->GetSubModelCount(); ++si)
                                 deleteUnused(me->GetSubModel(si));
                             undo_mgr.CreateUndoStep(); // needed for redo
-                            if (!singleElementPaste) {
+                            if (!singleElementPaste && !isModelGroupElement(me)) {
                                 me->ShowSubModels(true);
                                 me->ShowStrands(true);
                                 mSequenceElements->PopulateRowInformation();
@@ -6366,7 +6373,7 @@ Effect* EffectsGrid::Paste(const wxString& data, const wxString& pasteDataVersio
                         if (!singleElementPaste) {
                             for (auto& [elem, maxLayer] : elemMaxLayer) {
                                 ModelElement* me2 = dynamic_cast<ModelElement*>(elem);
-                                if (me2 != nullptr) {
+                                if (me2 != nullptr && !isModelGroupElement(me2)) {
                                     me2->ShowSubModels(true);
                                     me2->ShowStrands(true);
                                 }
@@ -9122,8 +9129,11 @@ void EffectsGrid::PasteModelEffectsWithSubModelLayers(ModelElement* me) {
         return;
 
     me->SetCollapsed(false);
-    me->ShowSubModels(true);
-    me->ShowStrands(true);
+    Model* destModel = xlights->AllModels[me->GetModelName()];
+    if (destModel == nullptr || destModel->GetDisplayAs() != DisplayAsType::ModelGroup) {
+        me->ShowSubModels(true);
+        me->ShowStrands(true);
+    }
 
     xLightsApp::GetFrame()->AbortRender();
 


### PR DESCRIPTION
Unnecessary to expand groups on paste. It will still do layers, just not expand the group itself.