### PR TITLE
Fix deleting a model leaving submodel entries behind in model groups (#7018)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -49,6 +49,9 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                  zero height and disappearing with no divider left to grab it back,
                                  which persisted across restarts; also fix Reset to Defaults not
                                  actually restoring it once collapsed (#7008)
+    -bug (derwin12)              Fix deleting a model leaving its submodels behind in any model
+                                 group it belonged to, showing as invalid entries in the group's
+                                 model list (#7018)
     -bug (dkulp)                 FPP Connect: fix a crash uploading controller config to a
                                  controller with no known capabilities or a multicast-only address
     -bug (dkulp)                 Fix a crash from two threads draining the finished-render list at

--- a/src-core/models/ModelGroup.cpp
+++ b/src-core/models/ModelGroup.cpp
@@ -886,17 +886,21 @@ void ModelGroup::AddModel(const std::string &name) {
 
 void ModelGroup::ModelRemoved(const std::string &oldName) {
     std::string trimmedOldName = Trim(oldName);
-    
-    // Remove all instances of the model from modelNames
+
+    // Remove all instances of the model from modelNames, including submodel
+    // references stored as "BaseName/SubModel" (see ModelRenamed for the
+    // same base-name extraction).
     auto it = modelNames.begin();
     while (it != modelNames.end()) {
-        if (Trim(*it) == trimmedOldName) {
+        std::string trimmed = Trim(*it);
+        std::string base = trimmed.substr(0, trimmed.find('/'));
+        if (trimmed == trimmedOldName || base == trimmedOldName) {
             it = modelNames.erase(it);
         } else {
             ++it;
         }
     }
-    
+
     // Rebuild the models and activeModels vectors from modelNames
     ResetModels();
 }


### PR DESCRIPTION
When deleting a model, delete the model from all groups and also delete all the submodels as well. Dont orphan submodels.