### PR TITLE
Don't let a zero default sequence duration brick new sequences

### DIFF
--- a/src-ui-wx/import_export/SeqFileUtilities.cpp
+++ b/src-ui-wx/import_export/SeqFileUtilities.cpp
@@ -120,10 +120,11 @@ void xLightsFrame::NewSequence(const std::string& media, uint32_t durationMS, ui
 
     if (wizardactive) {
         auto* cfg = GetXLightsConfig();
-        std::string savedDur = cfg->Read("DefaultSeqDuration", std::string("30.0"));
-        CurrentSeqXmlFile->SetSequenceDuration(savedDur);
+        CurrentSeqXmlFile->SetSequenceDuration(GetDefaultSeqDurationSeconds());
+        // Timing becomes the frame interval and is divided by, so a stored 0
+        // would be worse than a bad duration.
         std::string savedTiming = cfg->Read("DefaultSeqTiming", std::string(""));
-        if (!savedTiming.empty()) {
+        if (!savedTiming.empty() && wxAtoi(savedTiming) > 0) {
             CurrentSeqXmlFile->SetSequenceTiming(savedTiming);
         }
     }

--- a/src-ui-wx/import_export/SeqFileUtilities.cpp
+++ b/src-ui-wx/import_export/SeqFileUtilities.cpp
@@ -12,6 +12,7 @@
 #include "settings/XLightsConfigAdapter.h"
 #include <wx/regex.h>
 #include <wx/tokenzr.h>
+#include <wx/wxcrt.h> // wxAtoi — MSVC needs it explicitly (macOS PCH masks the miss)
 #include <wx/uri.h>
 #include <wx/wfstream.h>
 #include <wx/zipstrm.h>

--- a/src-ui-wx/sequencer/SeqSettingsDialog.cpp
+++ b/src-ui-wx/sequencer/SeqSettingsDialog.cpp
@@ -1876,9 +1876,9 @@ void SeqSettingsDialog::OnBitmapButton_Wiz_AnimClick(wxCommandEvent& event)
 {
     Choice_Xml_Seq_Type->SetSelection(1);
     xml_file->SetSequenceType("Animation");
-    wxString defaultDur = wxString(GetXLightsConfig()->Read("DefaultSeqDuration", std::string("30.0")));
-    TextCtrl_Xml_Seq_Duration->ChangeValue(defaultDur);
-    xml_file->SetSequenceDuration(wxAtof(defaultDur));
+    const double defaultDur = GetDefaultSeqDurationSeconds();
+    TextCtrl_Xml_Seq_Duration->ChangeValue(wxString::Format("%.3f", defaultDur));
+    xml_file->SetSequenceDuration(defaultDur);
     xLightsParent->SetSequenceEnd(xml_file->GetSequenceDurationMS());
     ProcessSequenceType();
     WizardPage2();
@@ -1889,9 +1889,9 @@ void SeqSettingsDialog::OnBitmapButton_Wiz_EffectClick(wxCommandEvent& event)
 {
     Choice_Xml_Seq_Type->SetSelection(Choice_Xml_Seq_Type->FindString("Effect"));
     xml_file->SetSequenceType("Effect");
-    wxString defaultDur = wxString(GetXLightsConfig()->Read("DefaultSeqDuration", std::string("30.0")));
-    TextCtrl_Xml_Seq_Duration->ChangeValue(defaultDur);
-    xml_file->SetSequenceDuration(wxAtof(defaultDur));
+    const double defaultDur = GetDefaultSeqDurationSeconds();
+    TextCtrl_Xml_Seq_Duration->ChangeValue(wxString::Format("%.3f", defaultDur));
+    xml_file->SetSequenceDuration(defaultDur);
     xLightsParent->SetSequenceEnd(xml_file->GetSequenceDurationMS());
     ProcessSequenceType();
     selected_view = "Empty";
@@ -2479,6 +2479,14 @@ void SeqSettingsDialog::OnButton_AudioEditShortnameClick(wxCommandEvent& /*event
 
 void SeqSettingsDialog::OnButton_SetDefaultDurationClick(wxCommandEvent& /*event*/)
 {
+    // Refuse a duration that would make every new sequence unusable: 0 frames
+    // reads as "no sequence loaded", which disables Sequence Settings and Save
+    // and so cannot be undone from the UI.
+    if (wxAtof(TextCtrl_Xml_Seq_Duration->GetValue()) <= 0.0) {
+        wxMessageBox(_("A default duration must be greater than zero."),
+                     _("Set Default"), wxOK | wxICON_WARNING, this);
+        return;
+    }
     auto* cfg = GetXLightsConfig();
     cfg->Write("DefaultSeqDuration", TextCtrl_Xml_Seq_Duration->GetValue());
     if (m_activeDefaultBtn) {
@@ -2491,6 +2499,11 @@ void SeqSettingsDialog::OnButton_SetDefaultDurationClick(wxCommandEvent& /*event
 
 void SeqSettingsDialog::OnButton_SetDefaultTimingClick(wxCommandEvent& /*event*/)
 {
+    if (wxAtoi(xml_file->GetSequenceTiming()) <= 0) {
+        wxMessageBox(_("A default timing must be greater than zero."),
+                     _("Set Default"), wxOK | wxICON_WARNING, this);
+        return;
+    }
     auto* cfg = GetXLightsConfig();
     cfg->Write("DefaultSeqTiming", xml_file->GetSequenceTiming());
     if (m_activeDefaultBtn) {

--- a/src-ui-wx/settings/XLightsConfigAdapter.cpp
+++ b/src-ui-wx/settings/XLightsConfigAdapter.cpp
@@ -13,6 +13,7 @@
 #if __has_include(<wx/config.h>)
 #include <wx/config.h>
 #endif
+#include <wx/string.h> // wxAtof — the macOS PCH provides it implicitly; Windows/Linux need it explicitly
 #include <filesystem>
 #include <log.h>
 

--- a/src-ui-wx/settings/XLightsConfigAdapter.cpp
+++ b/src-ui-wx/settings/XLightsConfigAdapter.cpp
@@ -88,6 +88,18 @@ std::string GetLogFileName() {
     return "xLights_spdlog.log";
 }
 
+double GetDefaultSeqDurationSeconds()
+{
+    wxString v;
+    if (GetXLightsConfig()->Read("DefaultSeqDuration", &v)) {
+        const double d = wxAtof(v);
+        if (d > 0.0) {
+            return d;
+        }
+    }
+    return DEFAULT_SEQ_DURATION_SECONDS;
+}
+
 std::filesystem::path GetLogFilePath() {
     return GetLogFileFolder() / GetLogFileName();
 }

--- a/src-ui-wx/settings/XLightsConfigAdapter.cpp
+++ b/src-ui-wx/settings/XLightsConfigAdapter.cpp
@@ -13,7 +13,8 @@
 #if __has_include(<wx/config.h>)
 #include <wx/config.h>
 #endif
-#include <wx/string.h> // wxAtof — the macOS PCH provides it implicitly; Windows/Linux need it explicitly
+#include <wx/string.h> // wxString
+#include <wx/wxcrt.h>  // wxAtof — declared here; the macOS PCH provides it implicitly, MSVC needs it explicit
 #include <filesystem>
 #include <log.h>
 

--- a/src-ui-wx/settings/XLightsConfigAdapter.h
+++ b/src-ui-wx/settings/XLightsConfigAdapter.h
@@ -107,3 +107,9 @@ std::string GetLogFileName();
 
 /// Wipe all settings to factory defaults (called from the -w command-line flag).
 void WipeXLightsConfig();
+
+// A stored non-positive or unparseable value is treated as absent: 0 duration
+// gives 0 frames, which reads as "no sequence loaded" and disables the very
+// controls needed to correct it.
+constexpr double DEFAULT_SEQ_DURATION_SECONDS = 30.0;
+double GetDefaultSeqDurationSeconds();


### PR DESCRIPTION
Fixes #6971.

A stored default sequence duration of `0` made every new **Animation** sequence unusable, and unrecoverable from the UI.

## What happened

**Set Default** beside the duration wrote whatever was in the box to config with no validation, reporting *"Saved!"* either way:

```cpp
cfg->Write("DefaultSeqDuration", TextCtrl_Xml_Seq_Duration->GetValue());
```

New sequences read it back with a fallback that only fires when the key is **absent**, not when its value is useless:

```cpp
std::string savedDur = cfg->Read("DefaultSeqDuration", std::string("30.0"));
```

So the sequence got 0 frames, and `EnableSequenceControls` treats 0 frames as *"no file is loaded"* — disabling the effects toolbar, Display Elements, Sequence Settings, Save, Save As and Close Sequence. The control needed to set a duration is itself disabled, so there is no way back.

Musical sequences were unaffected because their length comes from the audio, which is why this presents as intermittent.

## The fix

Two independent guards:

**On read** — `GetDefaultSeqDurationSeconds()` treats a non-positive or unparseable stored value as absent and returns 30s. This is the half that matters: a write-side guard alone would leave every already-poisoned config broken. The three read sites now share it rather than each repeating `Read(..., "30.0")`.

**On write** — **Set Default** refuses a non-positive duration or timing and says why, instead of storing a value that guarantees a broken sequence.

The stored **timing** gets the same read guard. It becomes the frame interval and is divided by, so a stored `0` is worse than a bad duration.

## Testing

- macOS Debug: pass
- macOS Debug with `NO_PCH`: pass
- Verified against a real config still containing `"DefaultSeqDuration": "0.000"` — new Animation sequences come up at 30s with all controls live, without editing settings by hand
- New Musical sequence still takes its length from the audio
- **Set Default** with `0` in the box is refused; with a valid value it saves and is picked up by the next new sequence

No new source files, so no `.cbp` / `.vcxproj` / CMake changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
