### PR TITLE
Backdate the .xbkp file on clean exist (#6955)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,6 +13,7 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
 2026.16  August ??, 2026
 
     -bug (derwin12)              Fix Text effect rendering nondeterministically (and occasionally crashing)
+    -bug (derwin12)              Don't re-prompt to use the rgbeffects autosave backup after the user already chose to discard those changes on exit
     -bug (dkulp)                 FPP Connect: uploading UDP outputs no longer resets FPP10's E1.31 Pacing
                                  and Sending mode - every setting on the universes output that xLights
                                  does not own is now carried forward unchanged

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -4100,6 +4100,20 @@ void xLightsFrame::CheckUnsavedChanges()
         if (wxYES == wxMessageBox("Save Models, Views, and Perspectives changes?",
                                   "Models, Views, and Perspectives Changes Confirmation", wxICON_QUESTION | wxYES_NO | wxNO_DEFAULT, this)) {
             SaveEffectsFile();
+        } else {
+            // Changes were explicitly discarded ... backdate the autosave backup (if
+            // any) below the real file's mtime so LoadEffectsFile() doesn't re-offer
+            // the same discarded changes as a "newer autosave found" prompt next open.
+            wxFileName fn(CurrentDir, XLIGHTS_RGBEFFECTS_FILE);
+            wxFileName bkp(CurrentDir, XLIGHTS_RGBEFFECTS_FILE_BACKUP);
+            if (FileExists(fn) && FileExists(bkp)) {
+                wxDateTime xmltime = fn.GetModificationTime();
+                wxDateTime xbkptime = bkp.GetModificationTime();
+                if (xmltime.IsValid() && xbkptime.IsValid() && xbkptime > xmltime) {
+                    xmltime -= wxTimeSpan(0, 0, 3, 0); // FAT time resolution is 2 seconds
+                    bkp.SetTimes(&xmltime, &xmltime, &xmltime);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
If you say no to saving the rgbeffect changes then backdate any autosave to prior date since you said you didnt want the changes. It will of course offer the backup if you come back from a crash.