### PR TITLE
#7002 - Fix/timer pending livelock

### DIFF
--- a/src-ui-wx/shared/utils/xLightsTimer.cpp
+++ b/src-ui-wx/shared/utils/xLightsTimer.cpp
@@ -238,11 +238,17 @@ void xLightsTimer::Notify() {
 }
 
 void xLightsTimer::DoSendTimer() {
-    // Cleared before delivering rather than after: a frame that overruns the
-    // interval by any amount would otherwise discard the tick that lands while it
-    // is still running and give up a whole interval, which is enough to drop the
-    // output frame.
-    _pending = false;
+    // Cleared only once the frame has been delivered. Clearing first lets a tick
+    // that lands mid-frame queue another CallAfter, and
+    // wxEvtHandler::ProcessPendingEvents loops until its queue is empty - with a
+    // frame slower than the interval it never is, so the main loop stops
+    // servicing paint and input and the app hangs.
+    struct ClearOnExit {
+        std::atomic<bool>& flag;
+        ~ClearOnExit() {
+            flag = false;
+        }
+    } clearOnExit{ _pending };
     wxTimer::Notify();
 }
 

--- a/xLights-Test/xLights-Test.vcxproj.user
+++ b/xLights-Test/xLights-Test.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/xLights/xLights.sln
+++ b/xLights/xLights.sln
@@ -25,13 +25,9 @@ Global
 		{48F219FA-C28E-457B-9A85-DC3A8F949F9B}.Release|x64.ActiveCfg = Release|x64
 		{48F219FA-C28E-457B-9A85-DC3A8F949F9B}.Release|x64.Build.0 = Release|x64
 		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Debug|ARM64EC.ActiveCfg = Debug|x64
-		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Debug|ARM64EC.Build.0 = Debug|x64
 		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Debug|x64.ActiveCfg = Debug|x64
-		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Debug|x64.Build.0 = Debug|x64
 		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Release|ARM64EC.ActiveCfg = Release|x64
-		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Release|ARM64EC.Build.0 = Release|x64
 		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Release|x64.ActiveCfg = Release|x64
-		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/xLights/xLights.sln
+++ b/xLights/xLights.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.5.33209.295
+# Visual Studio Version 18
+VisualStudioVersion = 18.9.12112.369 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "xLights", "xLights.vcxproj", "{48F219FA-C28E-457B-9A85-DC3A8F949F9B}"
 EndProject
@@ -25,10 +24,14 @@ Global
 		{48F219FA-C28E-457B-9A85-DC3A8F949F9B}.Release|ARM64EC.Build.0 = Release|ARM64EC
 		{48F219FA-C28E-457B-9A85-DC3A8F949F9B}.Release|x64.ActiveCfg = Release|x64
 		{48F219FA-C28E-457B-9A85-DC3A8F949F9B}.Release|x64.Build.0 = Release|x64
-		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Debug|ARM64EC.ActiveCfg = Debug|ARM64EC
+		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Debug|ARM64EC.ActiveCfg = Debug|x64
+		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Debug|ARM64EC.Build.0 = Debug|x64
 		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Debug|x64.ActiveCfg = Debug|x64
-		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Release|ARM64EC.ActiveCfg = Release|ARM64EC
+		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Debug|x64.Build.0 = Debug|x64
+		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Release|ARM64EC.ActiveCfg = Release|x64
+		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Release|ARM64EC.Build.0 = Release|x64
 		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Release|x64.ActiveCfg = Release|x64
+		{F6E38B1E-E34C-428D-B081-5719BDDCE385}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
---Fixes #7002 — 40fps animation freezes xLights on Windows.

xLightsTimer::DoSendTimer() cleared _pending before running wxTimer::Notify(). _pending is the only cap on outstanding CallAfters, so while a frame was being delivered the flag read false and the next thread-pool tick queued another one. wxAppConsoleBase::ProcessPendingEvents loops while (!m_handlersWithPendingEvents.IsEmpty()) — once a frame took longer than the timer interval the handler re-added itself faster than the loop drained it, so the loop never exited: no repaint, no input, "Not Responding" until the process was killed. Only a marginal overrun is needed (26ms against a 25ms interval is enough), which is why 40fps hangs and 20fps doesn't.

Clear _pending only after delivery, via a scope guard so an exception escaping Notify() can't leave the flag stuck true and silently kill playback (SafelyProcessEvent catches outside our frame).

Windows-only. macOS drives the timer from a main-thread CADisplayLink and Linux from a GLib timeout — neither hands the tick across a thread boundary, so neither can accumulate a backlog.

Testing: New sequence → Animation → 40fps → Quick Start → drop an effect on a model. Also worth a pass on the Pixel Test dialog, the only other xLightsTimer user.

Two things I'd flag for the reviewer, since I couldn't settle them here:

- Smoothness at 40fps is a separate question from the hang. A tick is now dropped only when the frame itself overran the interval. If frames fit in 25ms you get a true 40fps — better than 2026.15, which per Dan's measurements delivered a median 31.3ms tick and couldn't reach 40fps at all. If frames don't fit, the fix stops the hang but the effective rate drops, and no timer policy can fix that. We never measured actual frame cost on your box, so that's genuinely open.
- The lever if it turns out to be marginal is NeedToRenderFrame in tabSequencer.cpp:2749, which unconditionally returns true on Windows/Linux while macOS throttles per-canvas against screen present time.