### PR TITLE
Filterable pickers everywhere, with ticked items pinned to the top

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -77,6 +77,7 @@
 #include "model/WiringDialog.h"
 #include "model/ModelDimmingCurveDialog.h"
 #include "UtilFunctions.h"
+#include "shared/dialogs/CheckboxSelectDialog.h"
 #include "shared/utils/ExternalHooksUI.h"
 #include "color/ColorManager.h"
 #include "utils/VectorMath.h"
@@ -3658,7 +3659,10 @@ void LayoutPanel::AddSelectedToExistingGroups() {
         return;
     }
 
-    wxMultiChoiceDialog dlg(this, "Select existing groups to add selections to", "Existing Group", choices);
+    // Filterable picker - group lists get long. Groups you have already ticked
+    // stay visible when you change the filter, so you can search, tick, search
+    // again and tick more without losing your earlier choices.
+    CheckboxSelectDialog dlg(this, _("Select existing groups to add selections to"), choices);
     OptimiseDialogPosition(&dlg);
 
     std::string selectgroupName;
@@ -3666,8 +3670,8 @@ void LayoutPanel::AddSelectedToExistingGroups() {
 
     if (dlg.ShowModal() == wxID_OK) {
         xlights->AbortRender();
-        for (auto const& idx : dlg.GetSelections()) {
-            std::string groupName = choices.at(idx).ToStdString();
+        for (auto const& groupNameStr : dlg.GetSelectedItems()) {
+            std::string groupName = groupNameStr.ToStdString();
 
             Model* addToGroupModel = xlights->GetModel(groupName);
 
@@ -3722,14 +3726,15 @@ void LayoutPanel::RemoveSelectedFromExistingGroups() {
             for (const auto& it : inModelGroups) {
                 choices.Add(it);
             }
-            wxMultiChoiceDialog dlg(this, "Select groups to remove model from", "Model in Groups", choices);
+            // Same filterable picker as the add-to-groups path above.
+            CheckboxSelectDialog dlg(this, _("Select groups to remove model from"), choices);
             OptimiseDialogPosition(&dlg);
 
             bool reload = false;
             if (dlg.ShowModal() == wxID_OK) {
                 xlights->AbortRender();
-                for (auto const& idx : dlg.GetSelections()) {
-                    std::string groupName = choices.at(idx).ToStdString();
+                for (auto const& groupNameStr : dlg.GetSelectedItems()) {
+                    std::string groupName = groupNameStr.ToStdString();
                     Model* grp = xlights->GetModel(groupName);
                     if (grp != nullptr && grp->GetDisplayAs() == DisplayAsType::ModelGroup) {
                         ModelGroup* modelGroup = dynamic_cast<ModelGroup*>(grp);

--- a/src-ui-wx/model/ImportPreviewsModelsDialog.cpp
+++ b/src-ui-wx/model/ImportPreviewsModelsDialog.cpp
@@ -224,16 +224,16 @@ void ImportPreviewsModelsDialog::AddModels(wxTreeListCtrl* tree, wxTreeListItem 
     std::vector<std::pair<std::string, pugi::xml_node>> groups;
     std::vector<std::pair<std::string, pugi::xml_node>> mods;
 
-    auto collect = [&](pugi::xml_node parent, std::vector<std::pair<std::string, pugi::xml_node>>& into) {
+    auto collect = [&](pugi::xml_node parent, std::vector<std::pair<std::string, pugi::xml_node>>& into, ImpItemKind kind) {
         for (pugi::xml_node m = parent.first_child(); m; m = m.next_sibling()) {
             if (wxString(m.attribute("LayoutGroup").as_string()) == preview) {
                 wxString mn = m.attribute("name").as_string();
-                if (MatchesFilter(mn, filter)) into.emplace_back(mn.ToStdString(), m);
+                if (KeepInFilteredTree(mn, kind, filter)) into.emplace_back(mn.ToStdString(), m);
             }
         }
     };
-    if (modelgroups) collect(modelgroups, groups);
-    if (models) collect(models, mods);
+    if (modelgroups) collect(modelgroups, groups, ImpItemKind::ModelGroup);
+    if (models) collect(models, mods, ImpItemKind::Model);
 
     if (groups.empty() && mods.empty()) return;
 
@@ -258,7 +258,7 @@ void ImportPreviewsModelsDialog::AddViewpoints(wxTreeListCtrl* tree, wxTreeListI
     for (pugi::xml_node c = viewpoints.first_child(); c; c = c.next_sibling()) {
         if (std::string_view(c.name()) != "Camera") continue; // skip DefaultCamera2D/DefaultCamera3D
         wxString cn = UnXmlSafe(c.attribute("name").as_string(""));
-        if (MatchesFilter(cn, filter)) cams.emplace_back(cn.ToStdString(), c);
+        if (KeepInFilteredTree(cn, ImpItemKind::Viewpoint, filter)) cams.emplace_back(cn.ToStdString(), c);
     }
 
     if (cams.empty()) return;
@@ -270,6 +270,17 @@ void ImportPreviewsModelsDialog::AddViewpoints(wxTreeListCtrl* tree, wxTreeListI
         tree->AppendItem(item, label, -1, -1, new impTreeItemData(wxString(name), node, ImpItemKind::Viewpoint));
     }
     tree->Expand(item);
+}
+
+bool ImportPreviewsModelsDialog::KeepInFilteredTree(const wxString& name, ImpItemKind kind, const wxString& filterLower) const
+{
+    // A ticked row survives a filter that would otherwise exclude it. Its check
+    // state was already preserved in _checkedModels, but hiding the row made a
+    // selection built up across several filter terms impossible to review.
+    if (_checkedModels.count({ name.ToStdString(), kind }) != 0) {
+        return true;
+    }
+    return MatchesFilter(name, filterLower);
 }
 
 bool ImportPreviewsModelsDialog::MatchesFilter(const wxString& name, const wxString& filterLower)
@@ -384,9 +395,13 @@ void ImportPreviewsModelsDialog::PopulateTree()
 
     // While filtering, drop preview rows with no matching children (the Viewpoints row is
     // already guaranteed non-empty above, so this only ever prunes preview rows).
+    // A ticked preview row is kept even when empty, for the same reason a ticked
+    // model is: it represents a selection the user needs to still be able to see.
     if (!_filter.empty()) {
         for (wxTreeListItem p : topLevelRows) {
-            if (!TreeListCtrl1->GetFirstChild(p).IsOk()) TreeListCtrl1->DeleteItem(p);
+            if (TreeListCtrl1->GetFirstChild(p).IsOk()) continue;
+            if (_checkedPreviews.count(TreeListCtrl1->GetItemText(p).ToStdString()) != 0) continue;
+            TreeListCtrl1->DeleteItem(p);
         }
     }
 

--- a/src-ui-wx/model/ImportPreviewsModelsDialog.h
+++ b/src-ui-wx/model/ImportPreviewsModelsDialog.h
@@ -59,6 +59,9 @@ class ImportPreviewsModelsDialog: public wxDialog
     void AddModels(wxTreeListCtrl* tree, wxTreeListItem item, pugi::xml_node models, pugi::xml_node modelgroups, wxString preview, const wxString& filter);
     void AddViewpoints(wxTreeListCtrl* tree, wxTreeListItem item, pugi::xml_node viewpoints, const wxString& filter);
     static bool MatchesFilter(const wxString& name, const wxString& filterLower);
+    // MatchesFilter, plus rows the user has already ticked - those stay in the
+    // tree so a selection assembled across several filter terms remains visible.
+    bool KeepInFilteredTree(const wxString& name, ImpItemKind kind, const wxString& filterLower) const;
     bool IsViewpointsRow(wxTreeListItem it) const;
     // Filtering rebuilds the tree, so checked state is kept in these sets
     // (which survive filtered-out rows) and synced to/from the visible tree.

--- a/src-ui-wx/model/ModelFacesPanel.cpp
+++ b/src-ui-wx/model/ModelFacesPanel.cpp
@@ -1580,12 +1580,11 @@ void ModelFacesPanel::ImportSubmodel(wxGridEvent& event)
     }
 
     const std::string name = NameChoice->GetString(NameChoice->GetSelection()).ToStdString();
-    wxMultiChoiceDialog dlg(GetParent(), "", "Select SubModel", choices);
+    CheckboxSelectDialog dlg(GetParent(), _("Select SubModel"), choices);
 
     if (dlg.ShowModal() == wxID_OK) {
         wxArrayString allNodes;
-        for (auto const& idx : dlg.GetSelections()) {
-            wxString smName = choices.at(idx);
+        for (auto const& smName : dlg.GetSelectedItems()) {
             wxString nodes;
             if (_getSubModelRanges) {
                 nodes = _getSubModelRanges(smName.ToStdString());

--- a/src-ui-wx/model/ModelStatesPanel.cpp
+++ b/src-ui-wx/model/ModelStatesPanel.cpp
@@ -1306,12 +1306,11 @@ void ModelStatesPanel::ImportSubmodel(wxGridEvent& event)
     }
 
     const std::string name = NameChoice->GetString(NameChoice->GetSelection()).ToStdString();
-    wxMultiChoiceDialog dlg(GetParent(), "", "Select SubModel", choices);
+    CheckboxSelectDialog dlg(GetParent(), _("Select SubModel"), choices);
 
     if (dlg.ShowModal() == wxID_OK) {
         wxArrayString allNodes;
-        for (auto const& idx : dlg.GetSelections()) {
-            wxString smName = choices.at(idx);
+        for (auto const& smName : dlg.GetSelectedItems()) {
             wxString nodes;
             if (_getSubModelRanges) {
                 nodes = _getSubModelRanges(smName.ToStdString());
@@ -1612,11 +1611,11 @@ void ModelStatesPanel::CopyStates(wxGridEvent& event)
         return;
     }
 
-    wxMultiChoiceDialog dlg(GetParent(), "", "Select States", choices);
+    CheckboxSelectDialog dlg(GetParent(), _("Select States"), choices);
     if (dlg.ShowModal() == wxID_OK) {
         int stateIdx { 1 };
-        for (auto const& idx : dlg.GetSelections()) {
-            auto sd = stateData[choices.at(idx)];
+        for (auto const& stateName : dlg.GetSelectedItems()) {
+            auto sd = stateData[stateName.ToStdString()];
             if (sd["CustomColors"] == "1") {
                 stateData[name]["CustomColors"] = "1";
             }

--- a/src-ui-wx/model/SubModelsPanel.cpp
+++ b/src-ui-wx/model/SubModelsPanel.cpp
@@ -994,11 +994,11 @@ void SubModelsPanel::OnImportBtnPopup(wxCommandEvent& event)
                     if (choices2.GetCount() == 1) {
                         substates.push_back(choices2[0]);
                     } else {
-                        wxMultiChoiceDialog dlg2(GetParent(), "", "Select Sub-state(s)", choices2);
+                        CheckboxSelectDialog dlg2(GetParent(), _("Select Sub-state(s)"), choices2);
                         if (dlg2.ShowModal() == wxID_OK) {
-                            for (auto i : dlg2.GetSelections())
+                            for (auto const& ss : dlg2.GetSelectedItems())
                             {
-                                substates.push_back(choices2[i]);
+                                substates.push_back(ss.ToStdString());
                             }
                         }
                     }
@@ -1059,11 +1059,11 @@ void SubModelsPanel::OnImportBtnPopup(wxCommandEvent& event)
                         choices2.Add(it.first);
                     }
                 }
-                wxMultiChoiceDialog dlg2(GetParent(), "", "Select face elements", choices2);
+                CheckboxSelectDialog dlg2(GetParent(), _("Select face elements"), choices2);
                 if (dlg2.ShowModal() == wxID_OK) {
                     std::list<std::string> elements;
-                    for (auto i : dlg2.GetSelections()) {
-                        elements.push_back(choices2[i]);
+                    for (auto const& el : dlg2.GetSelectedItems()) {
+                        elements.push_back(el.ToStdString());
                     }
                     if (elements.size() > 0)
                     {

--- a/src-ui-wx/shared/dialogs/CheckboxSelectDialog.cpp
+++ b/src-ui-wx/shared/dialogs/CheckboxSelectDialog.cpp
@@ -21,6 +21,11 @@
 #include <wx/stattext.h>
 #include <wx/tokenzr.h>
 
+#include <algorithm>
+#include <vector>
+
+#include "utils/UtilFunctions.h"
+
 //(*IdInit(CheckboxSelectDialog)
 const wxWindowID CheckboxSelectDialog::ID_CHECKLISTBOXITEMS = wxNewId();
 const wxWindowID CheckboxSelectDialog::ID_BUTTONOK = wxNewId();
@@ -200,18 +205,43 @@ void CheckboxSelectDialog::SyncCheckedFromList()
 
 void CheckboxSelectDialog::PopulateList()
 {
-    CheckListBox_Items->Freeze();
-    CheckListBox_Items->Clear();
+    // Ticked items are listed first, then everything matching the filter, each
+    // block name-ordered. Ticked items stay listed even when the filter would
+    // exclude them, so you can filter, tick some, change the filter, tick more,
+    // and still see everything chosen before pressing OK.
+    //
+    // This only runs on construction and on a filter change - never on a tick -
+    // so ticking an item does not make it jump out from under the cursor.
+    std::vector<wxString> ticked;
+    std::vector<wxString> rest;
     for (const auto& item : _allItems)
     {
-        if (MatchesFilter(item))
+        if (_checked.find(item) != _checked.end())
         {
-            CheckListBox_Items->Append(item);
-            if (_checked.find(item) != _checked.end())
-            {
-                CheckListBox_Items->Check(CheckListBox_Items->GetCount() - 1);
-            }
+            ticked.push_back(item);
         }
+        else if (MatchesFilter(item))
+        {
+            rest.push_back(item);
+        }
+    }
+
+    auto byName = [](const wxString& a, const wxString& b) {
+        return stdlistNumberAwareStringCompare(a.ToStdString(), b.ToStdString());
+    };
+    std::sort(ticked.begin(), ticked.end(), byName);
+    std::sort(rest.begin(), rest.end(), byName);
+
+    CheckListBox_Items->Freeze();
+    CheckListBox_Items->Clear();
+    for (const auto& item : ticked)
+    {
+        CheckListBox_Items->Append(item);
+        CheckListBox_Items->Check(CheckListBox_Items->GetCount() - 1);
+    }
+    for (const auto& item : rest)
+    {
+        CheckListBox_Items->Append(item);
     }
     CheckListBox_Items->Thaw();
 }


### PR DESCRIPTION
Supersedes #6858, whose commit is included here.

## Filters where there were none

Five model/element pickers were still a plain `wxMultiChoiceDialog` with no filter, which is painful once a show has a lot of submodels or states:

| Picker | Where |
|---|---|
| Select SubModel | `ModelFacesPanel`, `ModelStatesPanel` |
| Select States | `ModelStatesPanel` |
| Select Sub-state(s) | `SubModelsPanel` |
| Select face elements | `SubModelsPanel` |
| Add / Remove to Existing Groups | `LayoutPanel` (from #6858) |

They now use the existing filterable `CheckboxSelectDialog`, the same one the Export-to-Other-Models pickers already use.

Selection is read by name via `GetSelectedItems()` rather than by index into the choices array. That returns items in `_allItems` order, so callers that depend on ordering — `Select States` assigns sequential state indices as it iterates — behave exactly as before.

## Ticked items go to the top, and stay visible

`CheckboxSelectDialog::PopulateList` now lists ticked items first, then everything matching the filter, each block name-ordered using the same number-aware comparator the Import Previews tree uses (so `Tree-2` precedes `Tree-10`).

Ticked items are also listed when the filter *stops* matching them. Their check state was already preserved — `_checked` has always been the source of truth — but the row disappearing made a selection assembled over several searches impossible to review, which reads as though the ticks were thrown away.

`PopulateList` runs only on construction and on a filter change, **never on a tick**, so an item can't jump out from under the cursor mid-selection.

**This re-sorts every caller's list.** Most were already alphabetical (the group pickers and all four Export pickers sort in the caller). Two were not: `Select SubModel` was in model definition order, and `Select Sub-state(s)` in map order over *values*, so effectively arbitrary. Both read better sorted, but it is a visible change and worth a look.

Thirteen call sites share this dialog, so they all gain the behaviour together.

## Import Previews/Models

Same treatment for its tree: ticked models, groups, viewpoints and preview rows all survive a filter that would otherwise exclude them.

Three separate spots needed it — the item kind is threaded through `collect()` because `_checkedModels` is keyed on `{name, kind}`, so a ticked group and a ticked model of the same name don't alias; and the empty-row prune now spares a preview row that is itself ticked, which would otherwise vanish even after its children were kept.

## Testing

- macOS Debug: pass
- macOS Debug with `NO_PCH`: pass
- Manual, all eight dialogs: tick several, filter them out, confirm they stay listed, ticked, and sorted to the top; confirm OK returns the full set.

`wxSingleChoiceDialog` pickers (Select Model, Select State, Select Face, Aspect Ratio, Order Type) are deliberately untouched — pick-exactly-one has no tick state to preserve. No new source files, so no `.cbp` / `.vcxproj` / CMake changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
