### PR TITLE
Fix clone and rename group ui issues (#7049)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -30,6 +30,8 @@ XLIGHTS/NUTCRACKER RELEASE NOTES
                                  3D no longer snaps it to Z=0 and locks up further Z-axis movement (#7045)
     -bug (derwin12)              Layout tab could land on the "Unassigned" preview instead of "Default"
                                  when the show's last-saved preview no longer existed, showing no models
+    -bug (derwin12)              Cloning a model group left both the original and the clone highlighted
+                                 in the tree, with the property grid actually still editing the original (#7049)
 
 
 2026.17  September 8, 2026

--- a/src-ui-wx/layout/LayoutPanel.cpp
+++ b/src-ui-wx/layout/LayoutPanel.cpp
@@ -2142,6 +2142,16 @@ void LayoutPanel::UpdateModelList(bool full_refresh, std::vector<Model*> &models
 
     if (full_refresh) {
         UnSelectAllModels();
+        // UnSelectAllModels() only clears our own bookkeeping (selectedTreeGroups/
+        // selectedTreeModels, per-model Selected() flags) - it does not touch the
+        // native tree control's selection. DeleteAllItems()/re-add below hands the
+        // tree brand new items, but some platforms (e.g. macOS NSOutlineView) can
+        // keep a row visually selected across that rebuild if a new item lands in
+        // the same row. Explicitly clear both trees so a freshly rebuilt tree never
+        // starts out with a stale selection (github issue #7049 - cloning a group
+        // left both the original and the clone highlighted).
+        TreeListViewModels->UnselectAll();
+        TreeListViewGroups->UnselectAll();
         TreeListViewModels->DeleteAllItems();
         TreeListViewGroups->DeleteAllItems();
 


### PR DESCRIPTION
UI was leaving duplicate items selected.