### PR TITLE
Import Effects (Map Channels): make the Find boxes filter the lists

### DIFF
--- a/src-ui-wx/import_export/xLightsImportChannelMapDialog.cpp
+++ b/src-ui-wx/import_export/xLightsImportChannelMapDialog.cpp
@@ -25,6 +25,7 @@
 #include <wx/colordlg.h>
 #include <wx/regex.h>
 #include <wx/stdpaths.h>
+#include <wx/tokenzr.h>
 
 #include "xLightsImportChannelMapDialog.h"
 #include "import_export/AutoMapper.h"
@@ -494,9 +495,11 @@ unsigned int xLightsImportTreeModel::GetChildren(const wxDataViewItem &parent,
     if (!node) {
         unsigned int count = m_children.size();
         for (unsigned int pos = 0; pos < count; ++pos) {
-            array.Add(wxDataViewItem((void*)m_children.Item(pos)));
+            xLightsImportModelNode* child = m_children.Item(pos);
+            if (!MatchesNameFilter(child->_model)) continue;
+            array.Add(wxDataViewItem((void*)child));
         }
-        return count;
+        return array.size();
     } else {
         if (node->GetChildCount() == 0) {
             return 0;
@@ -509,6 +512,25 @@ unsigned int xLightsImportTreeModel::GetChildren(const wxDataViewItem &parent,
         }
         return array.size();
     }
+}
+
+void xLightsImportTreeModel::SetNameFilter(const wxString& text)
+{
+    _nameFilterTokens.clear();
+    wxArrayString toks = wxStringTokenize(text.Lower(), " \t");
+    for (const auto& t : toks) {
+        _nameFilterTokens.push_back(t.ToStdString());
+    }
+}
+
+bool xLightsImportTreeModel::MatchesNameFilter(const std::string& name) const
+{
+    if (_nameFilterTokens.empty()) return true;
+    const std::string lname = ::Lower(name);
+    for (const auto& t : _nameFilterTokens) {
+        if (!Contains(lname, t)) return false;
+    }
+    return true;
 }
 
 wxDataViewItem xLightsImportTreeModel::GetNthItem(unsigned int n) const
@@ -1487,6 +1509,16 @@ void xLightsImportChannelMapDialog::SetXsqPkg(SequencePackage* xsqPkg) {
     _xsqPkg = xsqPkg;
 }
 
+static bool NameMatchesTokens(const std::string& name, const std::vector<std::string>& tokens)
+{
+    if (tokens.empty()) return true;
+    const std::string lname = ::Lower(name);
+    for (const auto& t : tokens) {
+        if (!Contains(lname, t)) return false;
+    }
+    return true;
+}
+
 void xLightsImportChannelMapDialog::PopulateAvailable(bool ccr)
 {
     ListCtrl_Available->Freeze();
@@ -1506,6 +1538,7 @@ void xLightsImportChannelMapDialog::PopulateAvailable(bool ccr)
     if (ccr) {
         int j{0};
         for (auto const& name : ccrNames) {
+            if (!NameMatchesTokens(name, _availFilterTokens)) continue;
             ListCtrl_Available->InsertItem(j, "");    // col 0 (icon col)
             ListCtrl_Available->SetItem(j, 1, name); // col 1 (name)
             ListCtrl_Available->SetItemData(j, j);
@@ -1583,6 +1616,7 @@ void xLightsImportChannelMapDialog::PopulateAvailable(bool ccr)
 
         bool countEnabled{false};
         for (auto const& m : importChannels) {
+            if (!NameMatchesTokens(m->name, _availFilterTokens)) continue;
             ListCtrl_Available->InsertItem(j, "");       // col 0 (icon)
             ListCtrl_Available->SetItem(j, 1, m->name); // col 1 (name)
             wxUIntPtr ptr = (wxUIntPtr)m.get();
@@ -4462,86 +4496,23 @@ void xLightsImportChannelMapDialog::generateMapHintsFile(wxString const& filenam
 
 void xLightsImportChannelMapDialog::OnTextCtrl_FindFromText(wxCommandEvent& event)
 {
-    // find the first line starting with the text
-    int index = -1;
-    auto from = TextCtrl_FindFrom->GetValue().Lower();
-
-    if (from == "")
-    {
-        // text just erased ... so scroll to the top
-        index = 0;
+    // Filter the Available (source) list to the typed terms (all terms must
+    // appear). It's a wxListCtrl, so repopulate with only the matching rows.
+    _availFilterTokens.clear();
+    wxArrayString toks = wxStringTokenize(TextCtrl_FindFrom->GetValue().Lower(), " \t");
+    for (const auto& t : toks) {
+        _availFilterTokens.push_back(t.ToStdString());
     }
-    else
-    {
-        for (size_t i = 0; i < (size_t)ListCtrl_Available->GetItemCount(); ++i)
-        {
-            if (ListCtrl_Available->GetItemText(i, 1).Lower().StartsWith(from))
-            {
-                index = i;
-                break;
-            }
-        }
-    }
-
-    // if nothing found then find the first line containing the text
-    if (index == -1)
-    {
-        for (size_t i = 0; i < (size_t)ListCtrl_Available->GetItemCount(); ++i) {
-            if (ListCtrl_Available->GetItemText(i, 1).Lower().Contains(from)) {
-                index = i;
-                break;
-            }
-        }
-
-    }
-
-    // scroll to it
-    ListCtrl_Available->EnsureVisible(index);
+    PopulateAvailable(CheckBox_MapCCRStrand != nullptr && CheckBox_MapCCRStrand->GetValue());
 }
 
 void xLightsImportChannelMapDialog::OnTextCtrl_FindToText(wxCommandEvent& event)
 {
-    // find the first line starting with the text
-    wxDataViewItem index = wxDataViewItem(0);
-    std::string to = TextCtrl_FindTo->GetValue().Lower().ToStdString();
-
-    if (to.empty()) {
-        if (TreeListCtrl_Mapping->GetSelectedItemsCount() == 1) {
-            // if there is a selection, scroll to it as that's the visible marker
-            // at this point.
-            TreeListCtrl_Mapping->EnsureVisible(TreeListCtrl_Mapping->GetSelection());
-        }
-#ifdef __WXMSW__
-        else {
-            // There isn't a way to scroll to top on MacOS and Linux as far as I can find. Honestly, this shouldn't
-            // work on Windows either as wxDataViewControl does not inherit from wxScrollHelperBase according
-            // to the wxWidgets docs and thus should not implement the Scroll method
-            TreeListCtrl_Mapping->Scroll(wxPoint(0, 0));
-        }
-#endif
-    } else {
-        for (size_t i = 0; i < _dataModel->GetChildCount(); ++i) {
-            xLightsImportModelNode* m = _dataModel->GetNthChild(i);
-            if (StartsWith(::Lower(m->_model), to)) {
-                index = (wxDataViewItem)m;
-                break;
-            }
-        }
-
-        // if nothing found then find the first line containing the text
-        if (index.GetID() == 0) {
-            for (size_t i = 0; i < _dataModel->GetChildCount(); ++i) {
-                xLightsImportModelNode* m = _dataModel->GetNthChild(i);
-                if (Contains(::Lower(m->_model), to)) {
-                    index = (wxDataViewItem)m;
-                    break;
-                }
-            }
-        }
-
-        // scroll to it
-        TreeListCtrl_Mapping->EnsureVisible(index);
-    }
+    // Filter the model list to the typed terms (all terms must appear), so the
+    // list narrows as you type rather than merely scrolling to a match.
+    if (_dataModel == nullptr) return;
+    _dataModel->SetNameFilter(TextCtrl_FindTo->GetValue());
+    _dataModel->Cleared();
 }
 
 void xLightsImportChannelMapDialog::OnButton_UpdateAliasesClick(wxCommandEvent& event)

--- a/src-ui-wx/import_export/xLightsImportChannelMapDialog.h
+++ b/src-ui-wx/import_export/xLightsImportChannelMapDialog.h
@@ -399,6 +399,13 @@ public:
     bool _hideUnmapped = false;
     void SetHideUnmapped(bool h) { _hideUnmapped = h; }
 
+    // Name filter for the top-level model list. Whitespace-separated terms all
+    // have to appear in the model name (case-insensitive), so "midwest pumpkin"
+    // matches "Midwest-Coro-Pumpkin". Empty = show everything.
+    std::vector<std::string> _nameFilterTokens;
+    void SetNameFilter(const wxString& text);
+    bool MatchesNameFilter(const std::string& name) const;
+
     bool GetSortSubmodelsByName() const { return _sortSubmodelsByName; }
     void SetSortSubmodelsByName(bool sort) { _sortSubmodelsByName = sort; Resort(); }
 
@@ -762,6 +769,11 @@ protected:
         std::vector<wxCheckBox*> _timingCheckboxes;
         int _timelineCol {-1};
         std::map<ImportChannel*, int> _channelImageMap;
+
+        // Name-filter terms for the Available (source) list; every term must
+        // appear in the name. Empty = show everything. The list is a wxListCtrl
+        // so filtering means repopulating with only the matching rows.
+        std::vector<std::string> _availFilterTokens;
 
         std::vector<std::unique_ptr<ImportChannel>> importChannels;
         std::map<int, int> m_iconIndexMap; // Order in list->one we got


### PR DESCRIPTION
## What
In the **Import Effects → Map Channels** dialog, the two **Find** boxes only *scrolled to* the first matching row and left everything else visible. That's inconsistent with the filters used across the rest of the app (Layout tabs, Export pickers, Test dialog, vendor catalog…), so typing e.g. `matrix` looked like it did nothing.

This makes both Find boxes **filter** their list instead:
- **Left (target Model list)** narrows to matching models.
- **Right (Available / source list)** narrows to matching source models.

Both support **whitespace-tokenized AND** matching — `midwest pumpkin` matches `Midwest-Coro-Pumpkin`. Clearing a box restores its full list.
<img width="1221" height="630" alt="Screenshot 2026-08-23 at 3 23 33 PM" src="https://github.com/user-attachments/assets/04a2b7f2-536c-4b54-9bf4-7f51b5d2faf4" />


## How
- **Left list** is a `wxDataViewCtrl` backed by `xLightsImportTreeModel`. Added a name filter (`SetNameFilter` / `MatchesNameFilter` + `_nameFilterTokens`) applied in the model's top-level `GetChildren`, driven by `OnTextCtrl_FindToText` (sets the filter and calls `Cleared()`). This reuses the same display-filtering path as the existing **Hide Unmapped** option, so the two compose.
- **Right list** is a `wxListCtrl`, which can't hide rows, so `OnTextCtrl_FindFromText` stores the terms and calls `PopulateAvailable`, which now skips non-matching rows in both its CCR and normal loops. The prebuilt timeline image list is keyed by model pointer and re-applied by `RefreshTimelineColumnImages`, so the timeline column stays correct for the filtered rows.
- Shared matcher reuses the file's existing `Lower`/`Contains` helpers; added `#include <wx/tokenzr.h>`.

This is a **behaviour change**: "Find" now filters rather than jump-scrolls. The two boxes were only ever a scroll-to (added in #3965); nothing regressed — this brings the dialog in line with every other list filter.

## Note
The two field labels still read **"Find:"** — they live inside a wxSmith `//(*Initialize` guard, so relabeling to "Filter:" would also need a matching `.wxs` edit; left as-is to keep the change minimal. Happy to relabel if wanted.

## Testing
Built (macOS Debug). Verified both lists narrow as you type (single and multi-term), clearing restores the full list, Hide Unmapped stacks with the left filter, and the right list's timeline bars remain correct after filtering.

## iPad parity
Desktop-only import UI (`src-ui-wx/import_export/`); the iPad import path is separate. No iPad counterpart to change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
