### PR TITLE
Fix house preview hiding export video prompts (#7003)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -65,6 +65,11 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -bug (derwin12)              Fix an Off effect on a moving head/DMX fixture with a dimmer
                                  resetting pan/tilt/color channels to black instead of just
                                  turning off the dimmer, which snapped the head out of position (#6990)
+    -bug (derwin12)              Fix Export House Preview Video appearing to hang when the House
+                                 Preview is undocked with Keep on Top enabled - its window was
+                                 covering the export dialogs (#7003)
+    -enh (derwin12)              House Preview's "Keep on Top" setting is now remembered across
+                                 restarts and reapplied automatically when it's undocked again
     -bug (derwin12)              Fix Auto Map import not mapping node-level effects (Dimmer, Pan,
                                  Tilt, etc.) on DMX moving-head strings when the model's strand also
                                  had its own effects (#7000)

--- a/src-ui-wx/layout/HousePreviewPanel.cpp
+++ b/src-ui-wx/layout/HousePreviewPanel.cpp
@@ -186,6 +186,10 @@ void HousePreviewPanel::OnResize(wxSizeEvent& event)
 
 void HousePreviewPanel::ValidateWindow(const wxSize& size)
 {
+    if (!_xLights->IsPaneDocked(this) && _xLights->HousePreviewKeepOnTop() && !_modelPreview->IsKeptOnTop()) {
+        _modelPreview->SetKeptOnTop(true);
+    }
+
     if (_showToolbar)
     {
         if (size.GetWidth() > 400 && size.GetHeight() > 300 && ! _xLights->IsPaneDocked(this))

--- a/src-ui-wx/layout/ModelPreview.cpp
+++ b/src-ui-wx/layout/ModelPreview.cpp
@@ -22,6 +22,13 @@
     #include <GL/gl.h>
 #endif
 
+#ifdef __WXMSW__
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
 #include "layout/ModelPreview.h"
 #include "models/Model.h"
 #include "models/ViewObject.h"
@@ -1339,7 +1346,7 @@ void ModelPreview::rightClick(wxMouseEvent& event) {
             if (topLevel != xlights) {
                 mnu.AppendSeparator();
                 wxMenuItem* keepOnTopItem = mnu.Append(0x3001, "Keep on Top", wxEmptyString, wxITEM_CHECK);
-                keepOnTopItem->Check(topLevel->GetWindowStyleFlag() & wxSTAY_ON_TOP);
+                keepOnTopItem->Check(IsKeptOnTop());
             }
             mnu.Connect(wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)& ModelPreview::OnPopup, nullptr, this);
             PopupMenu(&mnu);
@@ -1377,10 +1384,10 @@ void ModelPreview::OnPopup(wxCommandEvent& event)
     } else if (id == 0x1000) {
         is3d = !is3d;
     } else if (id == 0x3000) {
-        wxWindow* topLevel = wxGetTopLevelParent(this);
-        if (topLevel != xlights) {
-            long style = topLevel->GetWindowStyleFlag();
-            topLevel->SetWindowStyleFlag(style & wxSTAY_ON_TOP ? style & ~wxSTAY_ON_TOP : style | wxSTAY_ON_TOP);
+        bool nowOnTop = !IsKeptOnTop();
+        SetKeptOnTop(nowOnTop);
+        if (xlights != nullptr && this == xlights->GetHousePreviewModelPreview()) {
+            xlights->SetHousePreviewKeepOnTop(nowOnTop);
         }
     } else if (is3d) {
         long camIdx = event.GetId() - CAMERA_LOAD_BASE;
@@ -1465,6 +1472,49 @@ ModelPreview::ModelPreview(wxPanel* parent, xLightsFrame *xl)
     is3d = false;
     Mouse3DManager::INSTANCE.enableMotionEvents(this);
     SetMinSize(wxSize(50, 50));
+}
+
+bool ModelPreview::IsKeptOnTop() const
+{
+    wxWindow* topLevel = wxGetTopLevelParent(const_cast<ModelPreview*>(this));
+    if (topLevel == nullptr || topLevel == xlights) {
+        return false;
+    }
+#ifdef __WXMSW__
+    HWND floatingHwnd = (HWND)topLevel->GetHWND();
+    HWND xlightsHwnd = xlights != nullptr ? (HWND)xlights->GetHWND() : nullptr;
+    return floatingHwnd != nullptr && (HWND)::GetWindowLongPtr(floatingHwnd, GWLP_HWNDPARENT) == xlightsHwnd;
+#else
+    return (topLevel->GetWindowStyleFlag() & wxSTAY_ON_TOP) != 0;
+#endif
+}
+
+void ModelPreview::SetKeptOnTop(bool onTop)
+{
+    wxWindow* topLevel = wxGetTopLevelParent(this);
+    if (topLevel == nullptr || topLevel == xlights) {
+        return;
+    }
+#ifdef __WXMSW__
+    // A native owned-window relationship (GWLP_HWNDPARENT) keeps topLevel
+    // above xlights only -- not above every other application on the desktop
+    // like wxSTAY_ON_TOP does -- and the OS enforces it on its own, so unlike
+    // re-Raise()-ing on activate it can't steal the click used to reactivate
+    // xlights. xlights' own dialogs are owned windows too, so they still come
+    // to the front normally instead of being hidden behind this (#7003).
+    HWND floatingHwnd = (HWND)topLevel->GetHWND();
+    HWND xlightsHwnd = xlights != nullptr ? (HWND)xlights->GetHWND() : nullptr;
+    if (floatingHwnd == nullptr || xlightsHwnd == nullptr) {
+        return;
+    }
+    ::SetWindowLongPtr(floatingHwnd, GWLP_HWNDPARENT, onTop ? (LONG_PTR)xlightsHwnd : 0);
+    if (onTop) {
+        ::SetWindowPos(floatingHwnd, xlightsHwnd, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+    }
+#else
+    long style = topLevel->GetWindowStyleFlag();
+    topLevel->SetWindowStyleFlag(onTop ? style | wxSTAY_ON_TOP : style & ~wxSTAY_ON_TOP);
+#endif
 }
 
 ModelPreview::~ModelPreview()

--- a/src-ui-wx/layout/ModelPreview.h
+++ b/src-ui-wx/layout/ModelPreview.h
@@ -86,6 +86,10 @@ public:
     bool StartDrawing(double pointSize, bool fromPaint = false) override;
     void SetPointSize(wxDouble pointSize);
     void Reset();
+    // "Keep on Top" for this preview when undocked. Only meaningful once
+    // undocked (i.e. wxGetTopLevelParent(this) != xlights); no-ops otherwise.
+    bool IsKeptOnTop() const;
+    void SetKeptOnTop(bool onTop);
     void EndDrawing(bool swapBuffers=true) override;
 	void SetCanvasSize(int width,int height);
     void SetVirtualCanvasSize(int width, int height);

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -1587,6 +1587,9 @@ xLightsFrame::xLightsFrame(wxWindow* parent, int ab, wxWindowID id, bool renderO
     config->Read("xLightsAutoShowHousePreview", &_autoShowHousePreview, false);
     spdlog::debug("Autoshow House Preview: {}.", toStr(_autoShowHousePreview));
 
+    config->Read("xLightsHousePreviewKeepOnTop", &_housePreviewKeepOnTop, false);
+    spdlog::debug("House Preview Keep on Top: {}.", toStr(_housePreviewKeepOnTop));
+
     config->Read("xLightsZoomMethodToCursor", &_zoomMethodToCursor, true);
     spdlog::debug("Zoom Method To Cursor: {}.", toStr(_zoomMethodToCursor));
 
@@ -7445,6 +7448,17 @@ void xLightsFrame::SetShowBaseShowFolder(bool b)
 void xLightsFrame::SetAutoShowHousePreview(bool b)
 {
     _autoShowHousePreview = b;
+}
+
+ModelPreview* xLightsFrame::GetHousePreviewModelPreview() const
+{
+    return _housePreviewPanel != nullptr ? _housePreviewPanel->GetModelPreview() : nullptr;
+}
+
+void xLightsFrame::SetHousePreviewKeepOnTop(bool b)
+{
+    _housePreviewKeepOnTop = b;
+    wxConfigBase::Get()->Write("xLightsHousePreviewKeepOnTop", b);
 }
 
 void xLightsFrame::SetZoomMethodToCursor(bool b)

--- a/src-ui-wx/xLightsMain.h
+++ b/src-ui-wx/xLightsMain.h
@@ -1084,6 +1084,7 @@ public:
     bool _playControlsOnPreview = true;
     bool _showBaseShowFolder = false;
     bool _autoShowHousePreview = false;
+    bool _housePreviewKeepOnTop = false;
     bool _zoomMethodToCursor = true;
     bool _hidePresetPreview = false;
     bool _disableKeyAcceleration = false;
@@ -1352,6 +1353,10 @@ public:
 
     bool AutoShowHousePreview() const { return _autoShowHousePreview;}
     void SetAutoShowHousePreview(bool b);
+
+    bool HousePreviewKeepOnTop() const { return _housePreviewKeepOnTop; }
+    void SetHousePreviewKeepOnTop(bool b);
+    ModelPreview* GetHousePreviewModelPreview() const;
 
     bool ZoomMethodToCursor() const { return _zoomMethodToCursor;}
     void SetZoomMethodToCursor(bool b);


### PR DESCRIPTION
Also save the Keep On Top setting. Keep On Top means only on top of xLights - other apps can still cover the house preview.