### PR TITLE
Layout Models tree: Model Set actions on the right-click menu

### DIFF
--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -11060,6 +11060,10 @@ void LayoutPanel::OnModelsPopup(wxCommandEvent& event) {
         RemoveSelectedModelsFromGroup();
     } else if (id == ID_MNU_EDIT_SUBMODEL_ALIAS) {
         EditSubModelAlias();
+    } else if (id == ID_PREVIEW_MODEL_LINKASSET) {
+        // "Link as Set..." from the models-tree right-click (the Set submenu
+        // routes itself to OnPreviewModelPopup).
+        DoLinkAsSet();
     } else if (event.GetId() == ID_PREVIEW_REPLACEMODEL) {
         ReplaceModel();
     } else if (event.GetId() == ID_PREVIEW_MODEL_NODELAYOUT) {
@@ -12620,6 +12624,15 @@ void LayoutPanel::OnItemContextMenu(wxTreeListEvent& event)
     }
     if (foundOverlapping) {
         mnuContext.Append(ID_MNU_MAKEALLSCNOTOVERLAPPING, "Make All Start Channels Not Overlapping");
+    }
+
+    // Model Set actions (Link as Set / add / remove / manage), same as the
+    // preview right-click. Only for a plain model selection - not groups or
+    // submodels, which Sets don't operate on. The "Set" submenu self-binds to
+    // OnPreviewModelPopup; the top-level "Link as Set..." is routed below in
+    // OnModelsPopup.
+    if (selectedTreeModels.size() >= 1 && (selectedTreeGroups.size() + selectedTreeSubModels.size()) == 0) {
+        AddModelSetOptionsToMenu(mnuContext);
     }
 
     mnuContext.Connect(wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)&LayoutPanel::OnModelsPopup, nullptr, this);


### PR DESCRIPTION
## What
Model Set actions were only reachable from the **preview** right-click, not from the **Models tree** (Layout → Models). This adds the same actions to the tree's right-click menu:

- Select 2+ loose models → **Link as Set…**
- Right-click models already in a Set → **Set ▸** submenu (Add Selected to Set / Remove from Set / Rename / Manage / Delete)

## How
- `OnItemContextMenu` now calls the existing `AddModelSetOptionsToMenu(mnuContext)` when the selection is models-only (no groups/submodels, which Sets don't operate on). That helper already decides between "Link as Set…" and the Set submenu based on selection, and reads canvas selection via `GetSelectedModelsForSetActions()`, which is populated by tree selection too.
- The Set submenu it builds already self-binds to `OnPreviewModelPopup`, so those items work as-is. The one top-level item, `ID_PREVIEW_MODEL_LINKASSET`, is dispatched through the tree menu's handler `OnModelsPopup`, so that handler now routes it to `DoLinkAsSet()`.

No duplicated logic — identical helper and `Do*` handlers as the preview path.

## Testing
Built (macOS Debug). Verified from the Models tree: multi-select shows "Link as Set…" and creates a working set; a model in a set shows the Set submenu; groups/submodels don't get the options.

## iPad parity
Desktop-only Layout context menu (`src-ui-wx/layout/`); Model Sets have no iPad surface. No iPad counterpart to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
