### PR TITLE
Sanitize Face/State names the same way SubModel names already are (#7026)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,9 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.17  September ??, 2026
 
+    -bug (derwin12)              Face and State definition names can no longer contain commas or other
+                                 characters that submodel names already disallow, whether typed in or
+                                 brought in from an imported model file (#7026)
     -bug (dkulp)                 Fix a crash generating the preview for a video effect - the decoded
                                  frame is now copied using its own size and pixel format
     -bug (dkulp)                 Fix a crash rendering a Moving Head effect whose colour setting held

--- a/src-core/XmlSerializer/XmlSerializeFunctions.cpp
+++ b/src-core/XmlSerializer/XmlSerializeFunctions.cpp
@@ -199,7 +199,7 @@ std::vector<std::vector<std::vector<int>>> ParseCustomModelDataFromXml(pugi::xml
 }
 
 void DeserializeFaceInfo(pugi::xml_node f, FaceStateData & faceInfo) {
-    std::string name = f.attribute(XmlNodeKeys::StateNameAttribute).as_string("SingleNode");
+    std::string name = Model::SafeModelName(f.attribute(XmlNodeKeys::StateNameAttribute).as_string("SingleNode"));
     std::string type = f.attribute(XmlNodeKeys::StateTypeAttribute).as_string("SingleNode");
     if (name.empty()) {
         name = type;
@@ -230,7 +230,7 @@ void DeserializeFaceInfo(pugi::xml_node f, FaceStateData & faceInfo) {
 }
 
 void DeserializeStateInfo(pugi::xml_node f, FaceStateData & stateInfo) {
-    std::string name = f.attribute(XmlNodeKeys::StateNameAttribute).as_string("SingleNode");
+    std::string name = Model::SafeModelName(f.attribute(XmlNodeKeys::StateNameAttribute).as_string("SingleNode"));
     std::string type = f.attribute(XmlNodeKeys::StateTypeAttribute).as_string("SingleNode");
     if (name.empty()) {
         name = type;
@@ -287,7 +287,7 @@ std::optional<CustomModelImportData> LoadCustomModelFromXml(pugi::xml_node node)
     CustomModelImportData data;
 
     // Load basic attributes
-    data.name = node.attribute("name").as_string();
+    data.name = Model::SafeModelName(node.attribute("name").as_string());
     // Read new attribute names first, fall back to old parm names
     data.width = !node.attribute("CustomWidth").empty() ?
         node.attribute("CustomWidth").as_int(1) : node.attribute("parm1").as_int(1);
@@ -324,7 +324,7 @@ std::optional<CustomModelImportData> LoadCustomModelFromXml(pugi::xml_node node)
         }
         else if (childName == "faceInfo") {
             CustomModelImportData::FaceData face;
-            face.name = child.attribute("Name").as_string();
+            face.name = Model::SafeModelName(child.attribute("Name").as_string());
             face.type = child.attribute("Type").as_string();
 
             if (face.type == "NodeRange") {
@@ -337,7 +337,7 @@ std::optional<CustomModelImportData> LoadCustomModelFromXml(pugi::xml_node node)
         }
         else if (childName == "stateInfo") {
             CustomModelImportData::StateData state;
-            state.name = child.attribute("Name").as_string();
+            state.name = Model::SafeModelName(child.attribute("Name").as_string());
             state.type = child.attribute("Type").as_string();
 
             if (state.type == "NodeRange") {
@@ -359,7 +359,7 @@ std::optional<SubModelImportData> ParseSubModelNode(pugi::xml_node node) {
     }
 
     SubModelImportData sm;
-    sm.name = Trim(node.attribute(XmlNodeKeys::NameAttribute).as_string());
+    sm.name = Model::SafeModelName(node.attribute(XmlNodeKeys::NameAttribute).as_string());
     sm.isRanges = std::string_view(node.attribute(XmlNodeKeys::SMTypeAttribute).as_string("ranges")) == "ranges";
     sm.vertical = std::string_view(node.attribute(XmlNodeKeys::LayoutAttribute).as_string("vertical")) == "vertical";
     sm.subBuffer = node.attribute(XmlNodeKeys::SubBufferAttribute).as_string();

--- a/src-ui-wx/model/ModelFacesPanel.cpp
+++ b/src-ui-wx/model/ModelFacesPanel.cpp
@@ -750,8 +750,8 @@ void ModelFacesPanel::OnButtonMatrixAddClicked(wxCommandEvent& event)
 {
     wxTextEntryDialog dlg(this, "New Face", "Enter name for new face definition");
     if (dlg.ShowModal() == wxID_OK) {
-        std::string n = dlg.GetValue().ToStdString();
-        if (NameChoice->FindString(n) == wxNOT_FOUND) {
+        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString());
+        if (!n.empty() && NameChoice->FindString(n) == wxNOT_FOUND) {
             NameChoice->Append(n);
             NameChoice->SetStringSelection(n);
             SelectFaceModel(n);
@@ -1829,8 +1829,8 @@ void ModelFacesPanel::CopyFaceData()
     auto const& currentName = NameChoice->GetString(index);
     wxTextEntryDialog dlg(this, "Copy Face", "Enter name for copied face definition", currentName);
     if (dlg.ShowModal() == wxID_OK) {
-        std::string n = dlg.GetValue().ToStdString();
-        if (NameChoice->FindString(n) == wxNOT_FOUND) {
+        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString());
+        if (!n.empty() && NameChoice->FindString(n) == wxNOT_FOUND) {
             NameChoice->Append(n);
 
             faceData[n] = faceData[currentName];
@@ -1852,8 +1852,8 @@ void ModelFacesPanel::RenameFace()
     auto const& currentName = NameChoice->GetString(index);
     wxTextEntryDialog dlg(this, "Rename Face", "Enter new name for face definition", currentName);
     if (dlg.ShowModal() == wxID_OK) {
-        std::string n = dlg.GetValue().ToStdString();
-        if (NameChoice->FindString(n) == wxNOT_FOUND) {
+        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString());
+        if (!n.empty() && NameChoice->FindString(n) == wxNOT_FOUND) {
             NameChoice->Delete(index);
             NameChoice->Insert(n, index);
 

--- a/src-ui-wx/model/ModelStatesPanel.cpp
+++ b/src-ui-wx/model/ModelStatesPanel.cpp
@@ -586,8 +586,8 @@ void ModelStatesPanel::OnButtonMatrixAddClicked(wxCommandEvent& event)
 {
     wxTextEntryDialog dlg(this, "New State Model", "Enter name for new state model definition");
     if (dlg.ShowModal() == wxID_OK) {
-        std::string n = dlg.GetValue().ToStdString();
-        if (NameChoice->FindString(n) == wxNOT_FOUND) {
+        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString());
+        if (!n.empty() && NameChoice->FindString(n) == wxNOT_FOUND) {
             NameChoice->Append(n);
             NameChoice->SetStringSelection(n);
             NameChoice->Enable();
@@ -1520,8 +1520,8 @@ void ModelStatesPanel::ImportStatesFromSubModels()
     }
     wxTextEntryDialog dlg(this, "New State Model", "Enter name for new state model definition");
     if (dlg.ShowModal() == wxID_OK) {
-        std::string name = dlg.GetValue().ToStdString();
-        if (NameChoice->FindString(name) == wxNOT_FOUND) {
+        std::string name = Model::SafeModelName(dlg.GetValue().ToStdString());
+        if (!name.empty() && NameChoice->FindString(name) == wxNOT_FOUND) {
             NameChoice->Append(name);
             NameChoice->SetStringSelection(name);
             NameChoice->Enable();
@@ -1974,8 +1974,8 @@ void ModelStatesPanel::CopyStateData()
     auto const& currentName = NameChoice->GetString(index);
     wxTextEntryDialog dlg(this, "Copy State", "Enter name for copied state definition", currentName);
     if (dlg.ShowModal() == wxID_OK) {
-        std::string n = dlg.GetValue().ToStdString();
-        if (NameChoice->FindString(n) == wxNOT_FOUND) {
+        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString());
+        if (!n.empty() && NameChoice->FindString(n) == wxNOT_FOUND) {
             NameChoice->Append(n);
 
             stateData[n] = stateData[currentName];
@@ -1997,8 +1997,8 @@ void ModelStatesPanel::RenameState()
     auto const& currentName = NameChoice->GetString(index);
     wxTextEntryDialog dlg(this, "Rename State", "Enter new name for state definition", currentName);
     if (dlg.ShowModal() == wxID_OK) {
-        std::string n = dlg.GetValue().ToStdString();
-        if (NameChoice->FindString(n) == wxNOT_FOUND) {
+        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString());
+        if (!n.empty() && NameChoice->FindString(n) == wxNOT_FOUND) {
             NameChoice->Delete(index);
             NameChoice->Insert(n, index);
 


### PR DESCRIPTION
Special characters in names can cause many issues .. we blocked on submodels but didnt on states and faces.

This code also introduces a check on the .xmodel imports.