### PR TITLE
Fix state import from submodel (#6963)

### DIFF
--- a/src-ui-wx/model/ModelStatesPanel.cpp
+++ b/src-ui-wx/model/ModelStatesPanel.cpp
@@ -1524,6 +1524,7 @@ void ModelStatesPanel::ImportStatesFromSubModels()
             NameChoice->SetStringSelection(name);
             NameChoice->Enable();
             DeleteButton->Enable();
+            StateTypeChoice->Enable();
             StateTypeChoice->ChangeSelection(NODE_RANGE_STATE);
             UpdateStateType();
 
@@ -1554,6 +1555,7 @@ void ModelStatesPanel::ImportStatesFromSubModels()
                     break;
                 }
             }
+            ValidateWindow();
             NodeRangeGrid->Refresh();
         }
     }


### PR DESCRIPTION
When you imported from submodel, the state page was left disabled.