### PR TITLE
Fix Custom value curve copies prior effect (#6937)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,8 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.16  August ??, 2026
     -enh (derwin12)              Automation: BatchCheckSequence lua script
+    -bug (derwin12)              Fix value curves switched to Custom baking in the previous effect's custom
+                                 curve for that setting instead of the currently displayed preset curve (#6937)
     -enh (dkulp)                 FPP shift-string capes (K8/K16/K32 and the K16A-B, K64D-B, K128D-B) now offer
                                  the pixel protocols FPP can actually drive on them - the WS2811 family by name,
                                  TM1814, the 16 bit UCS8903/8904, and the slower parts such as UCS1903, TM1803,

--- a/README.txt
+++ b/README.txt
@@ -12,8 +12,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.16  August ??, 2026
     -enh (derwin12)              Automation: BatchCheckSequence lua script
-    -bug (derwin12)              Fix value curves switched to Custom baking in the previous effect's custom
-                                 curve for that setting instead of the currently displayed preset curve (#6937)
+    -bug (derwin12)              Fix Custom value curve copies prior effect (#6937)
     -enh (dkulp)                 FPP shift-string capes (K8/K16/K32 and the K16A-B, K64D-B, K128D-B) now offer
                                  the pixel protocols FPP can actually drive on them - the WS2811 family by name,
                                  TM1814, the 16 bit UCS8903/8904, and the slower parts such as UCS1903, TM1803,

--- a/src-core/render/ValueCurve.cpp
+++ b/src-core/render/ValueCurve.cpp
@@ -1875,6 +1875,9 @@ void ValueCurve::SetSerialisedValue(const std::string &k, const std::string &s)
 void ValueCurve::SetType(std::string type)
 {
     _hasPreloadedValues = false;
+    if (type != "Custom" && _type != type) {
+        _baseCustomValues.clear();
+    }
     _type = type;
     RenderType();
 }

--- a/src-core/render/ValueCurve.cpp
+++ b/src-core/render/ValueCurve.cpp
@@ -1457,6 +1457,7 @@ void ValueCurve::SetDefault(float min, float max, int divisor)
 {
     ClearCachedOffsets();
     _type = "Flat";
+    _baseCustomValues.clear();
     if (min != MINVOIDF)
     {
         _min = min;
@@ -1519,6 +1520,7 @@ void ValueCurve::Deserialise(const std::string& s, bool holdminmax)
         _realValues = false;
         _active = true;
         _values.clear();
+        _baseCustomValues.clear();
         _hasPreloadedValues = false;
         _hasStartEndLevel = false;
         _type = "Flat";


### PR DESCRIPTION
The custom VC should use the prior vc setting and not pull from a prior VC effect.