### PR TITLE
Show the count of blank rows in Presets (#6975)

### DIFF
--- a/src-ui-wx/sequencer/EffectTreeDialog.cpp
+++ b/src-ui-wx/sequencer/EffectTreeDialog.cpp
@@ -462,11 +462,18 @@ wxString EffectTreeDialog::ParseLayers(wxString name, wxString settings)
     //logger_base.debug("Settings: %s", (const char *)settings.c_str());
     int res = 0;
     bool ac = false;
+    // Extra empty layer rows the preset's saved lasso selection spanned above
+    // its first actual effect row (see ANCHOR_ROW: in
+    // MainSequencer::GetSelectedEffectsData) -- surfaced so a mis-drawn
+    // selection at save time is visible instead of silently causing a
+    // dropped layer on a later "Using Layers" paste.
+    int leadingEmpty = 0;
 
     if (settings.Contains("\t"))
     {
         int start = 9999;
         int end = -1;
+        int anchorRow = -1;
 
         wxArrayString all_efdata = wxSplit(settings, '\n');
 
@@ -482,6 +489,14 @@ wxString EffectTreeDialog::ParseLayers(wxString name, wxString settings)
                 if (efdata[0] == "CopyFormat1")
                 {
                     cf1 = true;
+                    for (size_t fi = 1; fi < efdata.size(); fi++)
+                    {
+                        if (efdata[fi].StartsWith("ANCHOR_ROW:"))
+                        {
+                            anchorRow = wxAtoi(efdata[fi].Mid(11));
+                            break;
+                        }
+                    }
                 }
                 else if (efdata[0] == "CopyFormatAC")
                 {
@@ -513,6 +528,10 @@ wxString EffectTreeDialog::ParseLayers(wxString name, wxString settings)
         if (end != -1)
         {
             res = end - start + 1;
+            if (anchorRow >= 0 && start > anchorRow)
+            {
+                leadingEmpty = start - anchorRow;
+            }
         }
     }
     else
@@ -526,13 +545,15 @@ wxString EffectTreeDialog::ParseLayers(wxString name, wxString settings)
 
     //logger_base.debug("    **** %d", res);
 
+    wxString countStr = (leadingEmpty > 0) ? wxString::Format("%d+%d", leadingEmpty, res) : wxString::Format("%d", res);
+
     if (ac)
     {
-        return wxString::Format("%d - AC", res);
+        return countStr + " - AC";
     }
     else
     {
-        return wxString::Format("%d", res);
+        return countStr;
     }
 }
 

--- a/src-ui-wx/sequencer/tabSequencer.cpp
+++ b/src-ui-wx/sequencer/tabSequencer.cpp
@@ -4378,7 +4378,7 @@ EffectPreset* xLightsFrame::CreateEffectPreset(EffectPresetGroup* parent, const 
 void xLightsFrame::UpdateEffectPreset(EffectPreset* preset)
 {
     wxString copy_data;
-    mainSequencer->GetSelectedEffectsData(copy_data);
+    mainSequencer->GetSelectedEffectsData(copy_data, false, true);
     _effectPresetManager.UpdatePresetSettings(preset,
                                               copy_data.ToStdString(),
                                               xlights_version_string);


### PR DESCRIPTION
Since we now capture blank leading rows in presets (not sure as of when) .. it was not obvious in the preset dropdown. Note that the leading blank lines were not being captured with the Update Preset - only Add Preset, so that was corrected.

Folks will have to change their lasso technique to be sure not to capture any empty lines.  This may be a sore point going forward..

<img width="335" height="186" alt="image" src="https://github.com/user-attachments/assets/e9f90dff-4217-4884-826a-42fb21cfc40c" />

Example presets showing leading blank lines in the preset are present..

<img width="180" height="144" alt="image" src="https://github.com/user-attachments/assets/8c3e08ab-b374-402d-aa95-942c6481a678" />

