### PR TITLE
The Off effect on a MH will only turn off the dimmer. #6990

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -46,6 +46,9 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -bug (derwin12)              Fix switching an effect's Render Style to "Per Preview" on a
                                  model group no longer applying the group's configured Default
                                  Camera - it was silently staying on 2D
+    -bug (derwin12)              Fix an Off effect on a moving head/DMX fixture with a dimmer
+                                 resetting pan/tilt/color channels to black instead of just
+                                 turning off the dimmer, which snapped the head out of position (#6990)
     -enh (dkulp)                 Large speedup rendering the Faces effect on big matrix models
     -bug (dkulp)                 Fixed a crash opening a show folder containing a Poly Line or
                                  Multi Point model saved with fewer than two points

--- a/src-core/effects/OffEffect.cpp
+++ b/src-core/effects/OffEffect.cpp
@@ -13,6 +13,8 @@
 #include "OffEffect.h"
 #include "../render/Effect.h"
 #include "../render/RenderBuffer.h"
+#include "../models/DMX/DmxDimmerAbility.h"
+#include "../models/DMX/DmxModel.h"
 #include "UtilFunctions.h"
 #include "models/Model.h"
 
@@ -84,7 +86,32 @@ void OffEffect::Render(Effect* effect, const SettingsMap& settings, RenderBuffer
     if (style == "Transparent") {
         // dont change any pixels at all if we are transparent
         return;
-    } else if (style == "Black") {
+    }
+
+    // Moving heads (and other DMX fixtures with a dimmer channel) shouldn't have their
+    // pan/tilt/color/etc. channels reset to black by an Off effect - only the dimmer
+    // should be turned off so the fixture stays where it was last positioned.
+    const DmxModel* dmxModel = dynamic_cast<const DmxModel*>(buffer.GetModel());
+    if (dmxModel != nullptr && dmxModel->HasDimmerAbility()) {
+        int dimmerChannel = dmxModel->GetDimmerAbility()->GetDimmerChannel();
+        if (dimmerChannel > 0 && (uint32_t)dimmerChannel <= buffer.GetPixelCount()) {
+            int idx = dimmerChannel - 1;
+            if (style == "Black") {
+                buffer.SetPixel(idx, 0, xlBLACK, false, false, true);
+            } else if (style == "Black -> Transparent") {
+                if (buffer.GetPixels()[idx] == xlBLACK) {
+                    buffer.GetPixels()[idx] = xlCLEAR;
+                }
+            } else if (style == "Transparent -> Black") {
+                if (buffer.GetPixels()[idx] == xlCLEAR) {
+                    buffer.SetPixel(idx, 0, xlBLACK, false, false, true);
+                }
+            }
+            return;
+        }
+    }
+
+    if (style == "Black") {
         //  Every Node, every frame set to BLACK
         buffer.Fill(xlBLACK);
     } else if (style == "Black -> Transparent") {


### PR DESCRIPTION
Prior to this change the off effect would reset the pan/tilt/etc. This way one can simply use the off effect to "bounce" mh lights.