### PR TITLE
Fix start/end times when dragging and effect over another one #6908

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,6 +13,8 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
 2026.16  August ??, 2026
     -bug (derwin12)              Fix Replace Model(s) With This Model now deletes the source model once it has
                                  been used to replace the selected target(s) (#6901)
+    -bug (cybercop23)            Fix effect start/end times becoming corrupted when dragging an effect past
+                                 another effect on the same row, then resizing it (#6908)
     -enh (AlexB)                 macOS/Linux: the scroll wheel and trackpad slides adjust sliders and dropdowns,
                                  matching Windows. The control has to be clicked or focused first, and a scroll
                                  already moving a panel keeps moving it, so scrolling past a control never

--- a/src-core/render/EffectLayer.cpp
+++ b/src-core/render/EffectLayer.cpp
@@ -246,46 +246,74 @@ void EffectLayer::SortEffects()
     NumberEffects();
 }
 
+Effect* EffectLayer::GetPriorEffect(int index) const
+{
+    if (index < 0 || index >= (int)mEffects.size()) return nullptr;
+    const Effect* self = mEffects[index];
+    Effect* prior = nullptr;
+    for (Effect* e : mEffects) {
+        if (e == self) continue;
+        if (e->GetStartTimeMS() < self->GetStartTimeMS() &&
+            (prior == nullptr || e->GetStartTimeMS() > prior->GetStartTimeMS())) {
+            prior = e;
+        }
+    }
+    return prior;
+}
+
+Effect* EffectLayer::GetNextEffect(int index) const
+{
+    if (index < 0 || index >= (int)mEffects.size()) return nullptr;
+    const Effect* self = mEffects[index];
+    Effect* next = nullptr;
+    for (Effect* e : mEffects) {
+        if (e == self) continue;
+        if (e->GetStartTimeMS() > self->GetStartTimeMS() &&
+            (next == nullptr || e->GetStartTimeMS() < next->GetStartTimeMS())) {
+            next = e;
+        }
+    }
+    return next;
+}
+
 bool EffectLayer::IsStartTimeLinked(int index) const
 {
-    if (index < (int)mEffects.size() && index > 0) {
-        return mEffects[index - 1]->GetEndTimeMS() == mEffects[index]->GetStartTimeMS();
-    } else {
-        return false;
-    }
+    Effect* prior = GetPriorEffect(index);
+    if (prior == nullptr) return false;
+    return prior->GetEndTimeMS() == mEffects[index]->GetStartTimeMS();
 }
 
 bool EffectLayer::IsEndTimeLinked(int index) const
 {
-    if (index < (int)mEffects.size() - 1) {
-        return mEffects[index]->GetEndTimeMS() == mEffects[index + 1]->GetStartTimeMS();
-    } else {
-        return false;
-    }
+    Effect* next = GetNextEffect(index);
+    if (next == nullptr) return false;
+    return mEffects[index]->GetEndTimeMS() == next->GetStartTimeMS();
 }
 
 int EffectLayer::GetMaximumEndTimeMS(int index, bool allow_collapse, int min_period) const
 {
-    if (index + 1 >= (int)mEffects.size()) {
+    Effect* next = GetNextEffect(index);
+    if (next == nullptr) {
         return NO_MIN_MAX_TIME;
     } else {
-        if (mEffects[index]->GetEndTimeMS() == mEffects[index + 1]->GetStartTimeMS() && allow_collapse) {
-            return mEffects[index + 1]->GetEndTimeMS() - min_period;
+        if (mEffects[index]->GetEndTimeMS() == next->GetStartTimeMS() && allow_collapse) {
+            return next->GetEndTimeMS() - min_period;
         } else {
-            return mEffects[index + 1]->GetStartTimeMS();
+            return next->GetStartTimeMS();
         }
     }
 }
 
 int EffectLayer::GetMinimumStartTimeMS(int index, bool allow_collapse, int min_period) const
 {
-    if (index == 0) {
+    Effect* prior = GetPriorEffect(index);
+    if (prior == nullptr) {
         return NO_MIN_MAX_TIME;
     } else {
-        if (mEffects[index - 1]->GetEndTimeMS() == mEffects[index]->GetStartTimeMS() && allow_collapse) {
-            return mEffects[index - 1]->GetStartTimeMS() + min_period;
+        if (prior->GetEndTimeMS() == mEffects[index]->GetStartTimeMS() && allow_collapse) {
+            return prior->GetStartTimeMS() + min_period;
         } else {
-            return mEffects[index - 1]->GetEndTimeMS();
+            return prior->GetEndTimeMS();
         }
     }
 }

--- a/src-core/render/EffectLayer.h
+++ b/src-core/render/EffectLayer.h
@@ -68,6 +68,12 @@ public:
     int GetMaximumEndTimeMS(int index, bool allow_collapse, int min_period) const;
     int GetMinimumStartTimeMS(int index, bool allow_collapse, int min_period) const;
 
+    // Chronological neighbor of mEffects[index] found by scanning start times rather than
+    // trusting adjacent array position, so a stale sort order (e.g. after dragging an effect
+    // past a sibling without a re-sort) can't return the wrong neighbor.
+    Effect* GetPriorEffect(int index) const;
+    Effect* GetNextEffect(int index) const;
+
     bool HitTestEffectByTime(int timeMS, int& index) const;
     bool HitTestEffectBetweenTime(int t1MS, int t2MS) const;
 

--- a/src-ui-wx/sequencer/EffectsGrid.cpp
+++ b/src-ui-wx/sequencer/EffectsGrid.cpp
@@ -6855,7 +6855,8 @@ void EffectsGrid::ResizeSingleEffectMS(int timems) {
     }
 
     if (mResizingMode == EFFECT_RESIZE_LEFT || mResizingMode == EFFECT_RESIZE_LEFT_EDGE) {
-        bool prevLocked = mResizeEffectIndex > 0 && mEffectLayer->GetEffect(mResizeEffectIndex - 1)->IsLocked();
+        Effect* priorEffect = mEffectLayer->GetPriorEffect(mResizeEffectIndex);
+        bool prevLocked = priorEffect != nullptr && priorEffect->IsLocked();
         int minimumTime = mEffectLayer->GetMinimumStartTimeMS(mResizeEffectIndex, mResizingMode == EFFECT_RESIZE_LEFT && !prevLocked, mSequenceElements->GetMinPeriod());
         // User has dragged left side to the right side exit
         if (time >= mEffectLayer->GetEffect(mResizeEffectIndex)->GetEndTimeMS()) {
@@ -6866,7 +6867,7 @@ void EffectsGrid::ResizeSingleEffectMS(int timems) {
                 time = 0;
             }
             if (mEffectLayer->IsStartTimeLinked(mResizeEffectIndex) && mResizingMode == EFFECT_RESIZE_LEFT && !prevLocked) {
-                Effect* eff = mEffectLayer->GetEffect(mResizeEffectIndex - 1);
+                Effect* eff = priorEffect;
                 if (mSequenceElements->get_undo_mgr().GetCaptureUndo()) {
                     mSequenceElements->get_undo_mgr().CaptureEffectToBeMoved(mEffectLayer->GetParentElement()->GetModelName(), mEffectLayer->GetIndex(), eff->GetID(),
                                                                              eff->GetStartTimeMS(), eff->GetEndTimeMS());
@@ -6880,24 +6881,25 @@ void EffectsGrid::ResizeSingleEffectMS(int timems) {
             }
             eff->SetStartTimeMS(time);
         } else {
-            if (mResizeEffectIndex != 0) {
+            if (priorEffect != nullptr) {
                 Effect* eff = mEffectLayer->GetEffect(mResizeEffectIndex);
                 if (mSequenceElements->get_undo_mgr().GetCaptureUndo()) {
                     mSequenceElements->get_undo_mgr().CaptureEffectToBeMoved(mEffectLayer->GetParentElement()->GetModelName(), mEffectLayer->GetIndex(), eff->GetID(),
                                                                              eff->GetStartTimeMS(), eff->GetEndTimeMS());
                 }
-                eff->SetStartTimeMS(mEffectLayer->GetEffect(mResizeEffectIndex - 1)->GetEndTimeMS());
+                eff->SetStartTimeMS(priorEffect->GetEndTimeMS());
             }
         }
     } else if (mResizingMode == EFFECT_RESIZE_RIGHT || mResizingMode == EFFECT_RESIZE_RIGHT_EDGE) {
-        bool nextLocked = mResizeEffectIndex + 1 < mEffectLayer->GetEffectCount() && mEffectLayer->GetEffect(mResizeEffectIndex + 1)->IsLocked();
+        Effect* nextEffect = mEffectLayer->GetNextEffect(mResizeEffectIndex);
+        bool nextLocked = nextEffect != nullptr && nextEffect->IsLocked();
         int maximumTime = mEffectLayer->GetMaximumEndTimeMS(mResizeEffectIndex, mResizingMode == EFFECT_RESIZE_RIGHT && !nextLocked, mSequenceElements->GetMinPeriod());
         // User has dragged right side to the left side exit
         if (time <= mEffectLayer->GetEffect(mResizeEffectIndex)->GetStartTimeMS()) {
             return;
         } else if (time <= maximumTime || maximumTime == NO_MIN_MAX_TIME) {
             if (mEffectLayer->IsEndTimeLinked(mResizeEffectIndex) && mResizingMode == EFFECT_RESIZE_RIGHT && !nextLocked) {
-                Effect* eff = mEffectLayer->GetEffect(mResizeEffectIndex + 1);
+                Effect* eff = nextEffect;
                 if (mSequenceElements->get_undo_mgr().GetCaptureUndo()) {
                     mSequenceElements->get_undo_mgr().CaptureEffectToBeMoved(mEffectLayer->GetParentElement()->GetModelName(), mEffectLayer->GetIndex(), eff->GetID(),
                                                                              eff->GetStartTimeMS(), eff->GetEndTimeMS());
@@ -6911,13 +6913,13 @@ void EffectsGrid::ResizeSingleEffectMS(int timems) {
             }
             eff->SetEndTimeMS(time);
         } else {
-            if (mResizeEffectIndex < mEffectLayer->GetEffectCount() - 1) {
+            if (nextEffect != nullptr) {
                 Effect* eff = mEffectLayer->GetEffect(mResizeEffectIndex);
                 if (mSequenceElements->get_undo_mgr().GetCaptureUndo()) {
                     mSequenceElements->get_undo_mgr().CaptureEffectToBeMoved(mEffectLayer->GetParentElement()->GetModelName(), mEffectLayer->GetIndex(), eff->GetID(),
                                                                              eff->GetStartTimeMS(), eff->GetEndTimeMS());
                 }
-                eff->SetEndTimeMS(mEffectLayer->GetEffect(mResizeEffectIndex + 1)->GetStartTimeMS());
+                eff->SetEndTimeMS(nextEffect->GetStartTimeMS());
             }
         }
     }


### PR DESCRIPTION
Don't screw up start/end times when dragging over another effect on the same row.