### PR TITLE
Visualizer: hide the shadowed model, not the shadow (fix #6802 regression)

### DIFF
--- a/src-ui-wx/setup/ControllerModelDialog.cpp
+++ b/src-ui-wx/setup/ControllerModelDialog.cpp
@@ -2415,9 +2415,24 @@ void ControllerModelDialog::ReloadModels()
     TextCtrl_Check->SetValue(check);
 
     wxString modelFilter = TextCtrl_ModelFilter->GetValue().Lower();
+
+    // Names of models that are shadowed by another model. A shadowed model's
+    // start channel is driven by its shadow, so it must NOT be placed on a port
+    // here (that would break the link) - hide it from the assignable list, while
+    // the shadow model itself stays assignable. #6802 hid the wrong side (it
+    // excluded models whose GetShadowModelFor was set - i.e. the shadows), which
+    // made shadow models impossible to place. Built once to stay O(N).
+    std::set<std::string> shadowedNames;
+    for (const auto& it : *_mm) {
+        const std::string sf = it.second->GetShadowModelFor();
+        if (!sf.empty()) {
+            shadowedNames.insert(sf);
+        }
+    }
+
     for (const auto& it : *_mm) {
         if (it.second->GetDisplayAs() != DisplayAsType::ModelGroup && it.second->IsActive() && it.second->GetLayoutGroup() != "Unassigned") {
-            if (it.second->GetShadowModelFor().empty() &&
+            if (shadowedNames.find(it.second->GetName()) == shadowedNames.end() &&
                 _cud->GetControllerPortModel(it.second->GetName(), 0) == nullptr &&
                 ((_autoLayout && !CheckBox_HideOtherControllerModels->GetValue()) || // hide models on other controllers not set
                     ((_autoLayout && CheckBox_HideOtherControllerModels->GetValue() && (it.second->GetController() == nullptr || _controller->GetName() == it.second->GetControllerName() || it.second->GetControllerName() == "" || it.second->GetControllerName() == NO_CONTROLLER || _controller->ContainsChannels(it.second->GetFirstChannel(), it.second->GetLastChannel()))) ||


### PR DESCRIPTION
## What
In the Controller Visualizer, **shadow models stopped appearing in the assignable-models list**, so they couldn't be placed on a controller port. This is a regression from #6802.

## Root cause
#6802 ("Autoset StartChannel for the shadowee…") intended to hide the **shadowed (original) model** from the visualizer — once a model is shadowed, its start channel is driven by its shadow, so placing it on a port would break that link. But the guard it added keyed off `GetShadowModelFor()`:

```cpp
if (it.second->GetShadowModelFor().empty() && ...) // only include NON-shadow models
```

`GetShadowModelFor()` is set on the **shadow** model, not the shadowee — so this hid the **shadows** (the models you actually want to place), while the shadowee stayed visible. Backwards.

## Fix
Hide the **shadowee** instead. Build the set of shadowed model names once (every model's non-empty `GetShadowModelFor()` target) and skip a model only when its own name is in that set:

```cpp
std::set<std::string> shadowedNames;
for (const auto& it : *_mm) {
    const std::string sf = it.second->GetShadowModelFor();
    if (!sf.empty()) shadowedNames.insert(sf);
}
...
if (shadowedNames.find(it.second->GetName()) == shadowedNames.end() &&
    _cud->GetControllerPortModel(it.second->GetName(), 0) == nullptr && ...)
```

Result:
- **Shadow model** → assignable again (can be dragged onto a port).
- **Shadowee** → hidden from the list (can't be placed and break the link), and its existing "…is shadowed by…" warning still shows.

Built once outside the loop, so it stays O(N) rather than the O(N²) that per-model `IsModelShadowing()`/`GetModelsShadowing()` would cost.

## Testing
Built (macOS Debug). Verified with a shadow-model show: the shadow appears and drops onto a port; the shadowee is absent from the assignable list and still warned about.

## iPad parity
Desktop-only setup UI (`src-ui-wx/setup/`); the visualizer has no iPad surface. No iPad counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
