### PR TITLE
Fix model flip warning false positive

### DIFF
--- a/src-core/diagnostics/SequenceChecker.cpp
+++ b/src-core/diagnostics/SequenceChecker.cpp
@@ -1129,33 +1129,30 @@ int SequenceChecker::RunModelChecks(CheckSequenceReport& report) {
                 last = newlast;
                 lastm = m;
             }
-            if (m->GetDisplayAs() == DisplayAsType::SingleLine) {
+            if (m->GetBaseObjectScreenLocation().hasX2()) {
                 size_t nodeCount = m->GetNodeCount();
                 if (nodeCount < 2)
                     continue;
                 TwoPointScreenLocation& screenLoc = dynamic_cast<TwoPointScreenLocation&>(m->GetBaseObjectScreenLocation());
-                float dx = screenLoc.GetX2();
-                float dy = screenLoc.GetY2();
-                float dz = screenLoc.GetZ2();
-                float deltaX = std::fabs(dx);
-                float deltaY = std::fabs(dy);
-                float deltaZ = std::fabs(dz);
-                if (deltaX > deltaY && deltaX > deltaZ) {
-                    if (dx < 0) {
-                        std::string msg = fmt::format("    WARN: Model '{}' should have the green square on the left of the blue square for best render results.",
-                                                      m->GetName());
-                        RecordIssue(report, "models",
-                                    CheckSequenceReport::ReportIssue::ForModel(
-                                        CheckSequenceReport::ReportIssue::WARNING, msg, "config", m->GetName()));
-                    }
-                } else if (deltaY > deltaX && deltaY > deltaZ) {
-                    if (dy < 0) {
-                        std::string msg = fmt::format("    WARN: Model '{}' should have the green square on the bottom of the blue square for best render results.",
-                                                      m->GetName());
-                        RecordIssue(report, "models",
-                                    CheckSequenceReport::ReportIssue::ForModel(
-                                        CheckSequenceReport::ReportIssue::WARNING, msg, "config", m->GetName()));
-                    }
+                switch (screenLoc.GetFlipDirection()) {
+                case TwoPointScreenLocation::FlipDirection::LeftRight: {
+                    std::string msg = fmt::format("    WARN: Model '{}' should have the green square on the left of the blue square for best render results.",
+                                                  m->GetName());
+                    RecordIssue(report, "models",
+                                CheckSequenceReport::ReportIssue::ForModel(
+                                    CheckSequenceReport::ReportIssue::WARNING, msg, "config", m->GetName()));
+                    break;
+                }
+                case TwoPointScreenLocation::FlipDirection::TopBottom: {
+                    std::string msg = fmt::format("    WARN: Model '{}' should have the green square on the bottom of the blue square for best render results.",
+                                                  m->GetName());
+                    RecordIssue(report, "models",
+                                CheckSequenceReport::ReportIssue::ForModel(
+                                    CheckSequenceReport::ReportIssue::WARNING, msg, "config", m->GetName()));
+                    break;
+                }
+                case TwoPointScreenLocation::FlipDirection::None:
+                    break;
                 }
             }
         }

--- a/src-core/models/TwoPointScreenLocation.h
+++ b/src-core/models/TwoPointScreenLocation.h
@@ -10,6 +10,8 @@
  * License: https://github.com/xLightsSequencer/xLights/blob/master/License.txt
  **************************************************************/
 
+#include <cmath>
+
 #include "ModelScreenLocation.h"
 
 //Location that uses two points to define start/end
@@ -99,6 +101,25 @@ public:
     void SetX2(float val) {x2 = val;}
     void SetY2(float val) {y2 = val;}
     void SetZ2(float val) {z2 = val;}
+
+    enum class FlipDirection { None, LeftRight, TopBottom };
+
+    // Shared by the layout tooltip and Check Sequence so both agree on what
+    // counts as "perhaps flipped": whichever axis (x/y/z, point2 relative to
+    // point1) has the largest magnitude is the model's intended direction; if
+    // that magnitude clears minMagnitude and is negative, the model looks
+    // flipped on that axis. Z dominant (e.g. a depth-only line) is never flagged.
+    FlipDirection GetFlipDirection(float minMagnitude = 30.0f) const {
+        float adx = std::fabs(x2);
+        float ady = std::fabs(y2);
+        float adz = std::fabs(z2);
+        if (adx >= ady && adx >= adz) {
+            if (adx > minMagnitude && x2 < 0.0f) return FlipDirection::LeftRight;
+        } else if (ady >= adx && ady >= adz) {
+            if (ady > minMagnitude && y2 < 0.0f) return FlipDirection::TopBottom;
+        }
+        return FlipDirection::None;
+    }
 
     virtual handles::Tool GetDefaultTool() const override { return handles::Tool::Translate; }
 

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -12701,21 +12701,21 @@ void LayoutPanel::HandleSelectionChanged() {
             }
             if (selectedBaseObject != nullptr && selectedBaseObject->GetBaseObjectScreenLocation().hasX2()) {
                 const TwoPointScreenLocation& screenLoc = dynamic_cast<const TwoPointScreenLocation&>(selectedBaseObject->GetBaseObjectScreenLocation());
-                // GetX2()/GetY2() are offsets of point 2 relative to point 1 (the model's
-                // world position), not absolute coordinates, so compare them against 0.
-                float x2 = screenLoc.GetX2();
-                float y2 = screenLoc.GetY2();
-                if (x2 < 0.0f && std::abs(x2) > 30.0) {
+                switch (screenLoc.GetFlipDirection()) {
+                case TwoPointScreenLocation::FlipDirection::LeftRight:
                     if (!tooltip.empty()) {
                         tooltip += "\n";
                     }
                     tooltip += "Warning: Model is perhaps flipped left to right.";
-                }
-                if (y2 < 0.0f && std::abs(x2) < 30.0) {
+                    break;
+                case TwoPointScreenLocation::FlipDirection::TopBottom:
                     if (!tooltip.empty()) {
                         tooltip += "\n";
                     }
                     tooltip += "Warning: Model is perhaps flipped top to bottom.";
+                    break;
+                case TwoPointScreenLocation::FlipDirection::None:
+                    break;
                 }
             }
             SetupPropGrid(model);

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -12701,18 +12701,17 @@ void LayoutPanel::HandleSelectionChanged() {
             }
             if (selectedBaseObject != nullptr && selectedBaseObject->GetBaseObjectScreenLocation().hasX2()) {
                 const TwoPointScreenLocation& screenLoc = dynamic_cast<const TwoPointScreenLocation&>(selectedBaseObject->GetBaseObjectScreenLocation());
-                glm::vec3 loc = screenLoc.GetWorldPosition();
-                float x1 = loc.x;
-                float y1 = loc.y;
+                // GetX2()/GetY2() are offsets of point 2 relative to point 1 (the model's
+                // world position), not absolute coordinates, so compare them against 0.
                 float x2 = screenLoc.GetX2();
                 float y2 = screenLoc.GetY2();
-                if (x2 < x1 && std::abs(x2 - x1) > 30.0) {
+                if (x2 < 0.0f && std::abs(x2) > 30.0) {
                     if (!tooltip.empty()) {
                         tooltip += "\n";
                     }
                     tooltip += "Warning: Model is perhaps flipped left to right.";
                 }
-                if (y2 < y1 && std::abs(x2 - x1) < 30.0) {
+                if (y2 < 0.0f && std::abs(x2) < 30.0) {
                     if (!tooltip.empty()) {
                         tooltip += "\n";
                     }


### PR DESCRIPTION
As a result of a change late last year there were situations the tooltip and check sequence  were incorrectly flagging a model as potentially being flipped (ie blue square on the left of the green square). This is corrected.
Done with a helper function so check sequence and tooltip share the same checks.