### PR TITLE
Directories: pinned favorite show folders for quick switching

### DIFF
--- a/src-ui-wx/app-shell/TabSetup.cpp
+++ b/src-ui-wx/app-shell/TabSetup.cpp
@@ -108,7 +108,60 @@ private:
 };
 std::atomic_int ControllerPingThread::pingCount(0);
 
+#include <wx/control.h>   // wxControl::EscapeMnemonics
+#include "setup/ShowDirectoriesDialog.h"
+
 #pragma region Show Directory
+void xLightsFrame::RebuildFavoriteShowFoldersMenu()
+{
+    if (FavoriteShowFoldersMenu == nullptr) return;
+
+    for (const auto& [id, path] : _favoriteMenuPaths) {
+        Disconnect(id, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuFavoriteShowFolder);
+    }
+    _favoriteMenuPaths.clear();
+    while (FavoriteShowFoldersMenu->GetMenuItemCount()) {
+        FavoriteShowFoldersMenu->Delete(FavoriteShowFoldersMenu->FindItemByPosition(0));
+    }
+
+    for (const auto& fav : ShowDirectoriesDialog::ReadFavoritesFromConfig()) {
+        const wxString& path = fav.path;
+        const wxString& name = fav.name;
+        const int menuID = wxNewId();
+        // Name only in the menu; the path lives in _favoriteMenuPaths. Escape
+        // mnemonics or an '&' in a folder name becomes an accelerator.
+        wxMenuItem* item = new wxMenuItem(FavoriteShowFoldersMenu, menuID,
+                                          wxControl::EscapeMnemonics(name), path);
+        item->SetBitmap(wxArtProvider::GetBitmapBundle("wxART_FOLDER_OPEN", wxART_MENU));
+        FavoriteShowFoldersMenu->Append(item);
+        _favoriteMenuPaths[menuID] = path;
+        Connect(menuID, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&xLightsFrame::OnMenuFavoriteShowFolder);
+    }
+    if (wxMenuItem* favItem = MenuFile->FindItem(ID_MENUITEM_FAVFOLDERS)) {
+        favItem->Enable(!_favoriteMenuPaths.empty());
+    }
+}
+
+void xLightsFrame::OnMenuFavoriteShowFolder(wxCommandEvent& event)
+{
+    auto it = _favoriteMenuPaths.find(event.GetId());
+    if (it == _favoriteMenuPaths.end()) return;
+    wxString newdir = it->second;
+
+    if (!wxFileName::DirExists(newdir)) {
+        DisplayError(wxString::Format(_("This favorite show folder no longer exists:\n%s"), newdir), this);
+        return;
+    }
+    if (!ObtainAccessToURL(newdir, true)) {
+        std::string dstr = newdir;
+        PromptForDirectorySelection("Reselect Show Directory", dstr);
+        newdir = dstr;
+    }
+    displayElementsPanel->SetSequenceElementsModelsViews(nullptr, nullptr, nullptr);
+    layoutPanel->ClearUndo();
+    SetDir(newdir, true);
+}
+
 void xLightsFrame::OnMenuMRU(wxCommandEvent& event) {
     int id = event.GetId();
     wxString newdir = RecentShowFoldersMenu->GetLabel(id);
@@ -324,6 +377,7 @@ bool xLightsFrame::SetDir(const wxString& newdir, bool permanent)
         RecentShowFoldersMenu->Append(mrud_MenuItem[i]);
     }
     RecentShowFoldersMenu->UpdateUI();
+    RebuildFavoriteShowFoldersMenu();
     MenuFile->FindItem(ID_MENUITEM_RECENTFOLDERS)->Enable(cnt != 0);
 
     if (!DirExists) {

--- a/src-ui-wx/setup/ShowDirectoriesDialog.cpp
+++ b/src-ui-wx/setup/ShowDirectoriesDialog.cpp
@@ -12,13 +12,22 @@
 #include "xLightsMain.h"
 #include "layout/LayoutPanel.h"
 #include "layout/ViewsModelsPanel.h"
+#include "settings/XLightsConfigAdapter.h"
+#include "ExternalHooks.h"
 #include <wx/sizer.h>
 #include <wx/statbox.h>
 #include <wx/gbsizer.h>
 #include <wx/dirdlg.h>
 #include <wx/settings.h>
+#include <wx/filename.h>
+#include <wx/msgdlg.h>
 
 #include <algorithm>
+
+namespace {
+    constexpr int MAX_SHOW_FAVORITES = 30;
+    const std::string FAV_KEY_PREFIX = "ShowFolderFavorite";
+}
 
 const wxWindowID ShowDirectoriesDialog::ID_BUTTON_CHANGE_PERMANENT = wxNewId();
 const wxWindowID ShowDirectoriesDialog::ID_BUTTON_CHANGE_TEMPORARY = wxNewId();
@@ -31,6 +40,11 @@ const wxWindowID ShowDirectoriesDialog::ID_BUTTON_CLEAR_BASE = wxNewId();
 const wxWindowID ShowDirectoriesDialog::ID_STATICTEXT_BASE_PATH = wxNewId();
 const wxWindowID ShowDirectoriesDialog::ID_CHECKBOX_AUTO_UPDATE = wxNewId();
 const wxWindowID ShowDirectoriesDialog::ID_BUTTON_UPDATE_BASE = wxNewId();
+const wxWindowID ShowDirectoriesDialog::ID_LISTBOX_FAVORITES = wxNewId();
+const wxWindowID ShowDirectoriesDialog::ID_BUTTON_ADD_FAV = wxNewId();
+const wxWindowID ShowDirectoriesDialog::ID_BUTTON_REMOVE_FAV = wxNewId();
+const wxWindowID ShowDirectoriesDialog::ID_BUTTON_GO_FAV_PERM = wxNewId();
+const wxWindowID ShowDirectoriesDialog::ID_BUTTON_GO_FAV_TEMP = wxNewId();
 
 wxBEGIN_EVENT_TABLE(ShowDirectoriesDialog, wxDialog)
     EVT_BUTTON(ID_BUTTON_CHANGE_PERMANENT, ShowDirectoriesDialog::OnButtonChangeShowDirPermanently)
@@ -41,6 +55,12 @@ wxBEGIN_EVENT_TABLE(ShowDirectoriesDialog, wxDialog)
     EVT_BUTTON(ID_BUTTON_CLEAR_BASE, ShowDirectoriesDialog::OnButtonClearBaseShowDir)
     EVT_CHECKBOX(ID_CHECKBOX_AUTO_UPDATE, ShowDirectoriesDialog::OnCheckBoxAutoUpdateBase)
     EVT_BUTTON(ID_BUTTON_UPDATE_BASE, ShowDirectoriesDialog::OnButtonUpdateBase)
+    EVT_BUTTON(ID_BUTTON_ADD_FAV, ShowDirectoriesDialog::OnAddFavorite)
+    EVT_BUTTON(ID_BUTTON_REMOVE_FAV, ShowDirectoriesDialog::OnRemoveFavorite)
+    EVT_BUTTON(ID_BUTTON_GO_FAV_PERM, ShowDirectoriesDialog::OnGoFavoritePermanent)
+    EVT_BUTTON(ID_BUTTON_GO_FAV_TEMP, ShowDirectoriesDialog::OnGoFavoriteTemporary)
+    EVT_LISTBOX(ID_LISTBOX_FAVORITES, ShowDirectoriesDialog::OnFavoriteSelectionChanged)
+    EVT_LISTBOX_DCLICK(ID_LISTBOX_FAVORITES, ShowDirectoriesDialog::OnFavoriteDoubleClick)
 wxEND_EVENT_TABLE()
 
 ShowDirectoriesDialog::ShowDirectoriesDialog(xLightsFrame* parent)
@@ -123,7 +143,27 @@ ShowDirectoriesDialog::ShowDirectoriesDialog(xLightsFrame* parent)
 
     gridBagSizer->AddGrowableCol(1);
     staticBoxSizer->Add(gridBagSizer, 1, wxALL | wxEXPAND, 5);
-    mainSizer->Add(staticBoxSizer, 1, wxALL | wxEXPAND, 10);
+    mainSizer->Add(staticBoxSizer, 0, wxALL | wxEXPAND, 10);
+
+    // Favorites: pinned quick-switch slots for show folders you use often.
+    wxStaticBoxSizer* favBox = new wxStaticBoxSizer(wxVERTICAL, this, _("Favorite Show Folders"));
+    FavoritesList = new wxListBox(this, ID_LISTBOX_FAVORITES, wxDefaultPosition, wxSize(-1, FromDIP(120)), 0, nullptr, wxLB_SINGLE);
+    favBox->Add(FavoritesList, 1, wxALL | wxEXPAND, 5);
+
+    wxBoxSizer* favButtons = new wxBoxSizer(wxHORIZONTAL);
+    Button_AddFavorite = new wxButton(this, ID_BUTTON_ADD_FAV, _("Add Current"));
+    Button_AddFavorite->SetToolTip(_("Pin the current show folder as a favorite"));
+    favButtons->Add(Button_AddFavorite, 0, wxRIGHT, 8);
+    Button_RemoveFavorite = new wxButton(this, ID_BUTTON_REMOVE_FAV, _("Remove"));
+    favButtons->Add(Button_RemoveFavorite, 0, wxRIGHT, 8);
+    favButtons->AddStretchSpacer(1);
+    Button_GoFavPermanent = new wxButton(this, ID_BUTTON_GO_FAV_PERM, _("Switch Permanently"));
+    favButtons->Add(Button_GoFavPermanent, 0, wxRIGHT, 8);
+    Button_GoFavTemporary = new wxButton(this, ID_BUTTON_GO_FAV_TEMP, _("Switch Temporarily"));
+    favButtons->Add(Button_GoFavTemporary, 0, 0, 0);
+    favBox->Add(favButtons, 0, wxALL | wxEXPAND, 5);
+
+    mainSizer->Add(favBox, 1, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 10);
 
     // Dialog buttons (Close)
     wxBoxSizer* buttonSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -134,6 +174,8 @@ ShowDirectoriesDialog::ShowDirectoriesDialog(xLightsFrame* parent)
     // Populate the real path labels before Fit() so the sizer measures their
     // actual (possibly long) text instead of the short placeholder strings the
     // labels were constructed with.
+    LoadFavorites();
+    RefreshFavoritesList();
     UpdateControlsState();
 
     SetSizerAndFit(mainSizer);
@@ -203,6 +245,7 @@ void ShowDirectoriesDialog::UpdateControlsState()
         Button_ChangeTemporarilyAgain->Show();
     }
 
+    UpdateFavoriteButtons();
     Layout();
 }
 
@@ -284,4 +327,118 @@ void ShowDirectoriesDialog::OnButtonUpdateBase(wxCommandEvent& event)
     _xLights->UpdateFromBaseShowFolder(true);
     SetCursor(wxCURSOR_ARROW);
     UpdateControlsState();
+}
+
+// ---- Favorite (pinned) show folders ----
+
+void ShowDirectoriesDialog::LoadFavorites()
+{
+    _favorites.clear();
+    auto* config = GetXLightsConfig();
+    for (int i = 0; i < MAX_SHOW_FAVORITES; ++i) {
+        wxString v;
+        if (config->Read(FAV_KEY_PREFIX + std::to_string(i), &v) && !v.IsEmpty()) {
+            _favorites.push_back(v);
+        }
+    }
+}
+
+void ShowDirectoriesDialog::SaveFavorites() const
+{
+    auto* config = GetXLightsConfig();
+    // Write current entries and blank out any trailing slots left from a longer
+    // previous list so removed favorites don't reappear on reload.
+    for (int i = 0; i < MAX_SHOW_FAVORITES; ++i) {
+        const wxString key = FAV_KEY_PREFIX + std::to_string(i);
+        config->Write(key, i < (int)_favorites.size() ? _favorites[i] : wxString());
+    }
+    config->Flush();
+}
+
+void ShowDirectoriesDialog::RefreshFavoritesList()
+{
+    if (FavoritesList == nullptr) return;
+    FavoritesList->Clear();
+    for (const auto& f : _favorites) {
+        FavoritesList->Append(f);
+    }
+    UpdateFavoriteButtons();
+}
+
+void ShowDirectoriesDialog::UpdateFavoriteButtons()
+{
+    if (FavoritesList == nullptr) return;
+    const bool hasSel = FavoritesList->GetSelection() != wxNOT_FOUND;
+    Button_RemoveFavorite->Enable(hasSel);
+    Button_GoFavPermanent->Enable(hasSel);
+    Button_GoFavTemporary->Enable(hasSel);
+
+    const wxString cur = _xLights->CurrentDir;
+    const bool already = std::find(_favorites.begin(), _favorites.end(), cur) != _favorites.end();
+    Button_AddFavorite->Enable(!cur.IsEmpty() && !already && (int)_favorites.size() < MAX_SHOW_FAVORITES);
+}
+
+void ShowDirectoriesDialog::SwitchToFolder(const wxString& dir, bool permanent)
+{
+    if (dir.IsEmpty() || dir == _xLights->CurrentDir) return;
+    if (!wxFileName::DirExists(dir)) {
+        wxMessageBox(wxString::Format(_("This show folder no longer exists:\n%s"), dir),
+                     _("Favorite Show Folder"), wxOK | wxICON_WARNING, this);
+        return;
+    }
+    if (!ObtainAccessToURL(dir.ToStdString(), true)) {
+        wxMessageBox(wxString::Format(_("xLights could not get access to:\n%s"), dir),
+                     _("Favorite Show Folder"), wxOK | wxICON_WARNING, this);
+        return;
+    }
+    _xLights->GetDisplayElementsPanel()->SetSequenceElementsModelsViews(nullptr, nullptr, nullptr);
+    _xLights->GetLayoutPanel()->ClearUndo();
+    _xLights->SetDir(dir, permanent);
+    UpdateControlsState();
+    UpdateFavoriteButtons();
+}
+
+void ShowDirectoriesDialog::OnAddFavorite(wxCommandEvent& event)
+{
+    const wxString cur = _xLights->CurrentDir;
+    if (cur.IsEmpty()) return;
+    if (std::find(_favorites.begin(), _favorites.end(), cur) != _favorites.end()) return;
+    if ((int)_favorites.size() >= MAX_SHOW_FAVORITES) return;
+    _favorites.push_back(cur);
+    SaveFavorites();
+    RefreshFavoritesList();
+    FavoritesList->SetSelection((int)_favorites.size() - 1);
+    UpdateFavoriteButtons();
+}
+
+void ShowDirectoriesDialog::OnRemoveFavorite(wxCommandEvent& event)
+{
+    const int sel = FavoritesList->GetSelection();
+    if (sel == wxNOT_FOUND || sel >= (int)_favorites.size()) return;
+    _favorites.erase(_favorites.begin() + sel);
+    SaveFavorites();
+    RefreshFavoritesList();
+}
+
+void ShowDirectoriesDialog::OnGoFavoritePermanent(wxCommandEvent& event)
+{
+    const int sel = FavoritesList->GetSelection();
+    if (sel != wxNOT_FOUND && sel < (int)_favorites.size()) SwitchToFolder(_favorites[sel], true);
+}
+
+void ShowDirectoriesDialog::OnGoFavoriteTemporary(wxCommandEvent& event)
+{
+    const int sel = FavoritesList->GetSelection();
+    if (sel != wxNOT_FOUND && sel < (int)_favorites.size()) SwitchToFolder(_favorites[sel], false);
+}
+
+void ShowDirectoriesDialog::OnFavoriteSelectionChanged(wxCommandEvent& event)
+{
+    UpdateFavoriteButtons();
+}
+
+void ShowDirectoriesDialog::OnFavoriteDoubleClick(wxCommandEvent& event)
+{
+    const int sel = FavoritesList->GetSelection();
+    if (sel != wxNOT_FOUND && sel < (int)_favorites.size()) SwitchToFolder(_favorites[sel], true);
 }

--- a/src-ui-wx/setup/ShowDirectoriesDialog.cpp
+++ b/src-ui-wx/setup/ShowDirectoriesDialog.cpp
@@ -9,6 +9,8 @@
  **************************************************************/
 
 #include "ShowDirectoriesDialog.h"
+
+#include <wx/textdlg.h>
 #include "xLightsMain.h"
 #include "layout/LayoutPanel.h"
 #include "layout/ViewsModelsPanel.h"
@@ -26,7 +28,8 @@
 
 namespace {
     constexpr int MAX_SHOW_FAVORITES = 30;
-    const std::string FAV_KEY_PREFIX = "ShowFolderFavorite";
+    const std::string FAV_KEY_PREFIX = "ShowFolderFavorite";      // legacy: path only
+    const std::string FAV_NAME_PREFIX = "ShowFolderFavoriteName";
 }
 
 const wxWindowID ShowDirectoriesDialog::ID_BUTTON_CHANGE_PERMANENT = wxNewId();
@@ -41,6 +44,7 @@ const wxWindowID ShowDirectoriesDialog::ID_STATICTEXT_BASE_PATH = wxNewId();
 const wxWindowID ShowDirectoriesDialog::ID_CHECKBOX_AUTO_UPDATE = wxNewId();
 const wxWindowID ShowDirectoriesDialog::ID_BUTTON_UPDATE_BASE = wxNewId();
 const wxWindowID ShowDirectoriesDialog::ID_LISTBOX_FAVORITES = wxNewId();
+const wxWindowID ShowDirectoriesDialog::ID_BUTTON_RENAME_FAV = wxNewId();
 const wxWindowID ShowDirectoriesDialog::ID_BUTTON_ADD_FAV = wxNewId();
 const wxWindowID ShowDirectoriesDialog::ID_BUTTON_REMOVE_FAV = wxNewId();
 const wxWindowID ShowDirectoriesDialog::ID_BUTTON_GO_FAV_PERM = wxNewId();
@@ -59,8 +63,10 @@ wxBEGIN_EVENT_TABLE(ShowDirectoriesDialog, wxDialog)
     EVT_BUTTON(ID_BUTTON_REMOVE_FAV, ShowDirectoriesDialog::OnRemoveFavorite)
     EVT_BUTTON(ID_BUTTON_GO_FAV_PERM, ShowDirectoriesDialog::OnGoFavoritePermanent)
     EVT_BUTTON(ID_BUTTON_GO_FAV_TEMP, ShowDirectoriesDialog::OnGoFavoriteTemporary)
-    EVT_LISTBOX(ID_LISTBOX_FAVORITES, ShowDirectoriesDialog::OnFavoriteSelectionChanged)
-    EVT_LISTBOX_DCLICK(ID_LISTBOX_FAVORITES, ShowDirectoriesDialog::OnFavoriteDoubleClick)
+    EVT_LIST_ITEM_SELECTED(ID_LISTBOX_FAVORITES, ShowDirectoriesDialog::OnFavoriteSelectionChanged)
+    EVT_LIST_ITEM_DESELECTED(ID_LISTBOX_FAVORITES, ShowDirectoriesDialog::OnFavoriteSelectionChanged)
+    EVT_LIST_ITEM_ACTIVATED(ID_LISTBOX_FAVORITES, ShowDirectoriesDialog::OnFavoriteDoubleClick)
+    EVT_BUTTON(ID_BUTTON_RENAME_FAV, ShowDirectoriesDialog::OnRenameFavorite)
 wxEND_EVENT_TABLE()
 
 ShowDirectoriesDialog::ShowDirectoriesDialog(xLightsFrame* parent)
@@ -147,13 +153,19 @@ ShowDirectoriesDialog::ShowDirectoriesDialog(xLightsFrame* parent)
 
     // Favorites: pinned quick-switch slots for show folders you use often.
     wxStaticBoxSizer* favBox = new wxStaticBoxSizer(wxVERTICAL, this, _("Favorite Show Folders"));
-    FavoritesList = new wxListBox(this, ID_LISTBOX_FAVORITES, wxDefaultPosition, wxSize(-1, FromDIP(120)), 0, nullptr, wxLB_SINGLE);
+    FavoritesList = new wxListCtrl(this, ID_LISTBOX_FAVORITES, wxDefaultPosition, wxSize(-1, FromDIP(120)),
+                                   wxLC_REPORT | wxLC_SINGLE_SEL);
+    FavoritesList->AppendColumn(_("Name"), wxLIST_FORMAT_LEFT, FromDIP(160));
+    FavoritesList->AppendColumn(_("Folder"), wxLIST_FORMAT_LEFT, FromDIP(420));
     favBox->Add(FavoritesList, 1, wxALL | wxEXPAND, 5);
 
     wxBoxSizer* favButtons = new wxBoxSizer(wxHORIZONTAL);
     Button_AddFavorite = new wxButton(this, ID_BUTTON_ADD_FAV, _("Add Current"));
     Button_AddFavorite->SetToolTip(_("Pin the current show folder as a favorite"));
     favButtons->Add(Button_AddFavorite, 0, wxRIGHT, 8);
+    Button_RenameFavorite = new wxButton(this, ID_BUTTON_RENAME_FAV, _("Rename"));
+    Button_RenameFavorite->SetToolTip(_("Change the name shown in the File menu"));
+    favButtons->Add(Button_RenameFavorite, 0, wxRIGHT, 8);
     Button_RemoveFavorite = new wxButton(this, ID_BUTTON_REMOVE_FAV, _("Remove"));
     favButtons->Add(Button_RemoveFavorite, 0, wxRIGHT, 8);
     favButtons->AddStretchSpacer(1);
@@ -331,16 +343,30 @@ void ShowDirectoriesDialog::OnButtonUpdateBase(wxCommandEvent& event)
 
 // ---- Favorite (pinned) show folders ----
 
-void ShowDirectoriesDialog::LoadFavorites()
+std::vector<ShowDirectoriesDialog::ShowFavorite> ShowDirectoriesDialog::ReadFavoritesFromConfig()
 {
-    _favorites.clear();
+    std::vector<ShowFavorite> out;
     auto* config = GetXLightsConfig();
     for (int i = 0; i < MAX_SHOW_FAVORITES; ++i) {
-        wxString v;
-        if (config->Read(FAV_KEY_PREFIX + std::to_string(i), &v) && !v.IsEmpty()) {
-            _favorites.push_back(v);
+        wxString path;
+        if (!config->Read(FAV_KEY_PREFIX + std::to_string(i), &path) || path.IsEmpty()) {
+            continue;
         }
+        wxString name;
+        config->Read(FAV_NAME_PREFIX + std::to_string(i), &name);
+        if (name.IsEmpty()) {
+            // Favorites saved before names existed - fall back to the folder name.
+            const wxFileName fn = wxFileName::DirName(path);
+            name = fn.GetDirs().IsEmpty() ? path : fn.GetDirs().Last();
+        }
+        out.push_back({ name, path });
     }
+    return out;
+}
+
+void ShowDirectoriesDialog::LoadFavorites()
+{
+    _favorites = ReadFavoritesFromConfig();
 }
 
 void ShowDirectoriesDialog::SaveFavorites() const
@@ -349,8 +375,9 @@ void ShowDirectoriesDialog::SaveFavorites() const
     // Write current entries and blank out any trailing slots left from a longer
     // previous list so removed favorites don't reappear on reload.
     for (int i = 0; i < MAX_SHOW_FAVORITES; ++i) {
-        const wxString key = FAV_KEY_PREFIX + std::to_string(i);
-        config->Write(key, i < (int)_favorites.size() ? _favorites[i] : wxString());
+        const bool live = i < (int)_favorites.size();
+        config->Write(FAV_KEY_PREFIX + std::to_string(i), live ? _favorites[i].path : wxString());
+        config->Write(FAV_NAME_PREFIX + std::to_string(i), live ? _favorites[i].name : wxString());
     }
     config->Flush();
 }
@@ -358,23 +385,51 @@ void ShowDirectoriesDialog::SaveFavorites() const
 void ShowDirectoriesDialog::RefreshFavoritesList()
 {
     if (FavoritesList == nullptr) return;
-    FavoritesList->Clear();
+    FavoritesList->DeleteAllItems();
     for (const auto& f : _favorites) {
-        FavoritesList->Append(f);
+        const long row = FavoritesList->InsertItem(FavoritesList->GetItemCount(), f.name);
+        FavoritesList->SetItem(row, 1, f.path);
     }
     UpdateFavoriteButtons();
+}
+
+long ShowDirectoriesDialog::SelectedFavorite() const
+{
+    if (FavoritesList == nullptr) return wxNOT_FOUND;
+    return FavoritesList->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
+}
+
+void ShowDirectoriesDialog::OnRenameFavorite(wxCommandEvent& event)
+{
+    const long sel = SelectedFavorite();
+    if (sel == wxNOT_FOUND || sel >= (long)_favorites.size()) return;
+    const wxString name = PromptFavoriteName(_favorites[sel].name, _("Rename Favorite"));
+    if (name.IsEmpty()) return;
+    _favorites[sel].name = name;
+    SaveFavorites();
+    RefreshFavoritesList();
+    FavoritesList->SetItemState(sel, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
+}
+
+wxString ShowDirectoriesDialog::PromptFavoriteName(const wxString& suggested, const wxString& title)
+{
+    wxTextEntryDialog dlg(this, _("Name for this show folder:"), title, suggested);
+    if (dlg.ShowModal() != wxID_OK) return wxEmptyString;
+    return dlg.GetValue().Trim(true).Trim(false);
 }
 
 void ShowDirectoriesDialog::UpdateFavoriteButtons()
 {
     if (FavoritesList == nullptr) return;
-    const bool hasSel = FavoritesList->GetSelection() != wxNOT_FOUND;
+    const bool hasSel = SelectedFavorite() != wxNOT_FOUND;
     Button_RemoveFavorite->Enable(hasSel);
+    Button_RenameFavorite->Enable(hasSel);
     Button_GoFavPermanent->Enable(hasSel);
     Button_GoFavTemporary->Enable(hasSel);
 
     const wxString cur = _xLights->CurrentDir;
-    const bool already = std::find(_favorites.begin(), _favorites.end(), cur) != _favorites.end();
+    const bool already = std::any_of(_favorites.begin(), _favorites.end(),
+                                     [&cur](const ShowFavorite& f) { return f.path == cur; });
     Button_AddFavorite->Enable(!cur.IsEmpty() && !already && (int)_favorites.size() < MAX_SHOW_FAVORITES);
 }
 
@@ -402,19 +457,29 @@ void ShowDirectoriesDialog::OnAddFavorite(wxCommandEvent& event)
 {
     const wxString cur = _xLights->CurrentDir;
     if (cur.IsEmpty()) return;
-    if (std::find(_favorites.begin(), _favorites.end(), cur) != _favorites.end()) return;
+    if (std::any_of(_favorites.begin(), _favorites.end(),
+                    [&cur](const ShowFavorite& f) { return f.path == cur; })) {
+        return;
+    }
     if ((int)_favorites.size() >= MAX_SHOW_FAVORITES) return;
-    _favorites.push_back(cur);
+
+    const wxFileName fn = wxFileName::DirName(cur);
+    const wxString suggested = fn.GetDirs().IsEmpty() ? cur : fn.GetDirs().Last();
+    const wxString name = PromptFavoriteName(suggested, _("Add Favorite"));
+    if (name.IsEmpty()) return; // cancelled, or blanked out
+
+    _favorites.push_back({ name, cur });
     SaveFavorites();
     RefreshFavoritesList();
-    FavoritesList->SetSelection((int)_favorites.size() - 1);
+    const long row = (long)_favorites.size() - 1;
+    FavoritesList->SetItemState(row, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
     UpdateFavoriteButtons();
 }
 
 void ShowDirectoriesDialog::OnRemoveFavorite(wxCommandEvent& event)
 {
-    const int sel = FavoritesList->GetSelection();
-    if (sel == wxNOT_FOUND || sel >= (int)_favorites.size()) return;
+    const long sel = SelectedFavorite();
+    if (sel == wxNOT_FOUND || sel >= (long)_favorites.size()) return;
     _favorites.erase(_favorites.begin() + sel);
     SaveFavorites();
     RefreshFavoritesList();
@@ -422,23 +487,23 @@ void ShowDirectoriesDialog::OnRemoveFavorite(wxCommandEvent& event)
 
 void ShowDirectoriesDialog::OnGoFavoritePermanent(wxCommandEvent& event)
 {
-    const int sel = FavoritesList->GetSelection();
-    if (sel != wxNOT_FOUND && sel < (int)_favorites.size()) SwitchToFolder(_favorites[sel], true);
+    const long sel = SelectedFavorite();
+    if (sel != wxNOT_FOUND && sel < (long)_favorites.size()) SwitchToFolder(_favorites[sel].path, true);
 }
 
 void ShowDirectoriesDialog::OnGoFavoriteTemporary(wxCommandEvent& event)
 {
-    const int sel = FavoritesList->GetSelection();
-    if (sel != wxNOT_FOUND && sel < (int)_favorites.size()) SwitchToFolder(_favorites[sel], false);
+    const long sel = SelectedFavorite();
+    if (sel != wxNOT_FOUND && sel < (long)_favorites.size()) SwitchToFolder(_favorites[sel].path, false);
 }
 
-void ShowDirectoriesDialog::OnFavoriteSelectionChanged(wxCommandEvent& event)
+void ShowDirectoriesDialog::OnFavoriteSelectionChanged(wxListEvent& event)
 {
     UpdateFavoriteButtons();
 }
 
-void ShowDirectoriesDialog::OnFavoriteDoubleClick(wxCommandEvent& event)
+void ShowDirectoriesDialog::OnFavoriteDoubleClick(wxListEvent& event)
 {
-    const int sel = FavoritesList->GetSelection();
-    if (sel != wxNOT_FOUND && sel < (int)_favorites.size()) SwitchToFolder(_favorites[sel], true);
+    const long sel = SelectedFavorite();
+    if (sel != wxNOT_FOUND && sel < (long)_favorites.size()) SwitchToFolder(_favorites[sel].path, true);
 }

--- a/src-ui-wx/setup/ShowDirectoriesDialog.h
+++ b/src-ui-wx/setup/ShowDirectoriesDialog.h
@@ -14,6 +14,9 @@
 #include <wx/button.h>
 #include <wx/stattext.h>
 #include <wx/checkbox.h>
+#include <wx/listbox.h>
+
+#include <vector>
 
 class xLightsFrame;
 
@@ -33,6 +36,27 @@ private:
     wxButton* Button_CheckShowFolderTemporarily = nullptr;
     wxButton* Button_ChangeTemporarilyAgain = nullptr;
     wxStaticText* ShowDirectoryLabel = nullptr;
+
+    // Favorite (pinned) show folders — quick-switch slots the user manages.
+    wxListBox* FavoritesList = nullptr;
+    wxButton* Button_AddFavorite = nullptr;
+    wxButton* Button_RemoveFavorite = nullptr;
+    wxButton* Button_GoFavPermanent = nullptr;
+    wxButton* Button_GoFavTemporary = nullptr;
+    std::vector<wxString> _favorites; // full paths, parallel to FavoritesList rows
+
+    void LoadFavorites();
+    void SaveFavorites() const;
+    void RefreshFavoritesList();
+    void UpdateFavoriteButtons();
+    void SwitchToFolder(const wxString& dir, bool permanent);
+
+    void OnAddFavorite(wxCommandEvent& event);
+    void OnRemoveFavorite(wxCommandEvent& event);
+    void OnGoFavoritePermanent(wxCommandEvent& event);
+    void OnGoFavoriteTemporary(wxCommandEvent& event);
+    void OnFavoriteSelectionChanged(wxCommandEvent& event);
+    void OnFavoriteDoubleClick(wxCommandEvent& event);
 
     // Base directory controls
     wxStaticText* StaticText_BaseShowDirLabel = nullptr;
@@ -65,6 +89,11 @@ private:
     static const wxWindowID ID_STATICTEXT_BASE_PATH;
     static const wxWindowID ID_CHECKBOX_AUTO_UPDATE;
     static const wxWindowID ID_BUTTON_UPDATE_BASE;
+    static const wxWindowID ID_LISTBOX_FAVORITES;
+    static const wxWindowID ID_BUTTON_ADD_FAV;
+    static const wxWindowID ID_BUTTON_REMOVE_FAV;
+    static const wxWindowID ID_BUTTON_GO_FAV_PERM;
+    static const wxWindowID ID_BUTTON_GO_FAV_TEMP;
 
     wxDECLARE_EVENT_TABLE();
 };

--- a/src-ui-wx/setup/ShowDirectoriesDialog.h
+++ b/src-ui-wx/setup/ShowDirectoriesDialog.h
@@ -11,6 +11,7 @@
  **************************************************************/
 
 #include <wx/dialog.h>
+#include <wx/listctrl.h>
 #include <wx/button.h>
 #include <wx/stattext.h>
 #include <wx/checkbox.h>
@@ -22,6 +23,16 @@ class xLightsFrame;
 
 class ShowDirectoriesDialog : public wxDialog
 {
+public:
+    // Name is what shows in the File menu; path is what we actually open.
+    struct ShowFavorite {
+        wxString name;
+        wxString path;
+    };
+    // Single source of truth for the config keys, shared with the File menu.
+    static std::vector<ShowFavorite> ReadFavoritesFromConfig();
+
+private:
 public:
     ShowDirectoriesDialog(xLightsFrame* parent);
     virtual ~ShowDirectoriesDialog();
@@ -38,12 +49,13 @@ private:
     wxStaticText* ShowDirectoryLabel = nullptr;
 
     // Favorite (pinned) show folders — quick-switch slots the user manages.
-    wxListBox* FavoritesList = nullptr;
+    wxListCtrl* FavoritesList = nullptr;
     wxButton* Button_AddFavorite = nullptr;
     wxButton* Button_RemoveFavorite = nullptr;
+    wxButton* Button_RenameFavorite = nullptr;
     wxButton* Button_GoFavPermanent = nullptr;
     wxButton* Button_GoFavTemporary = nullptr;
-    std::vector<wxString> _favorites; // full paths, parallel to FavoritesList rows
+    std::vector<ShowFavorite> _favorites; // parallel to FavoritesList rows
 
     void LoadFavorites();
     void SaveFavorites() const;
@@ -55,8 +67,12 @@ private:
     void OnRemoveFavorite(wxCommandEvent& event);
     void OnGoFavoritePermanent(wxCommandEvent& event);
     void OnGoFavoriteTemporary(wxCommandEvent& event);
-    void OnFavoriteSelectionChanged(wxCommandEvent& event);
-    void OnFavoriteDoubleClick(wxCommandEvent& event);
+    void OnFavoriteSelectionChanged(wxListEvent& event);
+    void OnFavoriteDoubleClick(wxListEvent& event);
+    void OnRenameFavorite(wxCommandEvent& event);
+    // Prompts for a display name, seeded with `suggested`. Empty return = cancelled.
+    wxString PromptFavoriteName(const wxString& suggested, const wxString& title);
+    long SelectedFavorite() const;
 
     // Base directory controls
     wxStaticText* StaticText_BaseShowDirLabel = nullptr;
@@ -90,6 +106,7 @@ private:
     static const wxWindowID ID_CHECKBOX_AUTO_UPDATE;
     static const wxWindowID ID_BUTTON_UPDATE_BASE;
     static const wxWindowID ID_LISTBOX_FAVORITES;
+    static const wxWindowID ID_BUTTON_RENAME_FAV;
     static const wxWindowID ID_BUTTON_ADD_FAV;
     static const wxWindowID ID_BUTTON_REMOVE_FAV;
     static const wxWindowID ID_BUTTON_GO_FAV_PERM;

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -274,6 +274,7 @@ const wxWindowID xLightsFrame::ID_EXPORT_VIDEO = wxNewId();
 const wxWindowID xLightsFrame::ID_MENUITEM2 = wxNewId();
 const wxWindowID xLightsFrame::ID_MENUITEM8 = wxNewId();
 const wxWindowID xLightsFrame::ID_MENUITEM_RECENTFOLDERS = wxNewId();
+const wxWindowID xLightsFrame::ID_MENUITEM_FAVFOLDERS = wxNewId();
 const wxWindowID xLightsFrame::ID_FILE_BACKUP = wxNewId();
 const wxWindowID xLightsFrame::ID_FILE_RESTOREBACKUP = wxNewId();
 const wxWindowID xLightsFrame::ID_FILE_ALTBACKUP = wxNewId();
@@ -970,6 +971,8 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     MenuItem11 = new wxMenuItem(RecentShowFoldersMenu, ID_MENUITEM8, _("RECENTFOLDER1"), wxEmptyString, wxITEM_NORMAL);
     RecentShowFoldersMenu->Append(MenuItem11);
     MenuFile->Append(ID_MENUITEM_RECENTFOLDERS, _("Recent Show Folders"), RecentShowFoldersMenu, wxEmptyString);
+    FavoriteShowFoldersMenu = new wxMenu();
+    MenuFile->Append(ID_MENUITEM_FAVFOLDERS, _("Favorite Show Folders"), FavoriteShowFoldersMenu, wxEmptyString);
     MenuItemBackup = new wxMenuItem(MenuFile, ID_FILE_BACKUP, _("Backup\tF10"), wxEmptyString, wxITEM_NORMAL);
     MenuItemBackup->SetBitmap(GetMenuItemBitmapBundle("wxART_HARDDISK"));
     MenuFile->Append(MenuItemBackup);
@@ -6667,6 +6670,9 @@ bool xLightsFrame::CleanupRGBEffectsFileLocations()
 void xLightsFrame::OpenShowDirectoriesDialog() {
     ShowDirectoriesDialog dlg(this);
     dlg.ShowModal();
+    // Favorites may have been added, renamed or removed - the dialog can close
+    // without a folder change, which is what otherwise refreshes the menu.
+    RebuildFavoriteShowFoldersMenu();
 }
 
 void xLightsFrame::OnMenuItem_CleanupFileLocationsSelected(wxCommandEvent& event)

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -774,6 +774,7 @@ public:
     static const wxWindowID ID_MENUITEM2;
     static const wxWindowID ID_MENUITEM8;
     static const wxWindowID ID_MENUITEM_RECENTFOLDERS;
+    static const wxWindowID ID_MENUITEM_FAVFOLDERS;
     static const wxWindowID ID_FILE_BACKUP;
     static const wxWindowID ID_FILE_RESTOREBACKUP;
     static const wxWindowID ID_FILE_ALTBACKUP;
@@ -912,6 +913,7 @@ public:
     wxMenu* MenuView;
     wxMenu* RecentSequencesMenu;
     wxMenu* RecentShowFoldersMenu;
+    wxMenu* FavoriteShowFoldersMenu = nullptr;
     wxMenuBar* MenuBar;
     wxMenuItem* ActionTestMenuItem;
     wxMenuItem* MenuItem33;
@@ -1413,6 +1415,11 @@ public:
     void OnButtonAddControllerNullClick(wxCommandEvent& event);
 
     void OnMenuMRU(wxCommandEvent& event);
+    // Favorites show a user-chosen name, so the path cannot be read back off the
+    // menu label the way OnMenuMRU does - keep an id -> path map instead.
+    void OnMenuFavoriteShowFolder(wxCommandEvent& event);
+    void RebuildFavoriteShowFoldersMenu();
+    std::map<int, wxString> _favoriteMenuPaths;
     void OnMRUSequence(wxCommandEvent& event);
     bool SetDir(const wxString& dirname, bool permanent);
     void SetBaseShowDir(const wxString& baseShowDir);


### PR DESCRIPTION
## What
Adds **pinned favorite show folders** to the Directories dialog so you can jump between shows you use often without browsing each time. Previously the dialog only let you Change Permanently / Temporarily via a folder picker.

A new **Favorite Show Folders** section shows a list of pinned folders with:
- **Add Current** — pin the current show folder (disabled when it's already pinned or empty)
- **Remove** — unpin the selected folder
- **Switch Permanently** / **Switch Temporarily** — switch to the selected folder (double-click a row = permanent)

Favorites are **persisted in the xLights config** (up to 30 slots) and survive restarts. They are **manual/pinned**, independent of the existing auto **Recent Show Folders** MRU on the File menu.
<img width="749" height="500" alt="Screenshot 2026-08-22 at 4 50 51 PM" src="https://github.com/user-attachments/assets/43d00ed1-f12e-4539-af63-18eb334c5079" />
<img width="532" height="571" alt="Screenshot 2026-08-22 at 4 51 49 PM" src="https://github.com/user-attachments/assets/f47567b8-c7c1-4b8c-b5ed-831f28571d4a" />



## How
- `ShowDirectoriesDialog` gains a `wxListBox` + four buttons and a `std::vector<wxString> _favorites`.
- Persistence via `GetXLightsConfig()` under keys `ShowFolderFavorite0..29`; unused trailing slots are blanked on save so removed favorites don't reappear.
- Switching reuses the real `xLightsFrame::SetDir(dir, permanent)` path with the `ObtainAccessToURL(dir, true)` sandbox check — mirroring `OnMenuMRU` (the recent-folders switch) — and clears display elements + layout undo first, matching the dialog's existing temporary-switch cleanup.
- Guards: skips a no-op switch to the current folder; warns (and does nothing) if a pinned folder no longer exists on disk or access can't be obtained; `Add` is disabled at the 30-slot cap or when the current folder is already pinned.

## Testing
Built (macOS Debug). Pinned/removed folders, switched permanently and temporarily, confirmed the list persists across a restart and that a deleted folder is handled gracefully.

## iPad parity
Desktop-only setup UI (`src-ui-wx/setup/`); the iPad has no equivalent Directories dialog. No iPad counterpart to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
