### PR TITLE
Restore ability to have @ in submodel, faces, state names

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,6 +12,9 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
 ---------------------------------
 2026.17  September ??, 2026
 
+    -change (derwin12)           SubModel, Face and State definition names can once again contain the
+                                 '@' character - it is still stripped from top-level model names, which
+                                 use it as a start channel reference syntax
     -bug (dkulp)                 The Batch Render dialog no longer flashes a progress window while it
                                  scans for sequences unless the scan is actually slow, and it updates
                                  that window far less often when it is shown

--- a/src-core/XmlSerializer/XmlSerializeFunctions.cpp
+++ b/src-core/XmlSerializer/XmlSerializeFunctions.cpp
@@ -199,7 +199,7 @@ std::vector<std::vector<std::vector<int>>> ParseCustomModelDataFromXml(pugi::xml
 }
 
 void DeserializeFaceInfo(pugi::xml_node f, FaceStateData & faceInfo) {
-    std::string name = Model::SafeModelName(f.attribute(XmlNodeKeys::StateNameAttribute).as_string("SingleNode"));
+    std::string name = Model::SafeModelName(f.attribute(XmlNodeKeys::StateNameAttribute).as_string("SingleNode"), true);
     std::string type = f.attribute(XmlNodeKeys::StateTypeAttribute).as_string("SingleNode");
     if (name.empty()) {
         name = type;
@@ -230,7 +230,7 @@ void DeserializeFaceInfo(pugi::xml_node f, FaceStateData & faceInfo) {
 }
 
 void DeserializeStateInfo(pugi::xml_node f, FaceStateData & stateInfo) {
-    std::string name = Model::SafeModelName(f.attribute(XmlNodeKeys::StateNameAttribute).as_string("SingleNode"));
+    std::string name = Model::SafeModelName(f.attribute(XmlNodeKeys::StateNameAttribute).as_string("SingleNode"), true);
     std::string type = f.attribute(XmlNodeKeys::StateTypeAttribute).as_string("SingleNode");
     if (name.empty()) {
         name = type;
@@ -324,7 +324,7 @@ std::optional<CustomModelImportData> LoadCustomModelFromXml(pugi::xml_node node)
         }
         else if (childName == "faceInfo") {
             CustomModelImportData::FaceData face;
-            face.name = Model::SafeModelName(child.attribute("Name").as_string());
+            face.name = Model::SafeModelName(child.attribute("Name").as_string(), true);
             face.type = child.attribute("Type").as_string();
 
             if (face.type == "NodeRange") {
@@ -337,7 +337,7 @@ std::optional<CustomModelImportData> LoadCustomModelFromXml(pugi::xml_node node)
         }
         else if (childName == "stateInfo") {
             CustomModelImportData::StateData state;
-            state.name = Model::SafeModelName(child.attribute("Name").as_string());
+            state.name = Model::SafeModelName(child.attribute("Name").as_string(), true);
             state.type = child.attribute("Type").as_string();
 
             if (state.type == "NodeRange") {
@@ -359,7 +359,7 @@ std::optional<SubModelImportData> ParseSubModelNode(pugi::xml_node node) {
     }
 
     SubModelImportData sm;
-    sm.name = Model::SafeModelName(node.attribute(XmlNodeKeys::NameAttribute).as_string());
+    sm.name = Model::SafeModelName(node.attribute(XmlNodeKeys::NameAttribute).as_string(), true);
     sm.isRanges = std::string_view(node.attribute(XmlNodeKeys::SMTypeAttribute).as_string("ranges")) == "ranges";
     sm.vertical = std::string_view(node.attribute(XmlNodeKeys::LayoutAttribute).as_string("vertical")) == "vertical";
     sm.subBuffer = node.attribute(XmlNodeKeys::SubBufferAttribute).as_string();

--- a/src-core/models/Model.h
+++ b/src-core/models/Model.h
@@ -89,11 +89,16 @@ public:
     Model(const ModelManager& manager);
     virtual ~Model();
     static std::vector<std::string> GetLayoutGroups(const ModelManager& mm);
-    static std::string SafeModelName(const std::string& name)
+    // allowAt: submodel/face/state names may contain '@' since, unlike a top-level
+    // model name, they are never parsed as an "@ModelName:1" start-channel reference.
+    static std::string SafeModelName(const std::string& name, bool allowAt = false)
     {
         std::string n = Trim(name);
-        for (char c : {',', '~', '!', ';', '<', '>', '"', '\'', '&', ':', '|', '@', '/', '\\', '\t', '\r', '\n'}) {
+        for (char c : {',', '~', '!', ';', '<', '>', '"', '\'', '&', ':', '|', '/', '\\', '\t', '\r', '\n'}) {
             std::erase(n, c);
+        }
+        if (!allowAt) {
+            std::erase(n, '@');
         }
         // Other characters I could remove
         // $%^*()?|][{}`.

--- a/src-ui-wx/model/ModelFacesPanel.cpp
+++ b/src-ui-wx/model/ModelFacesPanel.cpp
@@ -750,7 +750,7 @@ void ModelFacesPanel::OnButtonMatrixAddClicked(wxCommandEvent& event)
 {
     wxTextEntryDialog dlg(this, "New Face", "Enter name for new face definition");
     if (dlg.ShowModal() == wxID_OK) {
-        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString());
+        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString(), true);
         if (!n.empty() && NameChoice->FindString(n) == wxNOT_FOUND) {
             NameChoice->Append(n);
             NameChoice->SetStringSelection(n);
@@ -1828,7 +1828,7 @@ void ModelFacesPanel::CopyFaceData()
     auto const& currentName = NameChoice->GetString(index);
     wxTextEntryDialog dlg(this, "Copy Face", "Enter name for copied face definition", currentName);
     if (dlg.ShowModal() == wxID_OK) {
-        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString());
+        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString(), true);
         if (!n.empty() && NameChoice->FindString(n) == wxNOT_FOUND) {
             NameChoice->Append(n);
 
@@ -1851,7 +1851,7 @@ void ModelFacesPanel::RenameFace()
     auto const& currentName = NameChoice->GetString(index);
     wxTextEntryDialog dlg(this, "Rename Face", "Enter new name for face definition", currentName);
     if (dlg.ShowModal() == wxID_OK) {
-        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString());
+        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString(), true);
         if (!n.empty() && NameChoice->FindString(n) == wxNOT_FOUND) {
             NameChoice->Delete(index);
             NameChoice->Insert(n, index);

--- a/src-ui-wx/model/ModelStatesPanel.cpp
+++ b/src-ui-wx/model/ModelStatesPanel.cpp
@@ -586,7 +586,7 @@ void ModelStatesPanel::OnButtonMatrixAddClicked(wxCommandEvent& event)
 {
     wxTextEntryDialog dlg(this, "New State Model", "Enter name for new state model definition");
     if (dlg.ShowModal() == wxID_OK) {
-        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString());
+        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString(), true);
         if (!n.empty() && NameChoice->FindString(n) == wxNOT_FOUND) {
             NameChoice->Append(n);
             NameChoice->SetStringSelection(n);
@@ -1519,7 +1519,7 @@ void ModelStatesPanel::ImportStatesFromSubModels()
     }
     wxTextEntryDialog dlg(this, "New State Model", "Enter name for new state model definition");
     if (dlg.ShowModal() == wxID_OK) {
-        std::string name = Model::SafeModelName(dlg.GetValue().ToStdString());
+        std::string name = Model::SafeModelName(dlg.GetValue().ToStdString(), true);
         if (!name.empty() && NameChoice->FindString(name) == wxNOT_FOUND) {
             NameChoice->Append(name);
             NameChoice->SetStringSelection(name);
@@ -1973,7 +1973,7 @@ void ModelStatesPanel::CopyStateData()
     auto const& currentName = NameChoice->GetString(index);
     wxTextEntryDialog dlg(this, "Copy State", "Enter name for copied state definition", currentName);
     if (dlg.ShowModal() == wxID_OK) {
-        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString());
+        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString(), true);
         if (!n.empty() && NameChoice->FindString(n) == wxNOT_FOUND) {
             NameChoice->Append(n);
 
@@ -1996,7 +1996,7 @@ void ModelStatesPanel::RenameState()
     auto const& currentName = NameChoice->GetString(index);
     wxTextEntryDialog dlg(this, "Rename State", "Enter new name for state definition", currentName);
     if (dlg.ShowModal() == wxID_OK) {
-        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString());
+        std::string n = Model::SafeModelName(dlg.GetValue().ToStdString(), true);
         if (!n.empty() && NameChoice->FindString(n) == wxNOT_FOUND) {
             NameChoice->Delete(index);
             NameChoice->Insert(n, index);

--- a/src-ui-wx/model/SubModelsPanel.cpp
+++ b/src-ui-wx/model/SubModelsPanel.cpp
@@ -1452,7 +1452,7 @@ void SubModelsPanel::ApplySubmodelName()
     int index = GetSelectedIndex();
     wxASSERT(index >= 0);
 
-    wxString name = wxString(Model::SafeModelName(TextCtrl_Name->GetValue().ToStdString()));
+    wxString name = wxString(Model::SafeModelName(TextCtrl_Name->GetValue().ToStdString(), true));
 
     if (name.IsEmpty()) {
         TextCtrl_Name->SetBackgroundColour(*wxRED);
@@ -2232,7 +2232,7 @@ void SubModelsPanel::Generate()
         return;
 
     for (int i = 0; i < dialog.GetCount(); i++) {
-        wxString basename = wxString(Model::SafeModelName(dialog.GetBaseName().ToStdString()));
+        wxString basename = wxString(Model::SafeModelName(dialog.GetBaseName().ToStdString(), true));
         wxString name = GenerateSubModelName(basename);
 
         if (GetSubModelInfoIndex(name) != -1) {


### PR DESCRIPTION
During .16.1 testing found that @ was used in legacy Boscoyo prop submodels and faces - so restoring that ability.