### PR TITLE
Layout filters: match multiple search terms (Models, Groups, Controllers)

### DIFF
--- a/src-ui-wx/layout/ControllerListPanel.cpp
+++ b/src-ui-wx/layout/ControllerListPanel.cpp
@@ -541,10 +541,6 @@ void ControllerListPanel::OnFullColumnsClick(wxCommandEvent& event) {
 bool ControllerListPanel::ControllerMatchesFilter(const Controller* controller) const {
     if (_controllerFilterCtrl == nullptr || _controllerFilterString.IsEmpty()) return true;
 
-    // A single term keeps the existing behaviour (regex if it compiles, else a
-    // substring match). Multiple whitespace-separated terms narrow with AND -
-    // every term must appear in the name, in any order - matching the model and
-    // group filters.
     wxArrayString terms = wxStringTokenize(_controllerFilterString.Lower(), " \t");
     if (terms.size() <= 1) {
         if (_controllerFilterRegexValid)

--- a/src-ui-wx/layout/ControllerListPanel.cpp
+++ b/src-ui-wx/layout/ControllerListPanel.cpp
@@ -16,6 +16,7 @@
 #include <wx/dnd.h>
 #include <wx/menu.h>
 #include <wx/msgdlg.h>
+#include <wx/tokenzr.h>
 #include <wx/srchctrl.h>
 #include <wx/stopwatch.h>
 #include <wx/settings.h>
@@ -540,10 +541,23 @@ void ControllerListPanel::OnFullColumnsClick(wxCommandEvent& event) {
 bool ControllerListPanel::ControllerMatchesFilter(const Controller* controller) const {
     if (_controllerFilterCtrl == nullptr || _controllerFilterString.IsEmpty()) return true;
 
-    if (_controllerFilterRegexValid)
-        return _controllerFilterRegex.Matches(controller->GetName());
+    // A single term keeps the existing behaviour (regex if it compiles, else a
+    // substring match). Multiple whitespace-separated terms narrow with AND -
+    // every term must appear in the name, in any order - matching the model and
+    // group filters.
+    wxArrayString terms = wxStringTokenize(_controllerFilterString.Lower(), " \t");
+    if (terms.size() <= 1) {
+        if (_controllerFilterRegexValid)
+            return _controllerFilterRegex.Matches(controller->GetName());
+        return wxString(controller->GetName()).Lower().Contains(_controllerFilterString.Lower());
+    }
 
-    return wxString(controller->GetName()).Lower().Contains(_controllerFilterString.Lower());
+    const wxString name = wxString(controller->GetName()).Lower();
+    for (const auto& term : terms) {
+        if (!name.Contains(term))
+            return false;
+    }
+    return true;
 }
 
 void ControllerListPanel::OnSelectionChanged(wxTreeListEvent& event) {

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -13175,10 +13175,6 @@ void LayoutPanel::OnGroupFilterTextChanged(wxCommandEvent& event) {
 bool LayoutPanel::MatchesFilter(Model* model, const wxString& filterString, const wxRegEx& filterRegex, bool filterRegexValid) {
     if (filterString.IsEmpty()) return true;
 
-    // A single term keeps the existing behaviour (regex if it compiles, else a
-    // substring match). Multiple whitespace-separated terms narrow with AND -
-    // every term must appear somewhere in the name, in any order - so
-    // "midwest pumpkin" finds "Midwest-Coro-Pumpkin". Matches the other filters.
     wxArrayString terms = wxStringTokenize(filterString.Lower(), " \t");
     if (terms.size() <= 1) {
         if (filterRegexValid)

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -31,6 +31,7 @@
 #include <wx/propgrid/advprops.h>
 #include <wx/tglbtn.h>
 #include <wx/srchctrl.h>
+#include <wx/tokenzr.h>
 #include <wx/checklst.h>
 #include <pugixml.hpp>
 #include <cmath>
@@ -13174,10 +13175,23 @@ void LayoutPanel::OnGroupFilterTextChanged(wxCommandEvent& event) {
 bool LayoutPanel::MatchesFilter(Model* model, const wxString& filterString, const wxRegEx& filterRegex, bool filterRegexValid) {
     if (filterString.IsEmpty()) return true;
 
-    if (filterRegexValid)
-        return filterRegex.Matches(model->GetName());
+    // A single term keeps the existing behaviour (regex if it compiles, else a
+    // substring match). Multiple whitespace-separated terms narrow with AND -
+    // every term must appear somewhere in the name, in any order - so
+    // "midwest pumpkin" finds "Midwest-Coro-Pumpkin". Matches the other filters.
+    wxArrayString terms = wxStringTokenize(filterString.Lower(), " \t");
+    if (terms.size() <= 1) {
+        if (filterRegexValid)
+            return filterRegex.Matches(model->GetName());
+        return wxString(model->GetName()).Lower().Contains(filterString.Lower());
+    }
 
-    return wxString(model->GetName()).Lower().Contains(filterString.Lower());
+    const wxString name = wxString(model->GetName()).Lower();
+    for (const auto& term : terms) {
+        if (!name.Contains(term))
+            return false;
+    }
+    return true;
 }
 
 bool LayoutPanel::ModelMatchesFilter(Model* model) const {


### PR DESCRIPTION
## What
The Layout-panel **Models**, **Groups**, and **Controllers** search boxes treated the whole entry as one literal string, so a multi-word search failed: typing `midwest pumpkin` found nothing even though `Midwest-Coro-Pumpkin-1` contains both words (just not that contiguous string). Searching `pumpkin` alone worked.

This makes those three filters tokenize on whitespace and require **every** term to appear in the name, in any order — so `midwest pumpkin` now finds `Midwest-Coro-Pumpkin`. This matches the behaviour of the newer filters already in the app (vendor model catalog #6733, the Choose-Models / Export-to-Other-Models pickers #6670 / #6751).

## How
- `LayoutPanel::MatchesFilter` (drives both the Models and Groups tabs) and `ControllerListPanel::ControllerMatchesFilter`: split the filter text on whitespace; if there's more than one term, every term must be a case-insensitive substring of the model/controller name (AND).
- **A single term keeps the existing behaviour**, including the regex power-search (`filterRegex.Matches`) — so no existing single-word or regex search changes.

```cpp
wxArrayString terms = wxStringTokenize(filterString.Lower(), " \t");
if (terms.size() <= 1) {
    if (filterRegexValid) return filterRegex.Matches(name);   // unchanged
    return name.Lower().Contains(filterString.Lower());        // unchanged
}
for (const auto& term : terms)
    if (!name.Lower().Contains(term)) return false;
return true;
```

Added `#include <wx/tokenzr.h>` to both files.

## Testing
Built (macOS Debug). Verified `midwest pumpkin` matches `Midwest-Coro-Pumpkin`, single-word and regex searches behave as before, and the Groups/Controllers tabs get the same behaviour through the shared code paths.

## iPad parity
Desktop-only (`src-ui-wx/layout/`); the iPad model list has its own filtering path. No iPad counterpart to change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
