### PR TITLE
Fix mh position zones not previewing all the time.

### DIFF
--- a/src-core/models/DMX/DmxMovingHeadAdv.cpp
+++ b/src-core/models/DMX/DmxMovingHeadAdv.cpp
@@ -580,6 +580,35 @@ void DmxMovingHeadAdv::DrawModel(IModelPreview* preview, xlGraphicsContext* ctx,
     float sbl = std::max(scw, std::max(sch, scd));
     beam_length_displayed *= sbl;
 
+    // Pan/tilt values, and temporary position-zone channel overrides, used
+    // both for the beam appearance below and the zone-active indicator ring.
+    // Every ability below (shutter, dimmer, color wheel/RGB/CMY) reads its
+    // channel values straight out of Nodes, so patch the affected Nodes'
+    // colors for the duration of this draw and restore them afterward -
+    // that keeps the preview beam in sync with whatever the zone forces into
+    // the actual rendered output, without each ability needing its own
+    // zone-aware read.
+    int zonePanVal = -1;
+    int zoneTiltVal = -1;
+    std::vector<std::pair<int, xlColor>> zoneRestores;
+    if (active && !position_zones.empty()) {
+        int panCoarse = pan_motor->GetChannelCoarse();
+        int tiltCoarse = tilt_motor->GetChannelCoarse();
+        zonePanVal = (panCoarse > 0 && panCoarse <= (int)Nodes.size()) ? GetChannelValue(panCoarse - 1, false) : -1;
+        zoneTiltVal = (tiltCoarse > 0 && tiltCoarse <= (int)Nodes.size()) ? GetChannelValue(tiltCoarse - 1, false) : -1;
+        for (const auto& zone : position_zones) {
+            if (zone.channel < 1 || zone.channel > (int)Nodes.size())
+                continue;
+            if (zonePanVal >= zone.pan_min && zonePanVal <= zone.pan_max &&
+                zoneTiltVal >= zone.tilt_min && zoneTiltVal <= zone.tilt_max) {
+                xlColor orig;
+                Nodes[zone.channel - 1]->GetColor(orig);
+                zoneRestores.emplace_back(zone.channel - 1, orig);
+                Nodes[zone.channel - 1]->SetColor(xlColor(zone.value, zone.value, zone.value));
+            }
+        }
+    }
+
     // determine if shutter is open for heads that support it
     bool shutter_open = true;
     if (shutter_ability->GetShutterChannel() > 0 && shutter_ability->GetShutterChannel() <= (int)NodeCount && active) {
@@ -613,6 +642,10 @@ void DmxMovingHeadAdv::DrawModel(IModelPreview* preview, xlGraphicsContext* ctx,
         beam_color.green = (beam_color.green * hsv.value);
     }
 
+    for (const auto& restore : zoneRestores) {
+        Nodes[restore.first]->SetColor(restore.second);
+    }
+
     ApplyTransparency(beam_color, trans, trans);
 
     pan_angle_raw += beam_ability->GetBeamOrient();
@@ -622,14 +655,10 @@ void DmxMovingHeadAdv::DrawModel(IModelPreview* preview, xlGraphicsContext* ctx,
 
     // draw zone-active indicator ring at fixture base when a position zone is being applied
     if (active && !position_zones.empty() && preview->GetShowZoneIndicator()) {
-        int panCoarse = pan_motor->GetChannelCoarse();
-        int tiltCoarse = tilt_motor->GetChannelCoarse();
-        int panVal = (panCoarse > 0 && panCoarse <= (int)Nodes.size()) ? GetChannelValue(panCoarse - 1, false) : -1;
-        int tiltVal = (tiltCoarse > 0 && tiltCoarse <= (int)Nodes.size()) ? GetChannelValue(tiltCoarse - 1, false) : -1;
         bool zoneActive = false;
         for (const auto& zone : position_zones) {
-            if (panVal >= zone.pan_min && panVal <= zone.pan_max &&
-                tiltVal >= zone.tilt_min && tiltVal <= zone.tilt_max) {
+            if (zonePanVal >= zone.pan_min && zonePanVal <= zone.pan_max &&
+                zoneTiltVal >= zone.tilt_min && zoneTiltVal <= zone.tilt_max) {
                 zoneActive = true;
                 break;
             }

--- a/src-ui-wx/effectpanels/MovingHeadPanel.cpp
+++ b/src-ui-wx/effectpanels/MovingHeadPanel.cpp
@@ -3273,6 +3273,32 @@ void MovingHeadPanel::NotifyPositionUpdated()
     FireChangeEvent();
 }
 
+DmxMovingHeadComm* MovingHeadPanel::GetReferenceFixture()
+{
+    auto models = GetActiveModels();
+    for (const auto& it : models) {
+        if (it->GetDisplayAs() == DisplayAsType::DmxMovingHeadAdv || it->GetDisplayAs() == DisplayAsType::DmxMovingHead) {
+            auto* mhead = dynamic_cast<DmxMovingHeadComm*>(it);
+            if (mhead != nullptr && (IsHeadActive(mhead->GetFixtureVal()) || models.size() == 1)) {
+                return mhead;
+            }
+        }
+    }
+    return nullptr;
+}
+
+DmxMotor* MovingHeadPanel::GetReferencePanMotor()
+{
+    auto* mhead = GetReferenceFixture();
+    return mhead != nullptr ? mhead->GetPanMotor() : nullptr;
+}
+
+DmxMotor* MovingHeadPanel::GetReferenceTiltMotor()
+{
+    auto* mhead = GetReferenceFixture();
+    return mhead != nullptr ? mhead->GetTiltMotor() : nullptr;
+}
+
 void MovingHeadPanel::UpdatePositionCanvas(float pan, float tilt)
 {
     wxPoint2DDouble new_pos;

--- a/src-ui-wx/effectpanels/MovingHeadPanel.h
+++ b/src-ui-wx/effectpanels/MovingHeadPanel.h
@@ -44,6 +44,8 @@
 #include <vector>
 
 class Model;
+class DmxMotor;
+class DmxMovingHeadComm;
 class MHPresetBitmapButton;
 class MHPathPresetBitmapButton;
 class MHDimmerPresetBitmapButton;
@@ -466,6 +468,9 @@ public:
     void SetSketchDef(const std::string& sketchDef);
     
     void NotifyPositionUpdated() override;
+    DmxMotor* GetReferencePanMotor() override;
+    DmxMotor* GetReferenceTiltMotor() override;
+    DmxMovingHeadComm* GetReferenceFixture();
     void NotifyColorUpdated() override;
     void NotifyDimmerUpdated() override;
     const Element* GetDimmerTimingTrack() const override;

--- a/src-ui-wx/effectpanels/MovingHeadPanels/MovingHeadCanvasPanel.cpp
+++ b/src-ui-wx/effectpanels/MovingHeadPanels/MovingHeadCanvasPanel.cpp
@@ -13,6 +13,8 @@
 #include <wx/dcbuffer.h>
 #include <wx/graphics.h>
 
+#include "models/DMX/DmxMotor.h"
+
 namespace
 {
     const int BorderWidth = 5;
@@ -73,6 +75,26 @@ void MovingHeadCanvasPanel::OnMovingHeadPaint(wxPaintEvent& /*event*/)
         pdc.DrawLine(NormalizedToUI2(start_x), NormalizedToUI2(end_x));
         pdc.DrawLine(NormalizedToUI2(start_y), NormalizedToUI2(end_y));
     }
+
+    // P/T readout in the upper-left corner. When a reference fixture's motors
+    // are available, show the raw DMX byte that fixture would receive at this
+    // position (msb of DmxMotor::ConvertPostoCmd's 16-bit-domain command,
+    // matching how DmxModel::GetChannelValue packs an 8-bit channel);
+    // otherwise fall back to the pan/tilt degrees shown in the entries below.
+    float pos_x = m_mousePos.m_x * 360.0f - 180.0f;
+    float pos_y = -m_mousePos.m_y * 360.0f + 180.0f;
+    DmxMotor* panMotor = m_movingHeadCanvasParent ? m_movingHeadCanvasParent->GetReferencePanMotor() : nullptr;
+    DmxMotor* tiltMotor = m_movingHeadCanvasParent ? m_movingHeadCanvasParent->GetReferenceTiltMotor() : nullptr;
+    wxString ptLabel;
+    if (panMotor != nullptr && tiltMotor != nullptr) {
+        int panByte = (panMotor->ConvertPostoCmd(pos_x) >> 8) & 0xFF;
+        int tiltByte = (tiltMotor->ConvertPostoCmd(pos_y) >> 8) & 0xFF;
+        ptLabel = wxString::Format("P: %d  T: %d", panByte, tiltByte);
+    } else {
+        ptLabel = wxString::Format("P: %.1f  T: %.1f", pos_x, pos_y);
+    }
+    pdc.SetTextForeground(*wxBLACK);
+    pdc.DrawText(ptLabel, BorderWidth + 2, BorderWidth + 2);
 
     pdc.SetPen(*wxRED_PEN);
     wxPoint2DDouble lstart_x(0, m_mousePos.m_y);

--- a/src-ui-wx/effectpanels/MovingHeadPanels/MovingHeadCanvasPanel.h
+++ b/src-ui-wx/effectpanels/MovingHeadPanels/MovingHeadCanvasPanel.h
@@ -16,12 +16,20 @@
 #include <memory>
 #include <vector>
 
+class DmxMotor;
+
 class IMovingHeadCanvasParent
 {
 public:
     virtual ~IMovingHeadCanvasParent() {}
 
     virtual void NotifyPositionUpdated() = 0;
+
+    // Motors of the fixture the P/T readout should be expressed in raw DMX
+    // terms for (e.g. the first checked/active fixture). Return nullptr to
+    // fall back to a degrees readout when no such fixture is resolvable.
+    virtual DmxMotor* GetReferencePanMotor() { return nullptr; }
+    virtual DmxMotor* GetReferenceTiltMotor() { return nullptr; }
 };
 
 


### PR DESCRIPTION
We found that the orange preview indicator would show but it wouldnt always disable the beam in the preview.