### PR TITLE
Display Elements: find bar for the Added models list

### DIFF
--- a/src-ui-wx/layout/ViewsModelsPanel.cpp
+++ b/src-ui-wx/layout/ViewsModelsPanel.cpp
@@ -19,6 +19,7 @@
 #include <wx/artprov.h>
 #include <wx/dnd.h>
 #include <wx/srchctrl.h>
+#include <wx/settings.h>
 #include <wx/timer.h>
 
 #include "model-16.xpm"
@@ -278,6 +279,39 @@ ViewsModelsPanel::ViewsModelsPanel(xLightsFrame *frame, wxWindow* parent, wxWind
     TextCtrl_NonModelsFilter->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN,
         &ViewsModelsPanel::OnNonModelsFilterCancel, this);
 
+    // The "Added" list gets a find bar rather than a filter: its row order is
+    // the view's display order, so hiding rows would break reordering and every
+    // "all"-scoped operation. ListCtrlModels was placed at (3, 2) span(1, 2).
+    GridBagSizer1->Detach(ListCtrlModels);
+    TextCtrl_ModelsFind = new wxSearchCtrl(this, wxID_ANY, wxEmptyString,
+                                           wxDefaultPosition, wxDefaultSize,
+                                           wxTE_PROCESS_ENTER);
+    TextCtrl_ModelsFind->SetDescriptiveText(_("Find model..."));
+    TextCtrl_ModelsFind->ShowCancelButton(true);
+    Button_FindPrev = new wxButton(this, wxID_ANY, _T("▲"), wxDefaultPosition,
+                                   wxDLG_UNIT(this, wxSize(12, -1)));
+    Button_FindNext = new wxButton(this, wxID_ANY, _T("▼"), wxDefaultPosition,
+                                   wxDLG_UNIT(this, wxSize(12, -1)));
+    Button_FindPrev->SetToolTip(_("Previous match"));
+    Button_FindNext->SetToolTip(_("Next match"));
+    auto* findSizer = new wxBoxSizer(wxHORIZONTAL);
+    findSizer->Add(TextCtrl_ModelsFind, 1, wxEXPAND, 0);
+    findSizer->Add(Button_FindPrev, 0, wxLEFT | wxEXPAND, 2);
+    findSizer->Add(Button_FindNext, 0, wxLEFT | wxEXPAND, 2);
+    auto* modelsSizer = new wxBoxSizer(wxVERTICAL);
+    modelsSizer->Add(findSizer, 0, wxBOTTOM | wxEXPAND, 2);
+    modelsSizer->Add(ListCtrlModels, 1, wxEXPAND, 0);
+    GridBagSizer1->Add(modelsSizer, wxGBPosition(3, 2), wxGBSpan(1, 2),
+                       wxALL | wxEXPAND, 2);
+    TextCtrl_ModelsFind->Bind(wxEVT_TEXT,
+        &ViewsModelsPanel::OnModelsFindText, this);
+    TextCtrl_ModelsFind->Bind(wxEVT_TEXT_ENTER,
+        &ViewsModelsPanel::OnModelsFindNext, this);
+    TextCtrl_ModelsFind->Bind(wxEVT_SEARCHCTRL_CANCEL_BTN,
+        &ViewsModelsPanel::OnModelsFindCancel, this);
+    Button_FindNext->Bind(wxEVT_BUTTON, &ViewsModelsPanel::OnModelsFindNext, this);
+    Button_FindPrev->Bind(wxEVT_BUTTON, &ViewsModelsPanel::OnModelsFindPrev, this);
+
     // Debounce keystrokes so PopulateModels (full rebuild of both lists)
     // doesn't run on every character on large shows.
     _filterDebounceTimer = new wxTimer(this);
@@ -452,7 +486,11 @@ ViewsModelsPanel::~ViewsModelsPanel()
 
 void ViewsModelsPanel::PopulateModels(const std::string& selectModels)
 {
-    
+    // Freeze the whole panel, not just the two lists: a filter keystroke
+    // rebuilds both lists, so a change to one (e.g. the Added filter) would
+    // otherwise flash the other. A panel-level freeze paints everything once
+    // on Thaw, so unchanged content doesn't flicker.
+    Freeze();
     ListCtrlModels->Freeze();
     ListCtrlNonModels->Freeze();
 
@@ -652,6 +690,7 @@ void ViewsModelsPanel::PopulateModels(const std::string& selectModels)
     ListCtrlNonModels->Thaw();
     ListCtrlModels->Refresh();
     ListCtrlNonModels->Refresh();
+    Thaw();
 }
 
 bool ViewsModelsPanel::IsModelAGroup(const std::string& modelname) const
@@ -749,7 +788,6 @@ bool ViewsModelsPanel::SelectItem(wxListCtrl* ctrl, const std::string& item, int
 void ViewsModelsPanel::OnListView_ViewItemsBeginDrag(wxListEvent& event)
 {
     if (ListCtrlModels->GetSelectedItemCount() == 0) return;
-
     _dragRowModel = true;
     _dragRowNonModel = false;
 
@@ -1575,11 +1613,17 @@ void ViewsModelsPanel::AddModelToNotList(Element* model)
 
 void ViewsModelsPanel::OnNonModelsFilterText(wxCommandEvent& /*event*/)
 {
+    // Ignore no-op text events (e.g. holding backspace on an empty field) so
+    // we don't rebuild and flicker for a value that didn't change.
+    wxString value = TextCtrl_NonModelsFilter->GetValue().Lower();
+    if (value == _nonModelFilter) {
+        return;
+    }
     // Capture the current text immediately so the cached filter stays
     // in sync with what the user sees, but debounce the expensive
     // PopulateModels rebuild — restart the one-shot timer on each
     // keystroke and only rebuild after the user pauses for ~150 ms.
-    _nonModelFilter = TextCtrl_NonModelsFilter->GetValue().Lower();
+    _nonModelFilter = value;
     if (_filterDebounceTimer != nullptr) {
         _filterDebounceTimer->Start(kFilterDebounceMs, wxTIMER_ONE_SHOT);
     }
@@ -1595,6 +1639,89 @@ void ViewsModelsPanel::OnNonModelsFilterCancel(wxCommandEvent& /*event*/)
     TextCtrl_NonModelsFilter->ChangeValue(wxEmptyString);
     _nonModelFilter.Clear();
     PopulateModels();
+}
+
+bool ViewsModelsPanel::FindModelRow(int startRow, bool forward)
+{
+    const int count = ListCtrlModels->GetItemCount();
+    if (count == 0) return false;
+
+    // Whitespace-tokenised AND match, like the sequencer filter and
+    // CheckboxSelectDialog. A single contiguous match meant "mini tree" missed
+    // "Mini-Tree-2" and "MiniTree-Star" - the separator had to be typed
+    // exactly. Tokenised once here rather than per row.
+    wxArrayString tokens;
+    for (const auto& t : wxSplit(TextCtrl_ModelsFind->GetValue().Lower(), ' ')) {
+        if (!t.IsEmpty()) tokens.Add(t);
+    }
+    if (tokens.IsEmpty()) return false;
+
+    // Normalise so a wrap from either end lands inside the list.
+    int row = ((startRow % count) + count) % count;
+
+    for (int n = 0; n < count; ++n) {
+        // Column 2 holds the element name (0 and 1 are the checkbox and icon).
+        const wxString name = ListCtrlModels->GetItemText(row, 2).Lower();
+        bool match = true;
+        for (const auto& t : tokens) {
+            if (!name.Contains(t)) {
+                match = false;
+                break;
+            }
+        }
+        if (match) {
+            for (int i = 0; i < count; ++i) {
+                ListCtrlModels->SetItemState(i, i == row ? wxLIST_STATE_SELECTED : 0,
+                                             wxLIST_STATE_SELECTED);
+            }
+            ListCtrlModels->EnsureVisible(row);
+            ValidateWindow();
+            return true;
+        }
+        row = forward ? (row + 1) % count : ((row - 1) + count) % count;
+    }
+    return false;
+}
+
+void ViewsModelsPanel::RunModelFind(bool forward, bool fromCurrent)
+{
+    // Typing searches from the current row so an extra character narrows the
+    // same match; the next/prev buttons step past it.
+    const int selected = ListCtrlModels->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+    const int anchor = (selected == -1) ? 0 : selected;
+    const int start = fromCurrent ? anchor : (forward ? anchor + 1 : anchor - 1);
+
+    const bool hit = FindModelRow(start, forward);
+
+    // Tint the box on a miss rather than silently doing nothing.
+    const bool empty = TextCtrl_ModelsFind->GetValue().IsEmpty();
+    TextCtrl_ModelsFind->SetBackgroundColour(
+        (hit || empty) ? wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW)
+                       : wxColour(255, 210, 210));
+    TextCtrl_ModelsFind->Refresh();
+}
+
+void ViewsModelsPanel::OnModelsFindText(wxCommandEvent& /*event*/)
+{
+    RunModelFind(true, true);
+}
+
+void ViewsModelsPanel::OnModelsFindNext(wxCommandEvent& /*event*/)
+{
+    RunModelFind(true, false);
+}
+
+void ViewsModelsPanel::OnModelsFindPrev(wxCommandEvent& /*event*/)
+{
+    RunModelFind(false, false);
+}
+
+void ViewsModelsPanel::OnModelsFindCancel(wxCommandEvent& /*event*/)
+{
+    TextCtrl_ModelsFind->ChangeValue(wxEmptyString);
+    TextCtrl_ModelsFind->SetBackgroundColour(
+        wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
+    TextCtrl_ModelsFind->Refresh();
 }
 
 void ViewsModelsPanel::OnFilterDebounceTimer(wxTimerEvent& /*event*/)

--- a/src-ui-wx/layout/ViewsModelsPanel.h
+++ b/src-ui-wx/layout/ViewsModelsPanel.h
@@ -277,5 +277,25 @@ private:
     void OnFilterDebounceTimer(wxTimerEvent& event);
     bool IsFilteredOutOfNonModels(const std::string& name) const;
 
+    // Find (not filter) for the "Added" (models) list. That list's row order is
+    // the view's display order, so hiding rows would break drag-reorder, the
+    // move buttons and every "all"-scoped operation. Searching instead selects
+    // and scrolls to each match and leaves the list intact.
+    wxSearchCtrl* TextCtrl_ModelsFind = nullptr;
+    wxButton* Button_FindPrev = nullptr;
+    wxButton* Button_FindNext = nullptr;
+    void OnModelsFindText(wxCommandEvent& event);
+    void OnModelsFindCancel(wxCommandEvent& event);
+    void OnModelsFindNext(wxCommandEvent& event);
+    void OnModelsFindPrev(wxCommandEvent& event);
+    // Selects the next row at or after (forward) / at or before (backward)
+    // `startRow` whose name contains the search text, wrapping once. `startRow`
+    // may be out of range - it is normalised. Returns false when nothing
+    // matches, leaving the current selection alone.
+    bool FindModelRow(int startRow, bool forward);
+    // Runs a search from the current selection and reflects the outcome in the
+    // search box (normal background on a hit, tinted on a miss).
+    void RunModelFind(bool forward, bool fromCurrent);
+
     DECLARE_EVENT_TABLE()
 };


### PR DESCRIPTION
The Available list got a filter in #6241. The **Added** list — the models actually in the sequence view — had nothing, and that's the one that gets long.

## Why a find bar and not a filter

The Added list's row order **is** the view's display order. Hiding rows breaks:

- drag-reorder and the Move Up / Down / Top / Bottom buttons — a drop position maps to the wrong index in the real order
- Remove All, Hide All, Show All, Hide Unused, Remove Unused — each walks the list control, so they'd silently act on the visible subset while their names promise the whole view

An earlier revision of this branch added guards disabling all of the above while filtering. That works but leaves the feature useless for its main purpose: you search to *find* a model, usually because you want to move it. A find bar removes the hazard rather than defending against it — the list is never incomplete, so every operation stays correct and enabled.

## Behaviour

A search box with ▲ / ▼ above the list.

- Typing searches from the current selection, so extra characters narrow onto the same match rather than jumping away
- ▼ / Enter step forward, ▲ steps back, both wrapping at either end
- A hit is selected and scrolled into view; a miss tints the box rather than silently doing nothing
- Reordering is untouched and works with a search active

Matching is a **whitespace-tokenised AND**, matching `CheckboxSelectDialog` and the Import Previews tree: `mini tree` finds `Mini-Tree-2` and `MiniTree-Star`, where a contiguous `Contains()` required the separator to be typed exactly. Word order doesn't matter.

No debounce needed — nothing rebuilds, it's a linear scan over the visible rows.

## Also fixed

Two things in the neighbouring Available filter:

- It acted on `wxEVT_TEXT` events that didn't change the value — holding backspace on an already-empty field rebuilt both lists and flickered for nothing.
- `PopulateModels` now freezes the whole panel rather than the two lists separately, so filtering one list no longer flashes the other.

## Testing

- macOS Debug: pass
- macOS Debug with `NO_PCH`: pass
- Manual: `mini tree` matches hyphenated and run-together names; ▲▼ cycle and wrap; miss tints the box; drag and the move buttons behave normally with a search active.

No new source files, so no `.cbp` / `.vcxproj` / CMake changes.

## Note for reviewers

This wraps `ListCtrlModels` in a box sizer by detaching it from the GridBagSizer and re-adding — the same pattern the shipped Available-list filter already uses on `ListCtrlNonModels` two blocks above. I saw a wxWidgets Debug assert (`SetContainingSizer(): Adding a window already in a sizer`) when reopening the Display Elements pane while testing. Instrumentation showed the panel constructor is clean — the detach returns true and leaves no containing sizer — so it appears to come from the wxAUI pane show/hide path rather than this code, and the pattern it would implicate is already in master. Flagging it rather than leaving it unsaid; if a reviewer can reproduce it on plain master, that confirms it's pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
