### PR TITLE
Set preferred input protocol to 'DDP' on newly added WLED controllers

### DIFF
--- a/resources/controllers/wled.xcontroller
+++ b/resources/controllers/wled.xcontroller
@@ -37,6 +37,7 @@
             <Protocol>ddp</Protocol>
             <Protocol>artnet</Protocol>
         </InputProtocols>
+        <PreferredInputProtocol>DDP</PreferredInputProtocol>
         <ConfigDriver>WLED</ConfigDriver>
     </AbstractVariant>
     <AbstractVariant Name="ESP32WLEDSettings" Base="WLED:BaseWLEDSettings">


### PR DESCRIPTION
# Set preferred input protocol to 'DDP' on newly added WLED controllers

## Summary
Adds `<PreferredInputProtocol>DDP</PreferredInputProtocol>` to `resources/controllers/wled.xcontroller`, changing the default recommended protocol for WLED devices from E1.31 to DDP.

## Motivation
E1.31/sACN currently ships as the default for WLED controllers, but DDP is a better fit for these devices:

- **Lower overhead** — DDP has a simpler, more compact packet structure than E1.31, which uses less efficient sACN/DMX-style framing.
- **Higher effective throughput** — the reduced overhead lets DDP push more pixel data per packet, which matters as WLED-based prop pixel counts grow.
- **Native, mature WLED support** — WLED has had solid, actively maintained DDP support for some time, so switching the default carries no compatibility risk.
- **More consistent timing** — users running larger WLED layouts have reported steadier frame timing on DDP versus E1.31 in real-world shows.

Since `wled.xcontroller` drives the auto-configuration/recommendation logic in the WLED controller wizard, this change means new WLED controllers added in xLights will default to DDP instead of E1.31, saving users a manual protocol switch and steering them toward the better-performing option out of the box.

## Change
- Single-line addition of `<PreferredInputProtocol>DDP</PreferredInputProtocol>` to `resources/controllers/wled.xcontroller`.
- Only affects the default/recommended protocol for new WLED controllers — existing configurations that already specify E1.31 or another protocol are unaffected.

## Testing
- Verified the updated `.xcontroller` file loads correctly and the WLED controller wizard now proposes DDP as the default.
- Confirmed existing WLED configurations already set to E1.31 are unaffected and continue to work as before.