### PR TITLE
Block Save Layout when a sequence is opened read-only

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -18,6 +18,8 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
     -bug (dkulp)                 macOS - Uncompressed .mov files whose rows are not a multiple of 8 bytes
                                  (for example 50 pixels wide, 24-bit) were flagged as unsupported when the
                                  sequence opened even though they render correctly
+    -bug (derwin12)              Opening a sequence in read only mode (.xsqz) no longer allows the
+                                 layout to be saved
 
 
 2026.17  September 8, 2026

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -4438,6 +4438,9 @@ void LayoutPanel::OnCheckBoxOverlapClick(wxCommandEvent& event)
 
 bool LayoutPanel::SaveEffects()
 {
+    if (xlights->IsReadOnlyMode()) {
+        return false;
+    }
     xlights->SaveEffectsFile();
     xlights->SetStatusText(_("Preview layout saved"));
     SetDirtyHiLight(false);

--- a/src-ui-wx/xLightsMain.cpp
+++ b/src-ui-wx/xLightsMain.cpp
@@ -2967,7 +2967,7 @@ void xLightsFrame::OnNotebook1PageChanged1(wxAuiNotebookEvent& event)
     if (pagenum == LAYOUTTAB) {
         GetOutputModelManager()->AddASAPWork(OutputModelManager::WORK_REDRAW_LAYOUTPREVIEW, "OnNotebook1PageChanged");
         SetStatusText(_(""));
-        MenuItem_File_Save->Enable(true);
+        MenuItem_File_Save->Enable(!readOnlyMode);
         MenuItem_File_Save->SetItemLabel("Save Layout\tCTRL-s");
         layoutPanel->RestoreFloatingPanes();
     } else if (pagenum == NEWSEQUENCER) {
@@ -7893,6 +7893,10 @@ void xLightsFrame::SaveCurrentTab()
 {
     switch (Notebook1->GetSelection()) {
     case LAYOUTTAB:
+        if (readOnlyMode) {
+            DisplayError("Layout cannot be saved in read only mode!", this);
+            break;
+        }
         layoutPanel->SaveEffects();
         SaveNetworksFile();
         break;


### PR DESCRIPTION
We block the sequence saves .. saving the layout doesnt make sense as it would be sitting in %temp%