### PR TITLE
Bars Effect rounding issue

### DIFF
--- a/src-core/effects/BarsEffect.cpp
+++ b/src-core/effects/BarsEffect.cpp
@@ -325,7 +325,10 @@ void BarsEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBu
 
         for (int y = -2 * buffer.BufferHt; y < 2 * buffer.BufferHt; ++y) {
 
-            int n = buffer.BufferHt + y + f_offset;
+            // Offset by a multiple of blockHt (not BufferHt) so the modulo phase isn't
+            // shifted when BufferHt doesn't divide evenly by colorcnt (blockHt > BufferHt);
+            // adding BufferHt directly caused the first row to wrap to the wrong color.
+            int n = 4 * blockHt + y + f_offset;
             int colorIdx = std::abs(n % blockHt) / barHt;
             if (useFirstColorForHighlight) {
                 colorIdx += 1;
@@ -422,7 +425,9 @@ void BarsEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBu
             BlockWi = 1;
 
         for (int x = -2 * width; x < 2 * width; ++x) {
-            int n = width + x;
+            // See the note in the standard horizontal-bars branch above: offset by a
+            // multiple of BlockWi (not width) to avoid shifting the modulo phase.
+            int n = 4 * BlockWi + x;
             int colorIdx = (n % BlockWi) / BarWi;
             if (useFirstColorForHighlight) {
                 colorIdx += 1;
@@ -480,8 +485,12 @@ void BarsEffect::Render(Effect* effect, const SettingsMap& SettingsMap, RenderBu
         }
 
         direction = direction > 9 ? direction - 6 : direction;
+
         for (int x = -2 * buffer.BufferWi; x < 2 * buffer.BufferWi; ++x) {
-            int n = buffer.BufferWi + x + f_offset;
+            // Offset by a multiple of blockWi (not BufferWi) so the modulo phase isn't
+            // shifted when BufferWi doesn't divide evenly by colorcnt (blockWi > BufferWi);
+            // adding BufferWi directly caused the first column to wrap to the wrong color.
+            int n = 4 * blockWi + x + f_offset;
             int colorIdx = (n % blockWi) / barWi;
             if (useFirstColorForHighlight) {
                 colorIdx += 1;

--- a/src-core/effects/ispc/BarsFunctions.ispc
+++ b/src-core/effects/ispc/BarsFunctions.ispc
@@ -170,7 +170,10 @@ export void BarsEffectISPC(const uniform BarsData * uniform data,
             } else { // BARS_DIR_UP
                 y = height - py - 1;
             }
-            n = height + y + f_offset;
+            // Offset by a multiple of blockSize (not height) so the modulo phase isn't
+            // shifted when height doesn't divide evenly by colorCount (blockSize > height);
+            // adding height directly caused the first row to wrap to the wrong color.
+            n = 4 * data->blockSize + y + f_offset;
         } else {
             // Horizontal directions: bars run vertically, animate along X.
             int x;
@@ -183,7 +186,10 @@ export void BarsEffectISPC(const uniform BarsData * uniform data,
             } else { // BARS_DIR_LEFT
                 x = px;
             }
-            n = width + x + f_offset;
+            // Offset by a multiple of blockSize (not width) so the modulo phase isn't
+            // shifted when width doesn't divide evenly by colorCount (blockSize > width);
+            // adding width directly caused the first column to wrap to the wrong color.
+            n = 4 * data->blockSize + x + f_offset;
         }
 
         result[index] = computeBarColor(n, data);

--- a/src-core/effects/metal/BarsFunctions.metal
+++ b/src-core/effects/metal/BarsFunctions.metal
@@ -141,7 +141,10 @@ kernel void BarsEffect(constant MetalBarsData &data [[buffer(0)]],
                 y = (int)data.height - (int)py - 1;
                 break;
         }
-        n = (int)data.height + y + data.f_offset;
+        // Offset by a multiple of blockSize (not height) so the modulo phase isn't
+        // shifted when height doesn't divide evenly by colorCount (blockSize > height);
+        // adding height directly caused the first row to wrap to the wrong color.
+        n = 4 * (int)data.blockSize + y + data.f_offset;
     } else {
         // Horizontal modes: bars run vertically, animate along X.
         int x;
@@ -161,7 +164,10 @@ kernel void BarsEffect(constant MetalBarsData &data [[buffer(0)]],
                 x = (int)px;
                 break;
         }
-        n = (int)data.width + x + data.f_offset;
+        // Offset by a multiple of blockSize (not width) so the modulo phase isn't
+        // shifted when width doesn't divide evenly by colorCount (blockSize > width);
+        // adding width directly caused the first column to wrap to the wrong color.
+        n = 4 * (int)data.blockSize + x + data.f_offset;
     }
 
     result[index] = computeBarColor(n, data);


### PR DESCRIPTION
Found the Per Preview would wrap the color bars. @dkulp Can you check this as well.
3 color bars, no cycle, left.


<img width="734" height="268" alt="image" src="https://github.com/user-attachments/assets/c915ae43-0a36-4cbe-b753-51c430675b4f" />
