### PR TITLE
Fix Layout tab falling back to "Unassigned" instead of "Default"

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -20,6 +20,8 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                  sequence opened even though they render correctly
     -bug (derwin12)              Opening a sequence in read only mode (.xsqz) no longer allows the
                                  layout to be saved
+    -bug (derwin12)              Layout tab could land on the "Unassigned" preview instead of "Default"
+                                 when the show's last-saved preview no longer existed, showing no models
 
 
 2026.17  September 8, 2026

--- a/src-ui-wx/app-shell/TabSequence.cpp
+++ b/src-ui-wx/app-shell/TabSequence.cpp
@@ -662,6 +662,11 @@ void xLightsFrame::LoadEffectsFile()
     if (!found_saved_preview) {
         mStoredLayoutGroup = "Default";
     }
+    // layoutPanel->Reset() above seeded the current group from the raw,
+    // unvalidated setting (before LayoutGroups was even populated), so any
+    // correction just made above never reached the panel or its dropdown.
+    // Re-sync both now that mStoredLayoutGroup is known-good.
+    layoutPanel->SyncCurrentLayoutGroupFromStored();
 
     mBackgroundBrightness = (int)std::strtol(GetXmlSetting("backgroundBrightness", "100").c_str(), nullptr, 10);
     mBackgroundAlpha = (int)std::strtol(GetXmlSetting("backgroundAlpha", "100").c_str(), nullptr, 10);

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -11949,6 +11949,17 @@ void LayoutPanel::SwitchChoiceToCurrentLayoutGroup() {
     }
 }
 
+// Reset() (above) seeds the current group from xlights->GetStoredLayoutGroup()
+// before the caller has finished validating it against the just-loaded
+// LayoutGroups (a stored preview name that no longer exists gets corrected to
+// "Default" only after Reset() already ran). Call this once that correction is
+// done so the panel and its dropdown reflect the corrected value instead of
+// the raw, possibly-stale one.
+void LayoutPanel::SyncCurrentLayoutGroupFromStored() {
+    SetCurrentLayoutGroup(xlights->GetStoredLayoutGroup());
+    SwitchChoiceToCurrentLayoutGroup();
+}
+
 void LayoutPanel::DeleteCurrentPreview() {
     if (wxMessageBox("Are you sure you want to delete the " + currentLayoutGroup + " preview?", "Confirm Delete?", wxICON_QUESTION | wxYES_NO) == wxYES) {
         auto it = xlights->LayoutGroups.find(currentLayoutGroup);

--- a/src-ui-wx/layout/LayoutPanel.h
+++ b/src-ui-wx/layout/LayoutPanel.h
@@ -426,6 +426,7 @@ class LayoutPanel: public wxPanel
         int GetBackgroundAlphaForSelectedPreview();
         const std::string& GetCurrentLayoutGroup() const {return currentLayoutGroup;}
         void Reset();
+        void SyncCurrentLayoutGroupFromStored();
         void SetDirtyHiLight(bool dirty);
         std::string GetCurrentPreview() const;
         void SetDisplay2DBoundingBox(bool bb);


### PR DESCRIPTION
When switch showfolder or opening .xsqz make sure it points to a good layout preview.