### PR TITLE
Fix setting the Per Preview default camera (#6985)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -36,6 +36,9 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                  squishing buttons/text illegible) when docked/resized smaller than
                                  their contents (#6979)
     -bug (derwin12)              Fix images for ChatGPT service (#6969)
+    -bug (derwin12)              Fix switching an effect's Render Style to "Per Preview" on a
+                                 model group no longer applying the group's configured Default
+                                 Camera - it was silently staying on 2D
     -enh (dkulp)                 Large speedup rendering the Faces effect on big matrix models
     -bug (dkulp)                 Fixed a crash opening a show folder containing a Poly Line or
                                  Multi Point model saved with fewer than two points

--- a/src-ui-wx/sequencer/BufferPanel.cpp
+++ b/src-ui-wx/sequencer/BufferPanel.cpp
@@ -175,6 +175,7 @@ void BufferPanel::OnBufferStyleChoiceSelect(wxCommandEvent& event) {
     }
 
     std::string bs = bsInfo->choice->GetStringSelection().ToStdString();
+    bool prevWasCamera = BufferStyles::CanRenderBufferUseCamera(_prevBufferStyle);
     if (BufferStyles::CanRenderBufferUseCamera(bs)) {
         wxString currentCamera = camInfo->choice->GetStringSelection();
 
@@ -187,7 +188,11 @@ void BufferPanel::OnBufferStyleChoiceSelect(wxCommandEvent& event) {
             }
         }
 
-        if (camInfo->choice->FindString(currentCamera) != wxNOT_FOUND && !currentCamera.empty()) {
+        // Only preserve the existing selection when coming from another camera
+        // style (e.g. toggling Per Preview <-> Per Model Per Preview) — otherwise
+        // "2D" here is just the placeholder a non-camera style forces below, not
+        // a real user choice, and the group's Default Camera should win.
+        if (prevWasCamera && camInfo->choice->FindString(currentCamera) != wxNOT_FOUND && !currentCamera.empty()) {
             camInfo->choice->SetStringSelection(currentCamera);
         } else {
             camInfo->choice->SetStringSelection(_defaultCamera);
@@ -195,6 +200,7 @@ void BufferPanel::OnBufferStyleChoiceSelect(wxCommandEvent& event) {
     } else {
         camInfo->choice->SetStringSelection("2D");
     }
+    _prevBufferStyle = bs;
 
     ValidateWindow();
     // Must Skip so HandleCommandChange on the parent fires and the save
@@ -223,6 +229,8 @@ void BufferPanel::UpdateBufferStyles(const Model* model) {
         info->choice->Append("As Pixel");
     }
     info->choice->SetStringSelection(sel);
+    // Programmatic — doesn't fire OnBufferStyleChoiceSelect, so track it directly.
+    _prevBufferStyle = info->choice->GetStringSelection().ToStdString();
 }
 
 void BufferPanel::UpdateCamera(const Model* model) {

--- a/src-ui-wx/sequencer/BufferPanel.h
+++ b/src-ui-wx/sequencer/BufferPanel.h
@@ -60,5 +60,10 @@ private:
     BulkEditChoice* _rotoZoomPresetChoice = nullptr;
 
     std::string _defaultCamera = "2D";
+    // Tracks the BufferStyle in effect *before* the current OnBufferStyleChoiceSelect
+    // call, so it can tell "switching into a camera style from a non-camera style"
+    // (apply the group's Default Camera) apart from "toggling between two camera
+    // styles" (preserve whatever camera the user already picked).
+    std::string _prevBufferStyle = "Default";
     bool _mg = false;
 };


### PR DESCRIPTION
If a non 2D camera is set in the layout for a group, this becomes the default when you change to Per Preview in sequencer. This was a bug in the big conversion in 2026.04.