### PR TITLE
Handle the legacy model blending (#6841)

### DIFF
--- a/src-core/render/RenderEngine.cpp
+++ b/src-core/render/RenderEngine.cpp
@@ -1387,6 +1387,19 @@ public:
                         if (!ls.empty() && ls.back() == "Blend") {
                             doBlendLayer = true;
                             ls.pop_back();
+                        } else if (!ls.empty() && _seqElements != nullptr && _seqElements->SupportsModelBlending() &&
+                                   std::atoi(ls.back().c_str()) >= numLayers - layer - 1) {
+                            // Sequences saved before the "Blend" pseudo-layer existed (xLights
+                            // < 2024.09) could only select real layers below, so LayerSelectDialog
+                            // silently ignored any out-of-range index. Once the Blend row was added
+                            // immediately after the real layers, that same out-of-range value lines
+                            // up exactly with the Blend row's position - which is how the dialog
+                            // still reads it today (LayerSelectDialog.cpp's position-based parsing) -
+                            // it only offers/writes that row when SupportsModelBlending() is on, so
+                            // require the same here to avoid reinterpreting a stray legacy index as
+                            // blend for sequences that have model blending turned off globally.
+                            doBlendLayer = true;
+                            ls.pop_back();
                         }
                         for (int i = layer + 1; i < (int)vl.size(); i++) {
                             if (vl[i]) {


### PR DESCRIPTION
In 2024 the last option in the canvas layers was Model Blending but was stored as an extra layer. Now we expect it to say "Blend".
So 0|1|2, the 2 meant layer blend. 
The code now just throws away the 2 - sort of - it shows Model Blend as checked but it is ignored unless you go in and go out.
It needs to be stored as 0|1|Blend.
This change handles both cases ..

Going to need some second/third opinions on this one..